### PR TITLE
next attempt starts after tracking

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,8 @@
 - [x] run next attempt now RPC (expedite)
   - [ ] figure out how to avoid having to scan for all future tasks and delete performance issue
 - [x] get job info api
-- [ ] get job with attempts api
+- [x] get job with attempts api
+- [ ] performant, clear storage for job payload, result, and error data
 - [x] list jobs api
 - [x] clustering
   - [x] etcd leasing

--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -151,6 +151,7 @@ message GetJobResponse {
   JobStatus status = 8;                  // Current job status.
   int64 status_changed_at_ms = 9;        // Unix timestamp (ms) of last status change.
   repeated JobAttempt attempts = 10;     // All attempts for this job. Only populated if include_attempts was true in the request.
+  optional int64 next_attempt_starts_after_ms = 11; // Unix timestamp (ms) when the next attempt will start. Present for scheduled jobs, absent for running or terminal jobs.
 }
 
 // Request to get the result of a completed job.

--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -387,6 +387,7 @@ impl ClusterClient {
                 status: status.into(),
                 status_changed_at_ms,
                 attempts,
+                next_attempt_starts_after_ms: job_status.next_attempt_starts_after_ms,
             });
         }
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -191,34 +191,47 @@ impl JobStatusKind {
 pub struct JobStatus {
     pub kind: JobStatusKind,
     pub changed_at_ms: i64,
+    /// Unix timestamp (ms) when the next attempt will start.
+    /// Present for scheduled jobs (initial or retry), absent for running or terminal jobs.
+    pub next_attempt_starts_after_ms: Option<i64>,
 }
 
 impl JobStatus {
-    pub fn new(kind: JobStatusKind, changed_at_ms: i64) -> Self {
+    pub fn new(
+        kind: JobStatusKind,
+        changed_at_ms: i64,
+        next_attempt_starts_after_ms: Option<i64>,
+    ) -> Self {
         Self {
             kind,
             changed_at_ms,
+            next_attempt_starts_after_ms,
         }
     }
 
-    pub fn scheduled(changed_at_ms: i64) -> Self {
-        Self::new(JobStatusKind::Scheduled, changed_at_ms)
+    /// Create a Scheduled status with the next attempt start time.
+    pub fn scheduled(changed_at_ms: i64, next_attempt_starts_after_ms: i64) -> Self {
+        Self::new(
+            JobStatusKind::Scheduled,
+            changed_at_ms,
+            Some(next_attempt_starts_after_ms),
+        )
     }
 
     pub fn running(changed_at_ms: i64) -> Self {
-        Self::new(JobStatusKind::Running, changed_at_ms)
+        Self::new(JobStatusKind::Running, changed_at_ms, None)
     }
 
     pub fn failed(changed_at_ms: i64) -> Self {
-        Self::new(JobStatusKind::Failed, changed_at_ms)
+        Self::new(JobStatusKind::Failed, changed_at_ms, None)
     }
 
     pub fn cancelled(changed_at_ms: i64) -> Self {
-        Self::new(JobStatusKind::Cancelled, changed_at_ms)
+        Self::new(JobStatusKind::Cancelled, changed_at_ms, None)
     }
 
     pub fn succeeded(changed_at_ms: i64) -> Self {
-        Self::new(JobStatusKind::Succeeded, changed_at_ms)
+        Self::new(JobStatusKind::Succeeded, changed_at_ms, None)
     }
 
     pub fn is_terminal(&self) -> bool {

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -176,8 +176,8 @@ impl JobStoreShard {
                                 &next_task,
                             )?;
 
-                            // [SILO-RETRY-3] Set job status to Scheduled
-                            let job_status = JobStatus::scheduled(now_ms);
+                            // [SILO-RETRY-3] Set job status to Scheduled with next attempt time
+                            let job_status = JobStatus::scheduled(now_ms, next_time);
                             self.set_job_status_with_index(&mut batch, tenant, &job_id, job_status)
                                 .await?;
                             scheduled_followup = true;

--- a/src/server.rs
+++ b/src/server.rs
@@ -527,6 +527,7 @@ impl Silo for SiloService {
             status: status.into(),
             status_changed_at_ms,
             attempts,
+            next_attempt_starts_after_ms: job_status.next_attempt_starts_after_ms,
         };
         Ok(Response::new(resp))
     }

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -320,6 +320,11 @@ export interface Job {
   statusChangedAtMs: bigint;
   /** All attempts for this job. Only populated if includeAttempts was true in the request to fetch the job. */
   attempts?: JobAttempt[];
+  /**
+   * Timestamp (epoch ms) when the next attempt will start.
+   * Present for scheduled jobs (initial or after retry), absent for running or terminal jobs.
+   */
+  nextAttemptStartsAfterMs?: bigint;
 }
 
 /** Possible job statuses */
@@ -1145,6 +1150,7 @@ export class SiloGRPCClient {
             response.attempts.length > 0
               ? response.attempts.map(protoAttemptToPublic)
               : undefined,
+          nextAttemptStartsAfterMs: response.nextAttemptStartsAfterMs,
         };
       });
     } catch (error) {

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -360,6 +360,10 @@ export interface GetJobResponse {
      * @generated from protobuf field: repeated silo.v1.JobAttempt attempts = 10
      */
     attempts: JobAttempt[]; // All attempts for this job. Only populated if include_attempts was true in the request.
+    /**
+     * @generated from protobuf field: optional int64 next_attempt_starts_after_ms = 11
+     */
+    nextAttemptStartsAfterMs?: bigint; // Unix timestamp (ms) when the next attempt will start. Present for scheduled jobs, absent for running or terminal jobs.
 }
 /**
  * Request to get the result of a completed job.
@@ -1999,7 +2003,8 @@ class GetJobResponse$Type extends MessageType<GetJobResponse> {
             { no: 7, name: "metadata", kind: "map", K: 9 /*ScalarType.STRING*/, V: { kind: "scalar", T: 9 /*ScalarType.STRING*/ } },
             { no: 8, name: "status", kind: "enum", T: () => ["silo.v1.JobStatus", JobStatus, "JOB_STATUS_"] },
             { no: 9, name: "status_changed_at_ms", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
-            { no: 10, name: "attempts", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => JobAttempt }
+            { no: 10, name: "attempts", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => JobAttempt },
+            { no: 11, name: "next_attempt_starts_after_ms", kind: "scalar", opt: true, T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
     create(value?: PartialMessage<GetJobResponse>): GetJobResponse {
@@ -2050,6 +2055,9 @@ class GetJobResponse$Type extends MessageType<GetJobResponse> {
                     break;
                 case /* repeated silo.v1.JobAttempt attempts */ 10:
                     message.attempts.push(JobAttempt.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* optional int64 next_attempt_starts_after_ms */ 11:
+                    message.nextAttemptStartsAfterMs = reader.int64().toBigInt();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -2109,6 +2117,9 @@ class GetJobResponse$Type extends MessageType<GetJobResponse> {
         /* repeated silo.v1.JobAttempt attempts = 10; */
         for (let i = 0; i < message.attempts.length; i++)
             JobAttempt.internalBinaryWrite(message.attempts[i], writer.tag(10, WireType.LengthDelimited).fork(), options).join();
+        /* optional int64 next_attempt_starts_after_ms = 11; */
+        if (message.nextAttemptStartsAfterMs !== undefined)
+            writer.tag(11, WireType.Varint).int64(message.nextAttemptStartsAfterMs);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);


### PR DESCRIPTION
- **Add next attempt expediting**
- **Split up huge test files**
- **Track when the next attempt is going to start and return to api consumers**
