### PR TITLE
dst fixes 4

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -62,3 +62,4 @@
   - [ ] validate all sigils present
   - [ ] add split DST scenarios
   - [ ] ensure that cleanup is aborted cleanly when a shard is closed mid-cleanup
+- [ ] asynchronously hydrate concurrency queue counts to make startup faster

--- a/tests/turmoil_runner/helpers.rs
+++ b/tests/turmoil_runner/helpers.rs
@@ -27,6 +27,7 @@ use tracing_subscriber::prelude::*;
 use turmoil::net::TcpListener;
 
 // Re-export common types needed by scenarios
+pub use silo::pb::silo_client::SiloClient;
 pub use silo::pb::{
     AttemptStatus, ConcurrencyLimit, EnqueueRequest, GetJobRequest, JobStatus, LeaseTasksRequest,
     Limit, QueryRequest, ReportOutcomeRequest, RetryPolicy, SerializedBytes, Task, limit,
@@ -150,7 +151,7 @@ pub use silo::cluster_client::ClientConfig;
 pub async fn create_turmoil_client(
     uri: &str,
     config: &ClientConfig,
-) -> turmoil::Result<silo::pb::silo_client::SiloClient<tonic::transport::Channel>> {
+) -> turmoil::Result<SiloClient<tonic::transport::Channel>> {
     let endpoint = tonic::transport::Endpoint::new(uri.to_string())
         .map_err(|e| e.to_string())?
         .connect_timeout(config.connect_timeout)
@@ -201,8 +202,72 @@ pub async fn create_turmoil_client(
         .into())
 }
 
+/// Connect to a DST server, waiting for it to be ready.
+pub async fn connect_to_server(
+    uri: &str,
+) -> turmoil::Result<SiloClient<tonic::transport::Channel>> {
+    const MAX_ATTEMPTS: u32 = 20;
+    const INITIAL_BACKOFF_MS: u64 = 25;
+    const MAX_BACKOFF_MS: u64 = 500;
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+    let endpoint = tonic::transport::Endpoint::new(uri.to_string())
+        .map_err(|e| e.to_string())?
+        .connect_timeout(CONNECT_TIMEOUT);
+
+    let mut last_error = None;
+    let mut backoff_ms = INITIAL_BACKOFF_MS;
+
+    for attempt in 0..MAX_ATTEMPTS {
+        let connect_result = tokio::time::timeout(
+            CONNECT_TIMEOUT,
+            endpoint.connect_with_connector(turmoil_connector()),
+        )
+        .await;
+
+        match connect_result {
+            Ok(Ok(channel)) => {
+                tracing::trace!(attempt = attempt, uri = uri, "connected to server");
+                return Ok(SiloClient::new(channel));
+            }
+            Ok(Err(e)) => {
+                tracing::trace!(
+                    attempt = attempt,
+                    max_attempts = MAX_ATTEMPTS,
+                    error = %e,
+                    uri = uri,
+                    backoff_ms = backoff_ms,
+                    "connection attempt failed, retrying"
+                );
+                last_error = Some(e.to_string());
+            }
+            Err(_elapsed) => {
+                tracing::trace!(
+                    attempt = attempt,
+                    max_attempts = MAX_ATTEMPTS,
+                    uri = uri,
+                    backoff_ms = backoff_ms,
+                    "connection attempt timed out, retrying"
+                );
+                last_error = Some("connection timed out".to_string());
+            }
+        }
+
+        if attempt + 1 < MAX_ATTEMPTS {
+            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+            // Exponential backoff with cap
+            backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);
+        }
+    }
+
+    Err(last_error
+        .unwrap_or_else(|| "no connection attempts made".to_string())
+        .into())
+}
+
 /// Helper to create a standard server host for tests
 pub async fn setup_server(port: u16) -> turmoil::Result<()> {
+    tracing::trace!(port = port, "setup_server: starting");
     let cfg = AppConfig {
         server: silo::settings::ServerConfig {
             grpc_addr: format!("0.0.0.0:{}", port),
@@ -226,14 +291,18 @@ pub async fn setup_server(port: u16) -> turmoil::Result<()> {
     let factory = ShardFactory::new(cfg.database.clone(), rate_limiter, None);
     // For DST tests, use a fixed shard ID (zero UUID) for simplicity
     let test_shard_id = ShardId::parse("00000000-0000-0000-0000-000000000000").unwrap();
+    tracing::trace!("setup_server: opening shard");
     let _ = factory
         .open(&test_shard_id, &ShardRange::full())
         .await
         .map_err(|e| e.to_string())?;
     let factory = Arc::new(factory);
+    tracing::trace!("setup_server: shard opened");
 
     let addr = (IpAddr::from(Ipv4Addr::UNSPECIFIED), port);
+    tracing::trace!(port = port, "setup_server: binding TCP listener");
     let listener = TcpListener::bind(addr).await.map_err(|e| e.to_string())?;
+    tracing::trace!(port = port, "setup_server: TCP listener bound");
 
     struct Accepted(turmoil::net::TcpStream);
     impl tonic::transport::server::Connected for Accepted {
@@ -284,6 +353,7 @@ pub async fn setup_server(port: u16) -> turmoil::Result<()> {
     };
 
     // Create a NoneCoordinator for single-node DST test mode
+    tracing::trace!("setup_server: creating coordinator");
     let coordinator = Arc::new(
         NoneCoordinator::new(
             "dst-test-node",
@@ -293,19 +363,15 @@ pub async fn setup_server(port: u16) -> turmoil::Result<()> {
         )
         .await,
     );
+    tracing::trace!("setup_server: coordinator created");
 
     let (_tx, rx) = tokio::sync::broadcast::channel::<()>(1);
-    run_server_with_incoming(
-        incoming,
-        factory,
-        coordinator,
-        silo::settings::AppConfig::load(None).unwrap(),
-        None,
-        rx,
-    )
-    .await
-    .map_err(|e| e.to_string())?;
+    tracing::trace!("setup_server: starting server");
+    run_server_with_incoming(incoming, factory, coordinator, cfg, None, rx)
+        .await
+        .map_err(|e| e.to_string())?;
 
+    tracing::trace!("setup_server: server stopped");
     Ok(())
 }
 
@@ -637,6 +703,7 @@ pub fn verify_determinism(scenario: &str, seed: u64) {
 ///
 /// Note: The actual system uses `tenant|queue` as the composite key - each tenant
 /// has its own separate limit for each queue name. This tracker mirrors that behavior.
+/// Jobs for a given tenant should only be routed to one shard at a time.
 #[derive(Debug, Default)]
 pub struct GlobalConcurrencyTracker {
     /// Maps tenant|queue -> set of (task_id, job_id) pairs currently holding the limit

--- a/tests/turmoil_runner/scenarios/cancel_releases_ticket.rs
+++ b/tests/turmoil_runner/scenarios/cancel_releases_ticket.rs
@@ -24,10 +24,10 @@
 
 use crate::helpers::{
     ConcurrencyLimit, EnqueueRequest, HashMap, LeaseTasksRequest, Limit, ReportOutcomeRequest,
-    SerializedBytes, TEST_SHARD_ID, check_holder_limits, get_seed, limit, report_outcome_request,
-    run_scenario_impl, serialized_bytes, setup_server, turmoil_connector, verify_server_invariants,
+    SerializedBytes, SiloClient, TEST_SHARD_ID, check_holder_limits, connect_to_server, get_seed,
+    limit, report_outcome_request, run_scenario_impl, serialized_bytes, setup_server,
+    turmoil_connector, verify_server_invariants,
 };
-use silo::pb::silo_client::SiloClient;
 use silo::pb::{CancelJobRequest, HeartbeatRequest};
 use std::collections::HashMap as StdHashMap;
 use std::sync::Arc;
@@ -56,12 +56,7 @@ pub fn run() {
 
         // Producer: Enqueues jobs A, B, C
         sim.client("producer", async move {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-
-            let ch = Endpoint::new("http://server:9921")?
-                .connect_with_connector(turmoil_connector())
-                .await?;
-            let mut client = SiloClient::new(ch);
+            let mut client = connect_to_server("http://server:9921").await?;
 
             // Enqueue job A - will be leased first and then cancelled
             tracing::trace!(job_id = "job-A", "enqueue");

--- a/tests/turmoil_runner/scenarios/grpc_end_to_end.rs
+++ b/tests/turmoil_runner/scenarios/grpc_end_to_end.rs
@@ -2,12 +2,10 @@
 
 use crate::helpers::{
     AttemptStatus, EnqueueRequest, GetJobRequest, HashMap, JobStatus, LeaseTasksRequest,
-    ReportOutcomeRequest, SerializedBytes, TEST_SHARD_ID, get_seed, report_outcome_request,
-    run_scenario_impl, serialized_bytes, setup_server, turmoil_connector, verify_server_invariants,
+    ReportOutcomeRequest, SerializedBytes, TEST_SHARD_ID, connect_to_server, get_seed,
+    report_outcome_request, run_scenario_impl, serialized_bytes, setup_server,
+    verify_server_invariants,
 };
-use silo::pb::silo_client::SiloClient;
-use std::time::Duration;
-use tonic::transport::Endpoint;
 
 pub fn run() {
     let seed = get_seed();
@@ -15,13 +13,9 @@ pub fn run() {
         sim.host("server", || async move { setup_server(9900).await });
 
         sim.client("client", async move {
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            // Connect to server, waiting for it to be ready
+            let mut client = connect_to_server("http://server:9900").await?;
             tracing::trace!("client_start");
-
-            let ch = Endpoint::new("http://server:9900")?
-                .connect_with_connector(turmoil_connector())
-                .await?;
-            let mut client = SiloClient::new(ch);
 
             // Verify initial server state (no jobs)
             let initial_state = verify_server_invariants(&mut client, TEST_SHARD_ID).await;

--- a/tests/turmoil_runner/scenarios/k8s_coordination.rs
+++ b/tests/turmoil_runner/scenarios/k8s_coordination.rs
@@ -189,7 +189,7 @@ async fn setup_node_server(
             dev_mode: false,
         },
         coordination: silo::settings::CoordinationConfig::default(),
-        tenancy: silo::settings::TenancyConfig { enabled: false },
+        tenancy: silo::settings::TenancyConfig { enabled: true },
         gubernator: GubernatorSettings::default(),
         webui: WebUiConfig::default(),
         logging: LoggingConfig::default(),
@@ -322,7 +322,9 @@ pub fn run() {
         // Invariant tracker for DST events
         let tracker = Arc::new(InvariantTracker::new());
 
-        // Register concurrency limits
+        // Register concurrency limits - each tenant gets its own limits tracked separately.
+        // This scenario uses shard-specific tenants (e.g., "shard-0", "shard-1") so that
+        // jobs routed to different shards don't share concurrency limits in the tracker.
         for (key, max_conc) in WORKER_LIMITS {
             if *max_conc > 0 {
                 tracker.concurrency.register_limit(key, *max_conc);
@@ -492,9 +494,12 @@ pub fn run() {
                 let delay_ms = rng.random_range(50..200);
                 tokio::time::sleep(Duration::from_millis(delay_ms)).await;
 
-                // Round-robin across shards to exercise routing
+                // Round-robin across shards to exercise routing.
+                // Use a shard-specific tenant so each shard's concurrency limits are
+                // tracked independently (matching how the actual system works).
                 let shard_idx = (i as usize) % shard_ids.len();
                 let shard_id = &shard_ids[shard_idx];
+                let tenant = format!("shard-{}", shard_idx);
 
                 // Find the current owner of this shard (with retry on failure)
                 let owner = match producer_k8s_state
@@ -560,6 +565,7 @@ pub fn run() {
                 tracing::trace!(
                     job_id = %job_id,
                     shard = %shard_id,
+                    tenant = %tenant,
                     target_node = ?target_node,
                     limit_key = limit_key,
                     "enqueue"
@@ -582,7 +588,7 @@ pub fn run() {
                             )),
                         }),
                         limits,
-                        tenant: None,
+                        tenant: Some(tenant.clone()),
                         metadata: HashMap::new(),
                         task_group: "default".to_string(),
                     }))

--- a/typescript_client/src/TaskExecution.ts
+++ b/typescript_client/src/TaskExecution.ts
@@ -17,7 +17,10 @@ export type CancellationReason = "server" | "client" | "worker_shutdown";
  * @typeParam T The type of the decoded payload. Defaults to `unknown`.
  */
 
-export interface Task<Payload = unknown, Metadata extends Record<string, string> = Record<string, string>> {
+export interface Task<
+  Payload = unknown,
+  Metadata extends Record<string, string> = Record<string, string>,
+> {
   /** Unique task ID (different from job ID) */
   id: string;
   /** ID of the job this task belongs to */
@@ -44,7 +47,10 @@ export interface Task<Payload = unknown, Metadata extends Record<string, string>
 /**
  * Transform a raw protobuf Task into a userland Task with decoded payload.
  */
-export function transformTask<Payload = unknown, Metadata extends Record<string, string> = Record<string, string>>(protoTask: ProtoTask): Task<Payload, Metadata> {
+export function transformTask<
+  Payload = unknown,
+  Metadata extends Record<string, string> = Record<string, string>,
+>(protoTask: ProtoTask): Task<Payload, Metadata> {
   return {
     id: protoTask.id,
     jobId: protoTask.jobId,
@@ -54,7 +60,7 @@ export function transformTask<Payload = unknown, Metadata extends Record<string,
       protoTask.payload?.encoding.oneofKind === "msgpack"
         ? protoTask.payload.encoding.msgpack
         : undefined,
-      "payload"
+      "payload",
     ),
     priority: protoTask.priority,
     shard: protoTask.shard,
@@ -71,7 +77,10 @@ export function transformTask<Payload = unknown, Metadata extends Record<string,
  * to coordinate cancellation from various sources.
  * @internal
  */
-export class TaskExecution<Payload = unknown, Metadata extends Record<string, string> = Record<string, string>> {
+export class TaskExecution<
+  Payload = unknown,
+  Metadata extends Record<string, string> = Record<string, string>,
+> {
   /** The task being executed (raw proto format) */
   public readonly task: Task<Payload, Metadata>;
   /** The worker ID */
@@ -94,7 +103,7 @@ export class TaskExecution<Payload = unknown, Metadata extends Record<string, st
     task: Task<Payload, Metadata>,
     workerId: string,
     workerAbortSignal: AbortSignal,
-    client: SiloGRPCClient
+    client: SiloGRPCClient,
   ) {
     this.task = task;
     this.workerId = workerId;
@@ -105,7 +114,7 @@ export class TaskExecution<Payload = unknown, Metadata extends Record<string, st
     // Create a combined signal that aborts when EITHER the task or worker is aborted
     this._combinedSignal = combineAbortSignals(
       workerAbortSignal,
-      this._taskAbortController.signal
+      this._taskAbortController.signal,
     );
 
     // Track when worker shutdown causes abort
@@ -117,7 +126,7 @@ export class TaskExecution<Payload = unknown, Metadata extends Record<string, st
           this._cancellationReason = "worker_shutdown";
         }
       },
-      { once: true }
+      { once: true },
     );
   }
 
@@ -180,6 +189,3 @@ export class TaskExecution<Payload = unknown, Metadata extends Record<string, st
     await this._cancelPromise;
   }
 }
-
-
-

--- a/typescript_client/test/worker.test.ts
+++ b/typescript_client/test/worker.test.ts
@@ -12,7 +12,7 @@ function createMockClient(options?: {
     workerId: string,
     taskId: string,
     shard: number,
-    tenant?: string
+    tenant?: string,
   ) => Promise<{ cancelled: boolean }>;
 }): SiloGRPCClient {
   return {
@@ -32,14 +32,21 @@ function tasksResult(tasks: Task[]): LeaseTasksResult {
   return { tasks, refreshTasks: [] };
 }
 
-function createTask(id: string, jobId: string, shard: string = "00000000-0000-0000-0000-000000000001"): Task {
+function createTask(
+  id: string,
+  jobId: string,
+  shard: string = "00000000-0000-0000-0000-000000000001",
+): Task {
   return {
     id,
     jobId,
     attemptNumber: 1,
     leaseMs: 30000n,
     payload: {
-      encoding: { oneofKind: "msgpack", msgpack: encodeBytes({ test: "data" }) },
+      encoding: {
+        oneofKind: "msgpack",
+        msgpack: encodeBytes({ test: "data" }),
+      },
     },
     priority: 10,
     shard,
@@ -155,7 +162,7 @@ describe("SiloWorker", () => {
           maxTasks: expect.any(Number),
           taskGroup: "default",
         },
-        expect.any(Number) // serverIndex for per-worker round-robin
+        expect.any(Number), // serverIndex for per-worker round-robin
       );
     });
 
@@ -233,7 +240,7 @@ describe("SiloWorker", () => {
             jobId: task.jobId,
             payload: { test: "data" }, // Decoded payload
           }),
-        })
+        }),
       );
 
       expect(reportOutcome).toHaveBeenCalledWith({
@@ -447,7 +454,11 @@ describe("SiloWorker", () => {
 
       // Should have sent multiple heartbeats
       // heartbeat(workerId, taskId, shard)
-      expect(heartbeat).toHaveBeenCalledWith("test-worker", "task-hb", "00000000-0000-0000-0000-000000000001");
+      expect(heartbeat).toHaveBeenCalledWith(
+        "test-worker",
+        "task-hb",
+        "00000000-0000-0000-0000-000000000001",
+      );
       expect(heartbeat.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
 
@@ -519,7 +530,7 @@ describe("SiloWorker", () => {
       await worker.stop();
 
       expect(onError).toHaveBeenCalledWith(
-        expect.objectContaining({ message: "Connection failed" })
+        expect.objectContaining({ message: "Connection failed" }),
       );
     });
 
@@ -557,7 +568,7 @@ describe("SiloWorker", () => {
 
       expect(onError).toHaveBeenCalledWith(
         expect.objectContaining({ message: "Heartbeat failed" }),
-        expect.objectContaining({ taskId: "task-err" })
+        expect.objectContaining({ taskId: "task-err" }),
       );
     });
 


### PR DESCRIPTION
- **Improve robustness of DST test startup**
- **Eagerly hydrate concurrency queue counts to avoid asynchrony allowing race conditions to acquire tickets before counts have been loaded and violate invariants**
- **Use individual tenants in k8s coordination test**
