### PR TITLE
floating concurrency limit coverage

### DIFF
--- a/.ai/settings.json
+++ b/.ai/settings.json
@@ -3,6 +3,7 @@
     "allow": [
       "Bash(grep:*)",
       "Bash(ls:*)",
+      "Bash(rg:*)",
       "Bash(cargo:*)",
       "Bash(pnpm run:*)",
       "Bash(pnpm test:*)",
@@ -21,6 +22,7 @@
       "Bash(paste:*)",
       "Bash(join:*)",
       "Bash(split:*)",
+      "Bash(unzip:*)",
       "Bash(git branch)",
       "Bash(git log:*)",
       "Bash(git diff:*)",
@@ -31,6 +33,7 @@
       "Bash(gh cache:*)",
       "Bash(gh api:*)",
       "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
       "Bash(gh search:*)",
       "Bash(gh issue view:*)",
       "Bash(scripts/*)",

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@
   - [ ] figure out how to avoid having to scan for all future tasks and delete performance issue
 - [x] get job info api
 - [x] get job with attempts api
-- [ ] performant, clear storage for job payload, result, and error data
+- [x] performant, clear storage for job payload, result, and error data
 - [x] list jobs api
 - [x] job query api
   - [ ] unhappy path tests

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -2728,8 +2728,8 @@ async fn k8s_split_state_persists_across_restart() {
     c1.shutdown().await.unwrap();
     h1.abort();
 
-    // Small delay
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    // Wait for K8s resources to be cleaned up before restarting
+    tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Start new coordinator with same prefix (simulates restart)
     let (c2, h2) = K8sCoordinator::start(

--- a/typescript_client/test/client-integration.test.ts
+++ b/typescript_client/test/client-integration.test.ts
@@ -983,7 +983,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
           {
             type: "floatingConcurrency",
             key: queueKey,
-            defaultMaxConcurrency: 2,
+            defaultMaxConcurrency: 1, // Use 1 so second job becomes a waiter, triggering refresh
             refreshIntervalMs: 1n, // 1ms - will be stale immediately
             metadata: { testKey: "testValue" },
           },
@@ -1003,7 +1003,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
           {
             type: "floatingConcurrency",
             key: queueKey,
-            defaultMaxConcurrency: 2,
+            defaultMaxConcurrency: 1, // Use 1 so second job becomes a waiter, triggering refresh
             refreshIntervalMs: 1n,
             metadata: { testKey: "testValue" },
           },
@@ -1029,7 +1029,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       expect(refreshTask).toBeDefined();
       expect(refreshTask!.id).toBeTruthy();
       expect(refreshTask!.queueKey).toBe(queueKey);
-      expect(refreshTask!.currentMaxConcurrency).toBe(2);
+      expect(refreshTask!.currentMaxConcurrency).toBe(1);
       expect(refreshTask!.metadata).toEqual({ testKey: "testValue" });
       expect(refreshTask!.shard).toBe(shard);
 
@@ -1066,7 +1066,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
           {
             type: "floatingConcurrency",
             key: queueKey,
-            defaultMaxConcurrency: 3,
+            defaultMaxConcurrency: 1, // Use 1 so second job becomes a waiter, triggering refresh
             refreshIntervalMs: 1n,
             metadata: { apiEndpoint: "https://api.example.com" },
           },
@@ -1086,7 +1086,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
           {
             type: "floatingConcurrency",
             key: queueKey,
-            defaultMaxConcurrency: 3,
+            defaultMaxConcurrency: 1, // Use 1 so second job becomes a waiter, triggering refresh
             refreshIntervalMs: 1n,
             metadata: { apiEndpoint: "https://api.example.com" },
           },


### PR DESCRIPTION
- **Switch to using storekey for keys for performance**
- **Add more logging / assertions to help debug test flakes**
- **Only run floating refresh tasks if there are waiters**
