### PR TITLE
Enable HTTP/2 keepalive while idle to detect dead connections

### DIFF
--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -103,6 +103,7 @@ impl ClientConfig {
                 .timeout(self.request_timeout)
                 .http2_keep_alive_interval(self.keepalive_interval)
                 .keep_alive_timeout(self.keepalive_timeout)
+                .keep_alive_while_idle(true)
         })
     }
 


### PR DESCRIPTION
Without this setting, keepalive pings are only sent when there are active
streams. This means dead connections can go undetected between RPCs,
potentially causing failures when the next request is made on a stale
connection.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
