### PR TITLE
Fix shards not immediately available after resetShards RPC

### DIFF
--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -527,7 +527,7 @@ pub async fn create_coordinator(
                 factory,
                 config.placement_rings.clone(),
             )
-            .await;
+            .await?;
             Ok((Arc::new(coord), None))
         }
         crate::settings::CoordinationBackend::Etcd => {

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -112,7 +112,8 @@ async fn make_guard(
         factory.clone(),
         Vec::new(),
     )
-    .await;
+    .await
+    .unwrap();
     let coordinator: Arc<dyn Coordinator> = Arc::new(none_coord);
     let handle = tokio::spawn(async move {
         runner.run(owned_arc, factory, shard_map, coordinator).await;

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -828,7 +828,8 @@ async fn make_k8s_guard(
         factory.clone(),
         Vec::new(),
     )
-    .await;
+    .await
+    .unwrap();
     let coordinator: Arc<dyn Coordinator> = Arc::new(none_coord);
     let handle = tokio::spawn(async move {
         runner.run(owned_arc, factory, shard_map, coordinator).await;

--- a/tests/none_coordinator_tests.rs
+++ b/tests/none_coordinator_tests.rs
@@ -29,7 +29,8 @@ async fn none_coordinator_owns_all_shards() {
         make_test_factory(),
         Vec::new(),
     )
-    .await;
+    .await
+    .unwrap();
 
     let owned = coord.owned_shards().await;
     assert_eq!(owned.len(), 16);
@@ -47,7 +48,8 @@ async fn none_coordinator_always_converged() {
         make_test_factory(),
         Vec::new(),
     )
-    .await;
+    .await
+    .unwrap();
 
     assert!(coord.wait_converged(Duration::from_millis(1)).await);
 }
@@ -61,7 +63,8 @@ async fn none_coordinator_single_member() {
         make_test_factory(),
         Vec::new(),
     )
-    .await;
+    .await
+    .unwrap();
 
     let members = coord.get_members().await.unwrap();
     assert_eq!(members.len(), 1);
@@ -77,7 +80,8 @@ async fn none_coordinator_shard_map() {
         make_test_factory(),
         Vec::new(),
     )
-    .await;
+    .await
+    .unwrap();
 
     let map = coord.get_shard_owner_map().await.unwrap();
     assert_eq!(map.num_shards(), 4);

--- a/tests/turmoil_runner/helpers.rs
+++ b/tests/turmoil_runner/helpers.rs
@@ -397,7 +397,8 @@ pub async fn setup_server(port: u16) -> turmoil::Result<()> {
             factory.clone(),
             Vec::new(),
         )
-        .await,
+        .await
+        .unwrap(),
     );
     tracing::trace!("setup_server: coordinator created");
 

--- a/tests/webui_tests.rs
+++ b/tests/webui_tests.rs
@@ -42,7 +42,8 @@ async fn setup_test_state() -> (tempfile::TempDir, AppState, ShardMap) {
             factory.clone(),
             Vec::new(),
         )
-        .await,
+        .await
+        .unwrap(),
     );
 
     // Get the shard map from the coordinator
@@ -414,7 +415,8 @@ async fn setup_multi_shard_state(num_shards: usize) -> (tempfile::TempDir, AppSt
             factory.clone(),
             Vec::new(),
         )
-        .await,
+        .await
+        .unwrap(),
     );
 
     // Get the shard map from the coordinator


### PR DESCRIPTION
NoneCoordinator::new() previously swallowed shard open errors silently, which meant a misconfigured path template (e.g. data-%shard% instead of data/%shard%) would leave the server running with no shards loaded. Every subsequent request would fail with "shard not ready: acquisition in progress".

Three fixes:
- NoneCoordinator::new() now returns Result and fails fast on shard open errors
- reset_shards uses the coordinator's shard map as source of truth (not just factory instances), re-registers owned shards, and verifies accessibility
- Added tests for immediate shard availability after reset using the production NoneCoordinator::new() code path