### PR TITLE
Add tests for critical coverage gaps in codec, metrics, cluster_clien…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,55 @@ cd typescript_client
 RUN_INTEGRATION=true pnpm test
 ```
 
+## Code coverage
+
+Coverage uses [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov). It will be installed automatically if missing.
+
+### Quick coverage (main tests only)
+
+Runs all tests except etcd, k8s, and DST tests. No background services required beyond what normal tests need.
+
+```shell
+# HTML report at target/coverage/html/index.html
+just coverage
+
+# HTML report, then open in browser
+just coverage-open
+
+# Summary printed to terminal
+just coverage-summary
+```
+
+### Full coverage (all test groups)
+
+Runs main tests, etcd coordination tests, coordination split tests, and k8s coordination tests with merged coverage. Requires etcd running and a k8s cluster available (e.g. orbstack). DST tests are excluded (they require `--features dst` and are focused on determinism verification, not coverage).
+
+```shell
+# Run all test groups and generate HTML report
+just coverage-full
+
+# After running coverage-full, print summary to terminal
+just coverage-full-summary
+```
+
+The `coverage-full` target handles the multi-step process automatically:
+1. Cleans previous coverage data
+2. Runs main tests (skipping etcd/k8s tests)
+3. Runs etcd coordination tests single-threaded
+4. Runs coordination split tests single-threaded
+5. Runs k8s coordination tests single-threaded
+6. Generates a merged HTML report
+
+### Other formats
+
+```shell
+# LCOV format (for IDE integration)
+just coverage-lcov
+
+# JSON format (for programmatic analysis)
+just coverage-json
+```
+
 ## Running a local instance
 
 You can run a local server instance by using cargo to build and run the `silo` binary:

--- a/justfile
+++ b/justfile
@@ -17,26 +17,38 @@ etcd:
 _ensure-llvm-cov:
     @command -v cargo-llvm-cov >/dev/null 2>&1 || cargo install cargo-llvm-cov
 
-# Code coverage commands - generates HTML report
+# Quick coverage: run main tests only (skips etcd/k8s/DST) and generate HTML report
 coverage: _ensure-llvm-cov
-    cargo llvm-cov --html --output-dir target/coverage
+    cargo llvm-cov --html --output-dir target/coverage -- --skip k8s_ --skip etcd_ --skip coordination_split_tests
 
-# Generate and open HTML coverage report in browser
+# Quick coverage: generate and open HTML report in browser
 coverage-open: _ensure-llvm-cov
-    cargo llvm-cov --html --output-dir target/coverage --open
+    cargo llvm-cov --html --output-dir target/coverage --open -- --skip k8s_ --skip etcd_ --skip coordination_split_tests
 
-# Print coverage summary to terminal
+# Quick coverage: print summary to terminal
 coverage-summary: _ensure-llvm-cov
-    cargo llvm-cov
+    cargo llvm-cov -- --skip k8s_ --skip etcd_ --skip coordination_split_tests
+
+# Full coverage: run ALL test groups (main + etcd + k8s) and generate HTML report.
+# Requires etcd running and a k8s cluster available (e.g. orbstack).
+# Excludes turmoil DST tests (require --features dst).
+coverage-full: _ensure-llvm-cov
+    cargo llvm-cov clean --workspace
+    cargo llvm-cov --no-report -- --skip k8s_ --skip etcd_ --skip coordination_split_tests
+    cargo llvm-cov --no-report --test etcd_coordination_tests -- --test-threads=1
+    cargo llvm-cov --no-report --test coordination_split_tests -- --test-threads=1
+    cargo llvm-cov --no-report --test k8s_coordination_tests -- --test-threads=1
+    cargo llvm-cov report --html --output-dir target/coverage
+    @echo "Coverage report: target/coverage/html/index.html"
+
+# Full coverage: print summary to terminal (after running coverage-full)
+coverage-full-summary: _ensure-llvm-cov
+    cargo llvm-cov report
 
 # Generate lcov format for CI/IDE integration
 coverage-lcov: _ensure-llvm-cov
-    cargo llvm-cov --lcov --output-path target/coverage/lcov.info
+    cargo llvm-cov --lcov --output-path target/coverage/lcov.info -- --skip k8s_ --skip etcd_ --skip coordination_split_tests
 
 # Generate JSON coverage report for programmatic analysis
 coverage-json: _ensure-llvm-cov
-    cargo llvm-cov --json --output-path target/coverage/coverage.json
-
-# Run coverage including integration tests
-coverage-all: _ensure-llvm-cov
-    cargo llvm-cov --html --output-dir target/coverage --doctests
+    cargo llvm-cov --json --output-path target/coverage/coverage.json -- --skip k8s_ --skip etcd_ --skip coordination_split_tests

--- a/src/siloctl.rs
+++ b/src/siloctl.rs
@@ -801,7 +801,7 @@ pub async fn validate_config<W: Write>(
 }
 
 /// Compute the lexicographic midpoint of two strings
-fn compute_midpoint(start: &str, end: &str) -> Option<String> {
+pub fn compute_midpoint(start: &str, end: &str) -> Option<String> {
     if start >= end {
         return None;
     }

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -1,14 +1,16 @@
 use rkyv::Deserialize as RkyvDeserialize;
 use silo::codec::{
-    CONCURRENCY_ACTION_VERSION, CodecError, HOLDER_RECORD_VERSION, JOB_ATTEMPT_VERSION,
-    JOB_STATUS_VERSION, LEASE_RECORD_VERSION, TASK_VERSION, decode_attempt,
-    decode_concurrency_action, decode_holder, decode_job_status, decode_lease, decode_task,
-    encode_attempt, encode_concurrency_action, encode_holder, encode_job_status, encode_lease,
-    encode_task,
+    CONCURRENCY_ACTION_VERSION, CodecError, FLOATING_LIMIT_STATE_VERSION, HOLDER_RECORD_VERSION,
+    JOB_ATTEMPT_VERSION, JOB_CANCELLATION_VERSION, JOB_INFO_VERSION, JOB_STATUS_VERSION,
+    LEASE_RECORD_VERSION, TASK_VERSION, decode_attempt, decode_concurrency_action,
+    decode_floating_limit_state, decode_holder, decode_job_cancellation, decode_job_info,
+    decode_job_status, decode_lease, decode_task, encode_attempt, encode_concurrency_action,
+    encode_floating_limit_state, encode_holder, encode_job_cancellation, encode_job_info,
+    encode_job_status, encode_lease, encode_task,
 };
-use silo::job::{JobStatus, JobStatusKind};
+use silo::job::{FloatingLimitState, JobCancellation, JobInfo, JobStatus, JobStatusKind};
 use silo::job_attempt::{AttemptStatus, JobAttempt};
-use silo::task::{ConcurrencyAction, HolderRecord, LeaseRecord, Task};
+use silo::task::{ConcurrencyAction, GubernatorRateLimitData, HolderRecord, LeaseRecord, Task};
 
 #[silo::test]
 fn test_task_roundtrip() {
@@ -172,5 +174,308 @@ fn test_concurrency_action_roundtrip() {
             assert_eq!(*relative_attempt_number, 1);
             assert_eq!(task_group.as_str(), "default");
         }
+    }
+}
+
+#[silo::test]
+fn test_request_ticket_roundtrip() {
+    let task = Task::RequestTicket {
+        queue: "q1".to_string(),
+        start_time_ms: 5000,
+        priority: 3,
+        tenant: "tenant-1".to_string(),
+        job_id: "job-42".to_string(),
+        attempt_number: 2,
+        relative_attempt_number: 1,
+        request_id: "req-abc".to_string(),
+        task_group: "fast".to_string(),
+    };
+    let encoded = encode_task(&task).unwrap();
+    assert_eq!(encoded[0], TASK_VERSION);
+    let decoded = decode_task(&encoded).unwrap();
+    match decoded {
+        Task::RequestTicket {
+            queue,
+            start_time_ms,
+            priority,
+            tenant,
+            job_id,
+            attempt_number,
+            relative_attempt_number,
+            request_id,
+            task_group,
+        } => {
+            assert_eq!(queue, "q1");
+            assert_eq!(start_time_ms, 5000);
+            assert_eq!(priority, 3);
+            assert_eq!(tenant, "tenant-1");
+            assert_eq!(job_id, "job-42");
+            assert_eq!(attempt_number, 2);
+            assert_eq!(relative_attempt_number, 1);
+            assert_eq!(request_id, "req-abc");
+            assert_eq!(task_group, "fast");
+        }
+        _ => panic!("expected RequestTicket variant"),
+    }
+}
+
+#[silo::test]
+fn test_check_rate_limit_roundtrip() {
+    let task = Task::CheckRateLimit {
+        task_id: "task-99".to_string(),
+        tenant: "tenant-2".to_string(),
+        job_id: "job-7".to_string(),
+        attempt_number: 3,
+        relative_attempt_number: 2,
+        limit_index: 1,
+        rate_limit: GubernatorRateLimitData {
+            name: "api-limit".to_string(),
+            unique_key: "user-123".to_string(),
+            limit: 100,
+            duration_ms: 60000,
+            hits: 1,
+            algorithm: 0,
+            behavior: 2,
+            retry_initial_backoff_ms: 100,
+            retry_max_backoff_ms: 5000,
+            retry_backoff_multiplier: 2.0,
+            retry_max_retries: 5,
+        },
+        retry_count: 1,
+        started_at_ms: 9000,
+        priority: 7,
+        held_queues: vec!["hq-1".to_string(), "hq-2".to_string()],
+        task_group: "default".to_string(),
+    };
+    let encoded = encode_task(&task).unwrap();
+    assert_eq!(encoded[0], TASK_VERSION);
+    let decoded = decode_task(&encoded).unwrap();
+    match decoded {
+        Task::CheckRateLimit {
+            task_id,
+            tenant,
+            job_id,
+            attempt_number,
+            relative_attempt_number,
+            limit_index,
+            rate_limit,
+            retry_count,
+            started_at_ms,
+            priority,
+            held_queues,
+            task_group,
+        } => {
+            assert_eq!(task_id, "task-99");
+            assert_eq!(tenant, "tenant-2");
+            assert_eq!(job_id, "job-7");
+            assert_eq!(attempt_number, 3);
+            assert_eq!(relative_attempt_number, 2);
+            assert_eq!(limit_index, 1);
+            assert_eq!(rate_limit.name, "api-limit");
+            assert_eq!(rate_limit.unique_key, "user-123");
+            assert_eq!(rate_limit.limit, 100);
+            assert_eq!(rate_limit.duration_ms, 60000);
+            assert_eq!(rate_limit.hits, 1);
+            assert_eq!(rate_limit.algorithm, 0);
+            assert_eq!(rate_limit.behavior, 2);
+            assert_eq!(rate_limit.retry_initial_backoff_ms, 100);
+            assert_eq!(rate_limit.retry_max_backoff_ms, 5000);
+            assert_eq!(rate_limit.retry_backoff_multiplier, 2.0);
+            assert_eq!(rate_limit.retry_max_retries, 5);
+            assert_eq!(retry_count, 1);
+            assert_eq!(started_at_ms, 9000);
+            assert_eq!(priority, 7);
+            assert_eq!(held_queues, vec!["hq-1", "hq-2"]);
+            assert_eq!(task_group, "default");
+        }
+        _ => panic!("expected CheckRateLimit variant"),
+    }
+}
+
+#[silo::test]
+fn test_refresh_floating_limit_roundtrip() {
+    let task = Task::RefreshFloatingLimit {
+        task_id: "refresh-1".to_string(),
+        tenant: "tenant-3".to_string(),
+        queue_key: "queue-key-abc".to_string(),
+        current_max_concurrency: 50,
+        last_refreshed_at_ms: 123456,
+        metadata: vec![
+            ("key1".to_string(), "val1".to_string()),
+            ("key2".to_string(), "val2".to_string()),
+        ],
+        task_group: "workers".to_string(),
+    };
+    let encoded = encode_task(&task).unwrap();
+    assert_eq!(encoded[0], TASK_VERSION);
+    let decoded = decode_task(&encoded).unwrap();
+    match decoded {
+        Task::RefreshFloatingLimit {
+            task_id,
+            tenant,
+            queue_key,
+            current_max_concurrency,
+            last_refreshed_at_ms,
+            metadata,
+            task_group,
+        } => {
+            assert_eq!(task_id, "refresh-1");
+            assert_eq!(tenant, "tenant-3");
+            assert_eq!(queue_key, "queue-key-abc");
+            assert_eq!(current_max_concurrency, 50);
+            assert_eq!(last_refreshed_at_ms, 123456);
+            assert_eq!(metadata.len(), 2);
+            assert_eq!(metadata[0], ("key1".to_string(), "val1".to_string()));
+            assert_eq!(metadata[1], ("key2".to_string(), "val2".to_string()));
+            assert_eq!(task_group, "workers");
+        }
+        _ => panic!("expected RefreshFloatingLimit variant"),
+    }
+}
+
+#[silo::test]
+fn test_job_info_roundtrip() {
+    let job_info = JobInfo {
+        id: "job-info-1".to_string(),
+        priority: 42,
+        enqueue_time_ms: 1700000000000,
+        payload: vec![1, 2, 3, 4],
+        retry_policy: None,
+        metadata: vec![("env".to_string(), "prod".to_string())],
+        limits: vec![],
+        task_group: "default".to_string(),
+    };
+    let encoded = encode_job_info(&job_info).unwrap();
+    assert_eq!(encoded[0], JOB_INFO_VERSION);
+    let decoded = decode_job_info(&encoded).unwrap();
+    let archived = decoded.archived();
+    assert_eq!(archived.id.as_str(), "job-info-1");
+    assert_eq!(archived.priority, 42);
+    assert_eq!(archived.enqueue_time_ms, 1700000000000);
+    assert_eq!(archived.payload.as_slice(), &[1, 2, 3, 4]);
+    assert_eq!(archived.metadata.len(), 1);
+    assert_eq!(archived.task_group.as_str(), "default");
+}
+
+#[silo::test]
+fn test_job_cancellation_roundtrip() {
+    let cancellation = JobCancellation {
+        cancelled_at_ms: 9999999,
+    };
+    let encoded = encode_job_cancellation(&cancellation).unwrap();
+    assert_eq!(encoded[0], JOB_CANCELLATION_VERSION);
+    let decoded = decode_job_cancellation(&encoded).unwrap();
+    let archived = decoded.archived();
+    assert_eq!(archived.cancelled_at_ms, 9999999);
+}
+
+#[silo::test]
+fn test_floating_limit_state_roundtrip() {
+    let state = FloatingLimitState {
+        current_max_concurrency: 10,
+        last_refreshed_at_ms: 5000,
+        refresh_task_scheduled: true,
+        refresh_interval_ms: 30000,
+        default_max_concurrency: 5,
+        retry_count: 2,
+        next_retry_at_ms: Some(8000),
+        metadata: vec![("source".to_string(), "api".to_string())],
+    };
+    let encoded = encode_floating_limit_state(&state).unwrap();
+    assert_eq!(encoded[0], FLOATING_LIMIT_STATE_VERSION);
+    let decoded = decode_floating_limit_state(&encoded).unwrap();
+    let archived = decoded.archived();
+    assert_eq!(archived.current_max_concurrency, 10);
+    assert_eq!(archived.last_refreshed_at_ms, 5000);
+    assert_eq!(archived.refresh_task_scheduled, true);
+    assert_eq!(archived.refresh_interval_ms, 30000);
+    assert_eq!(archived.default_max_concurrency, 5);
+    assert_eq!(archived.retry_count, 2);
+    assert_eq!(archived.metadata.len(), 1);
+}
+
+#[silo::test]
+fn test_decoded_lease_accessors_run_attempt() {
+    let lease = LeaseRecord {
+        worker_id: "w1".to_string(),
+        task: Task::RunAttempt {
+            id: "task-10".to_string(),
+            tenant: "t1".to_string(),
+            job_id: "j1".to_string(),
+            attempt_number: 3,
+            relative_attempt_number: 2,
+            held_queues: vec!["q1".to_string(), "q2".to_string()],
+            task_group: "grp".to_string(),
+        },
+        expiry_ms: 50000,
+    };
+    let encoded = encode_lease(&lease).unwrap();
+    let decoded = decode_lease(&encoded).unwrap();
+
+    assert_eq!(decoded.worker_id(), "w1");
+    assert_eq!(decoded.expiry_ms(), 50000);
+    assert_eq!(decoded.tenant(), "t1");
+    assert_eq!(decoded.job_id(), "j1");
+    assert_eq!(decoded.attempt_number(), 3);
+    assert_eq!(decoded.relative_attempt_number(), 2);
+    assert_eq!(decoded.held_queues(), vec!["q1", "q2"]);
+    assert_eq!(decoded.task_group(), "grp");
+    assert_eq!(decoded.task_id(), Some("task-10"));
+
+    // to_task should reconstruct the original task
+    let task = decoded.to_task();
+    match task {
+        Task::RunAttempt { id, job_id, .. } => {
+            assert_eq!(id, "task-10");
+            assert_eq!(job_id, "j1");
+        }
+        _ => panic!("expected RunAttempt"),
+    }
+}
+
+#[silo::test]
+fn test_decoded_lease_accessors_refresh_floating_limit() {
+    let lease = LeaseRecord {
+        worker_id: "w2".to_string(),
+        task: Task::RefreshFloatingLimit {
+            task_id: "refresh-5".to_string(),
+            tenant: "t2".to_string(),
+            queue_key: "qk".to_string(),
+            current_max_concurrency: 25,
+            last_refreshed_at_ms: 7777,
+            metadata: vec![("a".to_string(), "b".to_string())],
+            task_group: "workers".to_string(),
+        },
+        expiry_ms: 60000,
+    };
+    let encoded = encode_lease(&lease).unwrap();
+    let decoded = decode_lease(&encoded).unwrap();
+
+    // RefreshFloatingLimit returns "" for job_id and 0 for attempt_number
+    assert_eq!(decoded.tenant(), "t2");
+    assert_eq!(decoded.job_id(), "");
+    assert_eq!(decoded.attempt_number(), 0);
+    assert_eq!(decoded.relative_attempt_number(), 0);
+    assert_eq!(decoded.held_queues(), Vec::<String>::new());
+    assert_eq!(decoded.task_group(), "workers");
+    assert_eq!(decoded.task_id(), None);
+
+    // refresh_floating_limit_info should return Some
+    let (task_id, queue_key) = decoded.refresh_floating_limit_info().unwrap();
+    assert_eq!(task_id, "refresh-5");
+    assert_eq!(queue_key, "qk");
+
+    // to_task should reconstruct
+    let task = decoded.to_task();
+    match task {
+        Task::RefreshFloatingLimit {
+            task_id,
+            current_max_concurrency,
+            ..
+        } => {
+            assert_eq!(task_id, "refresh-5");
+            assert_eq!(current_max_concurrency, 25);
+        }
+        _ => panic!("expected RefreshFloatingLimit"),
     }
 }

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -189,3 +189,204 @@ async fn test_metrics_gauge_values() {
         "buffer size for shard 1 should be 50"
     );
 }
+
+#[silo::test]
+async fn test_metrics_all_recording_methods() {
+    let (metrics, app) = create_metrics_router();
+
+    // record_attempt with retry and non-retry
+    metrics.record_attempt("0", "default", false);
+    metrics.record_attempt("0", "default", true);
+    metrics.record_attempt("0", "default", true);
+
+    // record_grpc_request
+    metrics.record_grpc_request("Enqueue", "OK");
+    metrics.record_grpc_request("Dequeue", "INTERNAL");
+
+    // record_grpc_duration
+    metrics.record_grpc_duration("Enqueue", 0.05);
+
+    // record_job_wait_time
+    metrics.record_job_wait_time("0", "default", 1.5);
+
+    // record_broker_scan_duration
+    metrics.record_broker_scan_duration("0", 0.01);
+
+    // inc/dec_task_leases_active
+    metrics.inc_task_leases_active("0", "default");
+    metrics.inc_task_leases_active("0", "default");
+    metrics.dec_task_leases_active("0", "default");
+
+    // set_concurrency_holders
+    metrics.set_concurrency_holders("tenant-1", "queue-a", 7);
+
+    // record_concurrency_ticket_granted
+    metrics.record_concurrency_ticket_granted();
+
+    // set_coordination_shards_open
+    metrics.set_coordination_shards_open(5);
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+
+    // Helper: find a metric line that contains all given substrings
+    let find_line = |substrings: &[&str]| -> Option<String> {
+        body_str
+            .lines()
+            .find(|l| substrings.iter().all(|s| l.contains(s)))
+            .map(|s| s.to_string())
+    };
+
+    // Verify attempt counter with is_retry labels
+    let non_retry_line = find_line(&[
+        "silo_job_attempts_total",
+        "is_retry=\"false\"",
+        "shard=\"0\"",
+    ]);
+    assert!(
+        non_retry_line.as_ref().map_or(false, |l| l.ends_with(" 1")),
+        "should have 1 non-retry attempt, found: {:?}",
+        non_retry_line
+    );
+    let retry_line = find_line(&[
+        "silo_job_attempts_total",
+        "is_retry=\"true\"",
+        "shard=\"0\"",
+    ]);
+    assert!(
+        retry_line.as_ref().map_or(false, |l| l.ends_with(" 2")),
+        "should have 2 retry attempts, found: {:?}",
+        retry_line
+    );
+
+    // Verify gRPC request counter
+    let grpc_enqueue = find_line(&[
+        "silo_grpc_requests_total",
+        "method=\"Enqueue\"",
+        "status=\"OK\"",
+    ]);
+    assert!(
+        grpc_enqueue.as_ref().map_or(false, |l| l.ends_with(" 1")),
+        "should have 1 Enqueue/OK request, found: {:?}",
+        grpc_enqueue
+    );
+    let grpc_dequeue = find_line(&[
+        "silo_grpc_requests_total",
+        "method=\"Dequeue\"",
+        "status=\"INTERNAL\"",
+    ]);
+    assert!(
+        grpc_dequeue.as_ref().map_or(false, |l| l.ends_with(" 1")),
+        "should have 1 Dequeue/INTERNAL request, found: {:?}",
+        grpc_dequeue
+    );
+
+    // Verify gRPC duration histogram was recorded
+    assert!(
+        body_str.contains("silo_grpc_request_duration_seconds"),
+        "should contain gRPC duration metric"
+    );
+
+    // Verify job wait time histogram was recorded
+    assert!(
+        body_str.contains("silo_job_wait_time_seconds"),
+        "should contain job wait time metric"
+    );
+
+    // Verify broker scan duration
+    assert!(
+        body_str.contains("silo_broker_scan_duration_seconds"),
+        "should contain broker scan duration metric"
+    );
+
+    // Verify task leases active (inc twice, dec once = 1)
+    let leases_line = find_line(&[
+        "silo_task_leases_active",
+        "shard=\"0\"",
+        "task_group=\"default\"",
+    ]);
+    assert!(
+        leases_line.as_ref().map_or(false, |l| l.ends_with(" 1")),
+        "task leases active should be 1 after 2 inc and 1 dec, found: {:?}",
+        leases_line
+    );
+
+    // Verify concurrency holders
+    let holders_line = find_line(&[
+        "silo_concurrency_holders",
+        "tenant=\"tenant-1\"",
+        "queue=\"queue-a\"",
+    ]);
+    assert!(
+        holders_line.as_ref().map_or(false, |l| l.ends_with(" 7")),
+        "concurrency holders should be 7, found: {:?}",
+        holders_line
+    );
+
+    // Verify concurrency tickets granted
+    assert!(
+        body_str.contains("silo_concurrency_tickets_granted_total 1"),
+        "concurrency tickets granted should be 1"
+    );
+
+    // Verify coordination shards open
+    assert!(
+        body_str.contains("silo_coordination_shards_open 5"),
+        "coordination shards open should be 5"
+    );
+}
+
+#[silo::test]
+async fn test_metrics_slatedb_stats() {
+    let (metrics, app) = create_metrics_router();
+
+    // Create a real SlateDB to get a StatRegistry with actual stats
+    let tmpdir = tempfile::tempdir().unwrap();
+    let object_store = std::sync::Arc::new(
+        object_store::local::LocalFileSystem::new_with_prefix(tmpdir.path()).unwrap(),
+    );
+    let db = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store)
+        .await
+        .unwrap();
+
+    // Do some writes to populate stats
+    db.put(b"key1", b"value1").await.unwrap();
+    db.put(b"key2", b"value2").await.unwrap();
+    let _ = db.get(b"key1").await;
+
+    let stat_registry = db.metrics();
+    metrics.update_slatedb_stats("0", &stat_registry);
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+
+    // Verify SlateDB metrics are present
+    assert!(
+        body_str.contains("silo_slatedb_write_ops_total"),
+        "should contain slatedb write ops metric"
+    );
+    assert!(
+        body_str.contains("silo_slatedb_get_requests_total"),
+        "should contain slatedb get requests metric"
+    );
+
+    db.close().await.unwrap();
+}

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -1063,3 +1063,44 @@ async fn siloctl_validate_config() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+// Unit tests for compute_midpoint
+
+#[silo::test]
+fn test_compute_midpoint_normal() {
+    let mid = siloctl::compute_midpoint("a", "z").unwrap();
+    assert!(mid.as_str() > "a", "midpoint should be > start");
+    assert!(mid.as_str() < "z", "midpoint should be < end");
+}
+
+#[silo::test]
+fn test_compute_midpoint_equal_strings() {
+    assert!(siloctl::compute_midpoint("abc", "abc").is_none());
+}
+
+#[silo::test]
+fn test_compute_midpoint_start_greater_than_end() {
+    assert!(siloctl::compute_midpoint("z", "a").is_none());
+}
+
+#[silo::test]
+fn test_compute_midpoint_prefix_case() {
+    let mid = siloctl::compute_midpoint("abc", "abcdef").unwrap();
+    assert!(mid.as_str() > "abc", "midpoint should be > start");
+    assert!(mid.as_str() < "abcdef", "midpoint should be < end");
+}
+
+#[silo::test]
+fn test_compute_midpoint_adjacent_chars() {
+    // 'a' and 'b' are adjacent, so midpoint extends with '~'
+    let mid = siloctl::compute_midpoint("a", "b").unwrap();
+    assert!(mid.as_str() > "a", "midpoint should be > start");
+    assert!(mid.as_str() < "b", "midpoint should be < end");
+}
+
+#[silo::test]
+fn test_compute_midpoint_same_prefix() {
+    let mid = siloctl::compute_midpoint("hello", "world").unwrap();
+    assert!(mid.as_str() > "hello", "midpoint should be > start");
+    assert!(mid.as_str() < "world", "midpoint should be < end");
+}


### PR DESCRIPTION
…t, and siloctl

- Codec: roundtrip tests for RequestTicket, CheckRateLimit, RefreshFloatingLimit task variants plus JobInfo, JobCancellation, FloatingLimitState types and DecodedLease accessor methods
- Metrics: tests for record_attempt, record_grpc_request, record_grpc_duration, record_job_wait_time, broker scan, task leases, concurrency holders/tickets, coordination_shards_open, and update_slatedb_stats with a real SlateDB
- ClusterClient: unit tests for ClientConfig default/unreliable/DST configs and backoff_for_attempt exponential backoff with cap
- Siloctl: make compute_midpoint pub for testability, add tests for normal midpoint, equal strings, prefix case, adjacent chars, and different prefixes