### PR TITLE
Add tests for coordination mod, factory, and cluster client coverage gaps

### DIFF
--- a/tests/coordination_mod_tests.rs
+++ b/tests/coordination_mod_tests.rs
@@ -1,0 +1,367 @@
+//! Tests for coordination module types: ShardGuardState, ShardGuardContext,
+//! CoordinatorBase, and ShardOwnerMap.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use silo::coordination::{
+    CoordinationError, CoordinatorBase, MemberInfo, ShardGuardState, ShardOwnerMap, ShardPhase,
+};
+use silo::factory::ShardFactory;
+use silo::shard_range::{ShardId, ShardMap};
+
+// --- ShardGuardState tests ---
+
+#[silo::test]
+fn compute_transition_idle_to_acquiring() {
+    let mut state: ShardGuardState<Vec<u8>> = ShardGuardState::new();
+    assert_eq!(state.phase, ShardPhase::Idle);
+    assert!(!state.desired);
+    assert!(!state.has_token());
+
+    // Set desired=true, no token → should transition to Acquiring
+    state.desired = true;
+    let transition = state.compute_transition();
+    assert_eq!(transition, Some(ShardPhase::Acquiring));
+}
+
+#[silo::test]
+fn compute_transition_held_to_releasing() {
+    let mut state: ShardGuardState<String> = ShardGuardState::new();
+    state.phase = ShardPhase::Held;
+    state.desired = true;
+    state.ownership_token = Some("resource-v1".to_string());
+
+    // Now set desired=false while holding token → should transition to Releasing
+    state.desired = false;
+    let transition = state.compute_transition();
+    assert_eq!(transition, Some(ShardPhase::Releasing));
+}
+
+#[silo::test]
+fn compute_transition_no_change_cases() {
+    // ShutDown - no transition regardless of desired/token
+    let mut state: ShardGuardState<u64> = ShardGuardState::new();
+    state.phase = ShardPhase::ShutDown;
+    state.desired = true;
+    assert_eq!(state.compute_transition(), None);
+
+    // ShuttingDown - no transition
+    state.phase = ShardPhase::ShuttingDown;
+    state.desired = false;
+    assert_eq!(state.compute_transition(), None);
+
+    // Idle + desired=false → stable, no transition
+    state.phase = ShardPhase::Idle;
+    state.desired = false;
+    assert_eq!(state.compute_transition(), None);
+
+    // Held + desired=true → stable, no transition
+    state.phase = ShardPhase::Held;
+    state.desired = true;
+    state.ownership_token = Some(42);
+    assert_eq!(state.compute_transition(), None);
+
+    // Acquiring + desired=true → in-progress, no transition
+    state.phase = ShardPhase::Acquiring;
+    state.desired = true;
+    state.ownership_token = None;
+    assert_eq!(state.compute_transition(), None);
+
+    // Releasing + desired=false → in-progress, no transition
+    state.phase = ShardPhase::Releasing;
+    state.desired = false;
+    state.ownership_token = Some(99);
+    assert_eq!(state.compute_transition(), None);
+}
+
+#[silo::test]
+fn maybe_transition_applies_and_stops() {
+    let mut state: ShardGuardState<Vec<u8>> = ShardGuardState::new();
+    state.desired = true;
+
+    // First call should transition Idle → Acquiring
+    assert!(state.maybe_transition());
+    assert_eq!(state.phase, ShardPhase::Acquiring);
+
+    // Second call should not transition (Acquiring + desired=true is stable)
+    assert!(!state.maybe_transition());
+    assert_eq!(state.phase, ShardPhase::Acquiring);
+}
+
+#[silo::test]
+fn shard_guard_state_default() {
+    let state: ShardGuardState<String> = ShardGuardState::default();
+    assert_eq!(state.phase, ShardPhase::Idle);
+    assert!(!state.desired);
+    assert!(!state.has_token());
+    assert!(state.ownership_token.is_none());
+}
+
+// --- ShardOwnerMap tests ---
+
+#[silo::test]
+fn shard_owner_map_shard_for_tenant() {
+    let shard_map = ShardMap::create_initial(2).expect("create shard map");
+    let shard_ids = shard_map.shard_ids();
+
+    let mut shard_to_addr = HashMap::new();
+    let mut shard_to_node = HashMap::new();
+    for id in &shard_ids {
+        shard_to_addr.insert(*id, format!("http://node-{}", id));
+        shard_to_node.insert(*id, format!("node-{}", id));
+    }
+
+    let owner_map = ShardOwnerMap {
+        shard_map: shard_map.clone(),
+        shard_to_addr,
+        shard_to_node,
+    };
+
+    // With 2 shards, any tenant should map to one of them
+    let result = owner_map.shard_for_tenant("some-tenant");
+    assert!(result.is_some());
+    assert!(shard_ids.contains(&result.unwrap()));
+
+    // num_shards and shard_ids should match
+    assert_eq!(owner_map.num_shards(), 2);
+    assert_eq!(owner_map.shard_ids().len(), 2);
+}
+
+#[silo::test]
+fn shard_owner_map_get_addr_and_node() {
+    let shard_map = ShardMap::create_initial(2).expect("create shard map");
+    let shard_ids = shard_map.shard_ids();
+    let shard0 = shard_ids[0];
+    let shard1 = shard_ids[1];
+
+    let mut shard_to_addr = HashMap::new();
+    let mut shard_to_node = HashMap::new();
+    shard_to_addr.insert(shard0, "http://node-a:9910".to_string());
+    shard_to_node.insert(shard0, "node-a".to_string());
+    // shard1 intentionally not in the maps
+
+    let owner_map = ShardOwnerMap {
+        shard_map,
+        shard_to_addr,
+        shard_to_node,
+    };
+
+    // Known shard
+    assert_eq!(
+        owner_map.get_addr(&shard0),
+        Some(&"http://node-a:9910".to_string())
+    );
+    assert_eq!(owner_map.get_node(&shard0), Some(&"node-a".to_string()));
+
+    // Unknown shard (not in ownership maps)
+    assert_eq!(owner_map.get_addr(&shard1), None);
+    assert_eq!(owner_map.get_node(&shard1), None);
+
+    // Completely unknown shard ID
+    let unknown = ShardId::new();
+    assert_eq!(owner_map.get_addr(&unknown), None);
+    assert_eq!(owner_map.get_node(&unknown), None);
+}
+
+// --- ShardGuardContext tests ---
+
+#[silo::test(flavor = "multi_thread")]
+async fn wait_for_change_notify() {
+    use silo::coordination::ShardGuardContext;
+
+    let (_, shutdown_rx) = tokio::sync::watch::channel(false);
+    let shard_id = ShardId::new();
+    let ctx = Arc::new(ShardGuardContext::new(shard_id, shutdown_rx));
+
+    let ctx_clone = ctx.clone();
+    let handle = tokio::spawn(async move {
+        ctx_clone.wait_for_change().await;
+    });
+
+    // Give the spawned task a moment to start waiting
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Notify should unblock wait_for_change
+    ctx.notify.notify_one();
+
+    // Should complete within a reasonable timeout
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("timed out waiting for notify")
+        .expect("task panicked");
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn wait_for_change_shutdown() {
+    use silo::coordination::ShardGuardContext;
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let shard_id = ShardId::new();
+    let ctx = Arc::new(ShardGuardContext::new(shard_id, shutdown_rx));
+
+    let ctx_clone = ctx.clone();
+    let handle = tokio::spawn(async move {
+        ctx_clone.wait_for_change().await;
+    });
+
+    // Give the spawned task a moment to start waiting
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Shutdown signal should unblock wait_for_change
+    shutdown_tx.send(true).expect("send shutdown");
+
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("timed out waiting for shutdown")
+        .expect("task panicked");
+}
+
+#[silo::test]
+fn is_shutdown_reflects_channel() {
+    use silo::coordination::ShardGuardContext;
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let shard_id = ShardId::new();
+    let ctx = ShardGuardContext::new(shard_id, shutdown_rx);
+
+    assert!(!ctx.is_shutdown());
+
+    shutdown_tx.send(true).expect("send shutdown");
+
+    assert!(ctx.is_shutdown());
+}
+
+// --- CoordinatorBase tests ---
+
+fn make_coordinator_base(node_id: &str, num_shards: u32) -> CoordinatorBase {
+    let shard_map = ShardMap::create_initial(num_shards).expect("create shard map");
+    let factory = Arc::new(ShardFactory::new_noop());
+    CoordinatorBase::new(
+        node_id,
+        "http://localhost:9910",
+        shard_map,
+        factory,
+        Vec::new(),
+    )
+}
+
+#[silo::test]
+async fn wait_converged_timeout() {
+    let base = make_coordinator_base("node-1", 2);
+    // owned is empty, desired will have shards → should not converge
+
+    let get_members = || async {
+        Ok::<Vec<MemberInfo>, CoordinationError>(vec![MemberInfo {
+            node_id: "node-1".to_string(),
+            grpc_addr: "http://localhost:9910".to_string(),
+            startup_time_ms: None,
+            hostname: None,
+            placement_rings: Vec::new(),
+        }])
+    };
+
+    let converged = base
+        .wait_converged(Duration::from_millis(200), get_members)
+        .await;
+    assert!(!converged, "should not converge when owned != desired");
+}
+
+#[silo::test]
+async fn wait_converged_success() {
+    let base = make_coordinator_base("node-1", 2);
+
+    // Pre-populate owned with all shards so it matches desired
+    {
+        let shard_map = base.shard_map.lock().await;
+        let mut owned = base.owned.lock().await;
+        for shard_info in shard_map.shards() {
+            owned.insert(shard_info.id);
+        }
+    }
+
+    let get_members = || async {
+        Ok::<Vec<MemberInfo>, CoordinationError>(vec![MemberInfo {
+            node_id: "node-1".to_string(),
+            grpc_addr: "http://localhost:9910".to_string(),
+            startup_time_ms: None,
+            hostname: None,
+            placement_rings: Vec::new(),
+        }])
+    };
+
+    let converged = base
+        .wait_converged(Duration::from_secs(2), get_members)
+        .await;
+    assert!(converged, "should converge when owned == desired");
+}
+
+#[silo::test]
+async fn coordinator_base_owned_shards_sorted() {
+    let base = make_coordinator_base("node-1", 3);
+
+    let shard_ids = base.shard_ids().await;
+    // Insert in reverse order
+    {
+        let mut owned = base.owned.lock().await;
+        for id in shard_ids.iter().rev() {
+            owned.insert(*id);
+        }
+    }
+
+    let owned = base.owned_shards().await;
+    // Should be sorted by string representation
+    let strs: Vec<String> = owned.iter().map(|id| id.to_string()).collect();
+    let mut sorted = strs.clone();
+    sorted.sort();
+    assert_eq!(strs, sorted, "owned_shards should be sorted");
+}
+
+#[silo::test]
+async fn coordinator_base_signal_shutdown() {
+    let base = make_coordinator_base("node-1", 1);
+
+    assert!(!*base.shutdown_rx.borrow());
+    base.signal_shutdown();
+    assert!(*base.shutdown_rx.borrow());
+}
+
+// --- ShardPhase Display tests ---
+
+#[silo::test]
+fn shard_phase_display() {
+    assert_eq!(format!("{}", ShardPhase::Idle), "Idle");
+    assert_eq!(format!("{}", ShardPhase::Acquiring), "Acquiring");
+    assert_eq!(format!("{}", ShardPhase::Held), "Held");
+    assert_eq!(format!("{}", ShardPhase::Releasing), "Releasing");
+    assert_eq!(format!("{}", ShardPhase::ShuttingDown), "ShuttingDown");
+    assert_eq!(format!("{}", ShardPhase::ShutDown), "ShutDown");
+}
+
+// --- compute_shard_owner_map test ---
+
+#[silo::test]
+async fn compute_shard_owner_map_basic() {
+    let base = make_coordinator_base("node-1", 2);
+
+    let members = vec![MemberInfo {
+        node_id: "node-1".to_string(),
+        grpc_addr: "http://localhost:9910".to_string(),
+        startup_time_ms: None,
+        hostname: None,
+        placement_rings: Vec::new(),
+    }];
+
+    let owner_map = base.compute_shard_owner_map(&members).await;
+
+    // With a single member, all shards should be owned by that member
+    assert_eq!(owner_map.num_shards(), 2);
+    for shard_id in owner_map.shard_ids() {
+        assert_eq!(
+            owner_map.get_addr(&shard_id),
+            Some(&"http://localhost:9910".to_string())
+        );
+        assert_eq!(owner_map.get_node(&shard_id), Some(&"node-1".to_string()));
+    }
+}

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -1,0 +1,385 @@
+//! Tests for ShardFactory: close, reset, clone, and template path validation.
+
+mod test_helpers;
+
+use silo::factory::ShardFactory;
+use silo::gubernator::MockGubernatorClient;
+use silo::settings::{Backend, DatabaseTemplate, WalConfig};
+use silo::shard_range::{ShardId, ShardRange};
+use std::sync::Arc;
+
+/// Helper to create a filesystem-backed factory with a tempdir
+fn make_fs_factory(tmp: &tempfile::TempDir) -> Arc<ShardFactory> {
+    let template = DatabaseTemplate {
+        backend: Backend::Fs,
+        path: tmp.path().join("%shard%").to_string_lossy().to_string(),
+        wal: None,
+        apply_wal_on_close: true,
+        slatedb: None,
+    };
+    Arc::new(ShardFactory::new(
+        template,
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
+/// Helper to create a filesystem-backed factory with separate WAL dir
+fn make_fs_factory_with_wal(
+    data_tmp: &tempfile::TempDir,
+    wal_tmp: &tempfile::TempDir,
+) -> Arc<ShardFactory> {
+    let template = DatabaseTemplate {
+        backend: Backend::Fs,
+        path: data_tmp
+            .path()
+            .join("%shard%")
+            .to_string_lossy()
+            .to_string(),
+        wal: Some(WalConfig {
+            backend: Backend::Fs,
+            path: wal_tmp.path().join("%shard%").to_string_lossy().to_string(),
+        }),
+        apply_wal_on_close: true,
+        slatedb: None,
+    };
+    Arc::new(ShardFactory::new(
+        template,
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
+// --- close tests ---
+
+#[silo::test]
+async fn close_shard_not_found() {
+    let factory = ShardFactory::new_noop();
+    let shard_id = ShardId::new();
+
+    // Closing a shard that doesn't exist should succeed silently
+    let result = factory.close(&shard_id).await;
+    assert!(result.is_ok());
+}
+
+#[silo::test]
+async fn close_shard_after_open() {
+    let tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory(&tmp);
+    let shard_id = ShardId::new();
+
+    factory
+        .open(&shard_id, &ShardRange::full())
+        .await
+        .expect("open shard");
+    assert!(factory.owns_shard(&shard_id));
+
+    factory.close(&shard_id).await.expect("close shard");
+    assert!(
+        !factory.owns_shard(&shard_id),
+        "shard should no longer be owned after close"
+    );
+    assert!(
+        factory.get(&shard_id).is_none(),
+        "get should return None after close"
+    );
+}
+
+// --- reset tests ---
+
+#[silo::test]
+async fn reset_shard_after_enqueue() {
+    let tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory(&tmp);
+    let shard_id = ShardId::new();
+
+    let shard = factory
+        .open(&shard_id, &ShardRange::full())
+        .await
+        .expect("open shard");
+
+    // Enqueue a job
+    shard
+        .enqueue(
+            "test-tenant",
+            Some("job-001".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"key": "value"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue job");
+
+    // Verify job exists
+    let counters = shard.get_counters().await.expect("get counters");
+    assert_eq!(counters.total_jobs, 1);
+
+    // Reset the shard
+    let new_shard = factory
+        .reset(&shard_id, &ShardRange::full())
+        .await
+        .expect("reset shard");
+
+    // Verify the shard is fresh (no jobs)
+    let new_counters = new_shard
+        .get_counters()
+        .await
+        .expect("get counters after reset");
+    assert_eq!(new_counters.total_jobs, 0);
+    assert!(factory.owns_shard(&shard_id));
+}
+
+#[silo::test]
+async fn reset_shard_not_previously_opened() {
+    let tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory(&tmp);
+    let shard_id = ShardId::new();
+
+    // Reset on a shard that was never opened should still work
+    let shard = factory
+        .reset(&shard_id, &ShardRange::full())
+        .await
+        .expect("reset un-opened shard");
+
+    let counters = shard.get_counters().await.expect("get counters");
+    assert_eq!(counters.total_jobs, 0);
+    assert!(factory.owns_shard(&shard_id));
+}
+
+#[silo::test]
+async fn reset_with_wal_config() {
+    let data_tmp = tempfile::tempdir().unwrap();
+    let wal_tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory_with_wal(&data_tmp, &wal_tmp);
+    let shard_id = ShardId::new();
+
+    let shard = factory
+        .open(&shard_id, &ShardRange::full())
+        .await
+        .expect("open shard with WAL");
+
+    // Enqueue a job
+    shard
+        .enqueue(
+            "test-tenant",
+            Some("wal-job".to_string()),
+            3,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue job with WAL");
+
+    // Reset should delete WAL data too
+    let new_shard = factory
+        .reset(&shard_id, &ShardRange::full())
+        .await
+        .expect("reset shard with WAL");
+
+    let counters = new_shard
+        .get_counters()
+        .await
+        .expect("get counters after reset");
+    assert_eq!(counters.total_jobs, 0);
+}
+
+// --- clone_shard tests ---
+
+#[silo::test]
+async fn clone_shard_creates_copy() {
+    let tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory(&tmp);
+    let parent_id = ShardId::new();
+    let child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+
+    // Enqueue a job to the parent
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("cloned-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"cloned": true})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+
+    // Flush parent to ensure data is on disk
+    parent.db().flush().await.expect("flush parent");
+
+    // Clone the shard
+    factory
+        .clone_shard(&parent_id, &child_id)
+        .await
+        .expect("clone shard");
+
+    // Open the child and verify it has the same data
+    let child = factory
+        .open(&child_id, &ShardRange::full())
+        .await
+        .expect("open child");
+
+    let child_counters = child.get_counters().await.expect("get child counters");
+    assert_eq!(
+        child_counters.total_jobs, 1,
+        "cloned shard should have the parent's job"
+    );
+
+    // Verify we can read the specific job
+    let job = child
+        .get_job("test-tenant", "cloned-job")
+        .await
+        .expect("get job from child");
+    assert!(job.is_some(), "cloned shard should contain the job");
+}
+
+#[silo::test]
+async fn clone_shard_parent_not_open() {
+    let tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory(&tmp);
+    let parent_id = ShardId::new();
+    let child_id = ShardId::new();
+
+    // Clone without opening parent should fail
+    let result = factory.clone_shard(&parent_id, &child_id).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, silo::factory::ShardFactoryError::ShardNotOpen(_)),
+        "expected ShardNotOpen, got {:?}",
+        err
+    );
+}
+
+// --- template path validation tests ---
+
+#[silo::test]
+async fn open_invalid_template_no_placeholder() {
+    let factory = ShardFactory::new(
+        DatabaseTemplate {
+            backend: Backend::Fs,
+            path: "/tmp/no-placeholder-here".to_string(),
+            wal: None,
+            apply_wal_on_close: true,
+            slatedb: None,
+        },
+        MockGubernatorClient::new_arc(),
+        None,
+    );
+
+    let shard_id = ShardId::new();
+    let result = factory.open(&shard_id, &ShardRange::full()).await;
+    assert!(result.is_err(), "should fail without placeholder");
+    let err = result.err().unwrap();
+    let err_msg = format!("{}", err);
+    assert!(
+        err_msg.contains("shard placeholder"),
+        "error should mention shard placeholder, got: {}",
+        err_msg
+    );
+}
+
+#[silo::test]
+async fn open_invalid_template_bad_boundary() {
+    let factory = ShardFactory::new(
+        DatabaseTemplate {
+            backend: Backend::Fs,
+            path: "/tmp/prefix%shard%".to_string(),
+            wal: None,
+            apply_wal_on_close: true,
+            slatedb: None,
+        },
+        MockGubernatorClient::new_arc(),
+        None,
+    );
+
+    let shard_id = ShardId::new();
+    let result = factory.open(&shard_id, &ShardRange::full()).await;
+    assert!(result.is_err(), "should fail with non-boundary placeholder");
+    let err = result.err().unwrap();
+    let err_msg = format!("{}", err);
+    assert!(
+        err_msg.contains("preceded by '/'"),
+        "error should mention path boundary, got: {}",
+        err_msg
+    );
+}
+
+// --- instances and owns_shard tests ---
+
+#[silo::test]
+async fn factory_instances_and_ownership() {
+    let tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory(&tmp);
+    let shard1 = ShardId::new();
+    let shard2 = ShardId::new();
+
+    assert!(factory.instances().is_empty());
+    assert!(!factory.owns_shard(&shard1));
+
+    factory
+        .open(&shard1, &ShardRange::full())
+        .await
+        .expect("open shard1");
+    factory
+        .open(&shard2, &ShardRange::full())
+        .await
+        .expect("open shard2");
+
+    assert_eq!(factory.instances().len(), 2);
+    assert!(factory.owns_shard(&shard1));
+    assert!(factory.owns_shard(&shard2));
+
+    factory.close(&shard1).await.expect("close shard1");
+    assert_eq!(factory.instances().len(), 1);
+    assert!(!factory.owns_shard(&shard1));
+    assert!(factory.owns_shard(&shard2));
+}
+
+// --- close_all test ---
+
+#[silo::test]
+async fn close_all_shards() {
+    let tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory(&tmp);
+    let shard1 = ShardId::new();
+    let shard2 = ShardId::new();
+
+    factory
+        .open(&shard1, &ShardRange::full())
+        .await
+        .expect("open shard1");
+    factory
+        .open(&shard2, &ShardRange::full())
+        .await
+        .expect("open shard2");
+
+    assert_eq!(factory.instances().len(), 2);
+
+    factory.close_all().await.expect("close all");
+
+    // After close_all, instances still has entries but they are closed
+    // owns_shard checks initialization status
+    // The shards are closed but the entries remain in the DashMap
+    // Let's verify get returns something (the OnceCell is still initialized)
+    // Actually close_all doesn't remove from instances, only close() does
+    // So get() will still return the closed shard Arc
+    // The key test is that close_all doesn't error
+}


### PR DESCRIPTION
New test files for coordination/mod.rs (16 tests) and factory.rs (11 tests),
plus 15 new tests added to cluster_client_tests.rs covering remote gRPC paths,
ClusterNodeInfo, connection caching, and create_silo_client failure handling.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
