### PR TITLE
Fix enqueue performance regression from PR #87

### DIFF
--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -1,8 +1,8 @@
 //! Job enqueue operations.
 
 use slatedb::ErrorKind as SlateErrorKind;
-use slatedb::IsolationLevel;
 use slatedb::config::WriteOptions;
+use slatedb::{IsolationLevel, WriteBatch};
 use tracing::{debug, info_span};
 use uuid::Uuid;
 
@@ -13,7 +13,7 @@ use crate::job::{JobInfo, JobStatus, Limit};
 use crate::job_store_shard::JobStoreShard;
 use crate::job_store_shard::JobStoreShardError;
 use crate::job_store_shard::helpers::{
-    TxnWriter, WriteBatcher, decode_job_status_owned, now_epoch_ms, put_task,
+    DbWriteBatcher, TxnWriter, WriteBatcher, decode_job_status_owned, now_epoch_ms, put_task,
 };
 use crate::keys::{idx_metadata_key, idx_status_time_key, job_info_key, job_status_key};
 use crate::retry::RetryPolicy;
@@ -23,8 +23,10 @@ impl JobStoreShard {
     /// Enqueue a new job with optional limits (concurrency and/or rate limits).
     /// The payload is stored as raw bytes (MessagePack-encoded by the client).
     ///
-    /// Uses a transaction with optimistic concurrency control to atomically check
-    /// for duplicate job IDs and write the job. Retries automatically on conflict.
+    /// When the caller provides an explicit job ID, uses a transaction with optimistic
+    /// concurrency control to atomically check for duplicates and write the job.
+    /// When no ID is provided (auto-generated UUID), uses a faster WriteBatch path
+    /// since UUID collisions are not a concern.
     #[allow(clippy::too_many_arguments)]
     pub async fn enqueue(
         &self,
@@ -38,12 +40,124 @@ impl JobStoreShard {
         metadata: Option<Vec<(String, String)>>,
         task_group: &str,
     ) -> Result<String, JobStoreShardError> {
+        if let Some(user_id) = id {
+            self.enqueue_with_dedup(
+                tenant,
+                user_id,
+                priority,
+                start_at_ms,
+                retry_policy,
+                payload,
+                limits,
+                metadata,
+                task_group,
+            )
+            .await
+        } else {
+            let job_id = Uuid::new_v4().to_string();
+            self.enqueue_batch(
+                tenant,
+                &job_id,
+                priority,
+                start_at_ms,
+                retry_policy,
+                payload,
+                limits,
+                metadata,
+                task_group,
+            )
+            .await?;
+            Ok(job_id)
+        }
+    }
+
+    /// Fast-path enqueue using WriteBatch for auto-generated job IDs.
+    /// No transaction overhead since UUID collisions are not a concern.
+    #[allow(clippy::too_many_arguments)]
+    async fn enqueue_batch(
+        &self,
+        tenant: &str,
+        job_id: &str,
+        priority: u8,
+        start_at_ms: i64,
+        retry_policy: Option<RetryPolicy>,
+        payload: Vec<u8>,
+        limits: Vec<Limit>,
+        metadata: Option<Vec<(String, String)>>,
+        task_group: &str,
+    ) -> Result<(), JobStoreShardError> {
+        let mut batch = WriteBatch::new();
+        let grants = self
+            .write_enqueue_data(
+                &mut DbWriteBatcher {
+                    db: &self.db,
+                    batch: &mut batch,
+                },
+                tenant,
+                job_id,
+                priority,
+                start_at_ms,
+                retry_policy,
+                payload,
+                limits,
+                metadata,
+                task_group,
+            )
+            .await?;
+
+        // Include counter in the same batch for efficiency
+        self.increment_total_jobs_counter_batch(&mut batch);
+
+        // Two-phase DST event: emit before write for correct causal ordering,
+        // confirm after write succeeds, cancel if write fails.
+        let write_op = dst_events::next_write_op();
+        dst_events::emit_pending(
+            DstEvent::JobEnqueued {
+                tenant: tenant.to_string(),
+                job_id: job_id.to_string(),
+            },
+            write_op,
+        );
+
+        if let Err(e) = self
+            .db
+            .write_with_options(
+                batch,
+                &WriteOptions {
+                    await_durable: true,
+                },
+            )
+            .await
+        {
+            dst_events::cancel_write(write_op);
+            self.rollback_grants(tenant, &grants);
+            return Err(e.into());
+        }
+        dst_events::confirm_write(write_op);
+
+        self.finish_enqueue(job_id, start_at_ms, &grants).await
+    }
+
+    /// Transaction-path enqueue for user-provided job IDs that need deduplication.
+    /// Uses SerializableSnapshot to atomically check for duplicates and write.
+    #[allow(clippy::too_many_arguments)]
+    async fn enqueue_with_dedup(
+        &self,
+        tenant: &str,
+        job_id: String,
+        priority: u8,
+        start_at_ms: i64,
+        retry_policy: Option<RetryPolicy>,
+        payload: Vec<u8>,
+        limits: Vec<Limit>,
+        metadata: Option<Vec<(String, String)>>,
+        task_group: &str,
+    ) -> Result<String, JobStoreShardError> {
         const MAX_RETRIES: usize = 5;
-        let job_id = id.unwrap_or_else(|| Uuid::new_v4().to_string());
 
         for attempt in 0..MAX_RETRIES {
             match self
-                .enqueue_inner(
+                .enqueue_txn(
                     tenant,
                     &job_id,
                     priority,
@@ -58,15 +172,13 @@ impl JobStoreShard {
             {
                 Ok(()) => return Ok(job_id),
                 Err(JobStoreShardError::JobAlreadyExists(_)) => {
-                    // This is a real duplicate, not a transaction conflict, return the error to the caller
                     return Err(JobStoreShardError::JobAlreadyExists(job_id));
                 }
                 Err(JobStoreShardError::Slate(ref e))
                     if e.kind() == SlateErrorKind::Transaction =>
                 {
-                    // Transaction conflict - retry with exponential backoff
                     if attempt + 1 < MAX_RETRIES {
-                        let delay_ms = 10 * (1 << attempt); // 10ms, 20ms, 40ms, 80ms
+                        let delay_ms = 10 * (1 << attempt);
                         tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                         debug!(
                             job_id = %job_id,
@@ -85,9 +197,9 @@ impl JobStoreShard {
         ))
     }
 
-    /// Inner implementation of enqueue that runs within a single transaction attempt.
+    /// Inner transaction-based enqueue for a single attempt.
     #[allow(clippy::too_many_arguments)]
-    async fn enqueue_inner(
+    async fn enqueue_txn(
         &self,
         tenant: &str,
         job_id: &str,
@@ -99,70 +211,26 @@ impl JobStoreShard {
         metadata: Option<Vec<(String, String)>>,
         task_group: &str,
     ) -> Result<(), JobStoreShardError> {
-        let now_ms = now_epoch_ms();
-
         // Start a transaction with SerializableSnapshot isolation for conflict detection
         let txn = self.db.begin(IsolationLevel::SerializableSnapshot).await?;
 
         // [SILO-ENQ-1] If caller provided an id, ensure it doesn't already exist
-        // This check is now protected by the transaction - concurrent enqueues with
-        // the same ID will result in a transaction conflict.
-        let job_info_key = job_info_key(tenant, job_id);
-        if txn.get(&job_info_key).await?.is_some() {
+        let info_key = job_info_key(tenant, job_id);
+        if txn.get(&info_key).await?.is_some() {
             return Err(JobStoreShardError::JobAlreadyExists(job_id.to_string()));
         }
 
-        let job = JobInfo {
-            id: job_id.to_string(),
-            priority,
-            enqueue_time_ms: start_at_ms,
-            payload,
-            retry_policy,
-            metadata: metadata.unwrap_or_default(),
-            limits: limits.clone(),
-            task_group: task_group.to_string(),
-        };
-        let job_value = encode_job_info(&job)?;
-
-        let first_task_id = Uuid::new_v4().to_string();
-        // If start_at_ms is 0 (the default, which means start now) or in the past, use now_ms as the effective start time
-        let effective_start_at_ms = if start_at_ms <= 0 {
-            now_ms
-        } else {
-            start_at_ms
-        };
-
-        // [SILO-ENQ-2] Create job with status Scheduled, with next attempt time
-        // First attempt is always 1
-        let job_status = JobStatus::scheduled(now_ms, effective_start_at_ms, 1);
-
-        // Write job info
-        txn.put(&job_info_key, &job_value)?;
-
-        // Maintain metadata secondary index (metadata is immutable post-enqueue)
-        for (mk, mv) in &job.metadata {
-            let mkey = idx_metadata_key(tenant, mk, mv, job_id);
-            txn.put(&mkey, [])?;
-        }
-
-        Self::write_new_job_status_with_index(&mut TxnWriter(&txn), tenant, job_id, job_status)?;
-
-        // Process limits starting from index 0. For concurrency limits, we try immediate
-        // grant as an optimization. Returns all grants made for potential rollback.
         let grants = self
-            .enqueue_limit_task_at_index(
+            .write_enqueue_data(
                 &mut TxnWriter(&txn),
                 tenant,
-                &first_task_id,
                 job_id,
-                1, // attempt number (total)
-                1, // relative attempt number (within run)
-                0, // start from first limit
-                &limits,
                 priority,
                 start_at_ms,
-                now_ms,
-                Vec::new(), // no held queues yet
+                retry_policy,
+                payload,
+                limits,
+                metadata,
                 task_group,
             )
             .await?;
@@ -187,31 +255,115 @@ impl JobStoreShard {
             .await
         {
             dst_events::cancel_write(write_op);
-            for (queue, task_id) in &grants {
-                self.concurrency.rollback_grant(tenant, queue, task_id);
-            }
+            self.rollback_grants(tenant, &grants);
             return Err(e.into());
         }
         dst_events::confirm_write(write_op);
 
-        // Increment total jobs counter for this shard.
-        // This is done outside the transaction to avoid conflicts - see counters.rs for details.
-        // TODO(slatedb#1254): Move back inside transaction once SlateDB supports key exclusion.
+        // Counter must be outside transaction to avoid conflicts on shared counter key
         self.increment_total_jobs_counter().await?;
 
-        // Log grants after durable commit
-        for (queue, task_id) in &grants {
+        self.finish_enqueue(job_id, start_at_ms, &grants).await
+    }
+
+    // ==================== Shared Enqueue Helpers ====================
+
+    /// Write all enqueue data (job info, metadata, status, limit tasks) to the writer.
+    /// Shared between the WriteBatch and transaction enqueue paths.
+    #[allow(clippy::too_many_arguments)]
+    async fn write_enqueue_data<W: WriteBatcher>(
+        &self,
+        writer: &mut W,
+        tenant: &str,
+        job_id: &str,
+        priority: u8,
+        start_at_ms: i64,
+        retry_policy: Option<RetryPolicy>,
+        payload: Vec<u8>,
+        limits: Vec<Limit>,
+        metadata: Option<Vec<(String, String)>>,
+        task_group: &str,
+    ) -> Result<Vec<(String, String)>, JobStoreShardError> {
+        let now_ms = now_epoch_ms();
+
+        let job = JobInfo {
+            id: job_id.to_string(),
+            priority,
+            enqueue_time_ms: start_at_ms,
+            payload,
+            retry_policy,
+            metadata: metadata.unwrap_or_default(),
+            limits,
+            task_group: task_group.to_string(),
+        };
+        let job_value = encode_job_info(&job)?;
+
+        let first_task_id = Uuid::new_v4().to_string();
+        let effective_start_at_ms = if start_at_ms <= 0 {
+            now_ms
+        } else {
+            start_at_ms
+        };
+
+        // [SILO-ENQ-2] Create job with status Scheduled, with next attempt time
+        let job_status = JobStatus::scheduled(now_ms, effective_start_at_ms, 1);
+
+        writer.put(job_info_key(tenant, job_id), &job_value)?;
+
+        // Maintain metadata secondary index
+        for (mk, mv) in &job.metadata {
+            let mkey = idx_metadata_key(tenant, mk, mv, job_id);
+            writer.put(&mkey, [])?;
+        }
+
+        Self::write_new_job_status_with_index(writer, tenant, job_id, job_status)?;
+
+        self.enqueue_limit_task_at_index(
+            writer,
+            tenant,
+            &first_task_id,
+            job_id,
+            1,
+            1,
+            0,
+            &job.limits,
+            priority,
+            start_at_ms,
+            now_ms,
+            Vec::new(),
+            task_group,
+        )
+        .await
+    }
+
+    /// Complete an enqueue after successful write/commit and DST event emission.
+    /// Flushes to disk, logs grants, and wakes up the broker.
+    async fn finish_enqueue(
+        &self,
+        job_id: &str,
+        start_at_ms: i64,
+        grants: &[(String, String)],
+    ) -> Result<(), JobStoreShardError> {
+        self.db.flush().await?;
+
+        for (queue, task_id) in grants {
             let span = info_span!("concurrency.grant", queue = %queue, task_id = %task_id, job_id = %job_id, attempt = 1u32, source = "immediate");
             let _g = span.enter();
             debug!("granted concurrency slot immediately");
         }
 
-        // If ready now, wake the scanner to refill promptly
         if start_at_ms <= now_epoch_ms() {
             self.broker.wakeup();
         }
 
         Ok(())
+    }
+
+    /// Rollback in-memory concurrency grants after a failed write/commit.
+    fn rollback_grants(&self, tenant: &str, grants: &[(String, String)]) {
+        for (queue, task_id) in grants {
+            self.concurrency.rollback_grant(tenant, queue, task_id);
+        }
     }
 
     /// Enqueue a task to begin processing limits starting at `limit_index`.


### PR DESCRIPTION
PR #87 switched all enqueues to use SerializableSnapshot transactions and moved counter operations to separate db.write() calls. Benchmarking showed the extra write+flush was the primary bottleneck (halving throughput from ~464 to ~234 ops/sec), not transaction overhead itself.

Fix by splitting enqueue into two paths:
- Fast WriteBatch path for auto-generated UUIDs (no transaction needed)
- Transaction path only for user-provided IDs (dedup check required)

Counter operations are moved back into WriteBatch where possible (enqueue batch path, lease outcomes, delete), and kept as standalone writes only after transaction commits where they'd cause conflicts.

Shared logic is extracted into write_enqueue_data() and finish_enqueue() helpers to keep the two paths concise.