### PR TITLE
Refactor enqueue/dequeue/cancel hot paths to reduce DRY violations

### DIFF
--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -11,8 +11,36 @@ use crate::job_attempt::{AttemptStatus, JobAttempt, JobAttemptView};
 use crate::job_store_shard::helpers::{DbWriteBatcher, now_epoch_ms};
 use crate::job_store_shard::{DequeueResult, JobStoreShard, JobStoreShardError};
 use crate::keys::{attempt_key, job_info_key, leased_task_key};
+use crate::shard_range::ShardRange;
 use crate::task::{DEFAULT_LEASE_MS, LeaseRecord, LeasedRefreshTask, LeasedTask, Task};
 use crate::task_broker::BrokerTask;
+
+/// Mutable accumulators for a single dequeue iteration.
+/// Bundles state that each task-type handler needs to read and write,
+/// keeping handler signatures clean.
+struct DequeueIterationState {
+    batch: WriteBatch,
+    ack_keys: Vec<Vec<u8>>,
+    grants_to_rollback: Vec<(String, String, String)>,
+    release_grants_to_rollback: Vec<ReleaseGrantRollback>,
+    leased_tasks_for_dst: Vec<(String, String, String)>,
+    pending_attempts: Vec<(String, JobView, Vec<u8>)>,
+    processed_internal: bool,
+}
+
+impl DequeueIterationState {
+    fn new(claimed_len: usize) -> Self {
+        Self {
+            batch: WriteBatch::new(),
+            ack_keys: Vec::with_capacity(claimed_len),
+            grants_to_rollback: Vec::new(),
+            release_grants_to_rollback: Vec::new(),
+            leased_tasks_for_dst: Vec::new(),
+            pending_attempts: Vec::new(),
+            processed_internal: false,
+        }
+    }
+}
 
 impl JobStoreShard {
     /// Dequeue up to `max_tasks` tasks available now, ordered by time then priority.
@@ -39,7 +67,7 @@ impl JobStoreShard {
         let mut refresh_out: Vec<LeasedRefreshTask> = Vec::new();
         // Tuple: (tenant, job_view, encoded_attempt_bytes)
         // We keep the encoded bytes to construct JobAttemptView without a DB readback.
-        let mut pending_attempts: Vec<(String, JobView, Vec<u8>)> = Vec::new();
+        let mut pending_attempts: Vec<(String, JobView, Vec<u8>)> = Vec::with_capacity(max_tasks);
 
         // Track grants made during this dequeue for rollback on failure
         // Format: (tenant, queue, task_id)
@@ -70,9 +98,7 @@ impl JobStoreShard {
 
             let now_ms = now_epoch_ms();
             let expiry_ms = now_ms + DEFAULT_LEASE_MS;
-            let mut batch = WriteBatch::new();
-            let mut ack_keys: Vec<Vec<u8>> = Vec::with_capacity(claimed.len());
-            let mut processed_internal = false;
+            let mut state = DequeueIterationState::new(claimed.len());
 
             // Get the shard range for split-aware filtering
             let shard_range = self.get_range();
@@ -86,8 +112,8 @@ impl JobStoreShard {
 
                 if !shard_range.contains(task_tenant) {
                     // Task is for a tenant outside our range - delete and skip
-                    batch.delete(&entry.key);
-                    ack_keys.push(entry.key.clone());
+                    state.batch.delete(&entry.key);
+                    state.ack_keys.push(entry.key.clone());
                     tracing::debug!(
                         tenant = %task_tenant,
                         range = %shard_range,
@@ -96,7 +122,6 @@ impl JobStoreShard {
                     continue;
                 }
 
-                // Internal tasks are processed inside the store and not leased
                 match task {
                     Task::RequestTicket {
                         queue,
@@ -109,124 +134,22 @@ impl JobStoreShard {
                         request_id,
                         task_group: req_task_group,
                     } => {
-                        // Process ticket request internally
-                        processed_internal = true;
-                        let tenant = tenant.to_string();
-
-                        // [SILO-DEQ-CXL] Check if job is cancelled - if so, skip and clean up task
-                        if self.is_job_cancelled(&tenant, job_id).await? {
-                            batch.delete(&entry.key);
-                            ack_keys.push(entry.key.clone());
-                            tracing::debug!(job_id = %job_id, "dequeue: skipping cancelled job RequestTicket");
-                            continue;
-                        }
-
-                        // Load job info
-                        let job_key = job_info_key(&tenant, job_id);
-                        let maybe_job = self.db.get(&job_key).await?;
-                        let job_view = maybe_job
-                            .as_ref()
-                            .and_then(|bytes| JobView::new(bytes.clone()).ok());
-
-                        // Process ticket via concurrency manager
-                        let outcome = self
-                            .concurrency
-                            .process_ticket_request_task(
-                                &self.db,
-                                &shard_range,
-                                &mut batch,
-                                &entry.key,
-                                &tenant,
-                                queue,
-                                request_id,
-                                job_id,
-                                *attempt_number,
-                                now_ms,
-                                job_view.as_ref(),
-                            )
-                            .await?;
-
-                        match outcome {
-                            RequestTicketTaskOutcome::Granted { request_id, queue } => {
-                                // Track grant for rollback if DB write fails
-                                // Grant already recorded by try_reserve in process_ticket_request_task
-                                grants_to_rollback.push((
-                                    tenant.clone(),
-                                    queue.clone(),
-                                    request_id.clone(),
-                                ));
-
-                                // Create lease and attempt records
-                                let run = Task::RunAttempt {
-                                    id: request_id.clone(),
-                                    tenant: tenant.clone(),
-                                    job_id: job_id.clone(),
-                                    attempt_number: *attempt_number,
-                                    relative_attempt_number: *relative_attempt_number,
-                                    held_queues: vec![queue.clone()],
-                                    task_group: req_task_group.clone(),
-                                };
-                                let lease_key = leased_task_key(&request_id);
-                                let record = LeaseRecord {
-                                    worker_id: worker_id.to_string(),
-                                    task: run,
-                                    expiry_ms,
-                                };
-                                let leased_value = encode_lease(&record)?;
-                                batch.put(&lease_key, &leased_value);
-
-                                // Mark job as running
-                                let job_status = JobStatus::running(now_ms);
-                                self.set_job_status_with_index(
-                                    &mut DbWriteBatcher {
-                                        db: &self.db,
-                                        batch: &mut batch,
-                                    },
-                                    &tenant,
-                                    job_id,
-                                    job_status,
-                                )
-                                .await?;
-
-                                // Attempt record
-                                let attempt = JobAttempt {
-                                    job_id: job_id.clone(),
-                                    attempt_number: *attempt_number,
-                                    relative_attempt_number: *relative_attempt_number,
-                                    task_id: request_id.clone(),
-                                    status: AttemptStatus::Running {
-                                        started_at_ms: now_ms,
-                                    },
-                                };
-                                let attempt_val = encode_attempt(&attempt)?;
-                                let akey = attempt_key(&tenant, job_id, *attempt_number);
-                                batch.put(&akey, &attempt_val);
-
-                                // Track for response
-                                let view = job_view.unwrap();
-                                pending_attempts.push((tenant.clone(), view, attempt_val));
-                                ack_keys.push(entry.key.clone());
-                                // Grant already recorded by try_reserve - no need to call record_grant
-
-                                // Track for DST event emission after commit
-                                leased_tasks_for_dst.push((
-                                    tenant.clone(),
-                                    job_id.clone(),
-                                    request_id.clone(),
-                                ));
-
-                                // Record concurrency ticket metric
-                                if let Some(ref m) = self.metrics {
-                                    m.record_concurrency_ticket_granted();
-                                }
-                            }
-                            RequestTicketTaskOutcome::Requested
-                            | RequestTicketTaskOutcome::JobMissing => {
-                                // Release inflight, task will be picked up later or cleaned up
-                                ack_keys.push(entry.key.clone());
-                            }
-                        }
-                        continue;
+                        self.handle_request_ticket(
+                            &mut state,
+                            entry,
+                            &shard_range,
+                            worker_id,
+                            now_ms,
+                            expiry_ms,
+                            queue,
+                            tenant,
+                            job_id,
+                            *attempt_number,
+                            *relative_attempt_number,
+                            request_id,
+                            req_task_group,
+                        )
+                        .await?;
                     }
                     Task::CheckRateLimit {
                         task_id: check_task_id,
@@ -242,116 +165,24 @@ impl JobStoreShard {
                         held_queues,
                         task_group: check_task_group,
                     } => {
-                        // Process rate limit check internally
-                        processed_internal = true;
-                        let tenant = tenant.to_string();
-                        batch.delete(&entry.key);
-                        ack_keys.push(entry.key.clone());
-
-                        // Load job info to get the full limits list
-                        let job_key = job_info_key(&tenant, job_id);
-                        let maybe_job = self.db.get(&job_key).await?;
-                        let job_view = match maybe_job {
-                            Some(bytes) => match JobView::new(bytes) {
-                                Ok(v) => v,
-                                Err(_) => continue, // Skip malformed job
-                            },
-                            None => continue, // Job deleted, skip
-                        };
-
-                        // Check the rate limit via Gubernator
-                        let rate_limit_result = self.check_gubernator_rate_limit(rate_limit).await;
-
-                        match rate_limit_result {
-                            Ok(result) if result.under_limit => {
-                                // Rate limit passed! Proceed to next limit or RunAttempt
-                                let grants = self
-                                    .enqueue_limit_task_at_index(
-                                        &mut DbWriteBatcher {
-                                            db: &self.db,
-                                            batch: &mut batch,
-                                        },
-                                        &tenant,
-                                        check_task_id,
-                                        job_id,
-                                        *attempt_number,
-                                        *check_relative_attempt_number,
-                                        (*limit_index + 1) as usize, // next limit after current
-                                        &job_view.limits(),
-                                        *priority,
-                                        now_ms,
-                                        now_ms,
-                                        held_queues.clone(),
-                                        check_task_group,
-                                    )
-                                    .await?;
-                                // Track any immediate grants for rollback if DB write fails
-                                for (queue, task_id) in grants {
-                                    grants_to_rollback.push((tenant.clone(), queue, task_id));
-                                }
-                            }
-                            Ok(result) => {
-                                // Over limit - schedule retry
-                                let max_retries = rate_limit.retry_max_retries;
-                                if max_retries > 0 && *retry_count >= max_retries {
-                                    tracing::warn!(
-                                        job_id = %job_id,
-                                        retry_count = retry_count,
-                                        max_retries = max_retries,
-                                        "rate limit check exceeded max retries"
-                                    );
-                                    continue;
-                                }
-
-                                let retry_backoff = self.calculate_rate_limit_backoff(
-                                    rate_limit,
-                                    *retry_count,
-                                    result.reset_time_ms,
-                                    now_ms,
-                                );
-                                self.schedule_rate_limit_retry(
-                                    &mut DbWriteBatcher {
-                                        db: &self.db,
-                                        batch: &mut batch,
-                                    },
-                                    &tenant,
-                                    job_id,
-                                    *attempt_number,
-                                    *check_relative_attempt_number,
-                                    *limit_index,
-                                    rate_limit,
-                                    *retry_count,
-                                    *started_at_ms,
-                                    *priority,
-                                    held_queues,
-                                    retry_backoff,
-                                    check_task_group,
-                                )?;
-                            }
-                            Err(e) => {
-                                tracing::warn!(job_id = %job_id, error = %e, "gubernator rate limit check failed, will retry");
-                                let retry_backoff = now_ms + rate_limit.retry_initial_backoff_ms;
-                                self.schedule_rate_limit_retry(
-                                    &mut DbWriteBatcher {
-                                        db: &self.db,
-                                        batch: &mut batch,
-                                    },
-                                    &tenant,
-                                    job_id,
-                                    *attempt_number,
-                                    *check_relative_attempt_number,
-                                    *limit_index,
-                                    rate_limit,
-                                    *retry_count,
-                                    *started_at_ms,
-                                    *priority,
-                                    held_queues,
-                                    retry_backoff,
-                                    check_task_group,
-                                )?;
-                            }
-                        }
-                        continue;
+                        self.handle_check_rate_limit(
+                            &mut state,
+                            entry,
+                            now_ms,
+                            check_task_id,
+                            tenant,
+                            job_id,
+                            *attempt_number,
+                            *check_relative_attempt_number,
+                            *limit_index,
+                            rate_limit,
+                            *retry_count,
+                            *started_at_ms,
+                            *priority,
+                            held_queues,
+                            check_task_group,
+                        )
+                        .await?;
                     }
                     Task::RefreshFloatingLimit {
                         task_id,
@@ -362,33 +193,22 @@ impl JobStoreShard {
                         metadata,
                         task_group: refresh_task_group,
                     } => {
-                        // RefreshFloatingLimit tasks are sent to workers - create lease
-                        let lease_key = leased_task_key(task_id);
-                        let record = LeaseRecord {
-                            worker_id: worker_id.to_string(),
-                            task: task.clone(),
+                        self.handle_refresh_floating_limit(
+                            &mut state,
+                            &mut refresh_out,
+                            entry,
+                            worker_id,
                             expiry_ms,
-                        };
-                        let leased_value = encode_lease(&record)?;
-                        batch.put(&lease_key, &leased_value);
-                        batch.delete(&entry.key);
-
-                        refresh_out.push(LeasedRefreshTask {
-                            task_id: task_id.clone(),
-                            tenant_id: task_tenant.clone(),
-                            queue_key: queue_key.clone(),
-                            current_max_concurrency: *current_max_concurrency,
-                            last_refreshed_at_ms: *last_refreshed_at_ms,
-                            metadata: metadata.clone(),
-                            task_group: refresh_task_group.clone(),
-                        });
-                        ack_keys.push(entry.key.clone());
-                        continue;
+                            task,
+                            task_id,
+                            task_tenant,
+                            queue_key,
+                            *current_max_concurrency,
+                            *last_refreshed_at_ms,
+                            metadata,
+                            refresh_task_group,
+                        )?;
                     }
-                    Task::RunAttempt { .. } => {}
-                }
-                let (task_id, tenant, job_id, attempt_number, relative_attempt_number) = match task
-                {
                     Task::RunAttempt {
                         id,
                         tenant,
@@ -396,122 +216,36 @@ impl JobStoreShard {
                         attempt_number,
                         relative_attempt_number,
                         ..
-                    } => (
-                        id.clone(),
-                        tenant.to_string(),
-                        job_id.to_string(),
-                        *attempt_number,
-                        *relative_attempt_number,
-                    ),
-                    Task::RequestTicket { .. }
-                    | Task::CheckRateLimit { .. }
-                    | Task::RefreshFloatingLimit { .. } => unreachable!(),
-                };
-
-                // [SILO-DEQ-2] Look up job info; if missing, delete the task and skip
-                let job_key = job_info_key(&tenant, &job_id);
-                let maybe_job = self.db.get(&job_key).await?;
-                if let Some(job_bytes) = maybe_job {
-                    // [SILO-DEQ-CXL] Check if job is cancelled - if so, skip and clean up task
-                    if self.is_job_cancelled(&tenant, &job_id).await? {
-                        batch.delete(&entry.key);
-                        ack_keys.push(entry.key.clone());
-
-                        // [SILO-DEQ-CXL-REL] Release any held concurrency tickets
-                        // This is required to maintain invariant: holders can only exist for active tasks
-                        let held_queues = match task {
-                            Task::RunAttempt { held_queues, .. } => held_queues.clone(),
-                            Task::CheckRateLimit { held_queues, .. } => held_queues.clone(),
-                            Task::RequestTicket { .. } | Task::RefreshFloatingLimit { .. } => {
-                                Vec::new()
-                            }
-                        };
-                        if !held_queues.is_empty() {
-                            // release_and_grant_next updates in-memory atomically before returning
-                            // Track rollback info in case DB write fails
-                            let release_rollbacks = self
-                                .concurrency
-                                .release_and_grant_next(
-                                    &self.db,
-                                    &mut batch,
-                                    &tenant,
-                                    &held_queues,
-                                    &task_id,
-                                    now_ms,
-                                )
-                                .await
-                                .map_err(JobStoreShardError::Rkyv)?;
-                            release_grants_to_rollback.extend(release_rollbacks);
-                            tracing::debug!(job_id = %job_id, queues = ?held_queues, "dequeue: released tickets for cancelled job task");
-                        }
-
-                        tracing::debug!(job_id = %job_id, "dequeue: skipping cancelled job task");
-                        continue;
+                    } => {
+                        self.handle_run_attempt(
+                            &mut state,
+                            entry,
+                            task,
+                            worker_id,
+                            now_ms,
+                            expiry_ms,
+                            id,
+                            tenant,
+                            job_id,
+                            *attempt_number,
+                            *relative_attempt_number,
+                        )
+                        .await?;
                     }
-
-                    let view = JobView::new(job_bytes)?;
-
-                    // [SILO-DEQ-CONC] Implicit: If job requires concurrency, task must hold all required queues.
-                    // This is guaranteed by construction: RunAttempt tasks are only created when concurrency
-                    // is granted (at enqueue or grant_next), with held_queues populated.
-
-                    // [SILO-DEQ-4] Create lease record
-                    let lease_key = leased_task_key(&task_id);
-                    let record = LeaseRecord {
-                        worker_id: worker_id.to_string(),
-                        task: task.clone(),
-                        expiry_ms,
-                    };
-                    let leased_value = encode_lease(&record)?;
-
-                    batch.put(&lease_key, &leased_value);
-                    // [SILO-DEQ-3] Delete task from task queue
-                    batch.delete(&entry.key);
-
-                    // [SILO-DEQ-6] Mark job as running (pure write, no status read)
-                    let job_status = JobStatus::running(now_ms);
-                    self.set_job_status_with_index(
-                        &mut DbWriteBatcher {
-                            db: &self.db,
-                            batch: &mut batch,
-                        },
-                        &tenant,
-                        &job_id,
-                        job_status,
-                    )
-                    .await?;
-
-                    // [SILO-DEQ-5] Also mark attempt as running
-                    let attempt = JobAttempt {
-                        job_id: job_id.clone(),
-                        attempt_number,
-                        relative_attempt_number,
-                        task_id: task_id.clone(),
-                        status: AttemptStatus::Running {
-                            started_at_ms: now_ms,
-                        },
-                    };
-                    let attempt_val = encode_attempt(&attempt)?;
-                    let akey = attempt_key(&tenant, &job_id, attempt_number);
-                    batch.put(&akey, &attempt_val);
-
-                    // Construct AttemptView directly from encoded bytes (no DB readback needed)
-                    pending_attempts.push((tenant.clone(), view, attempt_val));
-                    ack_keys.push(entry.key.clone());
-
-                    // Track for DST event emission after commit
-                    leased_tasks_for_dst.push((tenant.clone(), job_id.clone(), task_id.clone()));
-                } else {
-                    // If job missing, delete task key to clean up
-                    batch.delete(&entry.key);
-                    ack_keys.push(entry.key.clone());
                 }
             }
+
+            // Merge iteration state into outer accumulators
+            grants_to_rollback.append(&mut state.grants_to_rollback);
+            release_grants_to_rollback.append(&mut state.release_grants_to_rollback);
 
             // Two-phase DST events: emit before write for correct causal ordering,
             // confirm after write succeeds, cancel if write fails.
             let write_op = dst_events::next_write_op();
-            for (tenant, job_id, task_id) in leased_tasks_for_dst.drain(..) {
+            for (tenant, job_id, task_id) in leased_tasks_for_dst
+                .drain(..)
+                .chain(state.leased_tasks_for_dst.drain(..))
+            {
                 dst_events::emit_pending(
                     DstEvent::TaskLeased {
                         tenant: tenant.clone(),
@@ -536,7 +270,7 @@ impl JobStoreShard {
             if let Err(e) = self
                 .db
                 .write_with_options(
-                    batch,
+                    state.batch,
                     &WriteOptions {
                         await_durable: true,
                     },
@@ -566,21 +300,24 @@ impl JobStoreShard {
             grants_to_rollback.clear();
             release_grants_to_rollback.clear();
 
+            // Collect pending attempts from this iteration
+            pending_attempts.append(&mut state.pending_attempts);
+
             // [SILO-DEQ-3] Ack durable and evict from buffer; we no longer use TTL tombstones.
-            self.broker.ack_durable(&ack_keys);
-            self.broker.evict_keys(&ack_keys);
+            self.broker.ack_durable(&state.ack_keys);
+            self.broker.evict_keys(&state.ack_keys);
             tracing::debug!(
-                ack_keys = ack_keys.len(),
+                ack_keys = state.ack_keys.len(),
                 pending_attempts = pending_attempts.len(),
                 buffer_size = self.broker.buffer_len(),
                 inflight = self.broker.inflight_len(),
-                processed_internal = processed_internal,
+                processed_internal = state.processed_internal,
                 "dequeue: acked and evicted keys"
             );
 
             // If we only processed internal tasks and haven't filled max_tasks, loop again
             // to pick up the follow-up tasks we just inserted into the broker
-            if !processed_internal {
+            if !state.processed_internal {
                 // We processed real RunAttempt tasks, no need to loop
                 break;
             }
@@ -602,6 +339,451 @@ impl JobStoreShard {
             tasks: out,
             refresh_tasks: refresh_out,
         })
+    }
+
+    /// Write a lease record, set job status to Running, and create an attempt record.
+    /// Returns the encoded attempt bytes for constructing `pending_attempts`.
+    #[allow(clippy::too_many_arguments)]
+    async fn write_lease_and_attempt(
+        &self,
+        batch: &mut WriteBatch,
+        worker_id: &str,
+        task: &Task,
+        task_id: &str,
+        tenant: &str,
+        job_id: &str,
+        attempt_number: u32,
+        relative_attempt_number: u32,
+        now_ms: i64,
+        expiry_ms: i64,
+    ) -> Result<Vec<u8>, JobStoreShardError> {
+        // [SILO-DEQ-4] Create lease record
+        let lease_key = leased_task_key(task_id);
+        let record = LeaseRecord {
+            worker_id: worker_id.to_string(),
+            task: task.clone(),
+            expiry_ms,
+        };
+        let leased_value = encode_lease(&record)?;
+        batch.put(&lease_key, &leased_value);
+
+        // [SILO-DEQ-6] Mark job as running
+        let job_status = JobStatus::running(now_ms);
+        self.set_job_status_with_index(
+            &mut DbWriteBatcher {
+                db: &self.db,
+                batch,
+            },
+            tenant,
+            job_id,
+            job_status,
+        )
+        .await?;
+
+        // [SILO-DEQ-5] Create attempt record
+        let attempt = JobAttempt {
+            job_id: job_id.to_string(),
+            attempt_number,
+            relative_attempt_number,
+            task_id: task_id.to_string(),
+            status: AttemptStatus::Running {
+                started_at_ms: now_ms,
+            },
+        };
+        let attempt_val = encode_attempt(&attempt)?;
+        let akey = attempt_key(tenant, job_id, attempt_number);
+        batch.put(&akey, &attempt_val);
+
+        Ok(attempt_val)
+    }
+
+    /// Process a RequestTicket task: check cancellation, process concurrency ticket, maybe lease.
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_request_ticket(
+        &self,
+        state: &mut DequeueIterationState,
+        entry: &BrokerTask,
+        shard_range: &ShardRange,
+        worker_id: &str,
+        now_ms: i64,
+        expiry_ms: i64,
+        queue: &str,
+        tenant: &str,
+        job_id: &str,
+        attempt_number: u32,
+        relative_attempt_number: u32,
+        request_id: &str,
+        req_task_group: &str,
+    ) -> Result<(), JobStoreShardError> {
+        state.processed_internal = true;
+        let tenant = tenant.to_string();
+
+        // [SILO-DEQ-CXL] Check if job is cancelled - if so, skip and clean up task
+        if self.is_job_cancelled(&tenant, job_id).await? {
+            state.batch.delete(&entry.key);
+            state.ack_keys.push(entry.key.clone());
+            tracing::debug!(job_id = %job_id, "dequeue: skipping cancelled job RequestTicket");
+            return Ok(());
+        }
+
+        // Load job info
+        let job_key = job_info_key(&tenant, job_id);
+        let maybe_job = self.db.get(&job_key).await?;
+        let job_view = maybe_job
+            .as_ref()
+            .and_then(|bytes| JobView::new(bytes.clone()).ok());
+
+        // Process ticket via concurrency manager
+        let outcome = self
+            .concurrency
+            .process_ticket_request_task(
+                &self.db,
+                shard_range,
+                &mut state.batch,
+                &entry.key,
+                &tenant,
+                queue,
+                request_id,
+                job_id,
+                attempt_number,
+                now_ms,
+                job_view.as_ref(),
+            )
+            .await?;
+
+        match outcome {
+            RequestTicketTaskOutcome::Granted { request_id, queue } => {
+                // Track grant for rollback if DB write fails
+                state
+                    .grants_to_rollback
+                    .push((tenant.clone(), queue.clone(), request_id.clone()));
+
+                // Create RunAttempt task for the lease
+                let run = Task::RunAttempt {
+                    id: request_id.clone(),
+                    tenant: tenant.clone(),
+                    job_id: job_id.to_string(),
+                    attempt_number,
+                    relative_attempt_number,
+                    held_queues: vec![queue],
+                    task_group: req_task_group.to_string(),
+                };
+
+                let attempt_val = self
+                    .write_lease_and_attempt(
+                        &mut state.batch,
+                        worker_id,
+                        &run,
+                        &request_id,
+                        &tenant,
+                        job_id,
+                        attempt_number,
+                        relative_attempt_number,
+                        now_ms,
+                        expiry_ms,
+                    )
+                    .await?;
+
+                let view = job_view.unwrap();
+                state
+                    .pending_attempts
+                    .push((tenant.clone(), view, attempt_val));
+                state.ack_keys.push(entry.key.clone());
+
+                // Track for DST event emission after commit
+                state
+                    .leased_tasks_for_dst
+                    .push((tenant, job_id.to_string(), request_id));
+
+                // Record concurrency ticket metric
+                if let Some(ref m) = self.metrics {
+                    m.record_concurrency_ticket_granted();
+                }
+            }
+            RequestTicketTaskOutcome::Requested | RequestTicketTaskOutcome::JobMissing => {
+                // Release inflight, task will be picked up later or cleaned up
+                state.ack_keys.push(entry.key.clone());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Process a CheckRateLimit task: check rate limit, enqueue follow-up or retry.
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_check_rate_limit(
+        &self,
+        state: &mut DequeueIterationState,
+        entry: &BrokerTask,
+        now_ms: i64,
+        check_task_id: &str,
+        tenant: &str,
+        job_id: &str,
+        attempt_number: u32,
+        check_relative_attempt_number: u32,
+        limit_index: u32,
+        rate_limit: &crate::task::GubernatorRateLimitData,
+        retry_count: u32,
+        started_at_ms: i64,
+        priority: u8,
+        held_queues: &[String],
+        check_task_group: &str,
+    ) -> Result<(), JobStoreShardError> {
+        state.processed_internal = true;
+        let tenant = tenant.to_string();
+        state.batch.delete(&entry.key);
+        state.ack_keys.push(entry.key.clone());
+
+        // Load job info to get the full limits list
+        let job_key = job_info_key(&tenant, job_id);
+        let maybe_job = self.db.get(&job_key).await?;
+        let job_view = match maybe_job {
+            Some(bytes) => match JobView::new(bytes) {
+                Ok(v) => v,
+                Err(_) => return Ok(()), // Skip malformed job
+            },
+            None => return Ok(()), // Job deleted, skip
+        };
+
+        // Check the rate limit via Gubernator
+        let rate_limit_result = self.check_gubernator_rate_limit(rate_limit).await;
+
+        match rate_limit_result {
+            Ok(result) if result.under_limit => {
+                // Rate limit passed! Proceed to next limit or RunAttempt
+                let grants = self
+                    .enqueue_limit_task_at_index(
+                        &mut DbWriteBatcher {
+                            db: &self.db,
+                            batch: &mut state.batch,
+                        },
+                        &tenant,
+                        check_task_id,
+                        job_id,
+                        attempt_number,
+                        check_relative_attempt_number,
+                        (limit_index + 1) as usize, // next limit after current
+                        &job_view.limits(),
+                        priority,
+                        now_ms,
+                        now_ms,
+                        held_queues.to_vec(),
+                        check_task_group,
+                    )
+                    .await?;
+                // Track any immediate grants for rollback if DB write fails
+                for (queue, task_id) in grants {
+                    state
+                        .grants_to_rollback
+                        .push((tenant.clone(), queue, task_id));
+                }
+            }
+            Ok(result) => {
+                // Over limit - schedule retry
+                let max_retries = rate_limit.retry_max_retries;
+                if max_retries > 0 && retry_count >= max_retries {
+                    tracing::warn!(
+                        job_id = %job_id,
+                        retry_count = retry_count,
+                        max_retries = max_retries,
+                        "rate limit check exceeded max retries"
+                    );
+                    return Ok(());
+                }
+
+                let retry_backoff = self.calculate_rate_limit_backoff(
+                    rate_limit,
+                    retry_count,
+                    result.reset_time_ms,
+                    now_ms,
+                );
+                self.schedule_rate_limit_retry(
+                    &mut DbWriteBatcher {
+                        db: &self.db,
+                        batch: &mut state.batch,
+                    },
+                    &tenant,
+                    job_id,
+                    attempt_number,
+                    check_relative_attempt_number,
+                    limit_index,
+                    rate_limit,
+                    retry_count,
+                    started_at_ms,
+                    priority,
+                    held_queues,
+                    retry_backoff,
+                    check_task_group,
+                )?;
+            }
+            Err(e) => {
+                tracing::warn!(job_id = %job_id, error = %e, "gubernator rate limit check failed, will retry");
+                let retry_backoff = now_ms + rate_limit.retry_initial_backoff_ms;
+                self.schedule_rate_limit_retry(
+                    &mut DbWriteBatcher {
+                        db: &self.db,
+                        batch: &mut state.batch,
+                    },
+                    &tenant,
+                    job_id,
+                    attempt_number,
+                    check_relative_attempt_number,
+                    limit_index,
+                    rate_limit,
+                    retry_count,
+                    started_at_ms,
+                    priority,
+                    held_queues,
+                    retry_backoff,
+                    check_task_group,
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Process a RefreshFloatingLimit task: create lease and add to refresh output.
+    #[allow(clippy::too_many_arguments)]
+    fn handle_refresh_floating_limit(
+        &self,
+        state: &mut DequeueIterationState,
+        refresh_out: &mut Vec<LeasedRefreshTask>,
+        entry: &BrokerTask,
+        worker_id: &str,
+        expiry_ms: i64,
+        task: &Task,
+        task_id: &str,
+        task_tenant: &str,
+        queue_key: &str,
+        current_max_concurrency: u32,
+        last_refreshed_at_ms: i64,
+        metadata: &[(String, String)],
+        refresh_task_group: &str,
+    ) -> Result<(), JobStoreShardError> {
+        let lease_key = leased_task_key(task_id);
+        let record = LeaseRecord {
+            worker_id: worker_id.to_string(),
+            task: task.clone(),
+            expiry_ms,
+        };
+        let leased_value = encode_lease(&record)?;
+        state.batch.put(&lease_key, &leased_value);
+        state.batch.delete(&entry.key);
+
+        refresh_out.push(LeasedRefreshTask {
+            task_id: task_id.to_string(),
+            tenant_id: task_tenant.to_string(),
+            queue_key: queue_key.to_string(),
+            current_max_concurrency,
+            last_refreshed_at_ms,
+            metadata: metadata.to_vec(),
+            task_group: refresh_task_group.to_string(),
+        });
+        state.ack_keys.push(entry.key.clone());
+
+        Ok(())
+    }
+
+    /// Process a RunAttempt task: check cancellation, create lease, mark running.
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_run_attempt(
+        &self,
+        state: &mut DequeueIterationState,
+        entry: &BrokerTask,
+        task: &Task,
+        worker_id: &str,
+        now_ms: i64,
+        expiry_ms: i64,
+        task_id: &str,
+        tenant: &str,
+        job_id: &str,
+        attempt_number: u32,
+        relative_attempt_number: u32,
+    ) -> Result<(), JobStoreShardError> {
+        // [SILO-DEQ-2] Look up job info; if missing, delete the task and skip
+        let job_key = job_info_key(tenant, job_id);
+        let maybe_job = self.db.get(&job_key).await?;
+        let Some(job_bytes) = maybe_job else {
+            // If job missing, delete task key to clean up
+            state.batch.delete(&entry.key);
+            state.ack_keys.push(entry.key.clone());
+            return Ok(());
+        };
+
+        // [SILO-DEQ-CXL] Check if job is cancelled - if so, skip and clean up task
+        if self.is_job_cancelled(tenant, job_id).await? {
+            state.batch.delete(&entry.key);
+            state.ack_keys.push(entry.key.clone());
+
+            // [SILO-DEQ-CXL-REL] Release any held concurrency tickets
+            // This is required to maintain invariant: holders can only exist for active tasks
+            let held_queues = match task {
+                Task::RunAttempt { held_queues, .. } => held_queues.clone(),
+                Task::CheckRateLimit { held_queues, .. } => held_queues.clone(),
+                Task::RequestTicket { .. } | Task::RefreshFloatingLimit { .. } => Vec::new(),
+            };
+            if !held_queues.is_empty() {
+                // release_and_grant_next updates in-memory atomically before returning
+                // Track rollback info in case DB write fails
+                let release_rollbacks = self
+                    .concurrency
+                    .release_and_grant_next(
+                        &self.db,
+                        &mut state.batch,
+                        tenant,
+                        &held_queues,
+                        task_id,
+                        now_ms,
+                    )
+                    .await
+                    .map_err(JobStoreShardError::Rkyv)?;
+                state.release_grants_to_rollback.extend(release_rollbacks);
+                tracing::debug!(job_id = %job_id, queues = ?held_queues, "dequeue: released tickets for cancelled job task");
+            }
+
+            tracing::debug!(job_id = %job_id, "dequeue: skipping cancelled job task");
+            return Ok(());
+        }
+
+        let view = JobView::new(job_bytes)?;
+
+        // [SILO-DEQ-CONC] Implicit: If job requires concurrency, task must hold all required queues.
+        // This is guaranteed by construction: RunAttempt tasks are only created when concurrency
+        // is granted (at enqueue or grant_next), with held_queues populated.
+
+        // [SILO-DEQ-3] Delete task from task queue
+        state.batch.delete(&entry.key);
+
+        let attempt_val = self
+            .write_lease_and_attempt(
+                &mut state.batch,
+                worker_id,
+                task,
+                task_id,
+                tenant,
+                job_id,
+                attempt_number,
+                relative_attempt_number,
+                now_ms,
+                expiry_ms,
+            )
+            .await?;
+
+        // Construct AttemptView directly from encoded bytes (no DB readback needed)
+        state
+            .pending_attempts
+            .push((tenant.to_string(), view, attempt_val));
+        state.ack_keys.push(entry.key.clone());
+
+        // Track for DST event emission after commit
+        state.leased_tasks_for_dst.push((
+            tenant.to_string(),
+            job_id.to_string(),
+            task_id.to_string(),
+        ));
+
+        Ok(())
     }
 
     /// Peek up to `max_tasks` available tasks (time <= now), without deleting them.


### PR DESCRIPTION
- Add retry_on_txn_conflict helper, replacing duplicated retry loops in cancel/expedite/restart
- Extract DequeueIterationState struct and per-task-type handler methods in dequeue
- Extract write_lease_and_attempt helper to deduplicate lease+status+attempt writes
- Add record_grant_outcome helper to deduplicate grant match blocks in enqueue
- Move format!() and DST event emission outside mutex locks in concurrency.rs
- Pre-allocate pending_attempts with Vec::with_capacity

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
