### PR TITLE
Implement permanent shard leases to prevent WAL data loss on crash

### DIFF
--- a/deploy/local-test/Dockerfile
+++ b/deploy/local-test/Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1.89-bookworm AS builder
+WORKDIR /app
+RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
+COPY Cargo.toml Cargo.lock ./
+COPY silo-macros ./silo-macros
+COPY proto ./proto
+COPY build.rs ./
+COPY src ./src
+COPY templates ./templates
+COPY benches ./benches
+COPY tests ./tests
+RUN cargo build --release --locked --bin silo --bin siloctl
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/silo /usr/local/bin/silo
+COPY --from=builder /app/target/release/siloctl /usr/local/bin/siloctl
+EXPOSE 50051 50052 9090
+ENTRYPOINT ["/usr/local/bin/silo"]

--- a/deploy/local-test/config.toml
+++ b/deploy/local-test/config.toml
@@ -1,0 +1,34 @@
+[server]
+grpc_addr = "0.0.0.0:50051"
+
+[logging]
+format = "json"
+
+[coordination]
+backend = "k8s"
+cluster_prefix = "silo-local-test"
+lease_ttl_secs = 10
+initial_shard_count = 6
+k8s_namespace = "silo-test"
+advertised_grpc_addr = "${POD_IP}:50051"
+
+[tenancy]
+enabled = true
+
+[webui]
+enabled = true
+addr = "0.0.0.0:50052"
+
+[metrics]
+enabled = true
+addr = "0.0.0.0:9090"
+
+[database]
+backend = "fs"
+# Shared hostPath volume simulates shared object storage
+path = "/data/shared/%shard%"
+
+[database.wal]
+backend = "fs"
+# Local WAL per pod for low-latency writes
+path = "/data/wal/%shard%"

--- a/deploy/local-test/namespace.yaml
+++ b/deploy/local-test/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: silo-test

--- a/deploy/local-test/rbac.yaml
+++ b/deploy/local-test/rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: silo
+  namespace: silo-test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: silo-coordinator
+  namespace: silo-test
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: silo-coordinator
+  namespace: silo-test
+subjects:
+  - kind: ServiceAccount
+    name: silo
+    namespace: silo-test
+roleRef:
+  kind: Role
+  name: silo-coordinator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/local-test/statefulset.yaml
+++ b/deploy/local-test/statefulset.yaml
@@ -1,0 +1,130 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: silo-config
+  namespace: silo-test
+data:
+  config.toml: |
+    [server]
+    grpc_addr = "0.0.0.0:50051"
+
+    [logging]
+    format = "json"
+
+    [coordination]
+    backend = "k8s"
+    cluster_prefix = "silo-local-test"
+    lease_ttl_secs = 10
+    initial_shard_count = 6
+    k8s_namespace = "silo-test"
+    advertised_grpc_addr = "${POD_IP}:50051"
+    node_id = "${POD_NAME}"
+
+    [tenancy]
+    enabled = true
+
+    [webui]
+    enabled = true
+    addr = "0.0.0.0:50052"
+
+    [metrics]
+    enabled = true
+    addr = "0.0.0.0:9090"
+
+    [database]
+    backend = "fs"
+    path = "/data/shared/%shard%"
+
+    [database.wal]
+    backend = "fs"
+    path = "/data/wal/%shard%"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: silo
+  namespace: silo-test
+spec:
+  clusterIP: None
+  selector:
+    app: silo
+  ports:
+    - name: grpc
+      port: 50051
+      targetPort: 50051
+    - name: webui
+      port: 50052
+      targetPort: 50052
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: silo
+  namespace: silo-test
+spec:
+  serviceName: silo
+  replicas: 3
+  selector:
+    matchLabels:
+      app: silo
+  template:
+    metadata:
+      labels:
+        app: silo
+    spec:
+      serviceAccountName: silo
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: silo
+          image: silo:latest
+          imagePullPolicy: Never
+          args: ["-c", "/etc/silo/config.toml"]
+          ports:
+            - containerPort: 50051
+              name: grpc
+            - containerPort: 50052
+              name: webui
+            - containerPort: 9090
+              name: metrics
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: RUST_LOG
+              value: "info,silo::coordination=debug"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/silo
+              readOnly: true
+            - name: shared-data
+              mountPath: /data/shared
+            - name: wal-data
+              mountPath: /data/wal
+          readinessProbe:
+            grpc:
+              port: 50051
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            grpc:
+              port: 50051
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: silo-config
+        - name: shared-data
+          hostPath:
+            path: /tmp/silo-test-shared
+            type: DirectoryOrCreate
+        - name: wal-data
+          emptyDir: {}

--- a/example_configs/k8s-gcs.toml
+++ b/example_configs/k8s-gcs.toml
@@ -28,6 +28,12 @@ lease_ttl_secs = 15
 #
 advertised_grpc_addr = "${POD_IP}:50051"
 
+# Stable node identity for permanent shard leases.
+# With StatefulSets, POD_NAME is stable across restarts (e.g., silo-0, silo-1),
+# so a restarted pod automatically re-acquires its own shard leases.
+# If not set, a random UUID is generated on each startup.
+node_id = "${POD_NAME}"
+
 [webui]
 enabled = true
 addr = "0.0.0.0:50052"

--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -531,6 +531,16 @@ message ImportJobsResponse {
   repeated ImportJobResult results = 1;
 }
 
+// Request to force-release a shard's ownership lease.
+// Operator escape hatch for permanently lost nodes.
+message ForceReleaseShardRequest {
+  string shard = 1; // The shard ID (UUID) to force-release.
+}
+
+// Response after force-releasing a shard lease.
+message ForceReleaseShardResponse {
+  bool released = 1; // True if the lease was released.
+}
 // The Silo job queue service.
 service Silo {
   // Get cluster topology for client-side routing.
@@ -632,4 +642,9 @@ service Silo {
   // WARNING: Destructive operation. Only available in dev mode.
   // Clears all jobs, tasks, queues, and other data.
   rpc ResetShards(ResetShardsRequest) returns (ResetShardsResponse);
+
+  // Force-release a shard lease regardless of the current holder.
+  // Operator escape hatch for recovering from permanently lost nodes.
+  // After force-release, any live node that desires the shard can acquire it.
+  rpc ForceReleaseShard(ForceReleaseShardRequest) returns (ForceReleaseShardResponse);
 }

--- a/src/bin/siloctl.rs
+++ b/src/bin/siloctl.rs
@@ -125,6 +125,11 @@ enum ShardAction {
         #[arg(long)]
         ring: Option<String>,
     },
+    /// Force-release a shard lease (for operator recovery when a node is permanently lost)
+    ForceRelease {
+        /// Shard ID (UUID) to force-release
+        shard: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -208,6 +213,9 @@ async fn run(args: Args) -> anyhow::Result<()> {
             }
             ShardAction::Configure { shard, ring } => {
                 siloctl::shard_configure(&opts, &mut stdout, shard, ring.clone()).await
+            }
+            ShardAction::ForceRelease { shard } => {
+                siloctl::shard_force_release(&opts, &mut stdout, shard).await
             }
         },
         Command::Query { shard, sql } => siloctl::query(&opts, &mut stdout, shard, sql).await,

--- a/src/coordination/etcd.rs
+++ b/src/coordination/etcd.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use etcd_client::{Client, ConnectOptions, GetOptions, LockOptions, PutOptions};
+use etcd_client::{Client, ConnectOptions, GetOptions, PutOptions};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,6 +19,9 @@ use super::{
 };
 
 /// etcd-based coordinator for distributed shard ownership.
+///
+/// Shard leases are permanent (KV-based, not tied to any etcd lease).
+/// Only membership leases use etcd's built-in TTL/keepalive mechanism.
 #[derive(Clone)]
 pub struct EtcdCoordinator {
     /// Shared coordinator state (node_id, grpc_addr, owned set, shutdown, factory)
@@ -26,7 +29,6 @@ pub struct EtcdCoordinator {
     client: Client,
     cluster_prefix: String,
     membership_lease_id: i64,
-    liveness_lease_id: i64,
     shard_guards: Arc<Mutex<HashMap<ShardId, Arc<EtcdShardGuard>>>>,
 }
 
@@ -67,13 +69,9 @@ impl EtcdCoordinator {
             Self::load_or_create_shard_map(&mut client, &cluster_prefix, initial_shard_count)
                 .await?;
 
-        // Create membership and liveness leases
+        // Create membership lease (keepalive-based for liveness detection).
+        // Shard leases are permanent KV entries, not tied to any etcd lease.
         let membership_lease = client
-            .lease_grant(ttl_secs, None)
-            .await
-            .map_err(|e| CoordinationError::BackendError(e.to_string()))?
-            .id();
-        let liveness_lease = client
             .lease_grant(ttl_secs, None)
             .await
             .map_err(|e| CoordinationError::BackendError(e.to_string()))?
@@ -114,7 +112,6 @@ impl EtcdCoordinator {
             client: client.clone(),
             cluster_prefix: cluster_prefix.clone(),
             membership_lease_id: membership_lease,
-            liveness_lease_id: liveness_lease,
             shard_guards: Arc::new(Mutex::new(HashMap::new())),
         };
         let shutdown_rx = base.shutdown_rx.clone();
@@ -124,7 +121,6 @@ impl EtcdCoordinator {
         let nid = node_id.clone();
         let mut lease_bg = client.lease_client();
         let mut watch_bg = client.watch_client();
-        let mut lock_bg = client.lock_client();
 
         let handle = tokio::spawn(async move {
             // Start lease keepalives with retries
@@ -144,27 +140,8 @@ impl EtcdCoordinator {
                 }
             };
 
-            let (mut live_keeper, mut live_stream) = loop {
-                if *shutdown_rx.borrow() {
-                    return;
-                }
-                match lease_bg.keep_alive(liveness_lease).await {
-                    Ok(x) => {
-                        debug!(node_id = %nid, lease_id = liveness_lease, "liveness lease keepalive channel established");
-                        break x;
-                    }
-                    Err(e) => {
-                        warn!(node_id = %nid, error = %e, "failed to start liveness keepalive, retrying...");
-                        sleep(Duration::from_millis(200)).await;
-                    }
-                }
-            };
-
             if let Err(e) = memb_keeper.keep_alive().await {
                 error!(node_id = %nid, error = %e, "failed to send initial membership keepalive");
-            }
-            if let Err(e) = live_keeper.keep_alive().await {
-                error!(node_id = %nid, error = %e, "failed to send initial liveness keepalive");
             }
 
             // Establish member watch with retries
@@ -211,8 +188,15 @@ impl EtcdCoordinator {
                 }
             };
 
+            // Reclaim shards from a previous run before initial reconciliation.
+            // This opens shards we still own (triggering WAL recovery) and installs
+            // guards in Held state so reconciliation can manage them normally.
+            if let Err(e) = me_bg.reclaim_and_open_shards().await {
+                warn!(node_id = %nid, error = %e, "failed to reclaim shards from previous run");
+            }
+
             // Initial reconcile
-            if let Err(err) = me_bg.reconcile_shards(&mut lock_bg).await {
+            if let Err(err) = me_bg.reconcile_shards().await {
                 warn!(node_id = %nid, error = %err, "initial reconcile failed");
             }
 
@@ -228,17 +212,14 @@ impl EtcdCoordinator {
                 tokio::select! {
                     _ = keepalive_timer.tick() => {
                         if *shutdown_rx.borrow() { break; }
-                        // Send keepalive requests to both leases
+                        // Send keepalive for membership lease
                         if let Err(e) = memb_keeper.keep_alive().await {
                             error!(node_id = %nid, error = %e, "failed to send membership keepalive");
-                        }
-                        if let Err(e) = live_keeper.keep_alive().await {
-                            error!(node_id = %nid, error = %e, "failed to send liveness keepalive");
                         }
                     }
                     _ = resync.tick() => {
                         if *shutdown_rx.borrow() { break; }
-                        if let Err(err) = me_bg.reconcile_shards(&mut lock_bg).await {
+                        if let Err(err) = me_bg.reconcile_shards().await {
                             warn!(node_id = %nid, error = %err, "periodic reconcile failed");
                         }
                     }
@@ -247,7 +228,7 @@ impl EtcdCoordinator {
                         match resp {
                             Ok(Some(_msg)) => {
                                 info!(node_id = %nid, "membership changed; reconciling now");
-                                if let Err(err) = me_bg.reconcile_shards(&mut lock_bg).await {
+                                if let Err(err) = me_bg.reconcile_shards().await {
                                     warn!(node_id = %nid, error = %err, "watch-triggered reconcile failed");
                                 }
                             }
@@ -269,7 +250,7 @@ impl EtcdCoordinator {
                                     warn!(node_id = %nid, error = %err, "failed to reload shard map");
                                 } else {
                                     // Reconcile after shard map change to pick up ownership changes
-                                    if let Err(err) = me_bg.reconcile_shards(&mut lock_bg).await {
+                                    if let Err(err) = me_bg.reconcile_shards().await {
                                         warn!(node_id = %nid, error = %err, "post-shard-map-change reconcile failed");
                                     }
                                 }
@@ -293,20 +274,6 @@ impl EtcdCoordinator {
                             }
                             Err(e) => {
                                 error!(node_id = %nid, error = %e, "membership lease keepalive error");
-                            }
-                        }
-                    }
-                    resp = live_stream.message() => {
-                        if *shutdown_rx.borrow() { break; }
-                        match resp {
-                            Ok(Some(ka_resp)) => {
-                                debug!(node_id = %nid, ttl = ka_resp.ttl(), "liveness keepalive response received");
-                            }
-                            Ok(None) => {
-                                error!(node_id = %nid, "liveness lease keepalive stream closed! Lease will expire.");
-                            }
-                            Err(e) => {
-                                error!(node_id = %nid, error = %e, "liveness lease keepalive error");
                             }
                         }
                     }
@@ -401,10 +368,82 @@ impl EtcdCoordinator {
         }
     }
 
-    async fn reconcile_shards(
-        &self,
-        _lock: &mut etcd_client::LockClient,
-    ) -> Result<(), etcd_client::Error> {
+    /// Reclaim shards from a previous run and open them before normal reconciliation.
+    ///
+    /// This is called once at startup to recover shards this node still owns
+    /// from before a crash/restart. Each reclaimed shard is opened via the factory
+    /// (triggering SlateDB WAL recovery) and a guard in `Held` state is installed.
+    async fn reclaim_and_open_shards(&self) -> Result<(), CoordinationError> {
+        let reclaimed = self.reclaim_existing_leases().await?;
+        if reclaimed.is_empty() {
+            return Ok(());
+        }
+
+        let mut opened_count = 0u32;
+
+        for shard_id in &reclaimed {
+            // Look up range from shard map (short-lived lock)
+            let range = {
+                let shard_map = self.base.shard_map.lock().await;
+                match shard_map.get_shard(shard_id) {
+                    Some(info) => info.range.clone(),
+                    None => {
+                        warn!(shard_id = %shard_id, "reclaim: shard not found in shard map, skipping");
+                        continue;
+                    }
+                }
+            };
+
+            let shard = match self.base.factory.open(shard_id, &range).await {
+                Ok(shard) => shard,
+                Err(e) => {
+                    error!(shard_id = %shard_id, error = %e, "reclaim: failed to open shard, skipping");
+                    continue;
+                }
+            };
+
+            shard.maybe_spawn_background_cleanup(range);
+
+            {
+                let mut owned = self.base.owned.lock().await;
+                owned.insert(*shard_id);
+            }
+
+            let guard = EtcdShardGuard::new_reclaimed(
+                *shard_id,
+                self.client.clone(),
+                self.cluster_prefix.clone(),
+                self.base.node_id.clone(),
+                self.base.shutdown_rx.clone(),
+            );
+            let runner = guard.clone();
+            let owned_arc = self.base.owned.clone();
+            let factory = self.base.factory.clone();
+            let shard_map = self.base.shard_map.clone();
+            let coordinator: Arc<dyn Coordinator> = Arc::new(self.clone());
+            tokio::spawn(
+                async move { runner.run(owned_arc, factory, shard_map, coordinator).await },
+            );
+
+            {
+                let mut guards = self.shard_guards.lock().await;
+                guards.insert(*shard_id, guard);
+            }
+
+            opened_count += 1;
+        }
+
+        if opened_count > 0 {
+            info!(
+                count = opened_count,
+                "reclaimed and opened shards from previous run"
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn reconcile_shards(&self) -> Result<(), etcd_client::Error> {
         // Get full member info for ring-aware placement
         let members = self
             .get_members()
@@ -432,7 +471,7 @@ impl EtcdCoordinator {
             let g = self.shard_guards.lock().await;
             let mut v = Vec::new();
             for (sid, guard) in g.iter() {
-                if guard.state.lock().await.held_key.is_some() {
+                if guard.state.lock().await.is_held {
                     v.push(*sid);
                 }
             }
@@ -491,7 +530,7 @@ impl EtcdCoordinator {
             shard_id,
             self.client.clone(),
             self.cluster_prefix.clone(),
-            self.liveness_lease_id,
+            self.base.node_id.clone(),
             self.base.shutdown_rx.clone(),
         );
         let runner = guard.clone();
@@ -833,11 +872,6 @@ impl Coordinator for EtcdCoordinator {
             .clone()
             .lease_revoke(self.membership_lease_id)
             .await;
-        let _ = self
-            .client
-            .clone()
-            .lease_revoke(self.liveness_lease_id)
-            .await;
         Ok(())
     }
 
@@ -923,20 +957,78 @@ impl Coordinator for EtcdCoordinator {
             max_retries
         )))
     }
+
+    async fn force_release_shard_lease(&self, shard_id: &ShardId) -> Result<(), CoordinationError> {
+        let owner_key = keys::shard_owner_key(&self.cluster_prefix, shard_id);
+        let resp = self
+            .client
+            .kv_client()
+            .delete(owner_key, None)
+            .await
+            .map_err(|e| CoordinationError::BackendError(e.to_string()))?;
+
+        if resp.deleted() == 0 {
+            return Err(CoordinationError::ShardNotFound(*shard_id));
+        }
+
+        info!(shard_id = %shard_id, "force-released shard lease");
+        Ok(())
+    }
+
+    async fn reclaim_existing_leases(&self) -> Result<Vec<ShardId>, CoordinationError> {
+        let shards_prefix = keys::shards_prefix(&self.cluster_prefix);
+        let resp = self
+            .client
+            .kv_client()
+            .get(shards_prefix, Some(GetOptions::new().with_prefix()))
+            .await
+            .map_err(|e| CoordinationError::BackendError(e.to_string()))?;
+
+        let mut reclaimed = Vec::new();
+        for kv in resp.kvs() {
+            let value = String::from_utf8_lossy(kv.value());
+            if value == self.base.node_id {
+                // This shard's owner key has our node_id - parse the shard ID from the key path
+                let key_str = String::from_utf8_lossy(kv.key());
+                // Key format: {prefix}/coord/shards/{shard_id}/owner
+                if let Some(shard_id_str) = key_str
+                    .strip_suffix("/owner")
+                    .and_then(|s| s.rsplit('/').next())
+                {
+                    match shard_id_str.parse::<uuid::Uuid>() {
+                        Ok(uuid) => {
+                            let shard_id = ShardId::from(uuid);
+                            info!(shard_id = %shard_id, "found existing shard lease to reclaim");
+                            reclaimed.push(shard_id);
+                        }
+                        Err(e) => {
+                            warn!(key = %key_str, error = %e, "failed to parse shard ID from owner key");
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(reclaimed)
+    }
 }
 
 pub struct ShardState {
     pub desired: bool,
     pub phase: ShardPhase,
-    pub held_key: Option<Vec<u8>>,
+    pub is_held: bool,
 }
 
-/// Per-shard lock guard for etcd backend.
+/// Per-shard ownership guard for etcd backend.
+///
+/// Uses KV transactions (put-if-absent / delete-if-owner) for permanent shard
+/// ownership instead of the Lock API. Shard owner keys are not tied to any etcd
+/// lease, so they persist until explicitly deleted.
 pub struct EtcdShardGuard {
     pub shard_id: ShardId,
     pub client: Client,
     pub cluster_prefix: String,
-    pub liveness_lease_id: i64,
+    pub node_id: String,
     pub state: Mutex<ShardState>,
     pub notify: Notify,
     pub shutdown: watch::Receiver<bool>,
@@ -947,18 +1039,45 @@ impl EtcdShardGuard {
         shard_id: ShardId,
         client: Client,
         cluster_prefix: String,
-        liveness_lease_id: i64,
+        node_id: String,
         shutdown: watch::Receiver<bool>,
     ) -> Arc<Self> {
         Arc::new(Self {
             shard_id,
             client,
             cluster_prefix,
-            liveness_lease_id,
+            node_id,
             state: Mutex::new(ShardState {
                 desired: false,
                 phase: ShardPhase::Idle,
-                held_key: None,
+                is_held: false,
+            }),
+            notify: Notify::new(),
+            shutdown,
+        })
+    }
+
+    /// Create a guard already in Held state for a shard reclaimed from a previous run.
+    ///
+    /// The guard starts in `Held` phase with `desired: true` and `is_held: true`,
+    /// meaning it will sit in the `Idle | Held` wait arm until reconciliation
+    /// decides what to do with it.
+    pub fn new_reclaimed(
+        shard_id: ShardId,
+        client: Client,
+        cluster_prefix: String,
+        node_id: String,
+        shutdown: watch::Receiver<bool>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            shard_id,
+            client,
+            cluster_prefix,
+            node_id,
+            state: Mutex::new(ShardState {
+                desired: true,
+                phase: ShardPhase::Held,
+                is_held: true,
             }),
             notify: Notify::new(),
             shutdown,
@@ -1012,6 +1131,63 @@ impl EtcdShardGuard {
         debug!(shard_id = %self.shard_id, "wait_shutdown: timed out");
     }
 
+    /// Try to acquire shard ownership using a KV put-if-absent transaction.
+    /// Returns Ok(true) if acquired, Ok(false) if already owned by another node.
+    async fn try_acquire_ownership(&self) -> Result<bool, etcd_client::Error> {
+        let owner_key = self.owner_key();
+        let txn = etcd_client::Txn::new()
+            .when([etcd_client::Compare::create_revision(
+                owner_key.clone(),
+                etcd_client::CompareOp::Equal,
+                0,
+            )])
+            .and_then([etcd_client::TxnOp::put(
+                owner_key.clone(),
+                self.node_id.clone(),
+                None, // No lease - permanent ownership
+            )])
+            .or_else([etcd_client::TxnOp::get(owner_key, None)]);
+
+        let txn_resp = self.client.kv_client().txn(txn).await?;
+
+        if txn_resp.succeeded() {
+            return Ok(true);
+        }
+
+        // Key already exists - check if it's ours (reclaim scenario)
+        if let Some(etcd_client::TxnOpResponse::Get(get_resp)) = txn_resp.op_responses().first()
+            && let Some(kv) = get_resp.kvs().first()
+        {
+            let current_owner = String::from_utf8_lossy(kv.value());
+            if current_owner == self.node_id {
+                // Already ours from a previous run - reclaim
+                return Ok(true);
+            }
+            debug!(
+                shard_id = %self.shard_id,
+                current_owner = %current_owner,
+                "shard owned by another node"
+            );
+        }
+
+        Ok(false)
+    }
+
+    /// Release shard ownership using a KV delete-if-owner transaction.
+    async fn release_ownership(&self) -> Result<(), etcd_client::Error> {
+        let owner_key = self.owner_key();
+        let txn = etcd_client::Txn::new()
+            .when([etcd_client::Compare::value(
+                owner_key.clone(),
+                etcd_client::CompareOp::Equal,
+                self.node_id.clone(),
+            )])
+            .and_then([etcd_client::TxnOp::delete(owner_key, None)]);
+
+        let _ = self.client.kv_client().txn(txn).await?;
+        Ok(())
+    }
+
     pub async fn run(
         self: Arc<Self>,
         owned_arc: Arc<Mutex<HashSet<ShardId>>>,
@@ -1029,7 +1205,7 @@ impl EtcdShardGuard {
 
             {
                 let mut st = self.state.lock().await;
-                match (st.phase, st.desired, st.held_key.is_some()) {
+                match (st.phase, st.desired, st.is_held) {
                     (ShardPhase::ShutDown, _, _) => {}
                     (ShardPhase::ShuttingDown, _, _) => {}
                     (ShardPhase::Idle, true, false) => {
@@ -1054,11 +1230,9 @@ impl EtcdShardGuard {
             match phase {
                 ShardPhase::ShutDown => break,
                 ShardPhase::Acquiring => {
-                    let name = self.owner_key();
-                    let span =
-                        info_span!("shard.acquire", shard_id = %self.shard_id, lock_key = %name);
+                    let owner_key = self.owner_key();
+                    let span = info_span!("shard.acquire", shard_id = %self.shard_id, owner_key = %owner_key);
                     async {
-                        let mut lock_cli = self.client.lock_client();
                         let mut attempt: u32 = 0;
 
                         // Use first 8 bytes of UUID for jitter seed
@@ -1082,60 +1256,9 @@ impl EtcdShardGuard {
                                 }
                             }
 
-                            // Create a short-lived lease (3s TTL) for this specific lock attempt. If this attempt times out and we retry, the old lease will expire and clean up any orphan lock key, preventing it from blocking
-                            // subsequent attempts. We use 3s which is longer than our 500ms timeout to give etcd time to process the lock before it expires.
-                            let attempt_lease = match self.client.clone().lease_grant(3, None).await {
-                                Ok(resp) => resp.id(),
-                                Err(e) => {
-                                    warn!(shard_id = %self.shard_id, error = %e, "failed to create attempt lease, retrying");
-                                    tokio::time::sleep(Duration::from_millis(100)).await;
-                                    continue;
-                                }
-                            };
-
-                            match tokio::time::timeout(
-                                Duration::from_millis(500),
-                                lock_cli.lock(
-                                    name.as_bytes().to_vec(),
-                                    Some(LockOptions::new().with_lease(attempt_lease)),
-                                ),
-                            )
-                            .await
-                            {
-                                Ok(Ok(resp)) => {
-                                    let key = resp.key().to_vec();
-
-                                    // Successfully acquired the lock with the short-lived lease.
-                                    // Start keeping this lease alive so the lock doesn't expire.
-                                    let mut client_clone = self.client.clone();
-                                    let shutdown_rx = self.shutdown.clone();
-                                    tokio::spawn(async move {
-                                        // Keep the attempt lease alive until shutdown
-                                        let ka_result = client_clone.lease_keep_alive(attempt_lease).await;
-                                        if let Ok((mut keeper, mut stream)) = ka_result {
-                                            // Use an interval to enforce minimum 1 second between keepalives.
-                                            let mut keepalive_interval = tokio::time::interval(Duration::from_secs(1));
-                                            loop {
-                                                tokio::select! {
-                                                    _ = keepalive_interval.tick() => {
-                                                        if *shutdown_rx.borrow() {
-                                                            break;
-                                                        }
-                                                        if keeper.keep_alive().await.is_err() {
-                                                            break;
-                                                        }
-                                                    }
-                                                    resp = stream.message() => {
-                                                        // Process keepalive responses; break if stream closes
-                                                        if resp.is_err() || resp.unwrap().is_none() {
-                                                            break;
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    });
-
+                            // Try to acquire ownership via KV put-if-absent transaction
+                            match self.try_acquire_ownership().await {
+                                Ok(true) => {
                                     // Look up the shard's range from the shard map
                                     let range = {
                                         let map = shard_map.lock().await;
@@ -1143,20 +1266,17 @@ impl EtcdShardGuard {
                                             Some(info) => info.range.clone(),
                                             None => {
                                                 tracing::error!(shard_id = %self.shard_id, "shard not found in shard map");
-                                                let mut lock_cli = self.client.lock_client();
-                                                let _ = lock_cli.unlock(key).await;
+                                                let _ = self.release_ownership().await;
                                                 continue;
                                             }
                                         }
                                     };
-                                    // Open the shard BEFORE marking as Held - if open fails, we should release the lock and not claim ownership.
+                                    // Open the shard BEFORE marking as Held - if open fails, we should release ownership and not claim it.
                                     let shard = match factory.open(&self.shard_id, &range).await {
                                         Ok(shard) => shard,
                                         Err(e) => {
-                                            // Failed to open - release the lock and retry
-                                            tracing::error!(shard_id = %self.shard_id, error = %e, "failed to open shard, releasing lock");
-                                            let mut lock_cli = self.client.lock_client();
-                                            let _ = lock_cli.unlock(key).await;
+                                            tracing::error!(shard_id = %self.shard_id, error = %e, "failed to open shard, releasing ownership");
+                                            let _ = self.release_ownership().await;
                                             // Exponential backoff before retry
                                             let backoff_ms = 200 * (1 << attempt.min(5));
                                             tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
@@ -1171,7 +1291,7 @@ impl EtcdShardGuard {
 
                                     {
                                         let mut st = self.state.lock().await;
-                                        st.held_key = Some(key);
+                                        st.is_held = true;
                                         st.phase = ShardPhase::Held;
                                     }
                                     {
@@ -1181,14 +1301,8 @@ impl EtcdShardGuard {
                                     info!(shard_id = %self.shard_id, attempts = attempt, "shard: acquired and opened");
                                     break;
                                 }
-                                Ok(Err(_)) | Err(_) => {
-                                    // Lock attempt failed or timed out. Revoke the attempt lease to
-                                    // immediately clean up any orphan key (best effort - if this fails,
-                                    // the lease will expire in 3s anyway).
-                                    if let Err(e) = self.client.clone().lease_revoke(attempt_lease).await {
-                                        debug!(shard_id = %self.shard_id, error = %e, "failed to revoke attempt lease (will expire in 3s)");
-                                    }
-
+                                Ok(false) => {
+                                    // Owned by another node - retry with jitter
                                     attempt = attempt.wrapping_add(1);
                                     let jitter_ms = (jitter_seed
                                         .wrapping_mul(31)
@@ -1199,6 +1313,11 @@ impl EtcdShardGuard {
                                         debug!(shard_id = %self.shard_id, attempt = attempt, "shard: acquire retry");
                                     }
                                 }
+                                Err(e) => {
+                                    warn!(shard_id = %self.shard_id, error = %e, "shard: acquire txn error, retrying");
+                                    attempt = attempt.wrapping_add(1);
+                                    tokio::time::sleep(Duration::from_millis(100)).await;
+                                }
                             }
                         }
                     }
@@ -1206,15 +1325,14 @@ impl EtcdShardGuard {
                     .await;
                 }
                 ShardPhase::Releasing => {
-                    let name = self.owner_key();
-                    let span =
-                        info_span!("shard.release", shard_id = %self.shard_id, lock_key = %name);
+                    let owner_key = self.owner_key();
+                    let span = info_span!("shard.release", shard_id = %self.shard_id, owner_key = %owner_key);
                     async {
                         debug!(shard_id = %self.shard_id, "shard: release start (delay)");
                         tokio::time::sleep(Duration::from_millis(100)).await;
 
                         let mut cancelled = false;
-                        let key_opt = {
+                        let was_held = {
                             let mut st = self.state.lock().await;
                             if st.phase == ShardPhase::ShuttingDown {
                                 // fall through
@@ -1223,21 +1341,22 @@ impl EtcdShardGuard {
                                 cancelled = true;
                                 debug!(shard_id = %self.shard_id, "shard: release cancelled");
                             }
-                            st.held_key.clone()
+                            st.is_held
                         };
                         if cancelled {
                             return;
                         }
-                        if let Some(key) = key_opt {
-                            // Close the shard before releasing the lock
+                        if was_held {
+                            // Close the shard before releasing ownership
                             if let Err(e) = factory.close(&self.shard_id).await {
-                                tracing::error!(shard_id = %self.shard_id, error = %e, "failed to close shard before releasing lock");
+                                tracing::error!(shard_id = %self.shard_id, error = %e, "failed to close shard before releasing ownership");
                             }
-                            let mut lock_cli = self.client.lock_client();
-                            let _ = lock_cli.unlock(key).await;
+                            if let Err(e) = self.release_ownership().await {
+                                tracing::error!(shard_id = %self.shard_id, error = %e, "failed to release shard ownership");
+                            }
                             {
                                 let mut st = self.state.lock().await;
-                                st.held_key = None;
+                                st.is_held = false;
                                 st.phase = ShardPhase::Idle;
                             }
                             {
@@ -1255,14 +1374,15 @@ impl EtcdShardGuard {
                     .await;
                 }
                 ShardPhase::ShuttingDown => {
-                    let key_opt = { self.state.lock().await.held_key.clone() };
-                    if let Some(key) = key_opt {
-                        // Close the shard before releasing the lock
+                    let was_held = self.state.lock().await.is_held;
+                    if was_held {
+                        // Close the shard before releasing ownership
                         if let Err(e) = factory.close(&self.shard_id).await {
                             tracing::error!(shard_id = %self.shard_id, error = %e, "failed to close shard during shutdown");
                         }
-                        let mut lock_cli = self.client.lock_client();
-                        let _ = lock_cli.unlock(key).await;
+                        if let Err(e) = self.release_ownership().await {
+                            tracing::error!(shard_id = %self.shard_id, error = %e, "failed to release shard ownership during shutdown");
+                        }
                         {
                             let mut owned = owned_arc.lock().await;
                             owned.remove(&self.shard_id);
@@ -1270,7 +1390,7 @@ impl EtcdShardGuard {
                     }
                     {
                         let mut st = self.state.lock().await;
-                        st.held_key = None;
+                        st.is_held = false;
                         st.phase = ShardPhase::ShutDown;
                     }
                     break;

--- a/src/coordination/none.rs
+++ b/src/coordination/none.rs
@@ -160,6 +160,19 @@ impl Coordinator for NoneCoordinator {
         })
     }
 
+    async fn force_release_shard_lease(
+        &self,
+        _shard_id: &ShardId,
+    ) -> Result<(), CoordinationError> {
+        // No-op in single-node mode - no external coordination
+        Ok(())
+    }
+
+    async fn reclaim_existing_leases(&self) -> Result<Vec<ShardId>, CoordinationError> {
+        // Single-node mode always owns everything, no reclamation needed
+        Ok(vec![])
+    }
+
     async fn update_shard_placement_ring(
         &self,
         shard_id: &ShardId,

--- a/src/dst_events.rs
+++ b/src/dst_events.rs
@@ -65,6 +65,9 @@ pub enum DstEvent {
     /// A node acquired ownership of a shard.
     ShardAcquired { node_id: String, shard_id: String },
 
+    /// A node successfully closed a shard's storage (flushed to object storage).
+    ShardClosed { node_id: String, shard_id: String },
+
     /// A node released ownership of a shard.
     ShardReleased { node_id: String, shard_id: String },
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1698,6 +1698,21 @@ impl Silo for SiloService {
         }))
     }
 
+    async fn force_release_shard(
+        &self,
+        req: Request<ForceReleaseShardRequest>,
+    ) -> Result<Response<ForceReleaseShardResponse>, Status> {
+        let r = req.into_inner();
+        let shard_id = Self::parse_shard_id(&r.shard)?;
+
+        self.coordinator
+            .force_release_shard_lease(&shard_id)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        Ok(Response::new(ForceReleaseShardResponse { released: true }))
+    }
+
     async fn configure_shard(
         &self,
         req: Request<ConfigureShardRequest>,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -299,6 +299,15 @@ pub struct CoordinationConfig {
     /// To participate in both default and named rings, explicitly include "default".
     #[serde(default)]
     pub placement_rings: Vec<String>,
+
+    /// Stable node identity for this silo instance.
+    /// If not set, a random UUID is generated on each startup.
+    ///
+    /// For Kubernetes StatefulSet deployments with permanent shard leases,
+    /// set this to the pod name (e.g., `node_id = "${POD_NAME}"`) so that
+    /// a restarted pod re-acquires its own leases automatically.
+    #[serde(default)]
+    pub node_id: Option<String>,
 }
 
 impl Default for CoordinationConfig {
@@ -312,6 +321,7 @@ impl Default for CoordinationConfig {
             etcd_endpoints: default_etcd_endpoints(),
             k8s_namespace: default_k8s_namespace(),
             placement_rings: Vec::new(),
+            node_id: None,
         }
     }
 }

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -1168,6 +1168,17 @@ mod splitter_unit_tests {
             shard.placement_ring = current.clone();
             Ok((previous, current))
         }
+
+        async fn force_release_shard_lease(
+            &self,
+            _shard_id: &ShardId,
+        ) -> Result<(), CoordinationError> {
+            Ok(())
+        }
+
+        async fn reclaim_existing_leases(&self) -> Result<Vec<ShardId>, CoordinationError> {
+            Ok(vec![])
+        }
     }
 
     #[async_trait]

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -73,25 +73,33 @@ macro_rules! start_etcd_coordinator {
     }};
 }
 
-async fn make_guard(
+fn next_node_id() -> String {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    format!(
+        "test-node-{}",
+        COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    )
+}
+
+async fn make_guard_with_node_id(
     coord: &EtcdConnection,
     cluster_prefix: &str,
     shard_id: ShardId,
+    node_id: String,
 ) -> (
     std::sync::Arc<EtcdShardGuard>,
     std::sync::Arc<tokio::sync::Mutex<std::collections::HashSet<ShardId>>>,
     tokio::sync::watch::Sender<bool>,
     tokio::task::JoinHandle<()>,
 ) {
-    let mut client = coord.client();
-    let liveness_lease_id = client.lease_grant(5, None).await.unwrap().id();
+    let client = coord.client();
     let owned = std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashSet::new()));
     let (tx, rx) = tokio::sync::watch::channel(false);
     let guard = EtcdShardGuard::new(
         shard_id,
         client.clone(),
         cluster_prefix.to_string(),
-        liveness_lease_id,
+        node_id,
         rx,
     );
     let runner = guard.clone();
@@ -119,6 +127,19 @@ async fn make_guard(
         runner.run(owned_arc, factory, shard_map, coordinator).await;
     });
     (guard, owned, tx, handle)
+}
+
+async fn make_guard(
+    coord: &EtcdConnection,
+    cluster_prefix: &str,
+    shard_id: ShardId,
+) -> (
+    std::sync::Arc<EtcdShardGuard>,
+    std::sync::Arc<tokio::sync::Mutex<std::collections::HashSet<ShardId>>>,
+    tokio::sync::watch::Sender<bool>,
+    tokio::task::JoinHandle<()>,
+) {
+    make_guard_with_node_id(coord, cluster_prefix, shard_id, next_node_id()).await
 }
 
 async fn wait_until<F, Fut>(timeout: Duration, mut f: F) -> bool
@@ -164,7 +185,7 @@ async fn shard_guard_acquire_and_release() {
     let released = wait_until(Duration::from_secs(3), || async {
         let st = guard.state.lock().await;
         let ow = owned.lock().await;
-        st.phase == ShardPhase::Idle && st.held_key.is_none() && !ow.contains(&shard_id)
+        st.phase == ShardPhase::Idle && !st.is_held && !ow.contains(&shard_id)
     })
     .await;
     assert!(released, "guard should release lock and clear owned");
@@ -258,19 +279,18 @@ async fn shard_guard_idempotent_set_desired_true() {
     })
     .await;
     assert!(acquired, "should acquire initially");
-    let key1 = { guard.state.lock().await.held_key.clone() };
 
     // Calling set_desired(true) again should not cause release/reacquire
     guard.set_desired(true).await;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    let (phase, key2, in_owned) = {
+    let (phase, is_held, in_owned) = {
         let st = guard.state.lock().await;
         let ow = owned.lock().await;
-        (st.phase, st.held_key.clone(), ow.contains(&shard_id))
+        (st.phase, st.is_held, ow.contains(&shard_id))
     };
     assert_eq!(phase, ShardPhase::Held);
-    assert_eq!(key1, key2);
+    assert!(is_held);
     assert!(in_owned);
 
     // Cleanup: release
@@ -278,7 +298,7 @@ async fn shard_guard_idempotent_set_desired_true() {
     let released = wait_until(Duration::from_secs(3), || async {
         let st = guard.state.lock().await;
         let ow = owned.lock().await;
-        st.phase == ShardPhase::Idle && st.held_key.is_none() && !ow.contains(&shard_id)
+        st.phase == ShardPhase::Idle && !st.is_held && !ow.contains(&shard_id)
     })
     .await;
     assert!(released);
@@ -432,24 +452,22 @@ async fn shard_guard_release_cancelled_on_desired_true() {
     })
     .await;
     assert!(acquired);
-    let key_before = { g.state.lock().await.held_key.clone() };
-    assert!(key_before.is_some());
+    assert!(g.state.lock().await.is_held);
 
     // Begin release then flip desired back to true during the delay window
     g.set_desired(false).await;
     tokio::time::sleep(Duration::from_millis(50)).await; // < 100ms delay
     g.set_desired(true).await;
 
-    // Expect we remain Held and the held_key is unchanged (no unlock/reacquire)
+    // Expect we remain Held and ownership is unchanged (no release/reacquire)
     let still_held = wait_until(Duration::from_secs(3), || async {
         g.state.lock().await.phase == ShardPhase::Held
     })
     .await;
     assert!(still_held);
-    let key_after = { g.state.lock().await.held_key.clone() };
-    assert_eq!(
-        key_before, key_after,
-        "held key should be preserved if release is cancelled"
+    assert!(
+        g.state.lock().await.is_held,
+        "ownership should be preserved if release is cancelled"
     );
     assert!(owned.lock().await.contains(&shard_id));
 
@@ -476,7 +494,7 @@ async fn shard_guard_shutdown_in_idle() {
     {
         let st = guard.state.lock().await;
         assert_eq!(st.phase, ShardPhase::Idle);
-        assert!(st.held_key.is_none());
+        assert!(!st.is_held);
     }
     // Signal shutdown
     let _ = tx.send(true);
@@ -569,7 +587,7 @@ async fn shard_guard_shutdown_while_held() {
         "should reach ShutDown phase"
     );
     let st = g.state.lock().await;
-    assert_eq!(st.held_key, None);
+    assert_eq!(st.is_held, false);
     assert!(!owned.lock().await.contains(&shard_id));
     h.abort();
 }
@@ -610,7 +628,7 @@ async fn shard_guard_shutdown_while_releasing() {
         "should reach ShutDown phase"
     );
     let st = g.state.lock().await;
-    assert_eq!(st.held_key, None);
+    assert_eq!(st.is_held, false);
     assert!(!owned.lock().await.contains(&shard_id));
     h.abort();
 }
@@ -2968,4 +2986,560 @@ async fn etcd_reconciliation_cancels_in_flight_acquisitions() {
     c3.shutdown().await.unwrap();
     h1.abort();
     h3.abort();
+}
+
+// =============================================================================
+// Permanent shard lease tests
+// =============================================================================
+
+/// Test that aborting a guard (simulating crash) does NOT release the shard owner key in etcd.
+/// This is the core invariant of permanent leases: ownership survives crashes.
+#[silo::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shard_lease_persists_after_abort() {
+    let prefix = unique_prefix();
+    let cfg = silo::settings::AppConfig::load(None).expect("load default config");
+    let coord = EtcdConnection::connect(&cfg.coordination)
+        .await
+        .expect("connect etcd");
+
+    let shard_id = ShardId::new();
+    let node_id = "crash-node-1".to_string();
+    let (guard, _owned, _tx, handle) =
+        make_guard_with_node_id(&coord, &prefix, shard_id, node_id.clone()).await;
+
+    // Acquire the shard
+    guard.set_desired(true).await;
+    let acquired = wait_until(Duration::from_secs(3), || async {
+        guard.state.lock().await.phase == ShardPhase::Held
+    })
+    .await;
+    assert!(acquired, "guard should acquire shard");
+
+    // Abort the guard task (simulates crash -- no graceful release)
+    handle.abort();
+    let _ = handle.await; // wait for abort to complete
+
+    // Verify the owner key still exists in etcd with the original node_id
+    let owner_key = silo::coordination::keys::shard_owner_key(&prefix, &shard_id);
+    let resp = coord
+        .client()
+        .kv_client()
+        .get(owner_key, None)
+        .await
+        .expect("get owner key");
+    assert_eq!(
+        resp.kvs().len(),
+        1,
+        "owner key should persist after crash (abort)"
+    );
+    let value = std::str::from_utf8(resp.kvs()[0].value()).expect("valid utf8");
+    assert_eq!(value, node_id, "owner should still be the crashed node");
+}
+
+/// Test that a permanent lease blocks another node from acquiring the shard.
+/// When a node crashes, its shard stays unavailable until explicitly released.
+#[silo::test(flavor = "multi_thread", worker_threads = 2)]
+async fn permanent_lease_blocks_other_nodes() {
+    let prefix = unique_prefix();
+    let cfg = silo::settings::AppConfig::load(None).expect("load default config");
+    let coord1 = EtcdConnection::connect(&cfg.coordination)
+        .await
+        .expect("connect etcd #1");
+    let coord2 = EtcdConnection::connect(&cfg.coordination)
+        .await
+        .expect("connect etcd #2");
+
+    let shard_id = ShardId::new();
+
+    // Node 1 acquires the shard
+    let (g1, _owned1, _tx1, h1) =
+        make_guard_with_node_id(&coord1, &prefix, shard_id, "blocker-node".to_string()).await;
+    g1.set_desired(true).await;
+    let acquired = wait_until(Duration::from_secs(3), || async {
+        g1.state.lock().await.phase == ShardPhase::Held
+    })
+    .await;
+    assert!(acquired, "node 1 should acquire");
+
+    // Crash node 1 (abort without release)
+    h1.abort();
+    let _ = h1.await;
+
+    // Node 2 tries to acquire the same shard -- should be blocked
+    let (g2, _owned2, _tx2, h2) =
+        make_guard_with_node_id(&coord2, &prefix, shard_id, "blocked-node".to_string()).await;
+    g2.set_desired(true).await;
+
+    // Wait a bit -- node 2 should NOT be able to acquire
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let st2 = g2.state.lock().await;
+    assert_ne!(
+        st2.phase,
+        ShardPhase::Held,
+        "node 2 should NOT acquire shard owned by crashed node"
+    );
+    assert_eq!(
+        st2.phase,
+        ShardPhase::Acquiring,
+        "node 2 should be stuck in Acquiring phase"
+    );
+    drop(st2);
+
+    h2.abort();
+}
+
+/// Test that force_release_shard_lease clears the owner key and allows reacquisition.
+#[silo::test(flavor = "multi_thread", worker_threads = 2)]
+async fn force_release_allows_reacquisition() {
+    let prefix = unique_prefix();
+    let cfg = silo::settings::AppConfig::load(None).expect("load default config");
+    let coord1 = EtcdConnection::connect(&cfg.coordination)
+        .await
+        .expect("connect etcd #1");
+    let coord2 = EtcdConnection::connect(&cfg.coordination)
+        .await
+        .expect("connect etcd #2");
+
+    let shard_id = ShardId::new();
+
+    // Node 1 acquires the shard
+    let (g1, _owned1, _tx1, h1) =
+        make_guard_with_node_id(&coord1, &prefix, shard_id, "force-node-1".to_string()).await;
+    g1.set_desired(true).await;
+    let acquired = wait_until(Duration::from_secs(3), || async {
+        g1.state.lock().await.phase == ShardPhase::Held
+    })
+    .await;
+    assert!(acquired, "node 1 should acquire");
+
+    // Crash node 1
+    h1.abort();
+    let _ = h1.await;
+
+    // Force-release the shard via direct etcd KV delete
+    let owner_key = silo::coordination::keys::shard_owner_key(&prefix, &shard_id);
+    let resp = coord1
+        .client()
+        .kv_client()
+        .delete(owner_key, None)
+        .await
+        .expect("force-release");
+    assert_eq!(resp.deleted(), 1, "should delete one key");
+
+    // Node 2 should now be able to acquire
+    let (g2, owned2, _tx2, h2) =
+        make_guard_with_node_id(&coord2, &prefix, shard_id, "force-node-2".to_string()).await;
+    g2.set_desired(true).await;
+    let acquired2 = wait_until(Duration::from_secs(5), || async {
+        g2.state.lock().await.phase == ShardPhase::Held
+    })
+    .await;
+    assert!(
+        acquired2,
+        "node 2 should acquire after force-release of crashed node's lease"
+    );
+    assert!(owned2.lock().await.contains(&shard_id));
+
+    // Cleanup
+    g2.set_desired(false).await;
+    let _ = wait_until(Duration::from_secs(3), || async {
+        g2.state.lock().await.phase == ShardPhase::Idle
+    })
+    .await;
+    h2.abort();
+}
+
+/// Test that reclaim_existing_leases correctly finds leases owned by this node.
+#[silo::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reclaim_existing_leases_finds_owned_shards() {
+    let prefix = unique_prefix();
+    let num_shards: u32 = 4;
+
+    // Start coordinator and let it acquire shards
+    let (c1, h1) = start_etcd_coordinator!(
+        &prefix,
+        "reclaim-node",
+        "http://127.0.0.1:50051",
+        num_shards
+    );
+    assert!(
+        c1.wait_converged(Duration::from_secs(15)).await,
+        "coordinator should converge"
+    );
+    let owned_before: HashSet<ShardId> = c1.owned_shards().await.into_iter().collect();
+    assert_eq!(owned_before.len(), num_shards as usize);
+
+    // Shutdown (graceful -- this releases leases) then verify reclaim returns empty
+    c1.shutdown().await.unwrap();
+    h1.abort();
+
+    // Start a new coordinator with the same node_id and prefix -- since we gracefully
+    // shut down, reclaim should find nothing (leases were released)
+    let (c2, h2) = start_etcd_coordinator!(
+        &prefix,
+        "reclaim-node",
+        "http://127.0.0.1:50051",
+        num_shards
+    );
+    let reclaimed = c2.reclaim_existing_leases().await.expect("reclaim");
+    assert!(
+        reclaimed.is_empty(),
+        "graceful shutdown should release all leases, so reclaim finds nothing"
+    );
+    c2.shutdown().await.unwrap();
+    h2.abort();
+}
+
+/// Test that reclaim_existing_leases finds shards after a simulated crash.
+/// Uses raw etcd KV to pre-populate owner keys, simulating a crash scenario
+/// where the node's leases were not released.
+#[silo::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reclaim_existing_leases_finds_shards_after_crash() {
+    let prefix = unique_prefix();
+    let num_shards: u32 = 4;
+    let node_id = "reclaim-crash-node";
+
+    // Start coordinator, let it acquire shards, then simulate crash by aborting
+    let (c1, h1) = start_etcd_coordinator!(&prefix, node_id, "http://127.0.0.1:50051", num_shards);
+    assert!(
+        c1.wait_converged(Duration::from_secs(15)).await,
+        "coordinator should converge"
+    );
+    let owned_before: HashSet<ShardId> = c1.owned_shards().await.into_iter().collect();
+    assert_eq!(owned_before.len(), num_shards as usize);
+
+    // Simulate crash: abort the background task without graceful shutdown.
+    // Drop the coordinator -- the owner keys should persist.
+    h1.abort();
+    drop(c1);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Start a new coordinator with the same node_id -- reclaim should find the old leases
+    let (c2, h2) = start_etcd_coordinator!(&prefix, node_id, "http://127.0.0.1:50051", num_shards);
+    let reclaimed: HashSet<ShardId> = c2
+        .reclaim_existing_leases()
+        .await
+        .expect("reclaim")
+        .into_iter()
+        .collect();
+
+    assert_eq!(
+        reclaimed, owned_before,
+        "reclaim should find all shards from the crashed coordinator"
+    );
+
+    c2.shutdown().await.unwrap();
+    h2.abort();
+}
+
+/// Test that crash-restart automatically reclaims and opens shards from the previous run.
+///
+/// This tests the full startup reclamation integration: crash -> restart with same node_id ->
+/// shards are automatically reclaimed, opened (WAL recovery), and the coordinator converges
+/// owning all shards without requiring any manual intervention.
+#[silo::test(flavor = "multi_thread", worker_threads = 2)]
+async fn etcd_crash_restart_reclaims_and_opens_shards() {
+    let prefix = unique_prefix();
+    let num_shards: u32 = 4;
+    let node_id = "reclaim-restart-node";
+
+    // Start coordinator, let it acquire all shards
+    let (c1, h1) = start_etcd_coordinator!(&prefix, node_id, "http://127.0.0.1:50051", num_shards);
+    assert!(
+        c1.wait_converged(Duration::from_secs(15)).await,
+        "coordinator should converge"
+    );
+    let owned_before: HashSet<ShardId> = c1.owned_shards().await.into_iter().collect();
+    assert_eq!(owned_before.len(), num_shards as usize);
+
+    // Simulate crash: abort without graceful shutdown so leases persist
+    h1.abort();
+    drop(c1);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Start a new coordinator with the same node_id.
+    // The startup reclamation should automatically discover, open, and own the shards.
+    let (c2, h2) = start_etcd_coordinator!(&prefix, node_id, "http://127.0.0.1:50051", num_shards);
+
+    // The coordinator should converge quickly -- reclaimed shards are opened immediately
+    // during startup before the first reconcile, so owned set should match right away.
+    assert!(
+        c2.wait_converged(Duration::from_secs(15)).await,
+        "restarted coordinator should converge with reclaimed shards"
+    );
+
+    let owned_after: HashSet<ShardId> = c2.owned_shards().await.into_iter().collect();
+    assert_eq!(
+        owned_after, owned_before,
+        "restarted coordinator should own the same shards as before the crash"
+    );
+
+    c2.shutdown().await.unwrap();
+    h2.abort();
+}
+
+/// Test hash ring divergence on restart: A and B share shards, A crashes, restarts
+/// with the same node_id, reclaims all its old shards (WAL recovery), then releases
+/// the ones that the hash ring says should belong to B via reconciliation.
+#[silo::test(flavor = "multi_thread", worker_threads = 4)]
+async fn etcd_hash_ring_divergence_on_restart() {
+    let prefix = unique_prefix();
+    let num_shards: u32 = 8;
+
+    // Start A and B, let them partition shards
+    let (ca, ha) =
+        start_etcd_coordinator!(&prefix, "diverge-a", "http://127.0.0.1:50051", num_shards);
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let endpoints = get_etcd_endpoints();
+    let (cb, hb) = EtcdCoordinator::start(
+        &endpoints,
+        &prefix,
+        "diverge-b",
+        "http://127.0.0.1:50052",
+        num_shards,
+        10,
+        make_test_factory("diverge-b"),
+        Vec::new(),
+    )
+    .await
+    .expect("start cb");
+
+    assert!(
+        ca.wait_converged(Duration::from_secs(30)).await,
+        "ca should converge"
+    );
+    assert!(
+        cb.wait_converged(Duration::from_secs(30)).await,
+        "cb should converge"
+    );
+
+    let all_shards: HashSet<ShardId> = ca
+        .get_shard_map()
+        .await
+        .unwrap()
+        .shard_ids()
+        .into_iter()
+        .collect();
+    let a_owned_before: HashSet<ShardId> = ca.owned_shards().await.into_iter().collect();
+    let b_owned_before: HashSet<ShardId> = cb.owned_shards().await.into_iter().collect();
+    assert_eq!(
+        a_owned_before
+            .union(&b_owned_before)
+            .copied()
+            .collect::<HashSet<_>>(),
+        all_shards,
+        "all shards should be covered"
+    );
+    assert!(a_owned_before.is_disjoint(&b_owned_before), "no overlap");
+    // With 8 shards and 2 nodes, each should have some
+    assert!(!a_owned_before.is_empty() && !b_owned_before.is_empty());
+
+    // Crash A (abort without graceful shutdown -- permanent leases persist)
+    ha.abort();
+    drop(ca);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // B still owns its shards, but can't take A's due to permanent leases
+    let b_owned_during_crash: HashSet<ShardId> = cb.owned_shards().await.into_iter().collect();
+    assert_eq!(b_owned_during_crash, b_owned_before);
+
+    // Restart A with the same node_id -- reclaim opens old shards, then reconciliation
+    // hands off shards that the hash ring assigns to B
+    let (ca2, ha2) =
+        start_etcd_coordinator!(&prefix, "diverge-a", "http://127.0.0.1:50051", num_shards);
+
+    // Both should converge to the same distribution as before the crash
+    assert!(
+        ca2.wait_converged(Duration::from_secs(30)).await,
+        "restarted A should converge"
+    );
+    assert!(
+        cb.wait_converged(Duration::from_secs(30)).await,
+        "B should converge after A restarts"
+    );
+
+    let a_owned_after: HashSet<ShardId> = ca2.owned_shards().await.into_iter().collect();
+    let b_owned_after: HashSet<ShardId> = cb.owned_shards().await.into_iter().collect();
+
+    assert_eq!(
+        a_owned_after
+            .union(&b_owned_after)
+            .copied()
+            .collect::<HashSet<_>>(),
+        all_shards,
+        "all shards should be covered after restart"
+    );
+    assert!(
+        a_owned_after.is_disjoint(&b_owned_after),
+        "no overlap after restart"
+    );
+    // The distribution should match the pre-crash state (same nodes, same hash ring)
+    assert_eq!(
+        a_owned_after, a_owned_before,
+        "A should own the same shards after restart as before crash"
+    );
+    assert_eq!(
+        b_owned_after, b_owned_before,
+        "B should own the same shards after restart as before crash"
+    );
+
+    // Cleanup
+    ca2.shutdown().await.unwrap();
+    cb.shutdown().await.unwrap();
+    ha2.abort();
+    hb.abort();
+}
+
+/// Test the full coordinator-level flow: crash preserves leases, other nodes can't take them,
+/// force-release unblocks.
+#[silo::test(flavor = "multi_thread", worker_threads = 4)]
+async fn coordinator_crash_blocks_reacquisition_until_force_release() {
+    let prefix = unique_prefix();
+    let num_shards: u32 = 4;
+
+    // Start node 1, let it own all shards
+    let (c1, h1) = start_etcd_coordinator!(
+        &prefix,
+        "coord-crash-1",
+        "http://127.0.0.1:50051",
+        num_shards
+    );
+    assert!(c1.wait_converged(Duration::from_secs(15)).await);
+    let all_shards: HashSet<ShardId> = c1
+        .get_shard_map()
+        .await
+        .unwrap()
+        .shard_ids()
+        .into_iter()
+        .collect();
+    let c1_owned: HashSet<ShardId> = c1.owned_shards().await.into_iter().collect();
+    assert_eq!(c1_owned, all_shards);
+
+    // Crash node 1 (abort without shutdown)
+    h1.abort();
+    drop(c1);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Start node 2 -- it should NOT be able to acquire node 1's shards
+    let endpoints = get_etcd_endpoints();
+    let (c2, h2) = EtcdCoordinator::start(
+        &endpoints,
+        &prefix,
+        "coord-crash-2",
+        "http://127.0.0.1:50052",
+        num_shards,
+        10,
+        make_test_factory("coord-crash-2"),
+        Vec::new(),
+    )
+    .await
+    .expect("start c2");
+
+    // Give c2 time to try acquiring -- it should fail since leases are permanent
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let c2_owned: HashSet<ShardId> = c2.owned_shards().await.into_iter().collect();
+    assert!(
+        c2_owned.is_empty(),
+        "node 2 should NOT acquire any shards while node 1's permanent leases exist"
+    );
+
+    // Force-release all of node 1's shards via raw etcd client
+    let cfg = silo::settings::AppConfig::load(None).expect("load config");
+    let raw_conn = EtcdConnection::connect(&cfg.coordination)
+        .await
+        .expect("connect etcd for force-release");
+    for shard_id in &all_shards {
+        let owner_key = silo::coordination::keys::shard_owner_key(&prefix, shard_id);
+        raw_conn
+            .client()
+            .kv_client()
+            .delete(owner_key, None)
+            .await
+            .expect("force release");
+    }
+
+    // Now node 2 should be able to acquire -- may take a few reconciliation cycles
+    let all_acquired = wait_until(Duration::from_secs(30), || async {
+        let owned: HashSet<ShardId> = c2.owned_shards().await.into_iter().collect();
+        owned == all_shards
+    })
+    .await;
+    assert!(all_acquired, "c2 should own all shards after force-release");
+
+    c2.shutdown().await.unwrap();
+    h2.abort();
+}
+
+/// Test that force_release_shard_lease returns ShardNotFound for a non-existent shard.
+#[silo::test(flavor = "multi_thread", worker_threads = 2)]
+async fn force_release_nonexistent_shard_returns_error() {
+    let prefix = unique_prefix();
+    let num_shards: u32 = 4;
+
+    let (c1, h1) = start_etcd_coordinator!(
+        &prefix,
+        "force-err-node",
+        "http://127.0.0.1:50051",
+        num_shards
+    );
+    assert!(c1.wait_converged(Duration::from_secs(15)).await);
+
+    // Force-release a shard that doesn't exist (random UUID)
+    let fake_shard_id = ShardId::new();
+    let result = c1.force_release_shard_lease(&fake_shard_id).await;
+    assert!(
+        matches!(result, Err(CoordinationError::ShardNotFound(id)) if id == fake_shard_id),
+        "force-releasing a non-existent shard should return ShardNotFound, got: {:?}",
+        result,
+    );
+
+    c1.shutdown().await.unwrap();
+    h1.abort();
+}
+
+/// Test that reclaim_existing_leases does NOT return shards owned by a different node_id.
+/// This validates the critical node_id stability assumption of permanent leases.
+#[silo::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reclaim_with_different_node_id_returns_empty() {
+    let prefix = unique_prefix();
+    let num_shards: u32 = 4;
+
+    // Start coordinator A, let it acquire all shards
+    let (ca, ha) = start_etcd_coordinator!(
+        &prefix,
+        "original-node-a",
+        "http://127.0.0.1:50051",
+        num_shards
+    );
+    assert!(
+        ca.wait_converged(Duration::from_secs(15)).await,
+        "coordinator A should converge"
+    );
+    let owned: HashSet<ShardId> = ca.owned_shards().await.into_iter().collect();
+    assert_eq!(owned.len(), num_shards as usize);
+
+    // Crash coordinator A (abort without graceful shutdown -- permanent leases persist)
+    ha.abort();
+    drop(ca);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Start coordinator B with a DIFFERENT node_id but same prefix.
+    // reclaim_existing_leases should return empty because B doesn't own A's leases.
+    let (cb, hb) = start_etcd_coordinator!(
+        &prefix,
+        "different-node-b",
+        "http://127.0.0.1:50051",
+        num_shards
+    );
+    let reclaimed = cb.reclaim_existing_leases().await.expect("reclaim");
+    assert!(
+        reclaimed.is_empty(),
+        "different node_id should NOT reclaim another node's leases, but found: {:?}",
+        reclaimed,
+    );
+
+    cb.shutdown().await.unwrap();
+    hb.abort();
 }

--- a/tests/server_split_paused_tests.rs
+++ b/tests/server_split_paused_tests.rs
@@ -116,6 +116,17 @@ impl Coordinator for MockPausedCoordinator {
         shard.placement_ring = current.clone();
         Ok((previous, current))
     }
+
+    async fn force_release_shard_lease(
+        &self,
+        _shard_id: &ShardId,
+    ) -> Result<(), CoordinationError> {
+        Ok(())
+    }
+
+    async fn reclaim_existing_leases(&self) -> Result<Vec<ShardId>, CoordinationError> {
+        Ok(vec![])
+    }
 }
 
 /// Mock does not support split operations - returns errors or empty results.

--- a/tests/turmoil_runner/main.rs
+++ b/tests/turmoil_runner/main.rs
@@ -159,6 +159,26 @@ fn k8s_coordination() {
 
 #[test]
 #[cfg(feature = "k8s")]
+fn k8s_permanent_lease_reclaim() {
+    if is_subprocess() || is_fuzz_mode() {
+        scenarios::k8s_permanent_leases::run_reclaim();
+    } else {
+        verify_determinism("k8s_permanent_lease_reclaim", get_seed());
+    }
+}
+
+#[test]
+#[cfg(feature = "k8s")]
+fn k8s_permanent_lease_force_release() {
+    if is_subprocess() || is_fuzz_mode() {
+        scenarios::k8s_permanent_leases::run_force_release();
+    } else {
+        verify_determinism("k8s_permanent_lease_force_release", get_seed());
+    }
+}
+
+#[test]
+#[cfg(feature = "k8s")]
 fn k8s_shard_splits() {
     if is_subprocess() || is_fuzz_mode() {
         scenarios::k8s_shard_splits::run();

--- a/tests/turmoil_runner/scenarios/k8s_permanent_leases.rs
+++ b/tests/turmoil_runner/scenarios/k8s_permanent_leases.rs
@@ -1,0 +1,1055 @@
+//! K8s permanent lease scenarios: Tests crash recovery with permanent shard leases.
+//!
+//! These scenarios test the permanent shard lease behavior introduced to prevent
+//! WAL data loss on crash. Unlike TTL-based leases that auto-expire, permanent
+//! leases persist through crashes and must be explicitly reclaimed or force-released.
+//!
+//! Two variants:
+//!
+//! **Reclaim**: Crash a node, restart with same node_id. The restarted node
+//! reclaims its existing leases via `reclaim_and_open_shards()`, triggering
+//! WAL recovery. Verifies leases persist through crash and shards become
+//! functional after reclaim.
+//!
+//! **Force-release**: Crash a node, then simulate operator intervention by
+//! force-releasing the crashed node's shard leases. Remaining nodes acquire
+//! the orphaned shards. Verifies no split-brain and continued job processing.
+//!
+//! Invariants verified:
+//! - **leasePermanence**: Shard leases persist through crash (no auto-release)
+//! - **noSplitBrain**: A shard is owned by at most one node at any time
+//! - **validTransitions**: Only valid status transitions occur
+//! - **jobCompleteness**: Sufficient jobs reach terminal state after recovery
+
+use crate::helpers::{
+    EnqueueRequest, HashMap, InvariantTracker, LeaseTasksRequest, ReportOutcomeRequest,
+    RetryPolicy, SerializedBytes, create_turmoil_client, dst_turmoilfs_database_template,
+    get_seed, report_outcome_request, run_scenario_impl, serialized_bytes, turmoil,
+};
+use crate::mock_k8s::{MockK8sBackend, MockK8sState};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use silo::cluster_client::ClientConfig;
+use silo::coordination::{Coordinator, K8sCoordinator};
+use silo::factory::ShardFactory;
+use silo::gubernator::MockGubernatorClient;
+use silo::pb::Task;
+use silo::server::run_server_with_incoming;
+use silo::settings::{AppConfig, GubernatorSettings, LoggingConfig, WebUiConfig};
+use silo::shard_range::ShardId;
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::watch;
+use turmoil::net::TcpListener;
+
+const NUM_SHARDS: u32 = 4;
+const NUM_NODES: u32 = 3;
+const BASE_PORT: u16 = 9960;
+const CLUSTER_PREFIX: &str = "silo-perm-lease";
+const NAMESPACE: &str = "default";
+const STORAGE_ROOT: &str = "/data/silo-perm-lease-shards";
+const LEASE_DURATION_SECS: i64 = 10;
+const NUM_JOBS: u32 = 15;
+const NUM_WORKERS: u32 = 2;
+
+/// Node lifecycle state communicated via watch channel
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NodeState {
+    /// Node is waiting to be activated
+    #[allow(dead_code)]
+    Inactive,
+    /// Node should start its coordinator and server
+    Active,
+    /// Node should simulate a crash (drop coordinator without lease release)
+    Crash,
+    /// Node should shut down gracefully
+    Shutdown,
+}
+
+fn make_shard_factory() -> Arc<ShardFactory> {
+    let storage_root = std::path::Path::new(STORAGE_ROOT);
+    Arc::new(ShardFactory::new(
+        dst_turmoilfs_database_template(storage_root),
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
+/// Result from setting up a node server
+struct NodeServerHandle {
+    coordinator: Arc<K8sCoordinator<MockK8sBackend>>,
+    _shutdown_tx: tokio::sync::broadcast::Sender<()>,
+}
+
+/// Set up a server on a node with K8s coordination
+async fn setup_node_server(
+    port: u16,
+    node_id: String,
+    k8s_state: Arc<MockK8sState>,
+    lease_duration_secs: i64,
+) -> turmoil::Result<NodeServerHandle> {
+    let backend = MockK8sBackend::new(k8s_state, NAMESPACE);
+    let factory = make_shard_factory();
+
+    let (coordinator, _handle) = K8sCoordinator::start_with_backend(
+        backend,
+        silo::coordination::K8sCoordinatorConfig {
+            namespace: NAMESPACE.to_string(),
+            cluster_prefix: CLUSTER_PREFIX.to_string(),
+            node_id: node_id.clone(),
+            grpc_addr: format!("http://{}:{}", node_id, port),
+            initial_shard_count: NUM_SHARDS,
+            lease_duration_secs,
+            placement_rings: Vec::new(),
+        },
+        Arc::clone(&factory),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let coordinator = Arc::new(coordinator);
+
+    // Wait for initial convergence
+    let converged = coordinator.wait_converged(Duration::from_secs(30)).await;
+    if converged {
+        tracing::info!(node_id = %node_id, "initial convergence achieved");
+    } else {
+        tracing::warn!(node_id = %node_id, "convergence timeout");
+    }
+
+    // Start gRPC server
+    let cfg = AppConfig {
+        server: silo::settings::ServerConfig {
+            grpc_addr: format!("0.0.0.0:{}", port),
+            dev_mode: false,
+        },
+        coordination: silo::settings::CoordinationConfig::default(),
+        tenancy: silo::settings::TenancyConfig { enabled: true },
+        gubernator: GubernatorSettings::default(),
+        webui: WebUiConfig::default(),
+        logging: LoggingConfig::default(),
+        metrics: silo::settings::MetricsConfig::default(),
+        database: dst_turmoilfs_database_template(std::path::Path::new(STORAGE_ROOT)),
+    };
+
+    let addr = (IpAddr::from(Ipv4Addr::UNSPECIFIED), port);
+    let listener = TcpListener::bind(addr).await.map_err(|e| e.to_string())?;
+
+    struct Accepted(turmoil::net::TcpStream);
+    impl tonic::transport::server::Connected for Accepted {
+        type ConnectInfo = tonic::transport::server::TcpConnectInfo;
+        fn connect_info(&self) -> Self::ConnectInfo {
+            Self::ConnectInfo {
+                local_addr: self.0.local_addr().ok(),
+                remote_addr: self.0.peer_addr().ok(),
+            }
+        }
+    }
+    impl AsyncRead for Accepted {
+        fn poll_read(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> std::task::Poll<Result<(), std::io::Error>> {
+            std::pin::Pin::new(&mut self.0).poll_read(cx, buf)
+        }
+    }
+    impl AsyncWrite for Accepted {
+        fn poll_write(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<Result<usize, std::io::Error>> {
+            std::pin::Pin::new(&mut self.0).poll_write(cx, buf)
+        }
+        fn poll_flush(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), std::io::Error>> {
+            std::pin::Pin::new(&mut self.0).poll_flush(cx)
+        }
+        fn poll_shutdown(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), std::io::Error>> {
+            std::pin::Pin::new(&mut self.0).poll_shutdown(cx)
+        }
+    }
+
+    let incoming = async_stream::stream! {
+        loop {
+            match listener.accept().await {
+                Ok((s, _a)) => yield Ok::<_, std::io::Error>(Accepted(s)),
+                Err(e) => {
+                    tracing::trace!(error = %e, "accept error");
+                    break;
+                }
+            }
+        }
+    };
+
+    let (shutdown_tx, rx) = tokio::sync::broadcast::channel::<()>(1);
+
+    let coordinator_for_server = Arc::clone(&coordinator) as Arc<dyn Coordinator>;
+    tokio::spawn(async move {
+        if let Err(e) =
+            run_server_with_incoming(incoming, factory, coordinator_for_server, cfg, None, rx).await
+        {
+            tracing::trace!(error = %e, "server error");
+        }
+    });
+
+    Ok(NodeServerHandle {
+        coordinator,
+        _shutdown_tx: shutdown_tx,
+    })
+}
+
+/// Verify that no shard is owned by multiple nodes (checks ALL lease holders,
+/// not just "active" ones — important for crash scenarios where a crashed node
+/// may still appear as a holder).
+async fn verify_no_split_brain_all_holders(
+    k8s_state: &MockK8sState,
+) -> bool {
+    let holders = k8s_state
+        .get_shard_holders(NAMESPACE, CLUSTER_PREFIX)
+        .await;
+
+    let mut shard_owners: std::collections::HashMap<ShardId, Vec<String>> =
+        std::collections::HashMap::new();
+
+    for (shard_id, holder) in &holders {
+        shard_owners
+            .entry(*shard_id)
+            .or_default()
+            .push(holder.clone());
+    }
+
+    for (shard_id, owners) in &shard_owners {
+        if owners.len() > 1 {
+            tracing::error!(
+                shard_id = %shard_id,
+                owners = ?owners,
+                "SPLIT-BRAIN: shard has multiple owners"
+            );
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Shared scenario setup for both reclaim and force-release variants.
+/// The `controller_fn` parameter customizes the crash/recovery behavior.
+/// It receives shared state and returns a future that drives the crash/recovery timeline.
+fn run_scenario<C, F>(name: &str, seed: u64, controller_fn: C)
+where
+    C: FnOnce(
+            Arc<MockK8sState>,
+            Arc<std::sync::Mutex<Vec<watch::Sender<NodeState>>>>,
+            Arc<InvariantTracker>,
+            Arc<AtomicBool>,
+            u64,
+        ) -> F
+        + Send
+        + 'static,
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    run_scenario_impl(name, seed, 180, |sim| {
+        tracing::info!(
+            num_nodes = NUM_NODES,
+            num_shards = NUM_SHARDS,
+            num_jobs = NUM_JOBS,
+            num_workers = NUM_WORKERS,
+            "permanent_lease_scenario_config"
+        );
+
+        let scenario_done = Arc::new(AtomicBool::new(false));
+        let membership_changes_done = Arc::new(AtomicBool::new(false));
+        let total_enqueued = Arc::new(AtomicU32::new(0));
+        let total_completed = Arc::new(AtomicU32::new(0));
+
+        let k8s_state = MockK8sState::new();
+        let tracker = Arc::new(InvariantTracker::new());
+
+        let client_config = ClientConfig::for_dst();
+
+        // Create activation channels for each node
+        let mut node_state_senders_vec: Vec<watch::Sender<NodeState>> = Vec::new();
+        let mut node_state_receivers: Vec<watch::Receiver<NodeState>> = Vec::new();
+
+        for _node_num in 0..NUM_NODES {
+            let (tx, rx) = watch::channel(NodeState::Active);
+            node_state_senders_vec.push(tx);
+            node_state_receivers.push(rx);
+        }
+
+        let node_state_senders: Arc<std::sync::Mutex<Vec<watch::Sender<NodeState>>>> =
+            Arc::new(std::sync::Mutex::new(node_state_senders_vec));
+
+        // Create all node hosts — each runs a state machine handling Active, Crash, and restart
+        for node_num in 0..NUM_NODES {
+            let node_id = format!("node-{}", node_num);
+            let k8s_state = k8s_state.clone();
+            let host_name: &'static str = Box::leak(format!("node{}", node_num).into_boxed_str());
+            let state_rx = node_state_receivers[node_num as usize].clone();
+            let startup_delay_ms = (node_num as u64) * 150;
+            let port = BASE_PORT + node_num as u16;
+
+            sim.host(host_name, {
+                let node_id = node_id.clone();
+                move || {
+                    let node_id = node_id.clone();
+                    let k8s_state = k8s_state.clone();
+                    let mut state_rx = state_rx.clone();
+                    async move {
+                        // Stagger startup
+                        if startup_delay_ms > 0 {
+                            tokio::time::sleep(Duration::from_millis(startup_delay_ms)).await;
+                        }
+
+                        // Outer loop: handle crash + restart cycles
+                        loop {
+                            let state = *state_rx.borrow();
+                            match state {
+                                NodeState::Inactive => {
+                                    // Wait for activation
+                                    if state_rx.changed().await.is_err() {
+                                        return Ok(());
+                                    }
+                                    continue;
+                                }
+                                NodeState::Shutdown => {
+                                    tracing::info!(node_id = %node_id, "shutdown signal received");
+                                    return Ok(());
+                                }
+                                NodeState::Crash => {
+                                    // Should not start in Crash state; wait for next state
+                                    if state_rx.changed().await.is_err() {
+                                        return Ok(());
+                                    }
+                                    continue;
+                                }
+                                NodeState::Active => {
+                                    // Fall through to start the server
+                                }
+                            }
+
+                            tracing::info!(node_id = %node_id, "starting server");
+                            let handle = setup_node_server(
+                                port,
+                                node_id.clone(),
+                                k8s_state.clone(),
+                                LEASE_DURATION_SECS,
+                            )
+                            .await?;
+
+                            // Run until crash or shutdown signal
+                            let exit_state = loop {
+                                tokio::select! {
+                                    _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                                        let owned = handle.coordinator.owned_shards().await;
+                                        tracing::trace!(
+                                            node_id = %node_id,
+                                            owned = ?owned,
+                                            count = owned.len(),
+                                            "node_status"
+                                        );
+                                    }
+                                    result = state_rx.changed() => {
+                                        if result.is_err() {
+                                            break NodeState::Shutdown;
+                                        }
+                                        let state = *state_rx.borrow();
+                                        match state {
+                                            NodeState::Crash => {
+                                                tracing::info!(node_id = %node_id, "CRASH signal received");
+                                                // Crash: stop guards without releasing leases
+                                                handle.coordinator.crash().await;
+                                                break NodeState::Crash;
+                                            }
+                                            NodeState::Shutdown => {
+                                                tracing::info!(node_id = %node_id, "shutdown signal received");
+                                                if let Err(e) = handle.coordinator.shutdown().await {
+                                                    tracing::warn!(node_id = %node_id, error = %e, "shutdown error");
+                                                }
+                                                break NodeState::Shutdown;
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                }
+                            };
+
+                            // Drop the handle to close the server and its broadcast channel
+                            drop(handle);
+
+                            match exit_state {
+                                NodeState::Shutdown => return Ok(()),
+                                NodeState::Crash => {
+                                    tracing::info!(node_id = %node_id, "node crashed, waiting for restart signal");
+                                    // Wait for next Active signal (restart) or Shutdown
+                                    loop {
+                                        if state_rx.changed().await.is_err() {
+                                            return Ok(());
+                                        }
+                                        let state = *state_rx.borrow();
+                                        match state {
+                                            NodeState::Active => {
+                                                tracing::info!(node_id = %node_id, "restarting after crash");
+                                                break;
+                                            }
+                                            NodeState::Shutdown => {
+                                                return Ok(());
+                                            }
+                                            _ => continue,
+                                        }
+                                    }
+                                    // Loop back to create a new server (restart)
+                                    continue;
+                                }
+                                _ => return Ok(()),
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        // Producer: Enqueues jobs to the cluster
+        let producer_enqueued = Arc::clone(&total_enqueued);
+        let producer_k8s_state = Arc::clone(&k8s_state);
+        let producer_config = client_config.clone();
+        sim.client("producer", async move {
+            tokio::time::sleep(Duration::from_millis(2000)).await;
+            let mut rng = StdRng::seed_from_u64(seed.wrapping_add(1));
+
+            let shard_ids = loop {
+                match producer_k8s_state.get_shard_ids(NAMESPACE, CLUSTER_PREFIX).await {
+                    Ok(Some(ids)) if !ids.is_empty() => break ids,
+                    Ok(_) => tokio::time::sleep(Duration::from_millis(100)).await,
+                    Err(e) => {
+                        tracing::trace!(error = %e, "producer shard discovery failed, retrying");
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+                    }
+                }
+            };
+
+            let mut current_client: Option<(u32, silo::pb::silo_client::SiloClient<_>)> = None;
+            let mut consecutive_failures = 0u32;
+
+            for i in 0..NUM_JOBS {
+                let job_id = format!("perm-{}", i);
+                let priority = rng.random_range(1..100);
+                let delay_ms = rng.random_range(50..200);
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+
+                let shard_idx = (i as usize) % shard_ids.len();
+                let shard_id = &shard_ids[shard_idx];
+                let tenant = format!("shard-{}", shard_idx);
+
+                let owner = match producer_k8s_state
+                    .find_shard_owner(NAMESPACE, CLUSTER_PREFIX, shard_id)
+                    .await
+                {
+                    Ok(owner) => owner,
+                    Err(e) => {
+                        tracing::trace!(error = %e, "producer owner lookup failed");
+                        continue;
+                    }
+                };
+
+                let target_node = owner
+                    .as_ref()
+                    .and_then(|o| o.strip_prefix("node-"))
+                    .and_then(|n| n.parse::<u32>().ok());
+
+                let client = match (&mut current_client, target_node) {
+                    (Some((node, client)), Some(target)) if *node == target => client,
+                    (_, Some(target)) => {
+                        let uri = format!("http://node{}:{}", target, BASE_PORT + target as u16);
+                        match create_turmoil_client(&uri, &producer_config).await {
+                            Ok(new_client) => {
+                                current_client = Some((target, new_client));
+                                &mut current_client.as_mut().unwrap().1
+                            }
+                            Err(e) => {
+                                tracing::trace!(error = %e, "failed to create client");
+                                continue;
+                            }
+                        }
+                    }
+                    _ => continue,
+                };
+
+                let retry_policy = Some(RetryPolicy {
+                    retry_count: 5,
+                    initial_interval_ms: 200,
+                    max_interval_ms: 2000,
+                    randomize_interval: true,
+                    backoff_factor: 1.5,
+                });
+
+                match client
+                    .enqueue(tonic::Request::new(EnqueueRequest {
+                        shard: shard_id.to_string(),
+                        id: job_id.clone(),
+                        priority,
+                        start_at_ms: 0,
+                        retry_policy,
+                        payload: Some(SerializedBytes {
+                            encoding: Some(serialized_bytes::Encoding::Msgpack(
+                                rmp_serde::to_vec(&serde_json::json!({
+                                    "scenario": "permanent_lease",
+                                    "idx": i
+                                }))
+                                .unwrap(),
+                            )),
+                        }),
+                        limits: vec![],
+                        tenant: Some(tenant),
+                        metadata: HashMap::new(),
+                        task_group: "default".to_string(),
+                    }))
+                    .await
+                {
+                    Ok(_) => {
+                        producer_enqueued.fetch_add(1, Ordering::SeqCst);
+                        consecutive_failures = 0;
+                    }
+                    Err(e) => {
+                        tracing::trace!(job_id = %job_id, error = %e, "enqueue_failed");
+                        consecutive_failures += 1;
+                        if consecutive_failures >= 2 {
+                            current_client = None;
+                            consecutive_failures = 0;
+                        }
+                    }
+                }
+            }
+
+            tracing::trace!(
+                enqueued = producer_enqueued.load(Ordering::SeqCst),
+                "producer_done"
+            );
+            Ok(())
+        });
+
+        // Workers
+        for worker_num in 0..NUM_WORKERS {
+            let worker_seed = seed.wrapping_add(100 + worker_num as u64);
+            let worker_id = format!("perm-worker-{}", worker_num);
+            let worker_completed = Arc::clone(&total_completed);
+            let worker_done_flag = Arc::clone(&scenario_done);
+            let worker_config = client_config.clone();
+            let worker_k8s_state = Arc::clone(&k8s_state);
+
+            let client_name: &'static str =
+                Box::leak(format!("worker{}", worker_num).into_boxed_str());
+
+            sim.client(client_name, async move {
+                let start_delay = 2000 + (worker_num as u64 * 100);
+                tokio::time::sleep(Duration::from_millis(start_delay)).await;
+
+                let mut rng = StdRng::seed_from_u64(worker_seed);
+
+                let shard_ids = loop {
+                    match worker_k8s_state
+                        .get_shard_ids(NAMESPACE, CLUSTER_PREFIX)
+                        .await
+                    {
+                        Ok(Some(ids)) if !ids.is_empty() => break ids,
+                        Ok(_) => tokio::time::sleep(Duration::from_millis(100)).await,
+                        Err(e) => {
+                            tracing::trace!(worker = %worker_id, error = %e, "shard discovery failed");
+                            tokio::time::sleep(Duration::from_millis(200)).await;
+                        }
+                    }
+                };
+
+                let mut current_client: Option<(u32, silo::pb::silo_client::SiloClient<_>)> =
+                    None;
+                let mut completed = 0u32;
+                let mut processing: Vec<(Task, ShardId)> = Vec::new();
+
+                while !worker_done_flag.load(Ordering::SeqCst) {
+                    let shard_idx = rng.random_range(0..shard_ids.len());
+                    let shard_id = shard_ids[shard_idx];
+
+                    let owner = match worker_k8s_state
+                        .find_shard_owner(NAMESPACE, CLUSTER_PREFIX, &shard_id)
+                        .await
+                    {
+                        Ok(owner) => owner,
+                        Err(_) => {
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            continue;
+                        }
+                    };
+
+                    let target_node = owner
+                        .as_ref()
+                        .and_then(|o| o.strip_prefix("node-"))
+                        .and_then(|n| n.parse::<u32>().ok());
+
+                    let client = match (&mut current_client, target_node) {
+                        (Some((node, client)), Some(target)) if *node == target => client,
+                        (_, Some(target)) => {
+                            let uri =
+                                format!("http://node{}:{}", target, BASE_PORT + target as u16);
+                            match create_turmoil_client(&uri, &worker_config).await {
+                                Ok(new_client) => {
+                                    current_client = Some((target, new_client));
+                                    &mut current_client.as_mut().unwrap().1
+                                }
+                                Err(_) => {
+                                    tokio::time::sleep(Duration::from_millis(100)).await;
+                                    continue;
+                                }
+                            }
+                        }
+                        _ => {
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            continue;
+                        }
+                    };
+
+                    let lease_result = client
+                        .lease_tasks(tonic::Request::new(LeaseTasksRequest {
+                            shard: Some(shard_id.to_string()),
+                            worker_id: worker_id.clone(),
+                            max_tasks: rng.random_range(2..=4),
+                            task_group: "default".to_string(),
+                        }))
+                        .await;
+
+                    match lease_result {
+                        Ok(resp) => {
+                            for task in resp.into_inner().tasks {
+                                processing.push((task, shard_id));
+                            }
+                        }
+                        Err(_) => {
+                            current_client = None;
+                        }
+                    }
+
+                    if !processing.is_empty() {
+                        let num_to_complete = rng.random_range(1..=processing.len());
+                        let mut indices_to_remove: HashSet<usize> = HashSet::new();
+
+                        for i in 0..num_to_complete {
+                            if i >= processing.len() {
+                                break;
+                            }
+
+                            let (task, task_shard_id) = &processing[i];
+
+                            let task_owner = match worker_k8s_state
+                                .find_shard_owner(NAMESPACE, CLUSTER_PREFIX, task_shard_id)
+                                .await
+                            {
+                                Ok(owner) => owner,
+                                Err(_) => continue,
+                            };
+
+                            let task_target = task_owner
+                                .as_ref()
+                                .and_then(|o| o.strip_prefix("node-"))
+                                .and_then(|n| n.parse::<u32>().ok());
+
+                            let report_client = match (&mut current_client, task_target) {
+                                (Some((node, client)), Some(target)) if *node == target => client,
+                                (_, Some(target)) => {
+                                    let uri = format!(
+                                        "http://node{}:{}",
+                                        target,
+                                        BASE_PORT + target as u16
+                                    );
+                                    match create_turmoil_client(&uri, &worker_config).await {
+                                        Ok(new_client) => {
+                                            current_client = Some((target, new_client));
+                                            &mut current_client.as_mut().unwrap().1
+                                        }
+                                        Err(_) => continue,
+                                    }
+                                }
+                                _ => continue,
+                            };
+
+                            let process_time = rng.random_range(20..100);
+                            tokio::time::sleep(Duration::from_millis(process_time)).await;
+
+                            let outcome =
+                                report_outcome_request::Outcome::Success(SerializedBytes {
+                                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                                        rmp_serde::to_vec(&serde_json::json!("done")).unwrap(),
+                                    )),
+                                });
+
+                            match report_client
+                                .report_outcome(tonic::Request::new(ReportOutcomeRequest {
+                                    shard: task_shard_id.to_string(),
+                                    task_id: task.id.clone(),
+                                    outcome: Some(outcome),
+                                }))
+                                .await
+                            {
+                                Ok(_) => {
+                                    completed += 1;
+                                    worker_completed.fetch_add(1, Ordering::SeqCst);
+                                    indices_to_remove.insert(i);
+                                }
+                                Err(_) => {
+                                    indices_to_remove.insert(i);
+                                }
+                            }
+                        }
+
+                        let mut indices: Vec<_> = indices_to_remove.into_iter().collect();
+                        indices.sort_by(|a, b| b.cmp(a));
+                        for idx in indices {
+                            processing.remove(idx);
+                        }
+                    }
+
+                    let delay = rng.random_range(50..200);
+                    tokio::time::sleep(Duration::from_millis(delay)).await;
+                }
+
+                tracing::trace!(worker = %worker_id, completed = completed, "worker_done");
+                Ok(())
+            });
+        }
+
+        // Controller
+        let controller_k8s_state = k8s_state.clone();
+        let controller_node_senders = Arc::clone(&node_state_senders);
+        let controller_tracker = Arc::clone(&tracker);
+        let controller_membership_done = Arc::clone(&membership_changes_done);
+        sim.client("controller", async move {
+            controller_fn(
+                controller_k8s_state,
+                controller_node_senders,
+                controller_tracker,
+                controller_membership_done,
+                seed,
+            )
+            .await;
+            Ok(())
+        });
+
+        // Verifier
+        let verifier_tracker = Arc::clone(&tracker);
+        let verifier_completed = Arc::clone(&total_completed);
+        let verifier_enqueued = Arc::clone(&total_enqueued);
+        let verifier_scenario_done = Arc::clone(&scenario_done);
+        let verifier_membership_done = Arc::clone(&membership_changes_done);
+        let verifier_node_senders = Arc::clone(&node_state_senders);
+
+        sim.client("verifier", async move {
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+
+            // Wait for membership changes to complete
+            loop {
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                if verifier_membership_done.load(Ordering::SeqCst) {
+                    tracing::info!("membership changes done, entering convergence phase");
+                    break;
+                }
+            }
+
+            // Wait for convergence
+            let convergence_timeout_secs = 60;
+            let convergence_start = turmoil::sim_elapsed().unwrap_or_default();
+            let mut last_completed = 0u32;
+            let mut stall_count = 0u32;
+
+            loop {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+
+                let enqueued = verifier_enqueued.load(Ordering::SeqCst);
+                let completed = verifier_completed.load(Ordering::SeqCst);
+
+                tracing::trace!(enqueued, completed, "convergence_check");
+
+                if completed >= enqueued && enqueued > 0 {
+                    tracing::info!(enqueued, completed, "convergence achieved");
+                    break;
+                }
+
+                if completed == last_completed {
+                    stall_count += 1;
+                } else {
+                    stall_count = 0;
+                    last_completed = completed;
+                }
+
+                if stall_count >= 10 && completed > 0 {
+                    tracing::warn!(enqueued, completed, stall_count, "progress stalled");
+                }
+
+                let elapsed = turmoil::sim_elapsed().unwrap_or_default();
+                let convergence_duration = elapsed.saturating_sub(convergence_start);
+                if convergence_duration.as_secs() >= convergence_timeout_secs {
+                    tracing::warn!(enqueued, completed, "convergence timeout reached");
+                    break;
+                }
+            }
+
+            // Signal workers to stop
+            verifier_scenario_done.store(true, Ordering::SeqCst);
+
+            // Signal all nodes to shut down
+            {
+                let senders = verifier_node_senders.lock().unwrap();
+                for (i, sender) in senders.iter().enumerate() {
+                    if let Err(e) = sender.send(NodeState::Shutdown) {
+                        tracing::trace!(node = i, error = %e, "shutdown signal failed");
+                    }
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(2)).await;
+
+            // Final verification
+            verifier_tracker.process_and_validate();
+            verifier_tracker.verify_all();
+            verifier_tracker.jobs.verify_no_terminal_leases();
+
+            let transition_violations = verifier_tracker.jobs.verify_all_transitions();
+            if !transition_violations.is_empty() {
+                for v in &transition_violations {
+                    tracing::warn!(violation = %v, "transition_violation");
+                }
+                panic!(
+                    "INVARIANT VIOLATION: {} invalid state transitions detected",
+                    transition_violations.len()
+                );
+            }
+
+            let enqueued = verifier_enqueued.load(Ordering::SeqCst);
+            let completed = verifier_completed.load(Ordering::SeqCst);
+            let shard_ownership_violations = verifier_tracker.shards.has_violations();
+
+            tracing::info!(
+                enqueued,
+                completed,
+                shard_ownership_violations,
+                "final_verification"
+            );
+
+            verifier_tracker.shards.verify_no_split_brain();
+
+            assert!(
+                completed > 0 || enqueued == 0,
+                "No progress made: completed={}, enqueued={}",
+                completed,
+                enqueued
+            );
+
+            if enqueued > 0 {
+                let completion_rate = (completed as f64) / (enqueued as f64);
+                let acceptable_rate = 0.5; // Lower threshold for crash scenarios
+                let min_completed = 3;
+
+                tracing::info!(
+                    enqueued,
+                    completed,
+                    completion_rate = format!("{:.1}%", completion_rate * 100.0),
+                    "job_completion_stats"
+                );
+
+                if completion_rate < acceptable_rate && completed < min_completed {
+                    panic!(
+                        "Too many jobs lost: completed={}, enqueued={}, rate={:.1}%",
+                        completed, enqueued, completion_rate * 100.0,
+                    );
+                }
+            }
+
+            tracing::trace!("verifier_done");
+            Ok(())
+        });
+    });
+}
+
+/// Reclaim scenario: Crash node-0, verify leases persist, restart with same node_id.
+pub fn run_reclaim() {
+    let seed = get_seed();
+    run_scenario("k8s_permanent_lease_reclaim", seed, move |k8s_state, node_senders, _tracker, membership_done, _seed| async move {
+        // Wait for initial convergence
+        tracing::info!("waiting for initial convergence");
+        tokio::time::sleep(Duration::from_secs(8)).await;
+
+        // Record which shards node-0 owns before crash
+        let holders_before = k8s_state
+            .get_shard_holders(NAMESPACE, CLUSTER_PREFIX)
+            .await;
+        let node0_shards: Vec<ShardId> = holders_before
+            .iter()
+            .filter(|(_, holder)| *holder == "node-0")
+            .map(|(sid, _)| *sid)
+            .collect();
+        tracing::info!(
+            node0_shard_count = node0_shards.len(),
+            node0_shards = ?node0_shards,
+            "pre-crash shard ownership"
+        );
+
+        // Crash node-0
+        tracing::info!("CRASHING node-0");
+        {
+            let senders = node_senders.lock().unwrap();
+            let _ = senders[0].send(NodeState::Crash);
+        }
+
+        // Wait for crash to take effect
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // PERMANENCE CHECK: Verify leases are still held by node-0
+        let holders_after_crash = k8s_state
+            .get_shard_holders(NAMESPACE, CLUSTER_PREFIX)
+            .await;
+        let node0_shards_after: Vec<ShardId> = holders_after_crash
+            .iter()
+            .filter(|(_, holder)| *holder == "node-0")
+            .map(|(sid, _)| *sid)
+            .collect();
+        tracing::info!(
+            node0_shard_count_after = node0_shards_after.len(),
+            node0_shards_after = ?node0_shards_after,
+            "post-crash shard ownership (should match pre-crash)"
+        );
+        assert_eq!(
+            node0_shards.len(),
+            node0_shards_after.len(),
+            "Permanent leases should persist through crash! Before: {:?}, After: {:?}",
+            node0_shards,
+            node0_shards_after
+        );
+
+        // Restart node-0 with same node_id
+        tracing::info!("RESTARTING node-0");
+        {
+            let senders = node_senders.lock().unwrap();
+            let _ = senders[0].send(NodeState::Active);
+        }
+
+        // Wait for reclaim and re-convergence
+        tokio::time::sleep(Duration::from_secs(15)).await;
+
+        // Verify no split-brain after reclaim
+        assert!(
+            verify_no_split_brain_all_holders(&k8s_state).await,
+            "Split-brain detected after reclaim"
+        );
+
+        // Let work continue
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        membership_done.store(true, Ordering::SeqCst);
+        tracing::info!("reclaim controller done");
+    });
+}
+
+/// Force-release scenario: Crash node-0, force-release its leases, let other nodes take over.
+pub fn run_force_release() {
+    let seed = get_seed();
+    run_scenario("k8s_permanent_lease_force_release", seed, move |k8s_state, node_senders, tracker, membership_done, _seed| async move {
+        // Wait for initial convergence
+        tracing::info!("waiting for initial convergence");
+        tokio::time::sleep(Duration::from_secs(8)).await;
+
+        // Record which shards node-0 owns before crash
+        let holders_before = k8s_state
+            .get_shard_holders(NAMESPACE, CLUSTER_PREFIX)
+            .await;
+        let node0_shards: Vec<ShardId> = holders_before
+            .iter()
+            .filter(|(_, holder)| *holder == "node-0")
+            .map(|(sid, _)| *sid)
+            .collect();
+        tracing::info!(
+            node0_shard_count = node0_shards.len(),
+            node0_shards = ?node0_shards,
+            "pre-crash shard ownership"
+        );
+
+        // Crash node-0
+        tracing::info!("CRASHING node-0");
+        {
+            let senders = node_senders.lock().unwrap();
+            let _ = senders[0].send(NodeState::Crash);
+        }
+
+        // Wait for crash to take effect
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // PERMANENCE CHECK: Verify leases are still held by node-0
+        let holders_after_crash = k8s_state
+            .get_shard_holders(NAMESPACE, CLUSTER_PREFIX)
+            .await;
+        let node0_shards_after: Vec<ShardId> = holders_after_crash
+            .iter()
+            .filter(|(_, holder)| *holder == "node-0")
+            .map(|(sid, _)| *sid)
+            .collect();
+        tracing::info!(
+            node0_shard_count_after = node0_shards_after.len(),
+            "post-crash shard ownership (should match pre-crash)"
+        );
+        assert_eq!(
+            node0_shards.len(),
+            node0_shards_after.len(),
+            "Permanent leases should persist through crash!"
+        );
+
+        // Update tracker: node-0 crashed, clear its ownership records
+        // so subsequent acquisitions by other nodes don't trigger false split-brain
+        tracker.shards.node_crashed("node-0");
+
+        // Delete node-0's membership lease (simulates K8s TTL expiry)
+        let member_lease_name = format!("{}-member-node-0", CLUSTER_PREFIX);
+        let _ = k8s_state
+            .delete_lease(NAMESPACE, &member_lease_name)
+            .await;
+        tracing::info!("deleted node-0 membership lease");
+
+        // Wait a bit for membership change to propagate
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // Force-release each shard lease held by node-0
+        for shard_id in &node0_shards {
+            if let Err(e) = k8s_state
+                .force_release_shard_lease(NAMESPACE, CLUSTER_PREFIX, shard_id)
+                .await
+            {
+                tracing::warn!(shard_id = %shard_id, error = %e, "force-release failed");
+            }
+        }
+        tracing::info!(
+            count = node0_shards.len(),
+            "force-released node-0's shard leases"
+        );
+
+        // Wait for remaining nodes to acquire orphaned shards
+        tokio::time::sleep(Duration::from_secs(15)).await;
+
+        // Verify no split-brain after force-release
+        assert!(
+            verify_no_split_brain_all_holders(&k8s_state).await,
+            "Split-brain detected after force-release"
+        );
+
+        // Let work continue
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        membership_done.store(true, Ordering::SeqCst);
+        tracing::info!("force-release controller done");
+    });
+}

--- a/tests/turmoil_runner/scenarios/mod.rs
+++ b/tests/turmoil_runner/scenarios/mod.rs
@@ -14,6 +14,8 @@ pub mod high_message_loss;
 #[cfg(feature = "k8s")]
 pub mod k8s_coordination;
 #[cfg(feature = "k8s")]
+pub mod k8s_permanent_leases;
+#[cfg(feature = "k8s")]
 pub mod k8s_shard_splits;
 pub mod lease_expiry;
 pub mod multiple_workers;

--- a/typescript_client/src/pb/silo.client.ts
+++ b/typescript_client/src/pb/silo.client.ts
@@ -4,6 +4,8 @@
 import type { RpcTransport } from "@protobuf-ts/runtime-rpc";
 import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import { Silo } from "./silo";
+import type { ForceReleaseShardResponse } from "./silo";
+import type { ForceReleaseShardRequest } from "./silo";
 import type { ResetShardsResponse } from "./silo";
 import type { ResetShardsRequest } from "./silo";
 import type { ImportJobsResponse } from "./silo";
@@ -219,6 +221,14 @@ export interface ISiloClient {
      * @generated from protobuf rpc: ResetShards
      */
     resetShards(input: ResetShardsRequest, options?: RpcOptions): UnaryCall<ResetShardsRequest, ResetShardsResponse>;
+    /**
+     * Force-release a shard lease regardless of the current holder.
+     * Operator escape hatch for recovering from permanently lost nodes.
+     * After force-release, any live node that desires the shard can acquire it.
+     *
+     * @generated from protobuf rpc: ForceReleaseShard
+     */
+    forceReleaseShard(input: ForceReleaseShardRequest, options?: RpcOptions): UnaryCall<ForceReleaseShardRequest, ForceReleaseShardResponse>;
 }
 /**
  * The Silo job queue service.
@@ -456,5 +466,16 @@ export class SiloClient implements ISiloClient, ServiceInfo {
     resetShards(input: ResetShardsRequest, options?: RpcOptions): UnaryCall<ResetShardsRequest, ResetShardsResponse> {
         const method = this.methods[20], opt = this._transport.mergeOptions(options);
         return stackIntercept<ResetShardsRequest, ResetShardsResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * Force-release a shard lease regardless of the current holder.
+     * Operator escape hatch for recovering from permanently lost nodes.
+     * After force-release, any live node that desires the shard can acquire it.
+     *
+     * @generated from protobuf rpc: ForceReleaseShard
+     */
+    forceReleaseShard(input: ForceReleaseShardRequest, options?: RpcOptions): UnaryCall<ForceReleaseShardRequest, ForceReleaseShardResponse> {
+        const method = this.methods[21], opt = this._transport.mergeOptions(options);
+        return stackIntercept<ForceReleaseShardRequest, ForceReleaseShardResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -1428,6 +1428,29 @@ export interface ImportJobsResponse {
     results: ImportJobResult[];
 }
 /**
+ * Request to force-release a shard's ownership lease.
+ * Operator escape hatch for permanently lost nodes.
+ *
+ * @generated from protobuf message silo.v1.ForceReleaseShardRequest
+ */
+export interface ForceReleaseShardRequest {
+    /**
+     * @generated from protobuf field: string shard = 1
+     */
+    shard: string; // The shard ID (UUID) to force-release.
+}
+/**
+ * Response after force-releasing a shard lease.
+ *
+ * @generated from protobuf message silo.v1.ForceReleaseShardResponse
+ */
+export interface ForceReleaseShardResponse {
+    /**
+     * @generated from protobuf field: bool released = 1
+     */
+    released: boolean; // True if the lease was released.
+}
+/**
  * Rate limiting algorithm for Gubernator-based limits.
  *
  * @generated from protobuf enum silo.v1.GubernatorAlgorithm
@@ -5907,6 +5930,100 @@ class ImportJobsResponse$Type extends MessageType<ImportJobsResponse> {
  * @generated MessageType for protobuf message silo.v1.ImportJobsResponse
  */
 export const ImportJobsResponse = new ImportJobsResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ForceReleaseShardRequest$Type extends MessageType<ForceReleaseShardRequest> {
+    constructor() {
+        super("silo.v1.ForceReleaseShardRequest", [
+            { no: 1, name: "shard", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ForceReleaseShardRequest>): ForceReleaseShardRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.shard = "";
+        if (value !== undefined)
+            reflectionMergePartial<ForceReleaseShardRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ForceReleaseShardRequest): ForceReleaseShardRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string shard */ 1:
+                    message.shard = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ForceReleaseShardRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string shard = 1; */
+        if (message.shard !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.shard);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.ForceReleaseShardRequest
+ */
+export const ForceReleaseShardRequest = new ForceReleaseShardRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ForceReleaseShardResponse$Type extends MessageType<ForceReleaseShardResponse> {
+    constructor() {
+        super("silo.v1.ForceReleaseShardResponse", [
+            { no: 1, name: "released", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ForceReleaseShardResponse>): ForceReleaseShardResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.released = false;
+        if (value !== undefined)
+            reflectionMergePartial<ForceReleaseShardResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ForceReleaseShardResponse): ForceReleaseShardResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* bool released */ 1:
+                    message.released = reader.bool();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ForceReleaseShardResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* bool released = 1; */
+        if (message.released !== false)
+            writer.tag(1, WireType.Varint).bool(message.released);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.ForceReleaseShardResponse
+ */
+export const ForceReleaseShardResponse = new ForceReleaseShardResponse$Type();
 /**
  * @generated ServiceType for protobuf service silo.v1.Silo
  */
@@ -5931,5 +6048,6 @@ export const Silo = new ServiceType("silo.v1.Silo", [
     { name: "GetSplitStatus", options: {}, I: GetSplitStatusRequest, O: GetSplitStatusResponse },
     { name: "ConfigureShard", options: {}, I: ConfigureShardRequest, O: ConfigureShardResponse },
     { name: "ImportJobs", options: {}, I: ImportJobsRequest, O: ImportJobsResponse },
-    { name: "ResetShards", options: {}, I: ResetShardsRequest, O: ResetShardsResponse }
+    { name: "ResetShards", options: {}, I: ResetShardsRequest, O: ResetShardsResponse },
+    { name: "ForceReleaseShard", options: {}, I: ForceReleaseShardRequest, O: ForceReleaseShardResponse }
 ]);


### PR DESCRIPTION
Switch shard leases from keepalive-based (auto-expiring) to permanent
(persist until explicitly released). This ensures that if a node crashes,
its shards remain owned so the WAL can be recovered when it restarts,
preventing data loss from another node taking over without processing
the crashed node's unflushed writes.

Key changes:
- Etcd: Replace Lock API with KV transactions (put-if-absent/delete-if-owner)
- K8s: Remove lease renewal loop, remove expiry-based takeover
- Add startup lease reclamation (reclaim_and_open_shards) for both backends
- Add force_release_shard_lease as operator escape hatch for lost nodes
- Add ForceReleaseShard gRPC endpoint and siloctl command
- Update Alloy spec: remove leaseExpire, add forceReleaseLease, add
  flapPreservesLeases invariant (SILO-COORD-INV-14)
- Remove liveness_lease_id from etcd coordinator (only membership lease needed)

Test coverage for both etcd and k8s backends:
- Crash does not release shard lease
- Permanent lease blocks other nodes from acquiring
- Force-release allows reacquisition
- Graceful shutdown still releases leases
- Crash-restart reclaims and opens shards automatically
- Hash ring divergence on restart (reclaim then reconcile)
- Coordinator-level crash/force-release integration
- Different node_id does not reclaim another node's leases
- Force-release of non-existent shard returns ShardNotFound
- ForceReleaseShard gRPC endpoint (success + invalid ID error)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
