### PR TITLE
Add performant Waiting state queries via status/time index

### DIFF
--- a/src/job_store_shard/expedite.rs
+++ b/src/job_store_shard/expedite.rs
@@ -176,19 +176,13 @@ impl JobStoreShard {
         txn.put(&status_key, &new_status_value)?;
 
         // Update status/time index
-        let old_time_key = crate::keys::idx_status_time_key(
-            tenant,
-            status.kind.as_str(),
-            status.changed_at_ms,
-            id,
-        );
+        let old_ts = crate::keys::status_index_timestamp(&status);
+        let old_time_key =
+            crate::keys::idx_status_time_key(tenant, status.kind.as_str(), old_ts, id);
         txn.delete(&old_time_key)?;
-        let new_time_key = crate::keys::idx_status_time_key(
-            tenant,
-            new_status.kind.as_str(),
-            new_status.changed_at_ms,
-            id,
-        );
+        let new_ts = crate::keys::status_index_timestamp(&new_status);
+        let new_time_key =
+            crate::keys::idx_status_time_key(tenant, new_status.kind.as_str(), new_ts, id);
         txn.put(&new_time_key, [])?;
 
         // Commit the transaction

--- a/src/job_store_shard/restart.rs
+++ b/src/job_store_shard/restart.rs
@@ -162,12 +162,8 @@ impl JobStoreShard {
         txn.put(&status_key, &status_value)?;
 
         // Insert new status index entry
-        let new_time = idx_status_time_key(
-            tenant,
-            new_status.kind.as_str(),
-            new_status.changed_at_ms,
-            id,
-        );
+        let new_ts = crate::keys::status_index_timestamp(&new_status);
+        let new_time = idx_status_time_key(tenant, new_status.kind.as_str(), new_ts, id);
         txn.put(&new_time, [])?;
 
         // [SILO-RESTART-5] Post: Create new task in DB queue with next attempt number

--- a/src/job_store_shard/scan.rs
+++ b/src/job_store_shard/scan.rs
@@ -6,8 +6,8 @@ use crate::job::JobStatusKind;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
     end_bound, idx_metadata_prefix, idx_status_time_all_prefix, idx_status_time_prefix,
-    job_info_prefix, jobs_prefix, parse_job_info_key, parse_metadata_index_key,
-    parse_status_time_index_key,
+    idx_status_time_prefix_with_time, job_info_prefix, jobs_prefix, parse_job_info_key,
+    parse_metadata_index_key, parse_status_time_index_key,
 };
 
 impl JobStoreShard {
@@ -123,6 +123,142 @@ impl JobStoreShard {
             if let Some(parsed) = parse_status_time_index_key(&kv.key) {
                 // Filter by status since we're scanning all statuses
                 if parsed.status == status_str && !parsed.job_id.is_empty() {
+                    out.push((parsed.tenant, parsed.job_id));
+                }
+            }
+        }
+
+        Ok(out)
+    }
+
+    /// Scan jobs that are waiting (Scheduled with start_time <= now) for a tenant.
+    /// Uses range scan within the Scheduled prefix from inverted(now_ms) to end.
+    pub async fn scan_jobs_waiting(
+        &self,
+        tenant: &str,
+        now_ms: i64,
+        limit: usize,
+    ) -> Result<Vec<String>, JobStoreShardError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Waiting jobs have start_time <= now, which means inverted_timestamp >= u64::MAX - now
+        // These sort AFTER future jobs in the index, so scan from the boundary to end.
+        let inverted_now = u64::MAX - (now_ms.max(0) as u64);
+        let start = idx_status_time_prefix_with_time(tenant, "Scheduled", inverted_now);
+        let prefix_end = end_bound(&idx_status_time_prefix(tenant, "Scheduled"));
+        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(start..prefix_end).await?;
+        let mut out = Vec::with_capacity(limit);
+
+        while out.len() < limit {
+            let Some(kv) = iter.next().await? else {
+                break;
+            };
+            if let Some(parsed) = parse_status_time_index_key(&kv.key)
+                && !parsed.job_id.is_empty()
+            {
+                out.push(parsed.job_id);
+            }
+        }
+
+        Ok(out)
+    }
+
+    /// Scan waiting jobs across ALL tenants, returning (tenant, job_id) pairs.
+    pub async fn scan_all_jobs_waiting(
+        &self,
+        now_ms: i64,
+        limit: usize,
+    ) -> Result<Vec<(String, String)>, JobStoreShardError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let inverted_now = u64::MAX - (now_ms.max(0) as u64);
+        let start = idx_status_time_all_prefix();
+        let end = end_bound(&start);
+        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut out = Vec::with_capacity(limit);
+
+        while out.len() < limit {
+            let Some(kv) = iter.next().await? else {
+                break;
+            };
+            if let Some(parsed) = parse_status_time_index_key(&kv.key) {
+                // Filter: must be Scheduled status AND inverted_timestamp >= inverted_now (start_time <= now)
+                if parsed.status == "Scheduled"
+                    && parsed.inverted_timestamp >= inverted_now
+                    && !parsed.job_id.is_empty()
+                {
+                    out.push((parsed.tenant, parsed.job_id));
+                }
+            }
+        }
+
+        Ok(out)
+    }
+
+    /// Scan future-scheduled jobs (Scheduled with start_time > now) for a tenant.
+    /// Uses range scan from Scheduled prefix start to inverted(now_ms).
+    pub async fn scan_jobs_future_scheduled(
+        &self,
+        tenant: &str,
+        now_ms: i64,
+        limit: usize,
+    ) -> Result<Vec<String>, JobStoreShardError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Future jobs have start_time > now, which means inverted_timestamp < u64::MAX - now
+        // These sort BEFORE waiting jobs in the index, so scan from prefix start to the boundary.
+        let inverted_now = u64::MAX - (now_ms.max(0) as u64);
+        let start = idx_status_time_prefix(tenant, "Scheduled");
+        let boundary = idx_status_time_prefix_with_time(tenant, "Scheduled", inverted_now);
+        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(start..boundary).await?;
+        let mut out = Vec::with_capacity(limit);
+
+        while out.len() < limit {
+            let Some(kv) = iter.next().await? else {
+                break;
+            };
+            if let Some(parsed) = parse_status_time_index_key(&kv.key)
+                && !parsed.job_id.is_empty()
+            {
+                out.push(parsed.job_id);
+            }
+        }
+
+        Ok(out)
+    }
+
+    /// Scan future-scheduled jobs across ALL tenants, returning (tenant, job_id) pairs.
+    pub async fn scan_all_jobs_future_scheduled(
+        &self,
+        now_ms: i64,
+        limit: usize,
+    ) -> Result<Vec<(String, String)>, JobStoreShardError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let inverted_now = u64::MAX - (now_ms.max(0) as u64);
+        let start = idx_status_time_all_prefix();
+        let end = end_bound(&start);
+        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut out = Vec::with_capacity(limit);
+
+        while out.len() < limit {
+            let Some(kv) = iter.next().await? else {
+                break;
+            };
+            if let Some(parsed) = parse_status_time_index_key(&kv.key) {
+                // Filter: must be Scheduled status AND inverted_timestamp < inverted_now (start_time > now)
+                if parsed.status == "Scheduled"
+                    && parsed.inverted_timestamp < inverted_now
+                    && !parsed.job_id.is_empty()
+                {
                     out.push((parsed.tenant, parsed.job_id));
                 }
             }

--- a/tests/cluster_query_tests.rs
+++ b/tests/cluster_query_tests.rs
@@ -597,19 +597,19 @@ async fn cluster_query_multi_shard_filter_pushdown() {
         .await
         .expect("create engine");
 
-    // Query only scheduled jobs
+    // Query only waiting jobs (enqueued with start_at_ms = now, so they are Waiting)
     let batches = query_collect(
         &engine,
-        "SELECT id FROM jobs WHERE tenant = '-' AND status_kind = 'Scheduled'",
+        "SELECT id FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting'",
     )
     .await;
     let ids = extract_string_column(&batches, 0);
 
-    // Should only get the scheduled job from shard 1
+    // Should only get the waiting job from shard 1 (shard 0's job is Running)
     assert_eq!(
         ids.len(),
         1,
-        "expected 1 scheduled job but got {}: {:?}",
+        "expected 1 waiting job but got {}: {:?}",
         ids.len(),
         ids
     );
@@ -1468,10 +1468,10 @@ async fn cluster_query_by_status_no_tenant_filter() {
         .await
         .expect("create engine");
 
-    // Query by status without tenant filter
+    // Query by status without tenant filter (jobs enqueued with now are Waiting)
     let batches = query_collect(
         &engine,
-        "SELECT tenant, id FROM jobs WHERE status_kind = 'Scheduled' ORDER BY id",
+        "SELECT tenant, id FROM jobs WHERE status_kind = 'Waiting' ORDER BY id",
     )
     .await;
 

--- a/tests/query_waiting_tests.rs
+++ b/tests/query_waiting_tests.rs
@@ -1,0 +1,702 @@
+mod test_helpers;
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, Int64Array, StringArray};
+use datafusion::arrow::record_batch::RecordBatch;
+use silo::job_attempt::AttemptOutcome;
+use silo::job_store_shard::JobStoreShard;
+use silo::keys::{
+    ParsedStatusTimeIndexKey, end_bound, idx_status_time_prefix, parse_status_time_index_key,
+};
+use silo::query::ShardQueryEngine;
+use slatedb::DbIterator;
+use test_helpers::*;
+
+// Helper to extract string column values from batches
+fn extract_string_column(batches: &[RecordBatch], col_idx: usize) -> Vec<String> {
+    let mut result = Vec::new();
+    for batch in batches {
+        let col = batch.column(col_idx);
+        let sa = col
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string column");
+        for i in 0..sa.len() {
+            if !sa.is_null(i) {
+                result.push(sa.value(i).to_string());
+            }
+        }
+    }
+    result
+}
+
+// Helper to run SQL query and collect results
+async fn query_ids(sql: &ShardQueryEngine, query: &str) -> Vec<String> {
+    let batches = sql
+        .sql(query)
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    extract_string_column(&batches, 0)
+}
+
+// Helper to enqueue a simple job
+async fn enqueue_job(shard: &JobStoreShard, id: &str, priority: u8, start_at_ms: i64) -> String {
+    shard
+        .enqueue(
+            "-",
+            Some(id.to_string()),
+            priority,
+            start_at_ms,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue")
+}
+
+// Helper to enqueue a job for a specific tenant
+async fn enqueue_job_for_tenant(
+    shard: &JobStoreShard,
+    tenant: &str,
+    id: &str,
+    priority: u8,
+    start_at_ms: i64,
+) -> String {
+    shard
+        .enqueue(
+            tenant,
+            Some(id.to_string()),
+            priority,
+            start_at_ms,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue")
+}
+
+/// Collect all status/time index entries (0x03) for a given tenant and status.
+async fn collect_index_entries(
+    shard: &JobStoreShard,
+    tenant: &str,
+    status: &str,
+) -> Vec<ParsedStatusTimeIndexKey> {
+    let start = idx_status_time_prefix(tenant, status);
+    let end = end_bound(&start);
+    let mut iter: DbIterator = shard.db().scan::<Vec<u8>, _>(start..end).await.unwrap();
+    let mut out = Vec::new();
+    loop {
+        let maybe = iter.next().await.unwrap();
+        let Some(kv) = maybe else { break };
+        if let Some(parsed) = parse_status_time_index_key(&kv.key) {
+            out.push(parsed);
+        }
+    }
+    out
+}
+
+/// Collect ALL status/time index entries (0x03) across all tenants and statuses.
+async fn collect_all_index_entries(shard: &JobStoreShard) -> Vec<ParsedStatusTimeIndexKey> {
+    let start = vec![0x03u8];
+    let end = end_bound(&start);
+    let mut iter: DbIterator = shard.db().scan::<Vec<u8>, _>(start..end).await.unwrap();
+    let mut out = Vec::new();
+    loop {
+        let maybe = iter.next().await.unwrap();
+        let Some(kv) = maybe else { break };
+        if let Some(parsed) = parse_status_time_index_key(&kv.key) {
+            out.push(parsed);
+        }
+    }
+    out
+}
+
+// ===== SQL-level query tests =====
+
+#[silo::test]
+async fn sql_waiting_status_display() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Enqueue with past start time (should be Waiting)
+    enqueue_job(&shard, "past-job", 10, now - 5000).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT id, status_kind FROM jobs WHERE tenant = '-' AND id = 'past-job'")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    let ids = extract_string_column(&batches, 0);
+    assert_eq!(ids, vec!["past-job"]);
+
+    let statuses = extract_string_column(&batches, 1);
+    assert_eq!(statuses, vec!["Waiting"]);
+}
+
+#[silo::test]
+async fn sql_future_scheduled_status_display() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Enqueue with future start time (should be Scheduled)
+    enqueue_job(&shard, "future-job", 10, now + 60_000).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT id, status_kind FROM jobs WHERE tenant = '-' AND id = 'future-job'")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    let ids = extract_string_column(&batches, 0);
+    assert_eq!(ids, vec!["future-job"]);
+
+    let statuses = extract_string_column(&batches, 1);
+    assert_eq!(statuses, vec!["Scheduled"]);
+}
+
+#[silo::test]
+async fn sql_filter_waiting() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Waiting: start_time <= now
+    enqueue_job(&shard, "w1", 10, now - 1000).await;
+    enqueue_job(&shard, "w2", 10, now).await;
+
+    // Future-scheduled: start_time > now
+    enqueue_job(&shard, "f1", 10, now + 60_000).await;
+
+    // Running: dequeue one of the waiting jobs
+    shard
+        .dequeue("worker", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting' ORDER BY id",
+    )
+    .await;
+
+    // Only non-dequeued waiting jobs (w2 remains, w1 was dequeued and is now Running)
+    assert_eq!(got, vec!["w2"]);
+}
+
+#[silo::test]
+async fn sql_filter_scheduled_future_only() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Waiting jobs (start_time <= now)
+    enqueue_job(&shard, "w1", 10, now - 1000).await;
+    enqueue_job(&shard, "w2", 10, now).await;
+
+    // Future-scheduled jobs
+    enqueue_job(&shard, "f1", 10, now + 60_000).await;
+    enqueue_job(&shard, "f2", 10, now + 120_000).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant = '-' AND status_kind = 'Scheduled' ORDER BY id",
+    )
+    .await;
+
+    // Only future-scheduled jobs
+    assert_eq!(got, vec!["f1", "f2"]);
+}
+
+#[silo::test]
+async fn sql_filter_waiting_cross_tenant() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Waiting jobs across tenants
+    enqueue_job_for_tenant(&shard, "tenant_a", "a1", 10, now - 1000).await;
+    enqueue_job_for_tenant(&shard, "tenant_b", "b1", 10, now).await;
+
+    // Future-scheduled
+    enqueue_job_for_tenant(&shard, "tenant_a", "a2", 10, now + 60_000).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+
+    // Cross-tenant waiting query (no tenant filter)
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE status_kind = 'Waiting' ORDER BY id",
+    )
+    .await;
+
+    assert_eq!(got, vec!["a1", "b1"]);
+}
+
+#[silo::test]
+async fn sql_count_waiting() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // 3 waiting jobs
+    enqueue_job(&shard, "w1", 10, now - 2000).await;
+    enqueue_job(&shard, "w2", 10, now - 1000).await;
+    enqueue_job(&shard, "w3", 10, now).await;
+
+    // 1 future-scheduled
+    enqueue_job(&shard, "f1", 10, now + 60_000).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT COUNT(*) FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting'")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    assert!(!batches.is_empty());
+    let count_col = batches[0].column(0);
+    let count_arr = count_col
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("count column");
+    assert_eq!(count_arr.value(0), 3);
+}
+
+#[silo::test]
+async fn scheduled_start_index_lifecycle() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Enqueue with future start time
+    enqueue_job(&shard, "lifecycle", 10, now + 60_000).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+
+    // Should be future-scheduled
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant = '-' AND status_kind = 'Scheduled'",
+    )
+    .await;
+    assert_eq!(got, vec!["lifecycle"]);
+
+    // Should NOT be Waiting
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting'",
+    )
+    .await;
+    assert!(got.is_empty());
+
+    // Expedite the job to run now
+    shard
+        .expedite_job("-", "lifecycle")
+        .await
+        .expect("expedite");
+
+    // After expedite, should be Waiting (start_time = now)
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting'",
+    )
+    .await;
+    assert_eq!(got, vec!["lifecycle"]);
+
+    // Should no longer be in future-scheduled
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant = '-' AND status_kind = 'Scheduled'",
+    )
+    .await;
+    assert!(got.is_empty());
+
+    // Cancel the waiting/scheduled job (status transitions to Cancelled immediately for Scheduled jobs)
+    shard.cancel_job("-", "lifecycle").await.expect("cancel");
+
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant = '-' AND status_kind = 'Cancelled'",
+    )
+    .await;
+    assert_eq!(got, vec!["lifecycle"]);
+
+    // Should no longer appear as Waiting or Scheduled
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting'",
+    )
+    .await;
+    assert!(got.is_empty());
+}
+
+// ===== Storage-level index verification tests =====
+//
+// These tests directly scan the 0x03 status/time index prefix to verify
+// that exactly the right entries exist at each step. This ensures the
+// surgical single-delete approach correctly maintains the index.
+
+#[silo::test]
+async fn index_entry_uses_start_time_for_scheduled() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let future_start = now + 60_000;
+
+    enqueue_job(&shard, "j1", 10, future_start).await;
+
+    let entries = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(entries.len(), 1, "expected exactly 1 Scheduled index entry");
+    assert_eq!(entries[0].job_id, "j1");
+    // The index timestamp should be the inverted start_at_ms, not changed_at_ms
+    assert_eq!(
+        entries[0].inverted_timestamp,
+        u64::MAX - future_start as u64,
+        "index should be keyed by start_at_ms for Scheduled jobs"
+    );
+}
+
+#[silo::test]
+async fn index_entry_uses_start_time_for_waiting() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let past_start = now - 5000;
+
+    enqueue_job(&shard, "j1", 10, past_start).await;
+
+    let entries = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(entries.len(), 1, "expected exactly 1 Scheduled index entry");
+    assert_eq!(entries[0].job_id, "j1");
+    // Even for past start times, the index is keyed by start_at_ms
+    assert_eq!(
+        entries[0].inverted_timestamp,
+        u64::MAX - past_start as u64,
+        "index should be keyed by start_at_ms even for past start times"
+    );
+}
+
+#[silo::test]
+async fn index_dequeue_removes_scheduled_adds_running() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    enqueue_job(&shard, "j1", 10, now - 1000).await;
+
+    // Before dequeue: 1 Scheduled entry
+    let scheduled = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(scheduled.len(), 1);
+
+    // Dequeue
+    let result = shard
+        .dequeue("worker", "default", 1)
+        .await
+        .expect("dequeue");
+    assert_eq!(result.tasks.len(), 1);
+
+    // After dequeue: Scheduled entry removed, Running entry added
+    let scheduled = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(
+        scheduled.len(),
+        0,
+        "Scheduled index entry should be removed after dequeue"
+    );
+
+    let running = collect_index_entries(&shard, "-", "Running").await;
+    assert_eq!(
+        running.len(),
+        1,
+        "Running index entry should be added after dequeue"
+    );
+    assert_eq!(running[0].job_id, "j1");
+}
+
+#[silo::test]
+async fn index_cancel_scheduled_removes_scheduled_adds_cancelled() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    enqueue_job(&shard, "j1", 10, now + 60_000).await;
+
+    // Before cancel: 1 Scheduled entry
+    let scheduled = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(scheduled.len(), 1);
+
+    shard.cancel_job("-", "j1").await.expect("cancel");
+
+    // After cancel: Scheduled entry removed, Cancelled entry added
+    let scheduled = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(
+        scheduled.len(),
+        0,
+        "Scheduled index entry should be removed after cancel"
+    );
+
+    let cancelled = collect_index_entries(&shard, "-", "Cancelled").await;
+    assert_eq!(
+        cancelled.len(),
+        1,
+        "Cancelled index entry should be added after cancel"
+    );
+    assert_eq!(cancelled[0].job_id, "j1");
+}
+
+#[silo::test]
+async fn index_cancel_waiting_removes_scheduled_adds_cancelled() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Enqueue with past start time (Waiting = Scheduled + start_time <= now)
+    enqueue_job(&shard, "j1", 10, now - 5000).await;
+
+    let scheduled = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(
+        scheduled.len(),
+        1,
+        "waiting job has a Scheduled index entry"
+    );
+
+    shard.cancel_job("-", "j1").await.expect("cancel");
+
+    let scheduled = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(
+        scheduled.len(),
+        0,
+        "Scheduled index entry should be removed after cancelling a waiting job"
+    );
+
+    let cancelled = collect_index_entries(&shard, "-", "Cancelled").await;
+    assert_eq!(cancelled.len(), 1);
+    assert_eq!(cancelled[0].job_id, "j1");
+}
+
+#[silo::test]
+async fn index_expedite_replaces_scheduled_entry() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let future_start = now + 60_000;
+
+    enqueue_job(&shard, "j1", 10, future_start).await;
+
+    // Before expedite: 1 Scheduled entry keyed at future_start
+    let entries = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(entries.len(), 1);
+    let old_inverted = entries[0].inverted_timestamp;
+    assert_eq!(old_inverted, u64::MAX - future_start as u64);
+
+    shard.expedite_job("-", "j1").await.expect("expedite");
+
+    // After expedite: still 1 Scheduled entry, but now keyed at ~now
+    let entries = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(
+        entries.len(),
+        1,
+        "should have exactly 1 Scheduled index entry after expedite (old one removed, new one added)"
+    );
+    assert_eq!(entries[0].job_id, "j1");
+    // The new entry should have a larger inverted timestamp (closer to now = larger inverted value)
+    assert!(
+        entries[0].inverted_timestamp > old_inverted,
+        "expedited entry should have a larger inverted timestamp (earlier real time)"
+    );
+}
+
+#[silo::test]
+async fn index_no_orphaned_entries_through_expedite() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    enqueue_job(&shard, "j1", 10, now + 60_000).await;
+
+    // Total index entries should be exactly 1
+    let all = collect_all_index_entries(&shard).await;
+    assert_eq!(all.len(), 1, "1 entry after enqueue");
+
+    shard.expedite_job("-", "j1").await.expect("expedite");
+
+    // Still exactly 1 total index entry (old deleted, new added)
+    let all = collect_all_index_entries(&shard).await;
+    assert_eq!(
+        all.len(),
+        1,
+        "should still be exactly 1 index entry after expedite, no orphans"
+    );
+}
+
+#[silo::test]
+async fn index_restart_replaces_terminal_with_scheduled() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    enqueue_job(&shard, "j1", 10, now - 1000).await;
+
+    // Dequeue to get Running
+    let result = shard
+        .dequeue("worker", "default", 1)
+        .await
+        .expect("dequeue");
+    let task_id = result.tasks[0].attempt().task_id().to_string();
+
+    // Fail the job
+    shard
+        .report_attempt_outcome(
+            &task_id,
+            AttemptOutcome::Error {
+                error_code: "ERR".to_string(),
+                error: vec![],
+            },
+        )
+        .await
+        .expect("report error");
+
+    // Job should now be Failed (no retries configured)
+    let failed = collect_index_entries(&shard, "-", "Failed").await;
+    assert_eq!(failed.len(), 1, "should have 1 Failed entry");
+    assert_eq!(failed[0].job_id, "j1");
+
+    // No Running or Scheduled entries should remain
+    let running = collect_index_entries(&shard, "-", "Running").await;
+    assert_eq!(running.len(), 0);
+    let scheduled = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(scheduled.len(), 0);
+
+    // Restart the job
+    shard.restart_job("-", "j1").await.expect("restart");
+
+    // Failed entry should be gone, new Scheduled entry should exist
+    let failed = collect_index_entries(&shard, "-", "Failed").await;
+    assert_eq!(
+        failed.len(),
+        0,
+        "Failed index entry should be removed after restart"
+    );
+
+    let scheduled = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(
+        scheduled.len(),
+        1,
+        "Scheduled index entry should be added after restart"
+    );
+    assert_eq!(scheduled[0].job_id, "j1");
+}
+
+#[silo::test]
+async fn index_total_count_stable_through_lifecycle() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Enqueue 2 jobs
+    enqueue_job(&shard, "j1", 10, now - 1000).await;
+    enqueue_job(&shard, "j2", 10, now + 60_000).await;
+
+    let all = collect_all_index_entries(&shard).await;
+    assert_eq!(all.len(), 2, "2 entries after enqueue");
+
+    // Dequeue j1 (Scheduled -> Running)
+    let result = shard
+        .dequeue("worker", "default", 1)
+        .await
+        .expect("dequeue");
+    assert_eq!(result.tasks.len(), 1);
+
+    let all = collect_all_index_entries(&shard).await;
+    assert_eq!(
+        all.len(),
+        2,
+        "still 2 entries after dequeue (1 Running + 1 Scheduled)"
+    );
+
+    // Expedite j2 (Scheduled -> Scheduled at new time)
+    shard.expedite_job("-", "j2").await.expect("expedite");
+
+    let all = collect_all_index_entries(&shard).await;
+    assert_eq!(all.len(), 2, "still 2 entries after expedite");
+
+    // Cancel j2 (Scheduled -> Cancelled)
+    shard.cancel_job("-", "j2").await.expect("cancel");
+
+    let all = collect_all_index_entries(&shard).await;
+    assert_eq!(
+        all.len(),
+        2,
+        "still 2 entries after cancel (1 Running + 1 Cancelled)"
+    );
+
+    // Complete j1 successfully
+    let task_id = result.tasks[0].attempt().task_id().to_string();
+    shard
+        .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report success");
+
+    let all = collect_all_index_entries(&shard).await;
+    assert_eq!(
+        all.len(),
+        2,
+        "still 2 entries after success (1 Succeeded + 1 Cancelled)"
+    );
+
+    // Verify final state
+    let succeeded = collect_index_entries(&shard, "-", "Succeeded").await;
+    assert_eq!(succeeded.len(), 1);
+    assert_eq!(succeeded[0].job_id, "j1");
+
+    let cancelled = collect_index_entries(&shard, "-", "Cancelled").await;
+    assert_eq!(cancelled.len(), 1);
+    assert_eq!(cancelled[0].job_id, "j2");
+}
+
+#[silo::test]
+async fn index_multiple_jobs_independent() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Enqueue 3 jobs with different start times
+    enqueue_job(&shard, "past", 10, now - 5000).await;
+    enqueue_job(&shard, "present", 10, now).await;
+    enqueue_job(&shard, "future", 10, now + 60_000).await;
+
+    let entries = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(entries.len(), 3, "all 3 jobs should have Scheduled entries");
+
+    // Cancel only the past job
+    shard.cancel_job("-", "past").await.expect("cancel");
+
+    let scheduled = collect_index_entries(&shard, "-", "Scheduled").await;
+    assert_eq!(
+        scheduled.len(),
+        2,
+        "only 2 Scheduled entries after cancelling 1"
+    );
+    let ids: Vec<&str> = scheduled.iter().map(|e| e.job_id.as_str()).collect();
+    // Index is sorted by inverted timestamp, so future (smallest inverted) comes first
+    assert!(ids.contains(&"present"), "present should still be in index");
+    assert!(ids.contains(&"future"), "future should still be in index");
+    assert!(
+        !ids.contains(&"past"),
+        "past should be removed from Scheduled index"
+    );
+
+    let cancelled = collect_index_entries(&shard, "-", "Cancelled").await;
+    assert_eq!(cancelled.len(), 1);
+    assert_eq!(cancelled[0].job_id, "past");
+
+    // Total entries should be exactly 3
+    let all = collect_all_index_entries(&shard).await;
+    assert_eq!(all.len(), 3);
+}


### PR DESCRIPTION
Repurpose the timestamp field in the IDX_STATUS_TIME (0x03) index so
that Scheduled entries are keyed by next_attempt_starts_after_ms instead
of changed_at_ms. This enables efficient range scans to split waiting
(start_time <= now) from future-scheduled (start_time > now) jobs
without a new index or extra writes.

Key changes:
- status_index_timestamp() determines the index key timestamp based on
  status kind, used consistently for both writes and deletes
- Surgical single-delete on status transitions (no double-delete needed)
- New scan methods: scan_jobs_waiting, scan_jobs_future_scheduled, and
  cross-tenant variants
- Virtual "Waiting" and "Scheduled" status filters in the query layer
  backed by range scans on the Scheduled prefix boundary
- display_status_kind() renders "Waiting" for Scheduled jobs whose
  start time has passed

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
