### PR TITLE
Fix ShardRange::midpoint() failing for prefix ranges with low boundaries

### DIFF
--- a/src/shard_range.rs
+++ b/src/shard_range.rs
@@ -215,12 +215,13 @@ impl ShardRange {
         if diff_pos == min_len {
             // One is a prefix of the other
             if start_bytes.len() < end_bytes.len() {
-                // Start is shorter, we can split by extending start
-                let mut mid = effective_start.clone();
-                // Add a character that's midway through ASCII printable range
-                mid.push('M');
-                if mid.as_str() > effective_start.as_str() && mid.as_str() < effective_end.as_str()
-                {
+                // Start is shorter; extend start with a character that keeps us below end.
+                // Since start is a prefix of end, start + C < end when C < end_bytes[diff_pos].
+                let end_char_at_diff = end_bytes[diff_pos];
+                if end_char_at_diff >= 2 {
+                    let mid_char = end_char_at_diff / 2;
+                    let mut mid = effective_start.clone();
+                    mid.push(mid_char as char);
                     return Some(mid);
                 }
             }

--- a/tests/shard_split_tests.rs
+++ b/tests/shard_split_tests.rs
@@ -201,6 +201,33 @@ fn shard_range_midpoint_can_be_used_for_split() {
 }
 
 #[test]
+fn shard_range_midpoint_all_32_shard_ranges() {
+    // All ranges produced by create_initial(32) must have a midpoint
+    let shard_map = ShardMap::create_initial(32).expect("create shard map");
+    for shard_info in shard_map.shards() {
+        let mid = shard_info
+            .range
+            .midpoint()
+            .unwrap_or_else(|| panic!("range {} should have a midpoint", shard_info.range));
+        assert!(
+            shard_info.range.contains(&mid),
+            "midpoint {:?} should be within range {}",
+            mid,
+            shard_info.range
+        );
+    }
+}
+
+#[test]
+fn shard_range_midpoint_prefix_with_low_boundary() {
+    // Regression: ["0", "08") failed when midpoint appended 'M' > '8'
+    let range = ShardRange::new("0", "08");
+    let mid = range.midpoint().expect("should have a midpoint");
+    assert!(mid.as_str() > "0");
+    assert!(mid.as_str() < "08");
+}
+
+#[test]
 fn shard_info_new_has_no_parent() {
     let info = ShardInfo::new(ShardId::new(), ShardRange::full());
     assert!(info.parent_shard_id.is_none());


### PR DESCRIPTION
The midpoint function blindly appended 'M' (0x4D) when the start string was a prefix of end, which fails when end's boundary character is below 'M' (e.g. range ["0", "08") from 32-shard maps). Use end_bytes[diff_pos]/2 instead, which is guaranteed to stay below the end boundary.