### PR TITLE
Add LeaseTask RPC for directly leasing a specific job's task

### DIFF
--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -224,6 +224,21 @@ message RestartJobResponse {}
 message ExpediteJobRequest { string shard = 1; string id = 2; optional string tenant = 3; }
 message ExpediteJobResponse {}
 
+// Lease a specific job's task directly, putting it into Running state.
+// This is a test-oriented helper: workers should use LeaseTasks for normal processing.
+// Bypasses concurrency/rate-limit processing and creates a RunAttempt lease directly.
+// Returns FAILED_PRECONDITION if the job is running, terminal, or cancelled.
+// Returns NOT_FOUND if the job doesn't exist.
+message LeaseTaskRequest {
+  string shard = 1;          // Shard ID (UUID) where the job is stored.
+  string id = 2;             // The job's unique ID.
+  optional string tenant = 3; // Tenant ID if multi-tenancy is enabled.
+  string worker_id = 4;      // Worker ID to assign the lease to.
+}
+message LeaseTaskResponse {
+  Task task = 1;             // The leased task.
+}
+
 // Lease tasks for processing from this server.
 // By default, leases from all shards this server owns (fair distribution).
 // If shard is specified, filters to only that shard.
@@ -582,6 +597,12 @@ service Silo {
   // Returns NOT_FOUND if the job doesn't exist.
   rpc ExpediteJob(ExpediteJobRequest) returns (ExpediteJobResponse);
   
+  // Lease a specific job's task directly, putting it into Running state.
+  // Test-oriented helper: workers should use LeaseTasks for normal processing.
+  // Returns FAILED_PRECONDITION if the job is running, terminal, or cancelled.
+  // Returns NOT_FOUND if the job doesn't exist.
+  rpc LeaseTask(LeaseTaskRequest) returns (LeaseTaskResponse);
+
   // Lease tasks for a worker to process.
   // Workers should call this periodically to get work.
   // Returns both job tasks and floating limit refresh tasks.

--- a/src/job_store_shard/lease_task.rs
+++ b/src/job_store_shard/lease_task.rs
@@ -1,0 +1,227 @@
+//! Lease a specific job's task directly, putting it into Running state.
+//!
+//! This is a test-oriented helper that bypasses concurrency/rate-limit
+//! processing and creates a RunAttempt lease directly, similar to how
+//! `expedite_job` bypasses the normal scheduling path.
+
+use slatedb::IsolationLevel;
+use slatedb::config::WriteOptions;
+use uuid::Uuid;
+
+use crate::codec::{decode_task, encode_attempt, encode_lease};
+use crate::job::{JobStatusKind, JobView};
+use crate::job_attempt::{AttemptStatus, JobAttempt, JobAttemptView};
+use crate::job_store_shard::helpers::{
+    TxnWriter, decode_job_status_owned, now_epoch_ms, retry_on_txn_conflict,
+};
+use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
+use crate::keys::{
+    attempt_key, job_cancelled_key, job_info_key, job_status_key, leased_task_key, task_key,
+};
+use crate::task::{DEFAULT_LEASE_MS, LeaseRecord, LeasedTask, Task};
+
+/// Error returned when a job cannot be leased because it's not in a leaseable state.
+#[derive(Debug, Clone)]
+pub struct JobNotLeaseableError {
+    pub job_id: String,
+    pub status: JobStatusKind,
+    pub reason: String,
+}
+
+impl std::fmt::Display for JobNotLeaseableError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "cannot lease job {}: {} (status: {:?})",
+            self.job_id, self.reason, self.status
+        )
+    }
+}
+
+impl std::error::Error for JobNotLeaseableError {}
+
+impl JobStoreShard {
+    /// Lease a specific job's task directly, putting it into Running state.
+    ///
+    /// This is a test-oriented helper that bypasses concurrency/rate-limit
+    /// processing. For normal task processing, use `dequeue` via the
+    /// `LeaseTasks` RPC instead.
+    ///
+    /// Uses a transaction with optimistic concurrency control to atomically
+    /// read the job state, delete the pending task, create a lease, and
+    /// update the status.
+    pub async fn lease_task(
+        &self,
+        tenant: &str,
+        id: &str,
+        worker_id: &str,
+    ) -> Result<LeasedTask, JobStoreShardError> {
+        retry_on_txn_conflict("lease_task", || {
+            self.lease_task_inner(tenant, id, worker_id)
+        })
+        .await
+    }
+
+    /// Inner implementation of lease_task that runs within a single transaction attempt.
+    async fn lease_task_inner(
+        &self,
+        tenant: &str,
+        id: &str,
+        worker_id: &str,
+    ) -> Result<LeasedTask, JobStoreShardError> {
+        let now_ms = now_epoch_ms();
+
+        // Start a transaction with SerializableSnapshot isolation for conflict detection
+        let txn = self.db.begin(IsolationLevel::SerializableSnapshot).await?;
+
+        // Read job status - must exist
+        let status_key = job_status_key(tenant, id);
+        let maybe_status_raw = txn.get(&status_key).await?;
+        let Some(status_raw) = maybe_status_raw else {
+            return Err(JobStoreShardError::JobNotFound(id.to_string()));
+        };
+        let status = decode_job_status_owned(&status_raw)?;
+
+        // Validate: job must not be running
+        if status.kind == JobStatusKind::Running {
+            return Err(JobStoreShardError::JobNotLeaseable(JobNotLeaseableError {
+                job_id: id.to_string(),
+                status: status.kind,
+                reason: "job is currently running".to_string(),
+            }));
+        }
+
+        // Validate: job must not be terminal
+        if status.kind == JobStatusKind::Succeeded || status.kind == JobStatusKind::Failed {
+            return Err(JobStoreShardError::JobNotLeaseable(JobNotLeaseableError {
+                job_id: id.to_string(),
+                status: status.kind,
+                reason: "job is already in terminal state".to_string(),
+            }));
+        }
+
+        // Validate: job must not be cancelled
+        let cancelled_key = job_cancelled_key(tenant, id);
+        if txn.get(&cancelled_key).await?.is_some() {
+            return Err(JobStoreShardError::JobNotLeaseable(JobNotLeaseableError {
+                job_id: id.to_string(),
+                status: status.kind,
+                reason: "job is cancelled".to_string(),
+            }));
+        }
+
+        // Read job info for task_group, priority, payload, etc.
+        let info_key = job_info_key(tenant, id);
+        let maybe_job_raw = txn.get(&info_key).await?;
+        let Some(job_raw) = maybe_job_raw else {
+            return Err(JobStoreShardError::JobNotFound(id.to_string()));
+        };
+        let job_view = JobView::new(job_raw)?;
+        let priority = job_view.priority();
+        let task_group = job_view.task_group().to_string();
+
+        // Reconstruct the task key from status fields
+        let attempt_number = status.current_attempt.ok_or_else(|| {
+            JobStoreShardError::JobNotLeaseable(JobNotLeaseableError {
+                job_id: id.to_string(),
+                status: status.kind,
+                reason: "job has no pending task".to_string(),
+            })
+        })?;
+        let start_time_ms = status.next_attempt_starts_after_ms.ok_or_else(|| {
+            JobStoreShardError::JobNotLeaseable(JobNotLeaseableError {
+                job_id: id.to_string(),
+                status: status.kind,
+                reason: "job has no pending task".to_string(),
+            })
+        })?;
+
+        // Read the pending task via O(1) key reconstruction.
+        // When start_at_ms <= 0 at enqueue time, the task key uses 0 as its time
+        // component but the status stores the effective time (now_ms). Try the
+        // status time first, then fall back to 0 to handle immediate jobs.
+        let old_task_key = task_key(&task_group, start_time_ms, priority, id, attempt_number);
+        let (old_task_key, task_raw) = match txn.get(&old_task_key).await? {
+            Some(raw) => (old_task_key, raw),
+            None => {
+                // Fallback: try with time=0 (immediate scheduling case)
+                let zero_key = task_key(&task_group, 0, priority, id, attempt_number);
+                match txn.get(&zero_key).await? {
+                    Some(raw) => (zero_key, raw),
+                    None => {
+                        return Err(JobStoreShardError::JobNotLeaseable(JobNotLeaseableError {
+                            job_id: id.to_string(),
+                            status: status.kind,
+                            reason: "job has no pending task in queue".to_string(),
+                        }));
+                    }
+                }
+            }
+        };
+        let _existing_task = decode_task(&task_raw)?;
+
+        // Delete the pending task (regardless of type)
+        txn.delete(&old_task_key)?;
+
+        // Generate new task_id and create RunAttempt task
+        let new_task_id = Uuid::new_v4().to_string();
+        let run_task = Task::RunAttempt {
+            id: new_task_id.clone(),
+            tenant: tenant.to_string(),
+            job_id: id.to_string(),
+            attempt_number,
+            relative_attempt_number: attempt_number, // Same for non-restarted jobs
+            held_queues: vec![],
+            task_group: task_group.clone(),
+        };
+
+        // Write lease record
+        let expiry_ms = now_ms + DEFAULT_LEASE_MS;
+        let lease_key = leased_task_key(&new_task_id);
+        let record = LeaseRecord {
+            worker_id: worker_id.to_string(),
+            task: run_task.clone(),
+            expiry_ms,
+            started_at_ms: now_ms,
+        };
+        let leased_value = encode_lease(&record)?;
+        txn.put(&lease_key, &leased_value)?;
+
+        // Write attempt record
+        let attempt = JobAttempt {
+            job_id: id.to_string(),
+            attempt_number,
+            relative_attempt_number: attempt_number,
+            task_id: new_task_id,
+            started_at_ms: now_ms,
+            status: AttemptStatus::Running,
+        };
+        let attempt_val = encode_attempt(&attempt)?;
+        let akey = attempt_key(tenant, id, attempt_number);
+        txn.put(&akey, &attempt_val)?;
+
+        // Update job status to Running
+        let mut writer = TxnWriter(&txn);
+        self.set_job_status_with_index(
+            &mut writer,
+            tenant,
+            id,
+            crate::job::JobStatus::running(now_ms),
+        )
+        .await?;
+
+        // Commit the transaction with durable writes
+        txn.commit_with_options(&WriteOptions {
+            await_durable: true,
+        })
+        .await?;
+
+        // Post-commit: evict old task key from broker buffer and wake broker
+        self.broker.evict_keys(&[old_task_key]);
+        self.broker.wakeup();
+
+        // Build and return the LeasedTask
+        let attempt_view = JobAttemptView::new(&attempt_val)?;
+        Ok(LeasedTask::new(tenant.to_string(), job_view, attempt_view))
+    }
+}

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -9,6 +9,7 @@ mod floating;
 pub(crate) mod helpers;
 pub mod import;
 mod lease;
+mod lease_task;
 mod rate_limit;
 mod restart;
 mod scan;
@@ -17,6 +18,7 @@ pub use cleanup::{CleanupProgress, CleanupResult};
 
 pub use counters::{ShardCounters, counter_merge_operator};
 pub use expedite::JobNotExpediteableError;
+pub use lease_task::JobNotLeaseableError;
 pub use restart::JobNotRestartableError;
 
 pub(crate) use helpers::WriteBatcher;
@@ -125,6 +127,8 @@ pub enum JobStoreShardError {
     JobNotRestartable(#[from] JobNotRestartableError),
     #[error("cannot expedite job: {0}")]
     JobNotExpediteable(#[from] JobNotExpediteableError),
+    #[error("cannot lease job: {0}")]
+    JobNotLeaseable(#[from] JobNotLeaseableError),
     #[error("transaction conflict during {0}, exceeded max retries")]
     TransactionConflict(String),
 }

--- a/tests/grpc_lease_task_tests.rs
+++ b/tests/grpc_lease_task_tests.rs
@@ -1,0 +1,214 @@
+mod grpc_integration_helpers;
+
+use grpc_integration_helpers::{create_test_factory, setup_test_server, shutdown_server};
+use silo::pb::*;
+use silo::settings::AppConfig;
+
+/// Test leasing a specific job's task via gRPC - full round-trip.
+#[silo::test(flavor = "multi_thread")]
+async fn lease_task_grpc_basic() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        // Enqueue a job
+        let enq_resp = client
+            .enqueue(EnqueueRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: "lease-task-test-job".to_string(),
+                priority: 10,
+                start_at_ms: 0,
+                retry_policy: None,
+                payload: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({"test": true})).unwrap(),
+                    )),
+                }),
+                limits: vec![],
+                tenant: None,
+                metadata: std::collections::HashMap::new(),
+                task_group: "default".to_string(),
+            })
+            .await?
+            .into_inner();
+        let job_id = enq_resp.id;
+
+        // Lease the specific task
+        let lease_resp = client
+            .lease_task(LeaseTaskRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: job_id.clone(),
+                tenant: None,
+                worker_id: "test-worker".to_string(),
+            })
+            .await?
+            .into_inner();
+
+        let task = lease_resp.task.expect("should have task");
+        assert_eq!(task.job_id, job_id);
+        assert_eq!(task.attempt_number, 1);
+        assert_eq!(task.shard, crate::grpc_integration_helpers::TEST_SHARD_ID);
+
+        // Verify job is running
+        let job = client
+            .get_job(GetJobRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: job_id.clone(),
+                tenant: None,
+                include_attempts: false,
+            })
+            .await?
+            .into_inner();
+        assert_eq!(job.status, JobStatus::Running as i32);
+
+        // Complete the job via report outcome
+        client
+            .report_outcome(ReportOutcomeRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                task_id: task.id.clone(),
+                outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!("leased success")).unwrap(),
+                    )),
+                })),
+            })
+            .await?;
+
+        // Verify job succeeded
+        let job = client
+            .get_job(GetJobRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: job_id.clone(),
+                tenant: None,
+                include_attempts: false,
+            })
+            .await?
+            .into_inner();
+        assert_eq!(job.status, JobStatus::Succeeded as i32);
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test lease_task returns NOT_FOUND for non-existent job.
+#[silo::test(flavor = "multi_thread")]
+async fn lease_task_grpc_not_found() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let result = client
+            .lease_task(LeaseTaskRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: "does-not-exist".to_string(),
+                tenant: None,
+                worker_id: "test-worker".to_string(),
+            })
+            .await;
+
+        match result {
+            Err(status) => {
+                assert_eq!(status.code(), tonic::Code::NotFound);
+            }
+            Ok(_) => panic!("expected NOT_FOUND error"),
+        }
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test lease_task returns FAILED_PRECONDITION for already running job.
+#[silo::test(flavor = "multi_thread")]
+async fn lease_task_grpc_already_running() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        // Enqueue a job
+        let enq_resp = client
+            .enqueue(EnqueueRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: "lease-task-already-running".to_string(),
+                priority: 10,
+                start_at_ms: 0,
+                retry_policy: None,
+                payload: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({"test": true})).unwrap(),
+                    )),
+                }),
+                limits: vec![],
+                tenant: None,
+                metadata: std::collections::HashMap::new(),
+                task_group: "default".to_string(),
+            })
+            .await?
+            .into_inner();
+        let job_id = enq_resp.id;
+
+        // Lease via LeaseTasks to make it running
+        let lease_resp = client
+            .lease_tasks(LeaseTasksRequest {
+                shard: Some(crate::grpc_integration_helpers::TEST_SHARD_ID.to_string()),
+                worker_id: "worker-1".to_string(),
+                max_tasks: 1,
+                task_group: "default".to_string(),
+            })
+            .await?
+            .into_inner();
+        assert_eq!(lease_resp.tasks.len(), 1);
+        let task = &lease_resp.tasks[0];
+
+        // Try to lease again - should fail
+        let result = client
+            .lease_task(LeaseTaskRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: job_id.clone(),
+                tenant: None,
+                worker_id: "test-worker".to_string(),
+            })
+            .await;
+
+        match result {
+            Err(status) => {
+                assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+                assert!(
+                    status.message().contains("running"),
+                    "error should mention running, got: {}",
+                    status.message()
+                );
+            }
+            Ok(_) => panic!("expected FAILED_PRECONDITION error"),
+        }
+
+        // Clean up
+        client
+            .report_outcome(ReportOutcomeRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                task_id: task.id.clone(),
+                outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!("done")).unwrap(),
+                    )),
+                })),
+            })
+            .await?;
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}

--- a/tests/job_store_shard_lease_task_tests.rs
+++ b/tests/job_store_shard_lease_task_tests.rs
@@ -1,0 +1,386 @@
+mod test_helpers;
+
+use silo::job::JobStatusKind;
+use silo::job_attempt::AttemptOutcome;
+use silo::job_store_shard::JobStoreShardError;
+
+use test_helpers::*;
+
+/// Enqueue a scheduled job and lease it directly - verify it becomes Running with an attempt created.
+#[silo::test]
+async fn lease_task_scheduled_job() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Verify job is scheduled
+        let status = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("get status")
+            .expect("exists");
+        assert_eq!(status.kind, JobStatusKind::Scheduled);
+
+        // Lease the specific task
+        let leased = shard
+            .lease_task("-", &job_id, "test-worker")
+            .await
+            .expect("lease_task");
+
+        assert_eq!(leased.job().id(), job_id);
+        assert_eq!(leased.attempt().attempt_number(), 1);
+        assert_eq!(leased.tenant_id(), "-");
+
+        // Verify job is now Running
+        let status_after = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("get status")
+            .expect("exists");
+        assert_eq!(status_after.kind, JobStatusKind::Running);
+        assert_eq!(
+            status_after.current_attempt, None,
+            "Running job should have no current_attempt"
+        );
+
+        // Verify attempt was created
+        let attempt = shard
+            .get_job_attempt("-", &job_id, 1)
+            .await
+            .expect("get attempt")
+            .expect("attempt exists");
+        assert_eq!(attempt.attempt_number(), 1);
+    });
+}
+
+/// Enqueue a future-scheduled job and lease it directly - should work (expedites atomically).
+#[silo::test]
+async fn lease_task_future_scheduled_job() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let future_time_ms = now_ms() + 3_600_000; // 1 hour in the future
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                future_time_ms,
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Verify the task is NOT dequeue-able (future scheduled)
+        let tasks = shard
+            .dequeue("worker-1", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        assert!(tasks.is_empty(), "future task should not be dequeued yet");
+
+        // Lease it directly - should work even for future-scheduled jobs
+        let leased = shard
+            .lease_task("-", &job_id, "test-worker")
+            .await
+            .expect("lease_task");
+
+        assert_eq!(leased.job().id(), job_id);
+
+        // Verify job is now Running
+        let status = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("get status")
+            .expect("exists");
+        assert_eq!(status.kind, JobStatusKind::Running);
+    });
+}
+
+/// Lease a running job returns FAILED_PRECONDITION.
+#[silo::test]
+async fn lease_task_running_job_returns_error() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Dequeue to make it running
+        let tasks = shard
+            .dequeue("worker-1", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        assert_eq!(tasks.len(), 1);
+
+        // Verify running
+        let status = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("get status")
+            .expect("exists");
+        assert_eq!(status.kind, JobStatusKind::Running);
+
+        // Try to lease - should fail
+        let err = shard
+            .lease_task("-", &job_id, "test-worker")
+            .await
+            .expect_err("lease_task should fail for running job");
+
+        match err {
+            JobStoreShardError::JobNotLeaseable(e) => {
+                assert_eq!(e.job_id, job_id);
+                assert!(
+                    e.reason.contains("running"),
+                    "should mention running: {}",
+                    e.reason
+                );
+            }
+            other => panic!("expected JobNotLeaseable error, got {:?}", other),
+        }
+
+        // Clean up
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(
+                &task_id,
+                AttemptOutcome::Success {
+                    result: b"{}".to_vec(),
+                },
+            )
+            .await
+            .expect("report success");
+    });
+}
+
+/// Lease a completed (terminal) job returns FAILED_PRECONDITION.
+#[silo::test]
+async fn lease_task_terminal_job_returns_error() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Dequeue and complete
+        let tasks = shard
+            .dequeue("worker-1", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(
+                &task_id,
+                AttemptOutcome::Success {
+                    result: b"{}".to_vec(),
+                },
+            )
+            .await
+            .expect("report success");
+
+        // Verify succeeded
+        let status = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("get status")
+            .expect("exists");
+        assert_eq!(status.kind, JobStatusKind::Succeeded);
+
+        // Try to lease - should fail
+        let err = shard
+            .lease_task("-", &job_id, "test-worker")
+            .await
+            .expect_err("lease_task should fail for terminal job");
+
+        match err {
+            JobStoreShardError::JobNotLeaseable(e) => {
+                assert_eq!(e.job_id, job_id);
+                assert!(
+                    e.reason.contains("terminal"),
+                    "should mention terminal: {}",
+                    e.reason
+                );
+            }
+            other => panic!("expected JobNotLeaseable error, got {:?}", other),
+        }
+    });
+}
+
+/// Lease a cancelled job returns error.
+#[silo::test]
+async fn lease_task_cancelled_job_returns_error() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let future_time_ms = now_ms() + 3_600_000;
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                future_time_ms,
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Cancel the job
+        shard.cancel_job("-", &job_id).await.expect("cancel_job");
+
+        // Try to lease - should fail
+        let err = shard
+            .lease_task("-", &job_id, "test-worker")
+            .await
+            .expect_err("lease_task should fail for cancelled job");
+
+        match err {
+            JobStoreShardError::JobNotLeaseable(e) => {
+                assert_eq!(e.job_id, job_id);
+                assert!(
+                    e.reason.contains("cancelled"),
+                    "should mention cancelled: {}",
+                    e.reason
+                );
+            }
+            other => panic!("expected JobNotLeaseable error, got {:?}", other),
+        }
+    });
+}
+
+/// Lease a nonexistent job returns NOT_FOUND.
+#[silo::test]
+async fn lease_task_nonexistent_job_returns_error() {
+    with_timeout!(10000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let err = shard
+            .lease_task("-", "does-not-exist", "test-worker")
+            .await
+            .expect_err("lease_task should fail for nonexistent job");
+
+        match err {
+            JobStoreShardError::JobNotFound(id) => {
+                assert_eq!(id, "does-not-exist");
+            }
+            other => panic!("expected JobNotFound error, got {:?}", other),
+        }
+    });
+}
+
+/// Lease a task then report a successful outcome - verify the job reaches Succeeded.
+#[silo::test]
+async fn lease_task_then_report_outcome() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"action": "test"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Lease the task directly
+        let leased = shard
+            .lease_task("-", &job_id, "test-worker")
+            .await
+            .expect("lease_task");
+
+        let task_id = leased.attempt().task_id().to_string();
+
+        // Report success
+        shard
+            .report_attempt_outcome(
+                &task_id,
+                AttemptOutcome::Success {
+                    result: b"{\"done\": true}".to_vec(),
+                },
+            )
+            .await
+            .expect("report success");
+
+        // Verify job is succeeded
+        let status = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("get status")
+            .expect("exists");
+        assert_eq!(status.kind, JobStatusKind::Succeeded);
+
+        // Verify the attempt is succeeded
+        let attempt = shard
+            .get_job_attempt("-", &job_id, 1)
+            .await
+            .expect("get attempt")
+            .expect("attempt exists");
+        assert!(
+            matches!(
+                attempt.state(),
+                silo::job_attempt::AttemptStatus::Succeeded { .. }
+            ),
+            "attempt should be succeeded"
+        );
+    });
+}

--- a/typescript_client/src/pb/silo.client.ts
+++ b/typescript_client/src/pb/silo.client.ts
@@ -31,6 +31,8 @@ import type { ReportOutcomeResponse } from "./silo";
 import type { ReportOutcomeRequest } from "./silo";
 import type { LeaseTasksResponse } from "./silo";
 import type { LeaseTasksRequest } from "./silo";
+import type { LeaseTaskResponse } from "./silo";
+import type { LeaseTaskRequest } from "./silo";
 import type { ExpediteJobResponse } from "./silo";
 import type { ExpediteJobRequest } from "./silo";
 import type { RestartJobResponse } from "./silo";
@@ -124,6 +126,15 @@ export interface ISiloClient {
      * @generated from protobuf rpc: ExpediteJob
      */
     expediteJob(input: ExpediteJobRequest, options?: RpcOptions): UnaryCall<ExpediteJobRequest, ExpediteJobResponse>;
+    /**
+     * Lease a specific job's task directly, putting it into Running state.
+     * Test-oriented helper: workers should use LeaseTasks for normal processing.
+     * Returns FAILED_PRECONDITION if the job is running, terminal, or cancelled.
+     * Returns NOT_FOUND if the job doesn't exist.
+     *
+     * @generated from protobuf rpc: LeaseTask
+     */
+    leaseTask(input: LeaseTaskRequest, options?: RpcOptions): UnaryCall<LeaseTaskRequest, LeaseTaskResponse>;
     /**
      * Lease tasks for a worker to process.
      * Workers should call this periodically to get work.
@@ -335,6 +346,18 @@ export class SiloClient implements ISiloClient, ServiceInfo {
         return stackIntercept<ExpediteJobRequest, ExpediteJobResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * Lease a specific job's task directly, putting it into Running state.
+     * Test-oriented helper: workers should use LeaseTasks for normal processing.
+     * Returns FAILED_PRECONDITION if the job is running, terminal, or cancelled.
+     * Returns NOT_FOUND if the job doesn't exist.
+     *
+     * @generated from protobuf rpc: LeaseTask
+     */
+    leaseTask(input: LeaseTaskRequest, options?: RpcOptions): UnaryCall<LeaseTaskRequest, LeaseTaskResponse> {
+        const method = this.methods[9], opt = this._transport.mergeOptions(options);
+        return stackIntercept<LeaseTaskRequest, LeaseTaskResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
      * Lease tasks for a worker to process.
      * Workers should call this periodically to get work.
      * Returns both job tasks and floating limit refresh tasks.
@@ -342,7 +365,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: LeaseTasks
      */
     leaseTasks(input: LeaseTasksRequest, options?: RpcOptions): UnaryCall<LeaseTasksRequest, LeaseTasksResponse> {
-        const method = this.methods[9], opt = this._transport.mergeOptions(options);
+        const method = this.methods[10], opt = this._transport.mergeOptions(options);
         return stackIntercept<LeaseTasksRequest, LeaseTasksResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -352,7 +375,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ReportOutcome
      */
     reportOutcome(input: ReportOutcomeRequest, options?: RpcOptions): UnaryCall<ReportOutcomeRequest, ReportOutcomeResponse> {
-        const method = this.methods[10], opt = this._transport.mergeOptions(options);
+        const method = this.methods[11], opt = this._transport.mergeOptions(options);
         return stackIntercept<ReportOutcomeRequest, ReportOutcomeResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -362,7 +385,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ReportRefreshOutcome
      */
     reportRefreshOutcome(input: ReportRefreshOutcomeRequest, options?: RpcOptions): UnaryCall<ReportRefreshOutcomeRequest, ReportRefreshOutcomeResponse> {
-        const method = this.methods[11], opt = this._transport.mergeOptions(options);
+        const method = this.methods[12], opt = this._transport.mergeOptions(options);
         return stackIntercept<ReportRefreshOutcomeRequest, ReportRefreshOutcomeResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -373,7 +396,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: Heartbeat
      */
     heartbeat(input: HeartbeatRequest, options?: RpcOptions): UnaryCall<HeartbeatRequest, HeartbeatResponse> {
-        const method = this.methods[12], opt = this._transport.mergeOptions(options);
+        const method = this.methods[13], opt = this._transport.mergeOptions(options);
         return stackIntercept<HeartbeatRequest, HeartbeatResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -383,7 +406,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: Query
      */
     query(input: QueryRequest, options?: RpcOptions): UnaryCall<QueryRequest, QueryResponse> {
-        const method = this.methods[13], opt = this._transport.mergeOptions(options);
+        const method = this.methods[14], opt = this._transport.mergeOptions(options);
         return stackIntercept<QueryRequest, QueryResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -394,7 +417,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: QueryArrow
      */
     queryArrow(input: QueryArrowRequest, options?: RpcOptions): ServerStreamingCall<QueryArrowRequest, ArrowIpcMessage> {
-        const method = this.methods[14], opt = this._transport.mergeOptions(options);
+        const method = this.methods[15], opt = this._transport.mergeOptions(options);
         return stackIntercept<QueryArrowRequest, ArrowIpcMessage>("serverStreaming", this._transport, method, opt, input);
     }
     /**
@@ -405,7 +428,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: CpuProfile
      */
     cpuProfile(input: CpuProfileRequest, options?: RpcOptions): UnaryCall<CpuProfileRequest, CpuProfileResponse> {
-        const method = this.methods[15], opt = this._transport.mergeOptions(options);
+        const method = this.methods[16], opt = this._transport.mergeOptions(options);
         return stackIntercept<CpuProfileRequest, CpuProfileResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -418,7 +441,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: RequestSplit
      */
     requestSplit(input: RequestSplitRequest, options?: RpcOptions): UnaryCall<RequestSplitRequest, RequestSplitResponse> {
-        const method = this.methods[16], opt = this._transport.mergeOptions(options);
+        const method = this.methods[17], opt = this._transport.mergeOptions(options);
         return stackIntercept<RequestSplitRequest, RequestSplitResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -429,7 +452,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: GetSplitStatus
      */
     getSplitStatus(input: GetSplitStatusRequest, options?: RpcOptions): UnaryCall<GetSplitStatusRequest, GetSplitStatusResponse> {
-        const method = this.methods[17], opt = this._transport.mergeOptions(options);
+        const method = this.methods[18], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetSplitStatusRequest, GetSplitStatusResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -441,7 +464,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ConfigureShard
      */
     configureShard(input: ConfigureShardRequest, options?: RpcOptions): UnaryCall<ConfigureShardRequest, ConfigureShardResponse> {
-        const method = this.methods[18], opt = this._transport.mergeOptions(options);
+        const method = this.methods[19], opt = this._transport.mergeOptions(options);
         return stackIntercept<ConfigureShardRequest, ConfigureShardResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -453,7 +476,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ImportJobs
      */
     importJobs(input: ImportJobsRequest, options?: RpcOptions): UnaryCall<ImportJobsRequest, ImportJobsResponse> {
-        const method = this.methods[19], opt = this._transport.mergeOptions(options);
+        const method = this.methods[20], opt = this._transport.mergeOptions(options);
         return stackIntercept<ImportJobsRequest, ImportJobsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -464,7 +487,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ResetShards
      */
     resetShards(input: ResetShardsRequest, options?: RpcOptions): UnaryCall<ResetShardsRequest, ResetShardsResponse> {
-        const method = this.methods[20], opt = this._transport.mergeOptions(options);
+        const method = this.methods[21], opt = this._transport.mergeOptions(options);
         return stackIntercept<ResetShardsRequest, ResetShardsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -475,7 +498,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ForceReleaseShard
      */
     forceReleaseShard(input: ForceReleaseShardRequest, options?: RpcOptions): UnaryCall<ForceReleaseShardRequest, ForceReleaseShardResponse> {
-        const method = this.methods[21], opt = this._transport.mergeOptions(options);
+        const method = this.methods[22], opt = this._transport.mergeOptions(options);
         return stackIntercept<ForceReleaseShardRequest, ForceReleaseShardResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -578,6 +578,42 @@ export interface ExpediteJobRequest {
 export interface ExpediteJobResponse {
 }
 /**
+ * Lease a specific job's task directly, putting it into Running state.
+ * This is a test-oriented helper: workers should use LeaseTasks for normal processing.
+ * Bypasses concurrency/rate-limit processing and creates a RunAttempt lease directly.
+ * Returns FAILED_PRECONDITION if the job is running, terminal, or cancelled.
+ * Returns NOT_FOUND if the job doesn't exist.
+ *
+ * @generated from protobuf message silo.v1.LeaseTaskRequest
+ */
+export interface LeaseTaskRequest {
+    /**
+     * @generated from protobuf field: string shard = 1
+     */
+    shard: string; // Shard ID (UUID) where the job is stored.
+    /**
+     * @generated from protobuf field: string id = 2
+     */
+    id: string; // The job's unique ID.
+    /**
+     * @generated from protobuf field: optional string tenant = 3
+     */
+    tenant?: string; // Tenant ID if multi-tenancy is enabled.
+    /**
+     * @generated from protobuf field: string worker_id = 4
+     */
+    workerId: string; // Worker ID to assign the lease to.
+}
+/**
+ * @generated from protobuf message silo.v1.LeaseTaskResponse
+ */
+export interface LeaseTaskResponse {
+    /**
+     * @generated from protobuf field: silo.v1.Task task = 1
+     */
+    task?: Task; // The leased task.
+}
+/**
  * Lease tasks for processing from this server.
  * By default, leases from all shards this server owns (fair distribution).
  * If shard is specified, filters to only that shard.
@@ -3255,6 +3291,122 @@ class ExpediteJobResponse$Type extends MessageType<ExpediteJobResponse> {
  * @generated MessageType for protobuf message silo.v1.ExpediteJobResponse
  */
 export const ExpediteJobResponse = new ExpediteJobResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class LeaseTaskRequest$Type extends MessageType<LeaseTaskRequest> {
+    constructor() {
+        super("silo.v1.LeaseTaskRequest", [
+            { no: 1, name: "shard", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "tenant", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "worker_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<LeaseTaskRequest>): LeaseTaskRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.shard = "";
+        message.id = "";
+        message.workerId = "";
+        if (value !== undefined)
+            reflectionMergePartial<LeaseTaskRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: LeaseTaskRequest): LeaseTaskRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string shard */ 1:
+                    message.shard = reader.string();
+                    break;
+                case /* string id */ 2:
+                    message.id = reader.string();
+                    break;
+                case /* optional string tenant */ 3:
+                    message.tenant = reader.string();
+                    break;
+                case /* string worker_id */ 4:
+                    message.workerId = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: LeaseTaskRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string shard = 1; */
+        if (message.shard !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.shard);
+        /* string id = 2; */
+        if (message.id !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.id);
+        /* optional string tenant = 3; */
+        if (message.tenant !== undefined)
+            writer.tag(3, WireType.LengthDelimited).string(message.tenant);
+        /* string worker_id = 4; */
+        if (message.workerId !== "")
+            writer.tag(4, WireType.LengthDelimited).string(message.workerId);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.LeaseTaskRequest
+ */
+export const LeaseTaskRequest = new LeaseTaskRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class LeaseTaskResponse$Type extends MessageType<LeaseTaskResponse> {
+    constructor() {
+        super("silo.v1.LeaseTaskResponse", [
+            { no: 1, name: "task", kind: "message", T: () => Task }
+        ]);
+    }
+    create(value?: PartialMessage<LeaseTaskResponse>): LeaseTaskResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<LeaseTaskResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: LeaseTaskResponse): LeaseTaskResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* silo.v1.Task task */ 1:
+                    message.task = Task.internalBinaryRead(reader, reader.uint32(), options, message.task);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: LeaseTaskResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* silo.v1.Task task = 1; */
+        if (message.task)
+            Task.internalBinaryWrite(message.task, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.LeaseTaskResponse
+ */
+export const LeaseTaskResponse = new LeaseTaskResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class LeaseTasksRequest$Type extends MessageType<LeaseTasksRequest> {
     constructor() {
@@ -6037,6 +6189,7 @@ export const Silo = new ServiceType("silo.v1.Silo", [
     { name: "CancelJob", options: {}, I: CancelJobRequest, O: CancelJobResponse },
     { name: "RestartJob", options: {}, I: RestartJobRequest, O: RestartJobResponse },
     { name: "ExpediteJob", options: {}, I: ExpediteJobRequest, O: ExpediteJobResponse },
+    { name: "LeaseTask", options: {}, I: LeaseTaskRequest, O: LeaseTaskResponse },
     { name: "LeaseTasks", options: {}, I: LeaseTasksRequest, O: LeaseTasksResponse },
     { name: "ReportOutcome", options: {}, I: ReportOutcomeRequest, O: ReportOutcomeResponse },
     { name: "ReportRefreshOutcome", options: {}, I: ReportRefreshOutcomeRequest, O: ReportRefreshOutcomeResponse },


### PR DESCRIPTION
Adds a test-oriented LeaseTask (singular) RPC that targets a specific job
by ID and puts it directly into Running state, bypassing concurrency and
rate-limit processing. This simplifies test fixture setup from ~60 lines
of retry/mutex/cancel/restart workarounds to a single call.

- Proto: LeaseTaskRequest/LeaseTaskResponse messages and LeaseTask RPC
- Core: transaction-based direct lease with O(1) task key reconstruction
- Server: handler with shard routing, redirect support, error mapping
- Helpers: make retry_on_txn_conflict generic over return type T
- TypeScript: leaseTask() method with _withWrongShardRetry pattern
- Tests: 7 shard-level + 3 gRPC integration + 3 TS integration tests

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
