### PR TITLE
Fix DST high_latency and k8s_shard_splits flaky failures

### DIFF
--- a/tests/turmoil_runner/scenarios/high_latency.rs
+++ b/tests/turmoil_runner/scenarios/high_latency.rs
@@ -318,12 +318,13 @@ pub fn run() {
                 let mut completed = 0u32;
                 let mut failed = 0u32;
                 let mut processing: Vec<Task> = Vec::new();
+                let mut round = 0u32;
 
-                // More rounds to handle all jobs with delays
-                for round in 0..80 {
-                    if worker_done_flag.load(Ordering::SeqCst) {
-                        break;
-                    }
+                // Keep working until the verifier signals convergence.
+                // Under high latency with serial concurrency limits, jobs can take
+                // many rounds to process, so a fixed round limit is insufficient.
+                while !worker_done_flag.load(Ordering::SeqCst) {
+                    round += 1;
 
                     // Variable batch size
                     let max_tasks = rng.random_range(worker_batch_range.0..=worker_batch_range.1);


### PR DESCRIPTION
high_latency: Workers had a fixed 80-round limit that was insufficient
under high latency with many jobs, especially for serial concurrency
queues. Changed to a while loop that runs until the verifier signals
convergence.

k8s_shard_splits: The verifier declared convergence before the producer
finished enqueuing, causing it to see completed==enqueued on a partial
count. Added an enqueueing_done flag so convergence requires the
producer to finish first. Also added a 10s timeout on coordinator
shutdown to prevent scenario hangs, increased scenario max_time from
60s to 90s, and made the producer respect scenario_done to stop
enqueuing when nodes are shutting down.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
