### PR TITLE
Simplify job store shard, concurrency, and dequeue internals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
   test:
     name: Rust tests
     runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-test-env

--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -6,10 +6,7 @@
 //!
 //! ## Connection Resilience
 //!
-//! The client includes built-in timeout and reconnection logic to handle network
-//! failures gracefully. When a connection fails or times out, the client will
-//! automatically invalidate the cached connection and attempt to reconnect on
-//! the next request.
+//! The client includes built-in timeout and reconnection logic to handle network failures gracefully. When a connection fails or times out, the client will  automatically invalidate the cached connection and attempt to reconnect on the next request.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -31,8 +28,7 @@ use crate::shard_range::ShardId;
 
 /// Configuration for gRPC client connections.
 ///
-/// These settings control timeouts, retries, and connection behavior for both
-/// internal cluster communication and external client connections.
+/// These settings control timeouts, retries, and connection behavior for both internal cluster communication and external client connections.
 #[derive(Debug, Clone)]
 pub struct ClientConfig {
     /// Timeout for establishing a connection to a remote node.
@@ -83,8 +79,7 @@ impl ClientConfig {
     }
 
     /// Create a config optimized for deterministic simulation testing (DST).
-    /// Uses very short timeouts to ensure simulations complete within their time budgets,
-    /// while still being long enough to handle normal request processing.
+    /// Uses very short timeouts to ensure simulations complete within their time budgets, while still being long enough to handle normal request processing.
     pub fn for_dst() -> Self {
         Self {
             connect_timeout: Duration::from_secs(2),
@@ -116,13 +111,9 @@ impl ClientConfig {
 
 /// Helper to create a SiloClient with proper timeout and retry configuration.
 ///
-/// This function creates a gRPC client with configurable timeouts and automatic
-/// retry logic with exponential backoff. Retries are attempted when the initial
-/// connection fails.
+/// This function creates a gRPC client with configurable timeouts and automatic retry logic with exponential backoff. Retries are attempted when the initial connection fails.
 ///
-/// Each connection attempt is wrapped with a hard timeout to ensure we don't hang
-/// indefinitely when TCP/HTTP2 gets into a bad state (e.g., due to packet loss or
-/// network partitions that leave the connection half-open).
+/// Each connection attempt is wrapped with a hard timeout to ensure we don't hang indefinitely when TCP/HTTP2 gets into a bad state (e.g., due to packet loss or network partitions that leave the connection half-open).
 ///
 /// # Arguments
 /// * `uri` - The server URI (e.g., "http://localhost:9910")
@@ -148,10 +139,8 @@ pub async fn create_silo_client(
         .configure_endpoint(&full_uri)
         .map_err(|e| ClusterClientError::ConnectionFailed(full_uri.clone(), e.to_string()))?;
 
-    // Hard timeout per connection attempt. The endpoint has a connect_timeout, but
-    // in practice TCP/HTTP2 can get into states where the timeout doesn't fire
-    // (e.g., half-open connections, corrupted h2 streams). This ensures we don't
-    // hang indefinitely on any single attempt.
+    // Hard timeout per connection attempt. The endpoint has a connect_timeout, but in practice TCP/HTTP2 can get into states where the timeout doesn't fire
+    // (e.g., half-open connections, corrupted h2 streams). This ensures we don't hang indefinitely on any single attempt.
     let attempt_timeout = config.connect_timeout + Duration::from_secs(1);
 
     let mut last_error = None;
@@ -728,10 +717,7 @@ impl ClusterClient {
     }
 
     /// Get node information from all cluster members.
-    ///
-    /// Calls GetNodeInfo RPC on all cluster members and aggregates the results.
-    /// This returns counters and cleanup status for all shards across the cluster.
-    /// For the local node, gets information directly from the factory instead of gRPC.
+    /// Calls GetNodeInfo RPC on all cluster members and aggregates the results. This returns counters and cleanup status for all shards across the cluster. For the local node, gets information directly from the factory instead of gRPC.
     pub async fn get_all_node_info(&self) -> Result<ClusterNodeInfo, ClusterClientError> {
         let Some(coordinator) = &self.coordinator else {
             return Err(ClusterClientError::NoCoordinator);

--- a/src/cluster_query.rs
+++ b/src/cluster_query.rs
@@ -537,13 +537,7 @@ async fn query_remote_shard_batches(
     loop {
         attempt += 1;
 
-        // Ensure address has http:// scheme for gRPC connection
-        let full_addr =
-            if current_addr.starts_with("http://") || current_addr.starts_with("https://") {
-                current_addr.clone()
-            } else {
-                format!("http://{}", current_addr)
-            };
+        let full_addr = crate::cluster_client::ensure_http_scheme(&current_addr);
         debug!(shard_id = %shard_id, addr = %full_addr, sql = %sql, attempt, "querying remote shard");
 
         // Connect to remote node

--- a/src/cluster_query.rs
+++ b/src/cluster_query.rs
@@ -1,12 +1,8 @@
 //! Cluster-wide query engine using Apache DataFusion.
 //!
-//! This module provides a query engine that can execute SQL queries across all shards
-//! in a Silo cluster. It creates a multi-partition execution plan where each partition
-//! corresponds to a shard, enabling DataFusion to properly aggregate results across
-//! the entire cluster.
+//! This module provides a query engine that can execute SQL queries across all shards in a Silo cluster. It creates a multi-partition execution plan where each partition corresponds to a shard, enabling DataFusion to properly aggregate results across the entire cluster.
 //!
-//! For local shards, data is read directly. For remote shards, the engine makes
-//! gRPC calls using Arrow IPC for efficient data transfer.
+//! For local shards, data is read directly. For remote shards, the engine makes gRPC calls using Arrow IPC for efficient data transfer.
 
 use std::any::Any;
 use std::collections::HashMap;

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -31,7 +31,7 @@ use std::sync::Mutex;
 
 use slatedb::{Db, DbIterator, WriteBatch};
 
-use crate::job_store_shard::WriteBatcher;
+use crate::job_store_shard::helpers::WriteBatcher;
 
 use crate::codec::{
     decode_concurrency_action, encode_concurrency_action, encode_holder, encode_task,

--- a/src/coordination/etcd.rs
+++ b/src/coordination/etcd.rs
@@ -11,12 +11,9 @@ use crate::dst_events::{self, DstEvent};
 use crate::factory::ShardFactory;
 use crate::shard_range::{ShardId, ShardMap, SplitInProgress};
 
-// Re-export ShardPhase for backwards compatibility (tests reference it from here)
-pub use super::ShardPhase;
-
-use super::{
+use crate::coordination::{
     CoordinationError, Coordinator, CoordinatorBase, MemberInfo, ShardGuardContext,
-    ShardGuardState, ShardOwnerMap, SplitStorageBackend, get_hostname, keys,
+    ShardGuardState, ShardOwnerMap, ShardPhase, SplitStorageBackend, get_hostname, keys,
 };
 
 /// etcd-based coordinator for distributed shard ownership.

--- a/src/coordination/k8s.rs
+++ b/src/coordination/k8s.rs
@@ -14,8 +14,10 @@ use crate::dst_events::{self, DstEvent};
 use crate::factory::ShardFactory;
 use crate::shard_range::{ShardId, ShardMap, SplitInProgress};
 
-use super::k8s_backend::{ConfigMapWatchEvent, K8sBackend, KubeBackend, LeaseWatchEvent};
-use super::{
+use crate::coordination::k8s_backend::{
+    ConfigMapWatchEvent, K8sBackend, KubeBackend, LeaseWatchEvent,
+};
+use crate::coordination::{
     CoordinationError, Coordinator, CoordinatorBase, K8sOwnershipToken, MemberInfo,
     ShardGuardContext, ShardGuardState, ShardOwnerMap, ShardPhase, SplitStorageBackend,
     compute_desired_shards_for_node, get_hostname, keys,

--- a/src/coordination/k8s_backend.rs
+++ b/src/coordination/k8s_backend.rs
@@ -11,7 +11,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use tokio_stream::Stream;
 
-use super::CoordinationError;
+use crate::coordination::CoordinationError;
 
 /// Watch event types for lease changes
 #[derive(Debug, Clone)]

--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -9,7 +9,7 @@ use tracing::{debug, info};
 use crate::factory::ShardFactory;
 use crate::shard_range::{ShardId, ShardMap, SplitInProgress};
 
-use super::{CoordinationError, ShardOwnerMap};
+use crate::coordination::{CoordinationError, ShardOwnerMap};
 
 /// [SILO-COORD-INV-8] Status of post-split cleanup for a shard.
 ///
@@ -206,7 +206,7 @@ impl ShardSplitContext {
     }
 }
 
-use super::Coordinator;
+use crate::coordination::Coordinator;
 
 /// splitter for shard split operations.
 ///

--- a/src/gubernator.rs
+++ b/src/gubernator.rs
@@ -1,8 +1,6 @@
 //! Gubernator rate limit client with request coalescing.
 //!
-//! This module provides a client for the Gubernator rate limiting service.
-//! It supports request coalescing to batch multiple rate limit checks into
-//! a single RPC call for efficiency.
+//! This module provides a client for the Gubernator rate limiting service. It supports request coalescing to batch multiple rate limit checks into a single RPC call for efficiency.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -200,8 +198,7 @@ impl GubernatorClient {
         let handle = tokio::spawn(Self::coalesce_loop(client_clone, rx, config));
 
         // Replace the placeholder handle
-        // Note: This is a bit awkward but necessary for the self-referential setup
-        // In practice, the handle is just for cleanup and the loop runs independently
+        // Note: This is a bit awkward but necessary for the self-referential setup. In practice, the handle is just for cleanup and the loop runs independently
         drop(handle);
 
         client

--- a/src/job.rs
+++ b/src/job.rs
@@ -195,8 +195,7 @@ pub struct JobStatus {
     /// Present for scheduled jobs (initial or retry), absent for running or terminal jobs.
     pub next_attempt_starts_after_ms: Option<i64>,
     /// The current attempt number for this job's pending task.
-    /// Present when a task exists in the task queue (Scheduled status),
-    /// absent when the job is running (task became a lease) or terminal.
+    /// Present when a task exists in the task queue (Scheduled status), absent when the job is running (task became a lease) or terminal.
     /// Used for O(1) task key reconstruction in expedite operations.
     pub current_attempt: Option<u32>,
 }
@@ -309,7 +308,6 @@ impl JobView {
     }
 
     /// Decode the payload from MessagePack bytes into a serde_json::Value for display.
-    /// This is used by the web UI and SQL query engine for human-readable display.
     pub fn payload_as_json(&self) -> Result<serde_json::Value, rmp_serde::decode::Error> {
         rmp_serde::from_slice(self.payload_bytes())
     }
@@ -326,8 +324,7 @@ impl JobView {
         self.decoded.archived()
     }
 
-    /// Return the job's retry policy as a runtime struct, if present, by copying
-    /// primitive fields from the archived view.
+    /// Return the job's retry policy as a runtime struct, if present, by copying primitive fields from the archived view.
     pub fn retry_policy(&self) -> Option<RetryPolicy> {
         let a = self.archived();
         let pol = a.retry_policy.as_ref()?;

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -45,21 +45,7 @@ pub struct CleanupResult {
     pub cancelled: bool,
 }
 
-/// Namespace prefixes for different key types.
-/// These match the prefix bytes defined in keys.rs.
-mod prefix {
-    pub const JOB_INFO: u8 = 0x01;
-    pub const JOB_STATUS: u8 = 0x02;
-    pub const IDX_STATUS_TIME: u8 = 0x03;
-    pub const IDX_METADATA: u8 = 0x04;
-    // Note: TASK (0x05) cleanup is handled separately via tasks_prefix()
-    pub const LEASE: u8 = 0x06;
-    pub const ATTEMPT: u8 = 0x07;
-    pub const CONCURRENCY_REQUEST: u8 = 0x08;
-    pub const CONCURRENCY_HOLDER: u8 = 0x09;
-    pub const JOB_CANCELLED: u8 = 0x0A;
-    pub const FLOATING_LIMIT: u8 = 0x0B;
-}
+use crate::keys::prefix;
 
 impl JobStoreShard {
     /// Check if cleanup has been cancelled and return a result if so.

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -55,7 +55,6 @@ impl JobStoreShard {
         task_group: &str,
         max_tasks: usize,
     ) -> Result<DequeueResult, JobStoreShardError> {
-        let _ts_enter = now_epoch_ms();
         if max_tasks == 0 {
             return Ok(DequeueResult {
                 tasks: Vec::new(),

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -9,7 +9,7 @@ use crate::dst_events::{self, DstEvent};
 use crate::job::{JobStatus, JobView};
 use crate::job_attempt::{AttemptStatus, JobAttempt, JobAttemptView};
 use crate::job_store_shard::helpers::{DbWriteBatcher, now_epoch_ms};
-use crate::job_store_shard::{DequeueResult, JobStoreShard, JobStoreShardError};
+use crate::job_store_shard::{DequeueResult, JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{attempt_key, job_info_key, leased_task_key};
 use crate::shard_range::ShardRange;
 use crate::task::{DEFAULT_LEASE_MS, LeaseRecord, LeasedRefreshTask, LeasedTask, Task};
@@ -123,17 +123,7 @@ impl JobStoreShard {
                 }
 
                 match task {
-                    Task::RequestTicket {
-                        queue,
-                        start_time_ms: _,
-                        priority: _priority,
-                        tenant,
-                        job_id,
-                        attempt_number,
-                        relative_attempt_number,
-                        request_id,
-                        task_group: req_task_group,
-                    } => {
+                    Task::RequestTicket { .. } => {
                         self.handle_request_ticket(
                             &mut state,
                             entry,
@@ -141,96 +131,25 @@ impl JobStoreShard {
                             worker_id,
                             now_ms,
                             expiry_ms,
-                            queue,
-                            tenant,
-                            job_id,
-                            *attempt_number,
-                            *relative_attempt_number,
-                            request_id,
-                            req_task_group,
                         )
                         .await?;
                     }
-                    Task::CheckRateLimit {
-                        task_id: check_task_id,
-                        tenant,
-                        job_id,
-                        attempt_number,
-                        relative_attempt_number: check_relative_attempt_number,
-                        limit_index,
-                        rate_limit,
-                        retry_count,
-                        started_at_ms,
-                        priority,
-                        held_queues,
-                        task_group: check_task_group,
-                    } => {
-                        self.handle_check_rate_limit(
-                            &mut state,
-                            entry,
-                            now_ms,
-                            check_task_id,
-                            tenant,
-                            job_id,
-                            *attempt_number,
-                            *check_relative_attempt_number,
-                            *limit_index,
-                            rate_limit,
-                            *retry_count,
-                            *started_at_ms,
-                            *priority,
-                            held_queues,
-                            check_task_group,
-                        )
-                        .await?;
+                    Task::CheckRateLimit { .. } => {
+                        self.handle_check_rate_limit(&mut state, entry, now_ms)
+                            .await?;
                     }
-                    Task::RefreshFloatingLimit {
-                        task_id,
-                        tenant: task_tenant,
-                        queue_key,
-                        current_max_concurrency,
-                        last_refreshed_at_ms,
-                        metadata,
-                        task_group: refresh_task_group,
-                    } => {
+                    Task::RefreshFloatingLimit { .. } => {
                         self.handle_refresh_floating_limit(
                             &mut state,
                             &mut refresh_out,
                             entry,
                             worker_id,
                             expiry_ms,
-                            task,
-                            task_id,
-                            task_tenant,
-                            queue_key,
-                            *current_max_concurrency,
-                            *last_refreshed_at_ms,
-                            metadata,
-                            refresh_task_group,
                         )?;
                     }
-                    Task::RunAttempt {
-                        id,
-                        tenant,
-                        job_id,
-                        attempt_number,
-                        relative_attempt_number,
-                        ..
-                    } => {
-                        self.handle_run_attempt(
-                            &mut state,
-                            entry,
-                            task,
-                            worker_id,
-                            now_ms,
-                            expiry_ms,
-                            id,
-                            tenant,
-                            job_id,
-                            *attempt_number,
-                            *relative_attempt_number,
-                        )
-                        .await?;
+                    Task::RunAttempt { .. } => {
+                        self.handle_run_attempt(&mut state, entry, worker_id, now_ms, expiry_ms)
+                            .await?;
                     }
                 }
             }
@@ -398,7 +317,6 @@ impl JobStoreShard {
     }
 
     /// Process a RequestTicket task: check cancellation, process concurrency ticket, maybe lease.
-    #[allow(clippy::too_many_arguments)]
     async fn handle_request_ticket(
         &self,
         state: &mut DequeueIterationState,
@@ -407,14 +325,22 @@ impl JobStoreShard {
         worker_id: &str,
         now_ms: i64,
         expiry_ms: i64,
-        queue: &str,
-        tenant: &str,
-        job_id: &str,
-        attempt_number: u32,
-        relative_attempt_number: u32,
-        request_id: &str,
-        req_task_group: &str,
     ) -> Result<(), JobStoreShardError> {
+        let Task::RequestTicket {
+            queue,
+            tenant,
+            job_id,
+            attempt_number,
+            relative_attempt_number,
+            request_id,
+            task_group: req_task_group,
+            ..
+        } = &entry.task
+        else {
+            unreachable!()
+        };
+        let attempt_number = *attempt_number;
+        let relative_attempt_number = *relative_attempt_number;
         state.processed_internal = true;
         let tenant = tenant.to_string();
 
@@ -510,25 +436,35 @@ impl JobStoreShard {
     }
 
     /// Process a CheckRateLimit task: check rate limit, enqueue follow-up or retry.
-    #[allow(clippy::too_many_arguments)]
     async fn handle_check_rate_limit(
         &self,
         state: &mut DequeueIterationState,
         entry: &BrokerTask,
         now_ms: i64,
-        check_task_id: &str,
-        tenant: &str,
-        job_id: &str,
-        attempt_number: u32,
-        check_relative_attempt_number: u32,
-        limit_index: u32,
-        rate_limit: &crate::task::GubernatorRateLimitData,
-        retry_count: u32,
-        started_at_ms: i64,
-        priority: u8,
-        held_queues: &[String],
-        check_task_group: &str,
     ) -> Result<(), JobStoreShardError> {
+        let Task::CheckRateLimit {
+            task_id: check_task_id,
+            tenant,
+            job_id,
+            attempt_number,
+            relative_attempt_number: check_relative_attempt_number,
+            limit_index,
+            rate_limit,
+            retry_count,
+            started_at_ms,
+            priority,
+            held_queues,
+            task_group: check_task_group,
+        } = &entry.task
+        else {
+            unreachable!()
+        };
+        let attempt_number = *attempt_number;
+        let check_relative_attempt_number = *check_relative_attempt_number;
+        let limit_index = *limit_index;
+        let retry_count = *retry_count;
+        let started_at_ms = *started_at_ms;
+        let priority = *priority;
         state.processed_internal = true;
         let tenant = tenant.to_string();
         state.batch.delete(&entry.key);
@@ -557,18 +493,20 @@ impl JobStoreShard {
                             db: &self.db,
                             batch: &mut state.batch,
                         },
-                        &tenant,
-                        check_task_id,
-                        job_id,
-                        attempt_number,
-                        check_relative_attempt_number,
-                        (limit_index + 1) as usize, // next limit after current
-                        &job_view.limits(),
-                        priority,
-                        now_ms,
-                        now_ms,
-                        held_queues.to_vec(),
-                        check_task_group,
+                        LimitTaskParams {
+                            tenant: &tenant,
+                            task_id: check_task_id,
+                            job_id,
+                            attempt_number,
+                            relative_attempt_number: check_relative_attempt_number,
+                            limit_index: (limit_index + 1) as usize,
+                            limits: &job_view.limits(),
+                            priority,
+                            start_at_ms: now_ms,
+                            now_ms,
+                            held_queues: held_queues.to_vec(),
+                            task_group: check_task_group,
+                        },
                     )
                     .await?;
                 // Track any immediate grants for rollback if DB write fails
@@ -644,7 +582,6 @@ impl JobStoreShard {
     }
 
     /// Process a RefreshFloatingLimit task: create lease and add to refresh output.
-    #[allow(clippy::too_many_arguments)]
     fn handle_refresh_floating_limit(
         &self,
         state: &mut DequeueIterationState,
@@ -652,19 +589,24 @@ impl JobStoreShard {
         entry: &BrokerTask,
         worker_id: &str,
         expiry_ms: i64,
-        task: &Task,
-        task_id: &str,
-        task_tenant: &str,
-        queue_key: &str,
-        current_max_concurrency: u32,
-        last_refreshed_at_ms: i64,
-        metadata: &[(String, String)],
-        refresh_task_group: &str,
     ) -> Result<(), JobStoreShardError> {
+        let Task::RefreshFloatingLimit {
+            task_id,
+            tenant: task_tenant,
+            queue_key,
+            current_max_concurrency,
+            last_refreshed_at_ms,
+            metadata,
+            task_group: refresh_task_group,
+        } = &entry.task
+        else {
+            unreachable!()
+        };
+
         let lease_key = leased_task_key(task_id);
         let record = LeaseRecord {
             worker_id: worker_id.to_string(),
-            task: task.clone(),
+            task: entry.task.clone(),
             expiry_ms,
             started_at_ms: 0, // Not applicable for RefreshFloatingLimit tasks
         };
@@ -676,8 +618,8 @@ impl JobStoreShard {
             task_id: task_id.to_string(),
             tenant_id: task_tenant.to_string(),
             queue_key: queue_key.to_string(),
-            current_max_concurrency,
-            last_refreshed_at_ms,
+            current_max_concurrency: *current_max_concurrency,
+            last_refreshed_at_ms: *last_refreshed_at_ms,
             metadata: metadata.to_vec(),
             task_group: refresh_task_group.to_string(),
         });
@@ -687,21 +629,27 @@ impl JobStoreShard {
     }
 
     /// Process a RunAttempt task: check cancellation, create lease, mark running.
-    #[allow(clippy::too_many_arguments)]
     async fn handle_run_attempt(
         &self,
         state: &mut DequeueIterationState,
         entry: &BrokerTask,
-        task: &Task,
         worker_id: &str,
         now_ms: i64,
         expiry_ms: i64,
-        task_id: &str,
-        tenant: &str,
-        job_id: &str,
-        attempt_number: u32,
-        relative_attempt_number: u32,
     ) -> Result<(), JobStoreShardError> {
+        let Task::RunAttempt {
+            id: task_id,
+            tenant,
+            job_id,
+            attempt_number,
+            relative_attempt_number,
+            ..
+        } = &entry.task
+        else {
+            unreachable!()
+        };
+        let attempt_number = *attempt_number;
+        let relative_attempt_number = *relative_attempt_number;
         // [SILO-DEQ-2] Look up job info; if missing, delete the task and skip
         let job_key = job_info_key(tenant, job_id);
         let maybe_job = self.db.get(&job_key).await?;
@@ -719,7 +667,7 @@ impl JobStoreShard {
 
             // [SILO-DEQ-CXL-REL] Release any held concurrency tickets
             // This is required to maintain invariant: holders can only exist for active tasks
-            let held_queues = match task {
+            let held_queues = match &entry.task {
                 Task::RunAttempt { held_queues, .. } => held_queues.clone(),
                 Task::CheckRateLimit { held_queues, .. } => held_queues.clone(),
                 Task::RequestTicket { .. } | Task::RefreshFloatingLimit { .. } => Vec::new(),
@@ -737,8 +685,7 @@ impl JobStoreShard {
                         task_id,
                         now_ms,
                     )
-                    .await
-                    .map_err(JobStoreShardError::Rkyv)?;
+                    .await?;
                 state.release_grants_to_rollback.extend(release_rollbacks);
                 tracing::debug!(job_id = %job_id, queues = ?held_queues, "dequeue: released tickets for cancelled job task");
             }
@@ -760,7 +707,7 @@ impl JobStoreShard {
             .write_lease_and_attempt(
                 &mut state.batch,
                 worker_id,
-                task,
+                &entry.task,
                 task_id,
                 tenant,
                 job_id,

--- a/src/job_store_shard/lease_task.rs
+++ b/src/job_store_shard/lease_task.rs
@@ -158,7 +158,8 @@ impl JobStoreShard {
                 }
             }
         };
-        let _existing_task = decode_task(&task_raw)?;
+        // Validate that the raw bytes decode to a valid task before replacing it
+        decode_task(&task_raw)?;
 
         // Delete the pending task (regardless of type)
         txn.delete(&old_task_key)?;

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -21,8 +21,8 @@ pub use expedite::JobNotExpediteableError;
 pub use lease_task::JobNotLeaseableError;
 pub use restart::JobNotRestartableError;
 
+pub(crate) use enqueue::LimitTaskParams;
 use helpers::DbWriteBatcher;
-pub(crate) use helpers::WriteBatcher;
 pub use helpers::now_epoch_ms;
 
 use slatedb::Db;
@@ -140,20 +140,11 @@ impl From<CodecError> for JobStoreShardError {
     }
 }
 
-impl From<crate::concurrency::HandleEnqueueError> for JobStoreShardError {
-    fn from(e: crate::concurrency::HandleEnqueueError) -> Self {
+impl From<crate::concurrency::ConcurrencyError> for JobStoreShardError {
+    fn from(e: crate::concurrency::ConcurrencyError) -> Self {
         match e {
-            crate::concurrency::HandleEnqueueError::Slate(e) => JobStoreShardError::Slate(e),
-            crate::concurrency::HandleEnqueueError::Encoding(s) => JobStoreShardError::Rkyv(s),
-        }
-    }
-}
-
-impl From<crate::concurrency::ProcessTicketError> for JobStoreShardError {
-    fn from(e: crate::concurrency::ProcessTicketError) -> Self {
-        match e {
-            crate::concurrency::ProcessTicketError::Slate(e) => JobStoreShardError::Slate(e),
-            crate::concurrency::ProcessTicketError::Encoding(s) => JobStoreShardError::Rkyv(s),
+            crate::concurrency::ConcurrencyError::Slate(e) => JobStoreShardError::Slate(e),
+            crate::concurrency::ConcurrencyError::Encoding(s) => JobStoreShardError::Rkyv(s),
         }
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -692,6 +692,12 @@ pub fn cleanup_completed_at_key() -> Vec<u8> {
     vec![prefix::CLEANUP_COMPLETED_AT]
 }
 
+/// Construct a composite key for in-memory concurrency queue tracking.
+/// Uses storekey encoding for collision-safe (tenant, queue) pairing.
+pub fn concurrency_counts_key(tenant: &str, queue: &str) -> Vec<u8> {
+    encode_vec(&(tenant.to_string(), queue.to_string())).expect("storekey encoding should not fail")
+}
+
 /// Create an exclusive end bound for range scanning.
 ///
 /// This computes the lexicographically smallest key that is greater than all keys

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -12,7 +12,7 @@ use storekey::{Decode, Encode, decode, encode_vec};
 
 use crate::job::{JobStatus, JobStatusKind};
 
-mod prefix {
+pub(crate) mod prefix {
     pub const JOB_INFO: u8 = 0x01;
     pub const JOB_STATUS: u8 = 0x02;
     pub const IDX_STATUS_TIME: u8 = 0x03;

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -7,7 +7,6 @@
 //! - Strings use null-terminated escape encoding (embedded nulls are escaped)
 //! - Integers use big-endian encoding for correct lexicographic ordering
 //! - Tuples encode each field sequentially
-//!
 
 use storekey::{Decode, Encode, decode, encode_vec};
 
@@ -591,8 +590,7 @@ pub fn parse_concurrency_holder_key(key: &[u8]) -> Option<ParsedConcurrencyHolde
 }
 
 /// The KV store key for a job's cancellation flag.
-/// Cancellation is stored separately from status to allow dequeue to blindly write Running
-/// without losing cancellation info.
+/// Cancellation is stored separately from status to allow dequeue to blindly write Running without losing cancellation info.
 pub fn job_cancelled_key(tenant: &str, job_id: &str) -> Vec<u8> {
     encode_with_prefix(
         prefix::JOB_CANCELLED,
@@ -700,9 +698,7 @@ pub fn concurrency_counts_key(tenant: &str, queue: &str) -> Vec<u8> {
 
 /// Create an exclusive end bound for range scanning.
 ///
-/// This computes the lexicographically smallest key that is greater than all keys
-/// starting with the given prefix. This is done by incrementing the prefix as if
-/// it were a big-endian integer, handling carry-over for 0xFF bytes.
+/// This computes the lexicographically smallest key that is greater than all keys starting with the given prefix. This is done by incrementing the prefix as if it were a big-endian integer, handling carry-over for 0xFF bytes.
 ///
 /// Use this with the prefix functions to create a range like `prefix..end_bound(prefix)`.
 ///

--- a/src/query.rs
+++ b/src/query.rs
@@ -1498,6 +1498,8 @@ fn display_status_kind(status: &crate::job::JobStatus) -> String {
     format!("{:?}", status.kind)
 }
 
+/// Get the schema from a set of record batches.
+///
 /// Convert Arrow RecordBatches directly to MessagePack-encoded rows.
 /// Uses streaming serialization to avoid buffering intermediate structures.
 pub fn record_batches_to_msgpack(batches: &[RecordBatch]) -> Result<Vec<Vec<u8>>, String> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -397,6 +397,18 @@ pub enum Backend {
     TurmoilFs,
 }
 
+impl Backend {
+    /// Returns true for backends that store data on a local filesystem.
+    pub fn is_local_fs(&self) -> bool {
+        match self {
+            Backend::Fs => true,
+            #[cfg(feature = "dst")]
+            Backend::TurmoilFs => true,
+            _ => false,
+        }
+    }
+}
+
 /// Expand environment variables in a string.
 ///
 /// Supports two syntaxes:

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -314,15 +314,6 @@ impl TaskBroker {
         Vec::new()
     }
 
-    /// Try to claim up to `max` ready tasks for a specific task_group. If none, nudge scanner.
-    pub async fn claim_ready_for_task_group_or_nudge(
-        &self,
-        task_group: &str,
-        max: usize,
-    ) -> Vec<BrokerTask> {
-        self.claim_ready_or_nudge(task_group, max).await
-    }
-
     /// Requeue tasks back into the buffer after a failed durable write.
     pub fn requeue(&self, tasks: Vec<BrokerTask>) {
         let mut inflight = self.inflight.lock().unwrap();

--- a/tests/cluster_query_integration_tests.rs
+++ b/tests/cluster_query_integration_tests.rs
@@ -29,9 +29,11 @@ fn unique_prefix() -> String {
     format!("test-cluster-query-{}", Uuid::new_v4())
 }
 
-/// Create a test shard factory with memory backend
-fn make_test_factory(node_id: &str) -> Arc<ShardFactory> {
-    let tmpdir = std::env::temp_dir().join(format!("silo-cluster-query-test-{}", node_id));
+/// Create a test shard factory with memory backend.
+/// Uses a unique prefix to avoid path collisions between parallel tests.
+fn make_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
+    let tmpdir =
+        std::env::temp_dir().join(format!("silo-cluster-query-test-{}-{}", prefix, node_id));
     Arc::new(ShardFactory::new(
         DatabaseTemplate {
             backend: Backend::Memory,
@@ -177,8 +179,8 @@ async fn cluster_two_nodes_basic_query() {
     let prefix = unique_prefix();
     let cfg = silo::settings::AppConfig::load(None).expect("load config");
 
-    let factory1 = make_test_factory("query-n1");
-    let factory2 = make_test_factory("query-n2");
+    let factory1 = make_test_factory(&prefix, "n1");
+    let factory2 = make_test_factory(&prefix, "n2");
 
     // Bind listeners first to get available ports
     let listener1 = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -303,8 +305,8 @@ async fn cluster_two_nodes_status_filter_query() {
     let prefix = unique_prefix();
     let cfg = silo::settings::AppConfig::load(None).expect("load config");
 
-    let factory1 = make_test_factory("status-n1");
-    let factory2 = make_test_factory("status-n2");
+    let factory1 = make_test_factory(&prefix, "n1");
+    let factory2 = make_test_factory(&prefix, "n2");
 
     // Bind listeners first to get available ports
     let listener1 = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -428,8 +430,8 @@ async fn cluster_two_nodes_count_across_shards() {
     let prefix = unique_prefix();
     let cfg = silo::settings::AppConfig::load(None).expect("load config");
 
-    let factory1 = make_test_factory("groupby-n1");
-    let factory2 = make_test_factory("groupby-n2");
+    let factory1 = make_test_factory(&prefix, "n1");
+    let factory2 = make_test_factory(&prefix, "n2");
 
     // Bind listeners first to get available ports
     let listener1 = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -551,8 +553,8 @@ async fn cluster_two_nodes_queues_table() {
     let prefix = unique_prefix();
     let cfg = silo::settings::AppConfig::load(None).expect("load config");
 
-    let factory1 = make_test_factory("queues-n1");
-    let factory2 = make_test_factory("queues-n2");
+    let factory1 = make_test_factory(&prefix, "n1");
+    let factory2 = make_test_factory(&prefix, "n2");
 
     // Bind listeners first to get available ports
     let listener1 = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -650,8 +652,8 @@ async fn cluster_two_nodes_projection_remote_shards() {
     let prefix = unique_prefix();
     let cfg = silo::settings::AppConfig::load(None).expect("load config");
 
-    let factory1 = make_test_factory("proj-n1");
-    let factory2 = make_test_factory("proj-n2");
+    let factory1 = make_test_factory(&prefix, "n1");
+    let factory2 = make_test_factory(&prefix, "n2");
 
     // Bind listeners first to get available ports
     let listener1 = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/tests/coordination_mod_tests.rs
+++ b/tests/coordination_mod_tests.rs
@@ -173,7 +173,7 @@ async fn wait_for_change_notify() {
 
     let (_, shutdown_rx) = tokio::sync::watch::channel(false);
     let shard_id = ShardId::new();
-    let ctx = Arc::new(ShardGuardContext::new(shard_id, shutdown_rx));
+    let ctx = Arc::new(ShardGuardContext::<()>::new(shard_id, shutdown_rx));
 
     let ctx_clone = ctx.clone();
     let handle = tokio::spawn(async move {
@@ -199,7 +199,7 @@ async fn wait_for_change_shutdown() {
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let shard_id = ShardId::new();
-    let ctx = Arc::new(ShardGuardContext::new(shard_id, shutdown_rx));
+    let ctx = Arc::new(ShardGuardContext::<()>::new(shard_id, shutdown_rx));
 
     let ctx_clone = ctx.clone();
     let handle = tokio::spawn(async move {
@@ -224,7 +224,7 @@ fn is_shutdown_reflects_channel() {
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let shard_id = ShardId::new();
-    let ctx = ShardGuardContext::new(shard_id, shutdown_rx);
+    let ctx = ShardGuardContext::<()>::new(shard_id, shutdown_rx);
 
     assert!(!ctx.is_shutdown());
 

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 mod etcd_test_helpers;
 
 use etcd_test_helpers::EtcdConnection;
-use silo::coordination::etcd::{EtcdCoordinator, EtcdShardGuard, ShardPhase};
-use silo::coordination::{CoordinationError, Coordinator, ShardSplitter, SplitPhase};
+use silo::coordination::etcd::{EtcdCoordinator, EtcdShardGuard};
+use silo::coordination::{CoordinationError, Coordinator, ShardPhase, ShardSplitter, SplitPhase};
 use silo::factory::ShardFactory;
 use silo::gubernator::MockGubernatorClient;
 use silo::settings::{Backend, DatabaseTemplate};
@@ -3770,8 +3770,8 @@ async fn etcd_shard_close_failure_keeps_ownership() {
     //
     // Wait for the shard to be fully released after the close timeout + retry cycle.
     let released = wait_until(Duration::from_secs(15), || async {
-        let st = guard.state.lock().await;
-        st.phase == ShardPhase::Idle && !st.is_held
+        let st = guard.ctx.state.lock().await;
+        st.phase == ShardPhase::Idle && !st.has_token()
     })
     .await;
     assert!(released, "guard should release after close retry succeeds");


### PR DESCRIPTION
1. Dequeue handler signatures: refactored all 4 handler methods to accept
   &BrokerTask instead of individually destructured fields, collapsing the
   match block from ~100 lines to ~20.

2. LimitTaskParams struct: bundled the 14 parameters of
   enqueue_limit_task_at_index into a struct for readability and to avoid
   positional argument errors.

3. Unified ConcurrencyError: merged the duplicate HandleEnqueueError and
   ProcessTicketError into a single ConcurrencyError enum, removing
   redundant From impls.

4. enqueue_with_dedup retry loop: replaced hand-rolled transaction retry
   loop with the existing retry_on_txn_conflict helper for consistency.

5. cancel_job_inner status index: replaced 15 lines of manual status
   index bookkeeping with a single set_job_status_with_index call via
   TxnWriter.

6. Removed write_new_job_status_with_index: this was a trivial one-line
   wrapper around write_job_status_with_index that added no value. Made
   write_job_status_with_index pub(crate) instead.

7. Concurrency composite key: replaced raw format!("{}|{}", tenant, queue)
   string concatenation with storekey-encoded concurrency_counts_key() in
   src/keys.rs, matching the rest of the codebase's key encoding pattern.

9. Typed concurrency errors: changed append_grant_edits and
   append_request_edits from Result<(), String> to
   Result<(), ConcurrencyError>, removing .map_err(|e| e.to_string())
   calls throughout the concurrency module.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
