### PR TITLE
Use scan-generation tombstones in task broker

### DIFF
--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -221,7 +221,8 @@ impl JobStoreShard {
             // Collect pending attempts from this iteration
             pending_attempts.append(&mut state.pending_attempts);
 
-            // [SILO-DEQ-3] Ack durable and evict from buffer; we no longer use TTL tombstones.
+            // [SILO-DEQ-3] Ack durable and evict from buffer.
+            // TaskBroker keeps scan-generation tombstones to guard against stale scan re-inserts.
             self.broker.ack_durable(&state.ack_keys);
             self.broker.evict_keys(&state.ack_keys);
             tracing::debug!(

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -20,7 +20,8 @@ use crate::task_broker::BrokerTask;
 /// keeping handler signatures clean.
 struct DequeueIterationState {
     batch: WriteBatch,
-    ack_keys: Vec<Vec<u8>>,
+    release_keys: Vec<Vec<u8>>,
+    tombstone_keys: Vec<Vec<u8>>,
     grants_to_rollback: Vec<(String, String, String)>,
     release_grants_to_rollback: Vec<ReleaseGrantRollback>,
     leased_tasks_for_dst: Vec<(String, String, String)>,
@@ -32,13 +33,23 @@ impl DequeueIterationState {
     fn new(claimed_len: usize) -> Self {
         Self {
             batch: WriteBatch::new(),
-            ack_keys: Vec::with_capacity(claimed_len),
+            release_keys: Vec::with_capacity(claimed_len),
+            tombstone_keys: Vec::with_capacity(claimed_len),
             grants_to_rollback: Vec::new(),
             release_grants_to_rollback: Vec::new(),
             leased_tasks_for_dst: Vec::new(),
             pending_attempts: Vec::new(),
             processed_internal: false,
         }
+    }
+
+    fn ack_release(&mut self, key: &Vec<u8>) {
+        self.release_keys.push(key.clone());
+    }
+
+    fn ack_deleted(&mut self, key: &Vec<u8>) {
+        self.release_keys.push(key.clone());
+        self.tombstone_keys.push(key.clone());
     }
 }
 
@@ -112,7 +123,7 @@ impl JobStoreShard {
                 if !shard_range.contains(task_tenant) {
                     // Task is for a tenant outside our range - delete and skip
                     state.batch.delete(&entry.key);
-                    state.ack_keys.push(entry.key.clone());
+                    state.ack_deleted(&entry.key);
                     tracing::debug!(
                         tenant = %task_tenant,
                         range = %shard_range,
@@ -222,11 +233,14 @@ impl JobStoreShard {
             pending_attempts.append(&mut state.pending_attempts);
 
             // [SILO-DEQ-3] Ack durable and evict from buffer.
-            // TaskBroker keeps scan-generation tombstones to guard against stale scan re-inserts.
-            self.broker.ack_durable(&state.ack_keys);
-            self.broker.evict_keys(&state.ack_keys);
+            // TaskBroker tracks all release keys for inflight cleanup, but only
+            // installs tombstones for keys that were durably deleted.
+            self.broker
+                .ack_durable(&state.release_keys, &state.tombstone_keys);
+            self.broker.evict_keys(&state.release_keys);
             tracing::debug!(
-                ack_keys = state.ack_keys.len(),
+                release_keys = state.release_keys.len(),
+                tombstone_keys = state.tombstone_keys.len(),
                 pending_attempts = pending_attempts.len(),
                 buffer_size = self.broker.buffer_len(),
                 inflight = self.broker.inflight_len(),
@@ -344,7 +358,7 @@ impl JobStoreShard {
         // [SILO-DEQ-CXL] Check if job is cancelled - if so, skip and clean up task
         if self.is_job_cancelled(&tenant, job_id).await? {
             state.batch.delete(&entry.key);
-            state.ack_keys.push(entry.key.clone());
+            state.ack_deleted(&entry.key);
             tracing::debug!(job_id = %job_id, "dequeue: skipping cancelled job RequestTicket");
             return Ok(());
         }
@@ -411,7 +425,7 @@ impl JobStoreShard {
                 state
                     .pending_attempts
                     .push((tenant.clone(), view, attempt_val));
-                state.ack_keys.push(entry.key.clone());
+                state.ack_deleted(&entry.key);
 
                 // Track for DST event emission after commit
                 state
@@ -423,9 +437,14 @@ impl JobStoreShard {
                     m.record_concurrency_ticket_granted();
                 }
             }
-            RequestTicketTaskOutcome::Requested | RequestTicketTaskOutcome::JobMissing => {
-                // Release inflight, task will be picked up later or cleaned up
-                state.ack_keys.push(entry.key.clone());
+            RequestTicketTaskOutcome::Requested => {
+                // Release inflight only; task key remains in DB and must be eligible
+                // for future scans when capacity is available.
+                state.ack_release(&entry.key);
+            }
+            RequestTicketTaskOutcome::JobMissing => {
+                // process_ticket_request_task deleted the task key.
+                state.ack_deleted(&entry.key);
             }
         }
 
@@ -465,7 +484,7 @@ impl JobStoreShard {
         state.processed_internal = true;
         let tenant = tenant.to_string();
         state.batch.delete(&entry.key);
-        state.ack_keys.push(entry.key.clone());
+        state.ack_deleted(&entry.key);
 
         // Load job info to get the full limits list
         let job_key = job_info_key(&tenant, job_id);
@@ -611,7 +630,7 @@ impl JobStoreShard {
             metadata: metadata.to_vec(),
             task_group: refresh_task_group.to_string(),
         });
-        state.ack_keys.push(entry.key.clone());
+        state.ack_deleted(&entry.key);
 
         Ok(())
     }
@@ -644,14 +663,14 @@ impl JobStoreShard {
         let Some(job_bytes) = maybe_job else {
             // If job missing, delete task key to clean up
             state.batch.delete(&entry.key);
-            state.ack_keys.push(entry.key.clone());
+            state.ack_deleted(&entry.key);
             return Ok(());
         };
 
         // [SILO-DEQ-CXL] Check if job is cancelled - if so, skip and clean up task
         if self.is_job_cancelled(tenant, job_id).await? {
             state.batch.delete(&entry.key);
-            state.ack_keys.push(entry.key.clone());
+            state.ack_deleted(&entry.key);
 
             // [SILO-DEQ-CXL-REL] Release any held concurrency tickets
             // This is required to maintain invariant: holders can only exist for active tasks
@@ -710,7 +729,7 @@ impl JobStoreShard {
         state
             .pending_attempts
             .push((tenant.to_string(), view, attempt_val));
-        state.ack_keys.push(entry.key.clone());
+        state.ack_deleted(&entry.key);
 
         // Track for DST event emission after commit
         state.leased_tasks_for_dst.push((

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -1,8 +1,8 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::str;
 use std::sync::{
     Arc, Mutex,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
 };
 use std::time::Duration;
 
@@ -36,6 +36,12 @@ pub struct TaskBroker {
     buffer: Arc<SkipMap<Vec<u8>, BrokerTask>>,
     // The set of tasks already read out of the DB and claimed by a worker but not yet durably leased. Required so that the scanner doesn't re-add tasks that are in the middle of being dequeued to the buffer.
     inflight: Arc<Mutex<HashSet<Vec<u8>>>>,
+    // Tombstones for task keys that were durably acked, keyed by the most recent
+    // scan generation where that key should be suppressed.
+    ack_tombstones: Arc<Mutex<HashMap<Vec<u8>, u64>>>,
+    // Monotonic generation numbers for scanner iterations.
+    scan_generation_started: Arc<AtomicU64>,
+    scan_generation_completed: Arc<AtomicU64>,
     // Whether the background scanner is running
     running: Arc<AtomicBool>,
     // A notify object to wake up the background scanner when a task is claimed
@@ -55,6 +61,10 @@ pub struct TaskBroker {
 }
 
 impl TaskBroker {
+    // Keep ack tombstones for a bounded number of completed scan generations and
+    // refresh the tombstone generation whenever a stale key is observed again.
+    const ACK_TOMBSTONE_RETAIN_GENERATIONS: u64 = 64;
+
     pub fn new(
         db: Arc<Db>,
         shard_name: String,
@@ -65,6 +75,9 @@ impl TaskBroker {
             db,
             buffer: Arc::new(SkipMap::new()),
             inflight: Arc::new(Mutex::new(HashSet::new())),
+            ack_tombstones: Arc::new(Mutex::new(HashMap::new())),
+            scan_generation_started: Arc::new(AtomicU64::new(0)),
+            scan_generation_completed: Arc::new(AtomicU64::new(0)),
             running: Arc::new(AtomicBool::new(false)),
             notify: Arc::new(Notify::new()),
             scan_requested: Arc::new(AtomicBool::new(false)),
@@ -89,8 +102,22 @@ impl TaskBroker {
         self.inflight.lock().unwrap().len()
     }
 
+    fn begin_scan_generation(&self) -> u64 {
+        self.scan_generation_started.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    fn complete_scan_generation(&self, generation: u64) {
+        self.scan_generation_completed
+            .store(generation, Ordering::SeqCst);
+        let mut tombstones = self.ack_tombstones.lock().unwrap();
+        tombstones.retain(|_, last_seen_generation| {
+            generation.saturating_sub(*last_seen_generation)
+                <= Self::ACK_TOMBSTONE_RETAIN_GENERATIONS
+        });
+    }
+
     /// Scan tasks from DB and insert into buffer, skipping future tasks and inflight ones.
-    async fn scan_tasks(&self, now_ms: i64) -> usize {
+    async fn scan_tasks(&self, now_ms: i64, generation: u64) -> usize {
         // [SILO-SCAN-1] Tasks use binary storekey encoding with prefix byte
         let start = tasks_prefix();
         let end = end_bound(&start);
@@ -118,8 +145,25 @@ impl TaskBroker {
                 continue;
             }
 
+            let key_bytes = kv.key.to_vec();
+
             // [SILO-SCAN-3] Skip inflight tasks
-            if self.inflight.lock().unwrap().contains(&kv.key.to_vec()) {
+            if self.inflight.lock().unwrap().contains(&key_bytes) {
+                continue;
+            }
+
+            // Skip keys that were recently durably acked to avoid stale scan re-inserts.
+            // Refresh generation so persistent stale observations extend suppression.
+            let suppress_due_to_tombstone = {
+                let mut tombstones = self.ack_tombstones.lock().unwrap();
+                if let Some(last_seen_generation) = tombstones.get_mut(&key_bytes) {
+                    *last_seen_generation = generation;
+                    true
+                } else {
+                    false
+                }
+            };
+            if suppress_due_to_tombstone {
                 continue;
             }
 
@@ -144,7 +188,6 @@ impl TaskBroker {
                 continue;
             }
 
-            let key_bytes = kv.key.to_vec();
             let entry = BrokerTask {
                 key: key_bytes.clone(),
                 task,
@@ -211,7 +254,9 @@ impl TaskBroker {
                 // Scan for ready tasks
                 let now_ms = crate::job_store_shard::now_epoch_ms();
                 let scan_start = std::time::Instant::now();
-                let inserted = broker.scan_tasks(now_ms).await;
+                let generation = broker.begin_scan_generation();
+                let inserted = broker.scan_tasks(now_ms, generation).await;
+                broker.complete_scan_generation(generation);
                 if let Some(ref m) = broker.metrics {
                     m.record_broker_scan_duration(
                         &broker.shard_name,
@@ -317,8 +362,10 @@ impl TaskBroker {
     /// Requeue tasks back into the buffer after a failed durable write.
     pub fn requeue(&self, tasks: Vec<BrokerTask>) {
         let mut inflight = self.inflight.lock().unwrap();
+        let mut tombstones = self.ack_tombstones.lock().unwrap();
         for entry in tasks {
             inflight.remove(&entry.key);
+            tombstones.remove(&entry.key);
             self.buffer.insert(entry.key.clone(), entry);
         }
     }
@@ -326,8 +373,11 @@ impl TaskBroker {
     /// Acknowledge that these tasks are durably leased and can be removed from in-flight tracking.
     pub fn ack_durable(&self, keys: &[Vec<u8>]) {
         let mut inflight = self.inflight.lock().unwrap();
+        let mut tombstones = self.ack_tombstones.lock().unwrap();
+        let generation = self.scan_generation_started.load(Ordering::SeqCst);
         for k in keys {
             inflight.remove(k);
+            tombstones.insert(k.clone(), generation);
         }
     }
 

--- a/tests/turmoil_runner/helpers.rs
+++ b/tests/turmoil_runner/helpers.rs
@@ -1432,10 +1432,7 @@ impl JobStateTracker {
             .filter(|(job_id, _)| !terminal.contains(job_id.as_str()))
             .map(|(job_id, status)| {
                 let status_str = status_name(*status).to_string();
-                let lease_count = active_leases
-                    .get(job_id)
-                    .map(|l| l.len())
-                    .unwrap_or(0);
+                let lease_count = active_leases.get(job_id).map(|l| l.len()).unwrap_or(0);
                 (
                     job_id.clone(),
                     format!("{} (active_leases: {})", status_str, lease_count),

--- a/tests/turmoil_runner/mock_k8s.rs
+++ b/tests/turmoil_runner/mock_k8s.rs
@@ -627,10 +627,7 @@ impl MockK8sState {
         namespace: &str,
         cluster_prefix: &str,
     ) -> std::collections::HashMap<silo::shard_range::ShardId, String> {
-        let label_selector = format!(
-            "silo.dev/type=shard,silo.dev/cluster={}",
-            cluster_prefix
-        );
+        let label_selector = format!("silo.dev/type=shard,silo.dev/cluster={}", cluster_prefix);
         let leases = self.leases.lock().await;
         let Some(ns_leases) = leases.get(namespace) else {
             return std::collections::HashMap::new();
@@ -652,10 +649,7 @@ impl MockK8sState {
                 && let Some(id_part) = name.strip_prefix(&prefix)
                 && let Ok(uuid) = uuid::Uuid::parse_str(id_part)
             {
-                result.insert(
-                    silo::shard_range::ShardId::from_uuid(uuid),
-                    holder.clone(),
-                );
+                result.insert(silo::shard_range::ShardId::from_uuid(uuid), holder.clone());
             }
         }
         result

--- a/tests/turmoil_runner/scenarios/high_latency.rs
+++ b/tests/turmoil_runner/scenarios/high_latency.rs
@@ -35,10 +35,10 @@ use std::time::Duration;
 /// Concurrency limit configurations - mix of strict and permissive limits
 /// to stress concurrency tracking under latency conditions.
 const CONCURRENCY_LIMITS: &[(&str, u32)] = &[
-    ("latency-serial", 1),   // Strict serialization - most sensitive to races
-    ("latency-pair", 2),     // Small concurrency window
-    ("latency-quad", 4),     // Medium concurrency
-    ("latency-octet", 8),    // Larger concurrency
+    ("latency-serial", 1),    // Strict serialization - most sensitive to races
+    ("latency-pair", 2),      // Small concurrency window
+    ("latency-quad", 4),      // Medium concurrency
+    ("latency-octet", 8),     // Larger concurrency
     ("latency-unlimited", 0), // No limit (0 means unlimited)
 ];
 
@@ -587,7 +587,9 @@ pub fn run() {
             }
 
             // Verify concurrency limits were never exceeded
-            verifier_tracker.concurrency.verify_no_duplicate_job_leases();
+            verifier_tracker
+                .concurrency
+                .verify_no_duplicate_job_leases();
 
             let enqueued = verifier_enqueued.load(Ordering::SeqCst);
             let completed = verifier_completed.load(Ordering::SeqCst);
@@ -619,9 +621,7 @@ pub fn run() {
                     "Not all jobs reached terminal state: {}/{} jobs are terminal. \
                      With no message loss, all jobs should complete.\n\
                      Non-terminal jobs: {:?}",
-                    terminal,
-                    enqueued,
-                    non_terminal
+                    terminal, enqueued, non_terminal
                 );
             }
 


### PR DESCRIPTION
## Summary\n- replace broker ack tombstone TTL logic with scan-generation based tracking\n- refresh tombstone generation on stale-key observations and prune by completed-scan generation window\n- keep regression coverage for duplicate leasing stale-scan scenario\n\n## Validation\n- cargo test --test job_store_shard_dequeue_tests dequeue_ignores_recently_acked_task_keys -- --nocapture\n- cargo test --test job_store_shard_concurrency_tests concurrent_dequeue_many_workers_no_duplicates -- --nocapture\n- cargo test --test job_store_shard_dequeue_tests -- --nocapture