### PR TITLE
Close parent shard before cloning during split

### DIFF
--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -461,7 +461,27 @@ impl ShardSplitter {
                     // [SILO-COORD-INV-5] Traffic is paused before we reach this phase.
                     // The state machine ensures we pass through SplitPausing before
                     // SplitCloning, and traffic_paused() returns true for both phases.
-                    // Clone the database for both children
+
+                    // Fully close the parent shard before cloning. This guarantees
+                    // that all processing has stopped (broker, background tasks, in-flight
+                    // dequeues) and all data is flushed. By reopening just the raw SlateDB
+                    // database for the checkpoint, we ensure the snapshotter is the only
+                    // thing working on the shard -- no writes can land after the checkpoint.
+                    if let Some(parent_shard) = self.ctx.factory.get(&parent_shard_id) {
+                        parent_shard.close().await.map_err(|e| {
+                            SplitExecutionError::PreCommit(CoordinationError::BackendError(
+                                format!("failed to close parent shard before cloning: {}", e),
+                            ))
+                        })?;
+                        info!(
+                            parent_shard_id = %parent_shard_id,
+                            "closed parent shard before cloning"
+                        );
+                    }
+
+                    // Clone the closed parent's database for both children. This reopens
+                    // just the raw SlateDB database, creates a checkpoint, clones to both
+                    // children, then closes the raw database.
                     info!(
                         parent_shard_id = %parent_shard_id,
                         left_child = %split.left_child_id,
@@ -469,25 +489,17 @@ impl ShardSplitter {
                         "cloning database for split"
                     );
 
-                    // Clone for left child
                     self.ctx
                         .factory
-                        .clone_shard(&parent_shard_id, &split.left_child_id)
+                        .clone_closed_shard(
+                            &parent_shard_id,
+                            &split.left_child_id,
+                            &split.right_child_id,
+                        )
                         .await
                         .map_err(|e| {
                             SplitExecutionError::PreCommit(CoordinationError::BackendError(
-                                format!("failed to clone left child: {}", e),
-                            ))
-                        })?;
-
-                    // Clone for right child
-                    self.ctx
-                        .factory
-                        .clone_shard(&parent_shard_id, &split.right_child_id)
-                        .await
-                        .map_err(|e| {
-                            SplitExecutionError::PreCommit(CoordinationError::BackendError(
-                                format!("failed to clone right child: {}", e),
+                                format!("failed to clone children: {}", e),
                             ))
                         })?;
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -89,7 +89,7 @@ impl ShardFactory {
             instances: DashMap::new(),
             template: DatabaseTemplate {
                 backend: Backend::Memory,
-                path: "/noop/%shard%".to_string(),
+                path: "/noop".to_string(),
                 wal: None,
                 apply_wal_on_close: false,
                 slatedb: None,

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -43,13 +43,13 @@ impl DequeueIterationState {
         }
     }
 
-    fn ack_release(&mut self, key: &Vec<u8>) {
-        self.release_keys.push(key.clone());
+    fn ack_release(&mut self, key: &[u8]) {
+        self.release_keys.push(key.to_owned());
     }
 
-    fn ack_deleted(&mut self, key: &Vec<u8>) {
-        self.release_keys.push(key.clone());
-        self.tombstone_keys.push(key.clone());
+    fn ack_deleted(&mut self, key: &[u8]) {
+        self.release_keys.push(key.to_owned());
+        self.tombstone_keys.push(key.to_owned());
     }
 }
 

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -293,10 +293,7 @@ impl JobStoreShard {
     /// This ensures all data is durably stored in object storage before closing,
     /// allowing the shard to be safely reopened elsewhere (e.g., on a different node).
     pub async fn close(&self) -> Result<(), JobStoreShardError> {
-        tracing::trace!(shard = %self.name, "shard.close: signaling cancellation for background tasks");
         self.cancellation.cancel();
-
-        tracing::trace!(shard = %self.name, "shard.close: stopping broker");
         self.broker.stop();
 
         // If we have a local WAL with flush_on_close enabled, flush memtable to SSTs first


### PR DESCRIPTION
## Summary
- Fix race condition where parent shard's in-flight dequeue operations could commit after the split checkpoint, causing duplicate task processing and `noLeasesForTerminal` invariant violations
- Fully close the parent shard before cloning instead of introducing a partial "quiesce" concept, guaranteeing all processing has stopped
- Add `clone_closed_shard` factory method that reopens just the raw SlateDB database for checkpointing, ensuring the snapshotter is the only thing working on the shard

## Test plan
- [ ] All 5 previously-failing DST seeds pass (908240651, 2265155355, 1549861451, 3663926443, 980836091)
- [ ] CI passes (main test suite, split tests, coordination tests)
- [ ] Existing `clone_shard` method is preserved for other use cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)