### PR TITLE
Deserialize MessagePack rows in TS client query method

### DIFF
--- a/docs/src/content/docs/guides/querying.mdx
+++ b/docs/src/content/docs/guides/querying.mdx
@@ -12,17 +12,39 @@ Silo includes a built-in SQL query engine powered by [Apache DataFusion](https:/
 ### From the TypeScript Client
 
 ```typescript
+// Rows are automatically deserialized from MessagePack — no manual decoding needed.
 const result = await client.query(
   "SELECT id, status_kind, priority FROM jobs WHERE tenant = 'customer-123' LIMIT 10",
   "customer-123"  // tenant for shard routing
 );
 
 for (const row of result.rows) {
-  console.log(row);
+  console.log(row);  // { id: "job-abc", status_kind: "Running", priority: 10 }
+}
+
+// You can pass a generic type parameter for typed rows:
+interface JobRow {
+  id: string;
+  status_kind: string;
+  count: number;
+}
+
+const typed = await client.query<JobRow>(
+  "SELECT id, status_kind, COUNT(*) as count FROM jobs GROUP BY id, status_kind",
+  "customer-123"
+);
+
+for (const row of typed.rows) {
+  console.log(row.id, row.status_kind, row.count);  // fully typed
 }
 ```
 
 The second argument is the tenant used for routing the query to the correct shard. If you're not using multi-tenancy, you can omit it.
+
+The result includes:
+- `columns` — schema information (`name` and `dataType` for each column)
+- `rows` — deserialized JavaScript objects, one per row
+- `rowCount` — total number of rows returned
 
 ### From siloctl
 

--- a/typescript_client/src/index.ts
+++ b/typescript_client/src/index.ts
@@ -47,6 +47,8 @@ export {
   type ShardRoutingConfig,
   type ShardOwner,
   type ShardInfoWithRange,
+  type QueryResult,
+  type QueryColumnInfo,
 } from "./client";
 export {
   SiloWorker,
@@ -65,4 +67,4 @@ export {
   type GubernatorRateLimit,
 } from "./TaskExecution";
 export { JobHandle } from "./JobHandle";
-export type { QueryResponse, RetryPolicy, ColumnInfo, Failure } from "./pb/silo";
+export type { RetryPolicy, Failure } from "./pb/silo";


### PR DESCRIPTION
## Summary
- The `query()` method now automatically deserializes MessagePack-encoded rows into plain JavaScript objects instead of returning raw protobuf `SerializedBytes`
- Adds new `QueryResult<Row>` and `QueryColumnInfo` types that replace the protobuf `QueryResponse` export
- Supports a generic type parameter for typed query results: `client.query<MyRow>("SELECT ...")`
- Updates integration tests to validate deserialized row access
- Updates querying docs with the improved API and typed usage examples

## Test plan
- [x] Unit tests for `QueryResult` and `QueryColumnInfo` types
- [x] Unit tests for query deserialization with mocked gRPC responses
- [x] Integration tests updated to use deserialized rows directly
- [x] New integration test for generic row type parameter
- [x] All existing tests pass (`pnpm test`)
- [x] TypeScript type checking passes (`pnpm typecheck`)
- [x] Linting passes (`pnpm lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)