### PR TITLE
Fix internal doc links to include /silo base path

### DIFF
--- a/docs/src/content/docs/guides/cancel-restart-delete.mdx
+++ b/docs/src/content/docs/guides/cancel-restart-delete.mdx
@@ -501,6 +501,6 @@ Expedite is an immediate operation that bypasses time entirely. Priority adjusts
 
 ## Next Steps
 
-- Learn about [running workers](/guides/running-workers) to handle job execution and cancellation
-- Set up [observability](/guides/observability) to monitor cancellations and failures
-- Explore [concurrency limits](/guides/concurrency-limits) to control job execution
+- Learn about [running workers](/silo/guides/running-workers) to handle job execution and cancellation
+- Set up [observability](/silo/guides/observability) to monitor cancellations and failures
+- Explore [concurrency limits](/silo/guides/concurrency-limits) to control job execution

--- a/docs/src/content/docs/guides/concurrency-limits.mdx
+++ b/docs/src/content/docs/guides/concurrency-limits.mdx
@@ -7,7 +7,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 Silo provides three types of limits to control job execution: **concurrency limits**, **floating concurrency limits**, and **rate limits**. These limits can be attached to jobs when enqueueing and are checked in order before the job executes.
 
-This guide focuses on the two concurrency-based limits. For rate limits, see the [Enqueueing guide](/guides/enqueueing#rate-limits).
+This guide focuses on the two concurrency-based limits. For rate limits, see the [Enqueueing guide](/silo/guides/enqueueing#rate-limits).
 
 ## Concurrency Limits
 

--- a/docs/src/content/docs/guides/deployment.mdx
+++ b/docs/src/content/docs/guides/deployment.mdx
@@ -91,7 +91,7 @@ The cache is enabled when `root_folder` is set. Key options:
 - **`max_cache_size_bytes`**: Maximum total size of the cache on disk. When exceeded, older entries are evicted.
 - **`cache_puts`**: When `true`, data written to object storage is also written to the local cache, warming it for subsequent reads.
 
-All other options use SlateDB's sensible defaults when omitted. See the [Server Configuration reference](/reference/server-configuration/#slatedb-configuration) for more details on SlateDB tuning.
+All other options use SlateDB's sensible defaults when omitted. See the [Server Configuration reference](/silo/reference/server-configuration/#slatedb-configuration) for more details on SlateDB tuning.
 
 The cache directory does not need to be durable — if it is lost, reads will simply fall back to object storage and the cache will be rebuilt over time. This makes it a good fit for ephemeral local disks or instance storage.
 
@@ -132,7 +132,7 @@ advertised_grpc_addr = "10.0.1.5:7450"
 node_id = "silo-node-1"
 ```
 
-See the [Server Configuration reference](/reference/server-configuration/#coordination-configuration) for the full list of coordination options.
+See the [Server Configuration reference](/silo/reference/server-configuration/#coordination-configuration) for the full list of coordination options.
 
 ## Using Kubernetes for cluster membership
 

--- a/docs/src/content/docs/guides/enqueueing.mdx
+++ b/docs/src/content/docs/guides/enqueueing.mdx
@@ -105,7 +105,7 @@ Task groups allow you to:
 - **Isolate workloads**: Slow jobs in one task group won't block jobs in another
 
 <Aside type="tip" title="Choosing task groups">
-You must run separate workers for each task group. You can make as many task groups as you want, but the resources you need to run all the workers might be high if you create a lot of task groups. For high-cardinality concurrency management, use [concurrent limits](/guides/concurrency-limits) instead.
+You must run separate workers for each task group. You can make as many task groups as you want, but the resources you need to run all the workers might be high if you create a lot of task groups. For high-cardinality concurrency management, use [concurrent limits](/silo/guides/concurrency-limits) instead.
 </Aside>
 
 Task group names must be:
@@ -364,6 +364,6 @@ const handle = client.handle("job-456", "customer-123");
 ## Next Steps
 
 After enqueueing jobs, you'll need to:
-1. [Run workers](/guides/running-workers) to process the jobs
-2. Set up [observability](/guides/observability) to monitor job execution
-3. Configure [server settings](/reference/server-configuration) for production
+1. [Run workers](/silo/guides/running-workers) to process the jobs
+2. Set up [observability](/silo/guides/observability) to monitor job execution
+3. Configure [server settings](/silo/reference/server-configuration) for production

--- a/docs/src/content/docs/guides/querying.mdx
+++ b/docs/src/content/docs/guides/querying.mdx
@@ -355,6 +355,6 @@ Queries are read-only. You cannot use `INSERT`, `UPDATE`, `DELETE`, or any other
 
 ## Next Steps
 
-- Use [siloctl](/reference/siloctl) for command-line query access and common workflows
-- Set up [observability](/guides/observability) for continuous monitoring alongside ad-hoc queries
-- Learn about [concurrency limits](/guides/concurrency-limits) to understand the `queues` table
+- Use [siloctl](/silo/reference/siloctl) for command-line query access and common workflows
+- Set up [observability](/silo/guides/observability) for continuous monitoring alongside ad-hoc queries
+- Learn about [concurrency limits](/silo/guides/concurrency-limits) to understand the `queues` table

--- a/docs/src/content/docs/guides/running-workers.mdx
+++ b/docs/src/content/docs/guides/running-workers.mdx
@@ -291,7 +291,7 @@ Interval in milliseconds between heartbeats for running tasks. Should be less th
 
 ### `refreshHandler` (optional)
 
-Handler for floating concurrency limit refresh tasks. See [Concurrency Limits: Floating Limits](/guides/concurrency-limits#floating-concurrency-limits) for details.
+Handler for floating concurrency limit refresh tasks. See [Concurrency Limits: Floating Limits](/silo/guides/concurrency-limits#floating-concurrency-limits) for details.
 
 ### `onError` (optional)
 
@@ -371,6 +371,6 @@ You can scale workers horizontally by running more instances. Each worker indepe
 
 ## Next Steps
 
-- Learn about [enqueueing jobs](/guides/enqueueing) with different options
-- Configure [concurrency limits](/guides/concurrency-limits) to control throughput
-- Set up [observability](/guides/observability) to monitor your workers
+- Learn about [enqueueing jobs](/silo/guides/enqueueing) with different options
+- Configure [concurrency limits](/silo/guides/concurrency-limits) to control throughput
+- Set up [observability](/silo/guides/observability) to monitor your workers

--- a/docs/src/content/docs/introduction.md
+++ b/docs/src/content/docs/introduction.md
@@ -58,8 +58,8 @@ Silo partitions data across **shards**. Each shard is backed by its own SlateDB 
 
 ## Next Steps
 
-- [Enqueueing Jobs](/guides/enqueueing) — learn how to create jobs with payloads, priorities, scheduling, and limits
-- [Running Workers](/guides/running-workers) — set up workers to process jobs
-- [Concurrency Limits](/guides/concurrency-limits) — control job execution with concurrency and rate limits
-- [Deployment](/guides/deployment) — configure Silo for production with object storage and clustering
-- [Server Configuration](/reference/server-configuration) — full reference for all configuration options
+- [Enqueueing Jobs](/silo/guides/enqueueing) — learn how to create jobs with payloads, priorities, scheduling, and limits
+- [Running Workers](/silo/guides/running-workers) — set up workers to process jobs
+- [Concurrency Limits](/silo/guides/concurrency-limits) — control job execution with concurrency and rate limits
+- [Deployment](/silo/guides/deployment) — configure Silo for production with object storage and clustering
+- [Server Configuration](/silo/reference/server-configuration) — full reference for all configuration options

--- a/docs/src/content/docs/reference/server-configuration.mdx
+++ b/docs/src/content/docs/reference/server-configuration.mdx
@@ -122,7 +122,7 @@ When using a local WAL with cloud object storage:
 - Writes are faster because they go to local disk first
 - On graceful shard close (or node shutdown), WAL is flushed to object storage to ensure durability
 - The local WAL directory is deleted after successful flush
-- On crash, shard leases are permanent and persist until the node restarts and recovers the WAL. Set `node_id` to a stable value (e.g., `"${POD_NAME}"`) to enable automatic WAL recovery after restarts. See the [Internals guide](/guides/internals/#permanent-shard-leases) for details.
+- On crash, shard leases are permanent and persist until the node restarts and recovers the WAL. Set `node_id` to a stable value (e.g., `"${POD_NAME}"`) to enable automatic WAL recovery after restarts. See the [Internals guide](/silo/guides/internals/#permanent-shard-leases) for details.
 
 #### `apply_wal_on_close`
 
@@ -232,7 +232,7 @@ lease_ttl_secs = 10
 | `num_shards` | number | `8` | Total number of shards in the cluster |
 | `lease_ttl_secs` | number | `10` | TTL for the **membership** lease in seconds. This controls how quickly the cluster detects a node has crashed. Shard ownership leases are permanent and not affected by this TTL. |
 | `advertised_grpc_addr` | string | (none) | Address other nodes use to connect to this node |
-| `node_id` | string | (random UUID) | Stable node identity for this instance. If set, the node will reclaim shard leases from a previous run on startup, enabling WAL recovery after crashes. See [Permanent shard leases](/guides/internals/#permanent-shard-leases). |
+| `node_id` | string | (random UUID) | Stable node identity for this instance. If set, the node will reclaim shard leases from a previous run on startup, enabling WAL recovery after crashes. See [Permanent shard leases](/silo/guides/internals/#permanent-shard-leases). |
 
 ### Coordination Backends
 
@@ -348,7 +348,7 @@ addr = "127.0.0.1:9090"
 | `enabled` | bool | `true` | Enable the Prometheus metrics endpoint |
 | `addr` | string | `"127.0.0.1:9090"` | Address and port for the metrics server |
 
-Metrics are exposed in Prometheus format at `/metrics`. See the [Observability Guide](/guides/observability) for available metrics.
+Metrics are exposed in Prometheus format at `/metrics`. See the [Observability Guide](/silo/guides/observability) for available metrics.
 
 ---
 


### PR DESCRIPTION
## Summary
- All internal links in the documentation were missing the `/silo` base path prefix, causing 404s on GitHub Pages and locally (e.g. `/guides/enqueueing` instead of `/silo/guides/enqueueing`)
- Fixed 25 links across 8 files: introduction, enqueueing, running-workers, concurrency-limits, cancel-restart-delete, querying, deployment, and server-configuration

## Test plan
- [x] Built docs locally with `pnpm build` (no errors)
- [x] Ran `pnpm preview` and verified all fixed link targets return 200
- [x] Verified old paths without `/silo` prefix return 404
- [x] Grep confirmed no remaining internal links missing the `/silo` prefix