### PR TITLE
proof of concept: benchmark long polling latency vs current short polling

### DIFF
--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -286,6 +286,23 @@ message LeaseTasksResponse {
   repeated RefreshFloatingLimitTask refresh_tasks = 2; // Floating limit refresh tasks.
 }
 
+// Long-poll variant of LeaseTasksRequest.
+// Blocks until tasks are available or timeout is reached.
+// Avoids the latency overhead of short-polling intervals.
+message LeaseTasksLongPollRequest {
+  optional string shard = 1;  // optional filter - if set, only lease from this shard (UUID)
+  string worker_id = 2;
+  uint32 max_tasks = 3;
+  string task_group = 4;      // Required. Task group to poll tasks from.
+  uint32 timeout_ms = 5;      // Max time to wait for tasks (ms). Server caps at 60000. 0 = immediate (same as LeaseTasks).
+}
+
+// Response for long-poll lease. Same shape as LeaseTasksResponse.
+message LeaseTasksLongPollResponse {
+  repeated Task tasks = 1;                         // Job execution tasks.
+  repeated RefreshFloatingLimitTask refresh_tasks = 2; // Floating limit refresh tasks.
+}
+
 // Request to report the outcome of a completed task.
 // Note: tenant is determined from the task lease, not from the request.
 message ReportOutcomeRequest {
@@ -607,6 +624,12 @@ service Silo {
   // Workers should call this periodically to get work.
   // Returns both job tasks and floating limit refresh tasks.
   rpc LeaseTasks(LeaseTasksRequest) returns (LeaseTasksResponse);
+
+  // Long-poll variant of LeaseTasks.
+  // Blocks until tasks are available or timeout is reached.
+  // Returns immediately if tasks are already available.
+  // Avoids the latency overhead of short-polling intervals.
+  rpc LeaseTasksLongPoll(LeaseTasksLongPollRequest) returns (LeaseTasksLongPollResponse);
   
   // Report the outcome of a completed job task.
   // Must be called before the task lease expires.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1138,8 +1138,7 @@ impl Silo for SiloService {
         // Cap timeout at 60 seconds
         let timeout_ms = (r.timeout_ms as u64).min(60_000);
 
-        let deadline = tokio::time::Instant::now()
-            + std::time::Duration::from_millis(timeout_ms);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
 
         // Resolve shards once outside the loop
         let shards_to_poll: Vec<(crate::shard_range::ShardId, Arc<JobStoreShard>)> =

--- a/src/server.rs
+++ b/src/server.rs
@@ -1124,6 +1124,149 @@ impl Silo for SiloService {
         }))
     }
 
+    async fn lease_tasks_long_poll(
+        &self,
+        req: Request<LeaseTasksLongPollRequest>,
+    ) -> Result<Response<LeaseTasksLongPollResponse>, Status> {
+        let r = req.into_inner();
+        let max_tasks = r.max_tasks as usize;
+
+        if r.task_group.is_empty() {
+            return Err(Status::invalid_argument("task_group is required"));
+        }
+
+        // Cap timeout at 60 seconds
+        let timeout_ms = (r.timeout_ms as u64).min(60_000);
+
+        let deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_millis(timeout_ms);
+
+        loop {
+            // Determine which shards to poll (same logic as lease_tasks)
+            let shards_to_poll: Vec<(crate::shard_range::ShardId, Arc<JobStoreShard>)> =
+                if let Some(ref shard_filter) = r.shard {
+                    let shard_id = Self::parse_shard_id(shard_filter)?;
+                    let shard = self.shard_with_redirect(&shard_id).await?;
+                    vec![(shard_id, shard)]
+                } else {
+                    let mut shards: Vec<_> = self
+                        .factory
+                        .instances()
+                        .iter()
+                        .map(|(id, shard)| (*id, shard.clone()))
+                        .collect();
+                    shards.shuffle(&mut rand::rng());
+                    shards
+                };
+
+            let mut all_tasks = Vec::new();
+            let mut all_refresh_tasks = Vec::new();
+            let mut remaining = max_tasks;
+
+            for (shard_id, shard) in &shards_to_poll {
+                if remaining == 0 {
+                    break;
+                }
+
+                let result = shard
+                    .dequeue(&r.worker_id, &r.task_group, remaining)
+                    .await
+                    .map_err(map_err)?;
+
+                let tasks_added = result.tasks.len();
+                let shard_str = shard_id.to_string();
+                let now_ms = crate::job_store_shard::now_epoch_ms();
+
+                for lt in result.tasks {
+                    if let Some(ref m) = self.metrics {
+                        let job = lt.job();
+                        let task_group = job.task_group();
+                        let relative_attempt_number = lt.attempt().relative_attempt_number();
+                        m.record_attempt(&shard_str, task_group, relative_attempt_number > 1);
+
+                        let wait_time_secs =
+                            (now_ms - job.enqueue_time_ms()).max(0) as f64 / 1000.0;
+                        m.record_job_wait_time(&shard_str, task_group, wait_time_secs);
+                        m.inc_task_leases_active(&shard_str, task_group);
+                    }
+
+                    all_tasks.push(leased_task_to_proto(&lt, &shard_str));
+                }
+
+                for rt in result.refresh_tasks {
+                    let tenant_id = if rt.tenant_id == "-" {
+                        None
+                    } else {
+                        Some(rt.tenant_id)
+                    };
+
+                    all_refresh_tasks.push(RefreshFloatingLimitTask {
+                        id: rt.task_id,
+                        queue_key: rt.queue_key,
+                        current_max_concurrency: rt.current_max_concurrency,
+                        last_refreshed_at_ms: rt.last_refreshed_at_ms,
+                        metadata: rt.metadata.into_iter().collect(),
+                        lease_ms: DEFAULT_LEASE_MS,
+                        shard: shard_id.to_string(),
+                        task_group: rt.task_group,
+                        tenant_id,
+                    });
+                }
+
+                if let Some(ref m) = self.metrics
+                    && tasks_added > 0
+                {
+                    m.record_dequeue(&shard_str, &r.task_group, tasks_added as u64);
+                }
+
+                remaining = remaining.saturating_sub(tasks_added);
+            }
+
+            // If we got tasks, return immediately
+            if !all_tasks.is_empty() || !all_refresh_tasks.is_empty() {
+                return Ok(Response::new(LeaseTasksLongPollResponse {
+                    tasks: all_tasks,
+                    refresh_tasks: all_refresh_tasks,
+                }));
+            }
+
+            // No tasks found. If timeout is 0 or deadline passed, return empty.
+            if timeout_ms == 0 || tokio::time::Instant::now() >= deadline {
+                return Ok(Response::new(LeaseTasksLongPollResponse {
+                    tasks: Vec::new(),
+                    refresh_tasks: Vec::new(),
+                }));
+            }
+
+            // Wait for any shard's broker to signal new tasks, or timeout.
+            // Register notified futures for all shards before checking deadline.
+            let notified_futures: Vec<_> = shards_to_poll
+                .iter()
+                .map(|(_, shard)| shard.broker.notified())
+                .collect();
+
+            // Wait until any broker signals or deadline
+            tokio::select! {
+                _ = tokio::time::sleep_until(deadline) => {
+                    // Timeout reached, return empty
+                    return Ok(Response::new(LeaseTasksLongPollResponse {
+                        tasks: Vec::new(),
+                        refresh_tasks: Vec::new(),
+                    }));
+                }
+                _ = async {
+                    // Wait for any shard broker to signal
+                    futures::future::select_all(
+                        notified_futures.into_iter().map(|n| Box::pin(n))
+                    ).await;
+                } => {
+                    // A broker signaled new tasks available, loop back to try dequeue
+                    continue;
+                }
+            }
+        }
+    }
+
     async fn report_outcome(
         &self,
         req: Request<ReportOutcomeRequest>,

--- a/typescript_client/package.json
+++ b/typescript_client/package.json
@@ -22,6 +22,7 @@
     "lint:fix": "oxfmt && oxlint --type-aware --fix",
     "format": "oxfmt",
     "test:watch": "vitest",
+    "bench": "vitest bench",
     "prepublishOnly": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "prerelease": "gitpkg publish"

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -1159,9 +1159,8 @@ export class SiloGRPCClient {
 
   /**
    * Resolve the shard ID (string UUID) from tenant using range-based lookup.
-   * @internal
    */
-  private _resolveShard(tenant: string | undefined): string {
+  public resolveShard(tenant: string | undefined): string {
     const tenantId = tenant ?? DEFAULT_TENANT;
     if (this._shards.length === 0) {
       throw new Error("Cluster topology not discovered yet. Call refreshTopology() first.");
@@ -1226,7 +1225,7 @@ export class SiloGRPCClient {
     client: SiloClient;
     shard: string;
   } {
-    const shardId = this._resolveShard(tenant);
+    const shardId = this.resolveShard(tenant);
     return {
       client: this._getClientForShard(shardId),
       shard: shardId,
@@ -2003,7 +2002,7 @@ export class SiloGRPCClient {
    * @returns The shard ID (UUID string) or undefined if no shard found
    */
   public getShardForTenant(tenant: string): string {
-    return this._resolveShard(tenant);
+    return this.resolveShard(tenant);
   }
 
   /**

--- a/typescript_client/src/index.ts
+++ b/typescript_client/src/index.ts
@@ -22,6 +22,7 @@ export {
   type SiloGRPCClientOptions,
   type EnqueueJobOptions,
   type LeaseTasksOptions,
+  type LeaseTasksLongPollOptions,
   type LeaseTasksResult,
   type ReportOutcomeOptions,
   type SuccessOutcome,

--- a/typescript_client/src/pb/silo.client.ts
+++ b/typescript_client/src/pb/silo.client.ts
@@ -29,6 +29,8 @@ import type { ReportRefreshOutcomeResponse } from "./silo";
 import type { ReportRefreshOutcomeRequest } from "./silo";
 import type { ReportOutcomeResponse } from "./silo";
 import type { ReportOutcomeRequest } from "./silo";
+import type { LeaseTasksLongPollResponse } from "./silo";
+import type { LeaseTasksLongPollRequest } from "./silo";
 import type { LeaseTasksResponse } from "./silo";
 import type { LeaseTasksRequest } from "./silo";
 import type { LeaseTaskResponse } from "./silo";
@@ -143,6 +145,15 @@ export interface ISiloClient {
      * @generated from protobuf rpc: LeaseTasks
      */
     leaseTasks(input: LeaseTasksRequest, options?: RpcOptions): UnaryCall<LeaseTasksRequest, LeaseTasksResponse>;
+    /**
+     * Long-poll variant of LeaseTasks.
+     * Blocks until tasks are available or timeout is reached.
+     * Returns immediately if tasks are already available.
+     * Avoids the latency overhead of short-polling intervals.
+     *
+     * @generated from protobuf rpc: LeaseTasksLongPoll
+     */
+    leaseTasksLongPoll(input: LeaseTasksLongPollRequest, options?: RpcOptions): UnaryCall<LeaseTasksLongPollRequest, LeaseTasksLongPollResponse>;
     /**
      * Report the outcome of a completed job task.
      * Must be called before the task lease expires.
@@ -369,13 +380,25 @@ export class SiloClient implements ISiloClient, ServiceInfo {
         return stackIntercept<LeaseTasksRequest, LeaseTasksResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * Long-poll variant of LeaseTasks.
+     * Blocks until tasks are available or timeout is reached.
+     * Returns immediately if tasks are already available.
+     * Avoids the latency overhead of short-polling intervals.
+     *
+     * @generated from protobuf rpc: LeaseTasksLongPoll
+     */
+    leaseTasksLongPoll(input: LeaseTasksLongPollRequest, options?: RpcOptions): UnaryCall<LeaseTasksLongPollRequest, LeaseTasksLongPollResponse> {
+        const method = this.methods[11], opt = this._transport.mergeOptions(options);
+        return stackIntercept<LeaseTasksLongPollRequest, LeaseTasksLongPollResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
      * Report the outcome of a completed job task.
      * Must be called before the task lease expires.
      *
      * @generated from protobuf rpc: ReportOutcome
      */
     reportOutcome(input: ReportOutcomeRequest, options?: RpcOptions): UnaryCall<ReportOutcomeRequest, ReportOutcomeResponse> {
-        const method = this.methods[11], opt = this._transport.mergeOptions(options);
+        const method = this.methods[12], opt = this._transport.mergeOptions(options);
         return stackIntercept<ReportOutcomeRequest, ReportOutcomeResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -385,7 +408,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ReportRefreshOutcome
      */
     reportRefreshOutcome(input: ReportRefreshOutcomeRequest, options?: RpcOptions): UnaryCall<ReportRefreshOutcomeRequest, ReportRefreshOutcomeResponse> {
-        const method = this.methods[12], opt = this._transport.mergeOptions(options);
+        const method = this.methods[13], opt = this._transport.mergeOptions(options);
         return stackIntercept<ReportRefreshOutcomeRequest, ReportRefreshOutcomeResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -396,7 +419,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: Heartbeat
      */
     heartbeat(input: HeartbeatRequest, options?: RpcOptions): UnaryCall<HeartbeatRequest, HeartbeatResponse> {
-        const method = this.methods[13], opt = this._transport.mergeOptions(options);
+        const method = this.methods[14], opt = this._transport.mergeOptions(options);
         return stackIntercept<HeartbeatRequest, HeartbeatResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -406,7 +429,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: Query
      */
     query(input: QueryRequest, options?: RpcOptions): UnaryCall<QueryRequest, QueryResponse> {
-        const method = this.methods[14], opt = this._transport.mergeOptions(options);
+        const method = this.methods[15], opt = this._transport.mergeOptions(options);
         return stackIntercept<QueryRequest, QueryResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -417,7 +440,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: QueryArrow
      */
     queryArrow(input: QueryArrowRequest, options?: RpcOptions): ServerStreamingCall<QueryArrowRequest, ArrowIpcMessage> {
-        const method = this.methods[15], opt = this._transport.mergeOptions(options);
+        const method = this.methods[16], opt = this._transport.mergeOptions(options);
         return stackIntercept<QueryArrowRequest, ArrowIpcMessage>("serverStreaming", this._transport, method, opt, input);
     }
     /**
@@ -428,7 +451,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: CpuProfile
      */
     cpuProfile(input: CpuProfileRequest, options?: RpcOptions): UnaryCall<CpuProfileRequest, CpuProfileResponse> {
-        const method = this.methods[16], opt = this._transport.mergeOptions(options);
+        const method = this.methods[17], opt = this._transport.mergeOptions(options);
         return stackIntercept<CpuProfileRequest, CpuProfileResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -441,7 +464,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: RequestSplit
      */
     requestSplit(input: RequestSplitRequest, options?: RpcOptions): UnaryCall<RequestSplitRequest, RequestSplitResponse> {
-        const method = this.methods[17], opt = this._transport.mergeOptions(options);
+        const method = this.methods[18], opt = this._transport.mergeOptions(options);
         return stackIntercept<RequestSplitRequest, RequestSplitResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -452,7 +475,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: GetSplitStatus
      */
     getSplitStatus(input: GetSplitStatusRequest, options?: RpcOptions): UnaryCall<GetSplitStatusRequest, GetSplitStatusResponse> {
-        const method = this.methods[18], opt = this._transport.mergeOptions(options);
+        const method = this.methods[19], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetSplitStatusRequest, GetSplitStatusResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -464,7 +487,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ConfigureShard
      */
     configureShard(input: ConfigureShardRequest, options?: RpcOptions): UnaryCall<ConfigureShardRequest, ConfigureShardResponse> {
-        const method = this.methods[19], opt = this._transport.mergeOptions(options);
+        const method = this.methods[20], opt = this._transport.mergeOptions(options);
         return stackIntercept<ConfigureShardRequest, ConfigureShardResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -476,7 +499,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ImportJobs
      */
     importJobs(input: ImportJobsRequest, options?: RpcOptions): UnaryCall<ImportJobsRequest, ImportJobsResponse> {
-        const method = this.methods[20], opt = this._transport.mergeOptions(options);
+        const method = this.methods[21], opt = this._transport.mergeOptions(options);
         return stackIntercept<ImportJobsRequest, ImportJobsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -487,7 +510,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ResetShards
      */
     resetShards(input: ResetShardsRequest, options?: RpcOptions): UnaryCall<ResetShardsRequest, ResetShardsResponse> {
-        const method = this.methods[21], opt = this._transport.mergeOptions(options);
+        const method = this.methods[22], opt = this._transport.mergeOptions(options);
         return stackIntercept<ResetShardsRequest, ResetShardsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -498,7 +521,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ForceReleaseShard
      */
     forceReleaseShard(input: ForceReleaseShardRequest, options?: RpcOptions): UnaryCall<ForceReleaseShardRequest, ForceReleaseShardResponse> {
-        const method = this.methods[22], opt = this._transport.mergeOptions(options);
+        const method = this.methods[23], opt = this._transport.mergeOptions(options);
         return stackIntercept<ForceReleaseShardRequest, ForceReleaseShardResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -761,6 +761,50 @@ export interface LeaseTasksResponse {
     refreshTasks: RefreshFloatingLimitTask[]; // Floating limit refresh tasks.
 }
 /**
+ * Long-poll variant of LeaseTasksRequest.
+ * Blocks until tasks are available or timeout is reached.
+ * Avoids the latency overhead of short-polling intervals.
+ *
+ * @generated from protobuf message silo.v1.LeaseTasksLongPollRequest
+ */
+export interface LeaseTasksLongPollRequest {
+    /**
+     * @generated from protobuf field: optional string shard = 1
+     */
+    shard?: string; // optional filter - if set, only lease from this shard (UUID)
+    /**
+     * @generated from protobuf field: string worker_id = 2
+     */
+    workerId: string;
+    /**
+     * @generated from protobuf field: uint32 max_tasks = 3
+     */
+    maxTasks: number;
+    /**
+     * @generated from protobuf field: string task_group = 4
+     */
+    taskGroup: string; // Required. Task group to poll tasks from.
+    /**
+     * @generated from protobuf field: uint32 timeout_ms = 5
+     */
+    timeoutMs: number; // Max time to wait for tasks (ms). Server caps at 60000. 0 = immediate (same as LeaseTasks).
+}
+/**
+ * Response for long-poll lease. Same shape as LeaseTasksResponse.
+ *
+ * @generated from protobuf message silo.v1.LeaseTasksLongPollResponse
+ */
+export interface LeaseTasksLongPollResponse {
+    /**
+     * @generated from protobuf field: repeated silo.v1.Task tasks = 1
+     */
+    tasks: Task[]; // Job execution tasks.
+    /**
+     * @generated from protobuf field: repeated silo.v1.RefreshFloatingLimitTask refresh_tasks = 2
+     */
+    refreshTasks: RefreshFloatingLimitTask[]; // Floating limit refresh tasks.
+}
+/**
  * Request to report the outcome of a completed task.
  * Note: tenant is determined from the task lease, not from the request.
  *
@@ -3816,6 +3860,139 @@ class LeaseTasksResponse$Type extends MessageType<LeaseTasksResponse> {
  */
 export const LeaseTasksResponse = new LeaseTasksResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class LeaseTasksLongPollRequest$Type extends MessageType<LeaseTasksLongPollRequest> {
+    constructor() {
+        super("silo.v1.LeaseTasksLongPollRequest", [
+            { no: 1, name: "shard", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "worker_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "max_tasks", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 4, name: "task_group", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "timeout_ms", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+        ]);
+    }
+    create(value?: PartialMessage<LeaseTasksLongPollRequest>): LeaseTasksLongPollRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.workerId = "";
+        message.maxTasks = 0;
+        message.taskGroup = "";
+        message.timeoutMs = 0;
+        if (value !== undefined)
+            reflectionMergePartial<LeaseTasksLongPollRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: LeaseTasksLongPollRequest): LeaseTasksLongPollRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional string shard */ 1:
+                    message.shard = reader.string();
+                    break;
+                case /* string worker_id */ 2:
+                    message.workerId = reader.string();
+                    break;
+                case /* uint32 max_tasks */ 3:
+                    message.maxTasks = reader.uint32();
+                    break;
+                case /* string task_group */ 4:
+                    message.taskGroup = reader.string();
+                    break;
+                case /* uint32 timeout_ms */ 5:
+                    message.timeoutMs = reader.uint32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: LeaseTasksLongPollRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional string shard = 1; */
+        if (message.shard !== undefined)
+            writer.tag(1, WireType.LengthDelimited).string(message.shard);
+        /* string worker_id = 2; */
+        if (message.workerId !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.workerId);
+        /* uint32 max_tasks = 3; */
+        if (message.maxTasks !== 0)
+            writer.tag(3, WireType.Varint).uint32(message.maxTasks);
+        /* string task_group = 4; */
+        if (message.taskGroup !== "")
+            writer.tag(4, WireType.LengthDelimited).string(message.taskGroup);
+        /* uint32 timeout_ms = 5; */
+        if (message.timeoutMs !== 0)
+            writer.tag(5, WireType.Varint).uint32(message.timeoutMs);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.LeaseTasksLongPollRequest
+ */
+export const LeaseTasksLongPollRequest = new LeaseTasksLongPollRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class LeaseTasksLongPollResponse$Type extends MessageType<LeaseTasksLongPollResponse> {
+    constructor() {
+        super("silo.v1.LeaseTasksLongPollResponse", [
+            { no: 1, name: "tasks", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Task },
+            { no: 2, name: "refresh_tasks", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => RefreshFloatingLimitTask }
+        ]);
+    }
+    create(value?: PartialMessage<LeaseTasksLongPollResponse>): LeaseTasksLongPollResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.tasks = [];
+        message.refreshTasks = [];
+        if (value !== undefined)
+            reflectionMergePartial<LeaseTasksLongPollResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: LeaseTasksLongPollResponse): LeaseTasksLongPollResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated silo.v1.Task tasks */ 1:
+                    message.tasks.push(Task.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* repeated silo.v1.RefreshFloatingLimitTask refresh_tasks */ 2:
+                    message.refreshTasks.push(RefreshFloatingLimitTask.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: LeaseTasksLongPollResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated silo.v1.Task tasks = 1; */
+        for (let i = 0; i < message.tasks.length; i++)
+            Task.internalBinaryWrite(message.tasks[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* repeated silo.v1.RefreshFloatingLimitTask refresh_tasks = 2; */
+        for (let i = 0; i < message.refreshTasks.length; i++)
+            RefreshFloatingLimitTask.internalBinaryWrite(message.refreshTasks[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.LeaseTasksLongPollResponse
+ */
+export const LeaseTasksLongPollResponse = new LeaseTasksLongPollResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class ReportOutcomeRequest$Type extends MessageType<ReportOutcomeRequest> {
     constructor() {
         super("silo.v1.ReportOutcomeRequest", [
@@ -6191,6 +6368,7 @@ export const Silo = new ServiceType("silo.v1.Silo", [
     { name: "ExpediteJob", options: {}, I: ExpediteJobRequest, O: ExpediteJobResponse },
     { name: "LeaseTask", options: {}, I: LeaseTaskRequest, O: LeaseTaskResponse },
     { name: "LeaseTasks", options: {}, I: LeaseTasksRequest, O: LeaseTasksResponse },
+    { name: "LeaseTasksLongPoll", options: {}, I: LeaseTasksLongPollRequest, O: LeaseTasksLongPollResponse },
     { name: "ReportOutcome", options: {}, I: ReportOutcomeRequest, O: ReportOutcomeResponse },
     { name: "ReportRefreshOutcome", options: {}, I: ReportRefreshOutcomeRequest, O: ReportRefreshOutcomeResponse },
     { name: "Heartbeat", options: {}, I: HeartbeatRequest, O: HeartbeatResponse },

--- a/typescript_client/src/worker.ts
+++ b/typescript_client/src/worker.ts
@@ -295,7 +295,8 @@ export class SiloWorker<
   }
 
   /**
-   * Start the worker. This will begin polling for tasks and executing them.
+   * Start the worker with short polling. This will begin polling for tasks
+   * at regular intervals and executing them.
    * Returns immediately after starting the polling loops.
    */
   public start(): void {
@@ -312,6 +313,30 @@ export class SiloWorker<
     // Start the configured number of pollers
     for (let i = 0; i < this._concurrentPollers; i++) {
       this._pollerPromises.push(this._pollLoop());
+    }
+  }
+
+  /**
+   * Start the worker with long polling. The server will hold requests open
+   * until tasks are available, providing much lower latency than short polling.
+   *
+   * @param longPollTimeoutMs Maximum time each long-poll request will block on the
+   *   server waiting for tasks. Server caps at 60000ms. Default: 30000ms.
+   */
+  public startLongPoll(longPollTimeoutMs = 30000): void {
+    if (this._running) {
+      return;
+    }
+
+    this._running = true;
+    this._abortController = new AbortController();
+
+    // Reset the queue in case we're restarting
+    this._taskQueue = new PQueue({ concurrency: this._maxConcurrentTasks });
+
+    // Start long-poll loops
+    for (let i = 0; i < this._concurrentPollers; i++) {
+      this._pollerPromises.push(this._longPollLoop(longPollTimeoutMs));
     }
   }
 
@@ -353,7 +378,7 @@ export class SiloWorker<
   }
 
   /**
-   * The main polling loop for a single poller.
+   * The main polling loop for a single poller (short polling).
    */
   private async _pollLoop(): Promise<void> {
     while (this._running) {
@@ -368,6 +393,24 @@ export class SiloWorker<
       // Wait before polling again if we're still running
       if (this._running) {
         await this._sleep(this._pollIntervalMs);
+      }
+    }
+  }
+
+  /**
+   * The main polling loop for long-poll mode.
+   * No sleep between polls since the server handles the waiting.
+   */
+  private async _longPollLoop(timeoutMs: number): Promise<void> {
+    while (this._running) {
+      try {
+        await this._longPoll(timeoutMs);
+      } catch (error) {
+        if (this._running) {
+          this._onError(error instanceof Error ? error : new Error(String(error)));
+          // Brief backoff on error to avoid tight error loop
+          await this._sleep(1000);
+        }
       }
     }
   }
@@ -412,6 +455,53 @@ export class SiloWorker<
     }
 
     // Handle refresh tasks
+    if (result.refreshTasks.length > 0) {
+      if (!this._refreshHandler) {
+        throw new Error(
+          `Worker received ${result.refreshTasks.length} floating limit refresh task(s) but no refreshHandler is configured. ` +
+            `Configure a refreshHandler in SiloWorkerOptions to handle floating concurrency limits.`,
+        );
+      }
+      for (const refreshTask of result.refreshTasks) {
+        this._enqueueRefreshTask(refreshTask);
+      }
+    }
+  }
+
+  /**
+   * Long-poll variant: blocks on the server until tasks are available.
+   */
+  private async _longPoll(timeoutMs: number): Promise<void> {
+    // Wait if the queue is too full
+    while (this._running && this._taskQueue.size >= this._maxConcurrentTasks) {
+      await this._sleep(this._pollIntervalMs / 2);
+    }
+
+    if (!this._running) {
+      return;
+    }
+
+    const availableQueueSlots = this._maxConcurrentTasks - this._taskQueue.size;
+    if (availableQueueSlots <= 0) {
+      return;
+    }
+
+    const tasksToRequest = Math.min(availableQueueSlots, this._tasksPerPoll);
+    const serverIndex = this._pollCounter++;
+    const result = await this._client.leaseTasksLongPoll(
+      {
+        workerId: this._workerId,
+        maxTasks: tasksToRequest,
+        taskGroup: this._taskGroup,
+        timeoutMs,
+      },
+      serverIndex,
+    );
+
+    for (const task of result.tasks) {
+      this._enqueueTask(task);
+    }
+
     if (result.refreshTasks.length > 0) {
       if (!this._refreshHandler) {
         throw new Error(

--- a/typescript_client/test/worker-integration.test.ts
+++ b/typescript_client/test/worker-integration.test.ts
@@ -1443,16 +1443,17 @@ describe.skipIf(!RUN_INTEGRATION)("SiloWorker integration", () => {
       });
       console.log(`\n  Drain: ${emptyResult.tasks.length} stale tasks`);
 
+      // Resolve which shard owns this tenant so we long-poll the correct server
+      const shard = client.resolveShard(DEFAULT_TENANT);
+
       // --- Enqueue #1: start long-poll, then enqueue ---
-      const lp1 = client.leaseTasksLongPoll(
-        {
-          workerId: "test-lp",
-          maxTasks: 1,
-          taskGroup: DEFAULT_TASK_GROUP,
-          timeoutMs: 10000,
-        },
-        0,
-      );
+      const lp1 = client.leaseTasksLongPoll({
+        workerId: "test-lp",
+        maxTasks: 1,
+        taskGroup: DEFAULT_TASK_GROUP,
+        timeoutMs: 10000,
+        shard,
+      });
 
       await new Promise((r) => setTimeout(r, 200));
 
@@ -1470,15 +1471,13 @@ describe.skipIf(!RUN_INTEGRATION)("SiloWorker integration", () => {
       expect(r1.tasks.length).toBe(1);
 
       // --- Enqueue #2: start another long-poll, then enqueue ---
-      const lp2 = client.leaseTasksLongPoll(
-        {
-          workerId: "test-lp",
-          maxTasks: 1,
-          taskGroup: DEFAULT_TASK_GROUP,
-          timeoutMs: 10000,
-        },
-        0,
-      );
+      const lp2 = client.leaseTasksLongPoll({
+        workerId: "test-lp",
+        maxTasks: 1,
+        taskGroup: DEFAULT_TASK_GROUP,
+        timeoutMs: 10000,
+        shard,
+      });
 
       await new Promise((r) => setTimeout(r, 200));
 

--- a/typescript_client/test/worker-latency.bench.ts
+++ b/typescript_client/test/worker-latency.bench.ts
@@ -1,0 +1,128 @@
+import { bench, describe } from "vitest";
+import { SiloGRPCClient } from "../src/client";
+import { SiloWorker, type TaskHandler } from "../src/worker";
+
+const SILO_SERVERS = (
+  process.env.SILO_SERVERS ||
+  process.env.SILO_SERVER ||
+  "localhost:7450"
+).split(",");
+
+const DEFAULT_TENANT = "test-tenant";
+const DEFAULT_TASK_GROUP = "bench-task-group";
+
+/**
+ * Wait until a condition becomes true, polling at intervals.
+ */
+async function waitFor(
+  condition: () => boolean | Promise<boolean>,
+  options?: { timeout?: number; interval?: number },
+): Promise<void> {
+  const timeout = options?.timeout ?? 10000;
+  const interval = options?.interval ?? 10;
+  const start = Date.now();
+  while (!(await condition())) {
+    if (Date.now() - start > timeout) {
+      throw new Error(`waitFor timed out after ${timeout}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+}
+
+// Create client at module level so it's available during warmup
+const client = new SiloGRPCClient({
+  servers: SILO_SERVERS,
+  useTls: false,
+  shardRouting: { topologyRefreshIntervalMs: 0 },
+});
+
+// Track whether topology has been fetched
+let topologyReady = false;
+
+async function ensureReady(): Promise<void> {
+  if (!topologyReady) {
+    await client.refreshTopology();
+    topologyReady = true;
+  }
+}
+
+describe("enqueue-to-pickup latency", () => {
+  bench(
+    "short polling (pollIntervalMs=50)",
+    async () => {
+      await ensureReady();
+      await client.resetShards();
+
+      const delays: number[] = [];
+      const handler: TaskHandler<{ enqueueTime: number }> = async (ctx) => {
+        delays.push(performance.now() - ctx.task.payload.enqueueTime);
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker<{ enqueueTime: number }>({
+        client,
+        workerId: `bench-worker-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        handler,
+        tenant: DEFAULT_TENANT,
+        taskGroup: DEFAULT_TASK_GROUP,
+        pollIntervalMs: 50,
+        heartbeatIntervalMs: 1000,
+        maxConcurrentTasks: 1,
+      });
+      worker.start();
+
+      for (let i = 0; i < 10; i++) {
+        await client.enqueue({
+          tenant: DEFAULT_TENANT,
+          taskGroup: DEFAULT_TASK_GROUP,
+          payload: { enqueueTime: performance.now() },
+          priority: 1,
+        });
+        await waitFor(() => delays.length > i);
+      }
+
+      await worker.stop();
+    },
+    { iterations: 3, time: 0, warmupIterations: 0 },
+  );
+
+  bench(
+    "long polling",
+    async () => {
+      await ensureReady();
+      await client.resetShards();
+
+      const delays: number[] = [];
+      const handler: TaskHandler<{ enqueueTime: number }> = async (ctx) => {
+        delays.push(performance.now() - ctx.task.payload.enqueueTime);
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker<{ enqueueTime: number }>({
+        client,
+        workerId: `bench-worker-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        handler,
+        tenant: DEFAULT_TENANT,
+        taskGroup: DEFAULT_TASK_GROUP,
+        pollIntervalMs: 50,
+        heartbeatIntervalMs: 1000,
+        maxConcurrentTasks: 10,
+        concurrentPollers: client.serverCount,
+      });
+      worker.startLongPoll(30000);
+
+      for (let i = 0; i < 10; i++) {
+        await client.enqueue({
+          tenant: DEFAULT_TENANT,
+          taskGroup: DEFAULT_TASK_GROUP,
+          payload: { enqueueTime: performance.now() },
+          priority: 1,
+        });
+        await waitFor(() => delays.length > i);
+      }
+
+      await worker.stop();
+    },
+    { iterations: 3, time: 0, warmupIterations: 0 },
+  );
+});

--- a/typescript_client/vitest.config.ts
+++ b/typescript_client/vitest.config.ts
@@ -15,5 +15,8 @@ export default defineConfig({
     pool: "threads",
     // Timeout for tearing down test environment
     teardownTimeout: 1000,
+    benchmark: {
+      include: ["test/**/*.bench.ts"],
+    },
   },
 });


### PR DESCRIPTION
Still need to take a look at what this means for routing. Temporal uses long polling, and it can help here, in the best case it may reduce latency by 50ms.

5 runs with 10 enqueues each, running `pnpm bench` from the typescript_client dir in a loop and summarizing the results:

```
  ┌─────┬───────────────┬──────────────┬─────────┐
  │ Run │ Short Polling │ Long Polling │ Speedup │
  ├─────┼───────────────┼──────────────┼─────────┤
  │ 1   │ 3,791ms       │ 3,005ms      │ 1.26x   │
  ├─────┼───────────────┼──────────────┼─────────┤
  │ 2   │ 3,650ms       │ 2,844ms      │ 1.28x   │
  ├─────┼───────────────┼──────────────┼─────────┤
  │ 3   │ 3,613ms       │ 2,625ms      │ 1.38x   │
  ├─────┼───────────────┼──────────────┼─────────┤
  │ 4   │ 3,703ms       │ 2,653ms      │ 1.40x   │
  ├─────┼───────────────┼──────────────┼─────────┤
  │ 5   │ 3,803ms       │ 2,856ms      │ 1.33x   │
  └─────┴───────────────┴──────────────┴─────────┘

  Averages across 5 runs:
  - Short polling: 3,712ms (~371ms per task)
  - Long polling: 2,797ms (~280ms per task)
  - Speedup: 1.33x (long polling is ~25% faster)
```

actual output for one run:


```
 DEV  v4.0.14 /Users/kirin/src/gadget/silo/typescript_client


 ✓ test/worker-latency.bench.ts > enqueue-to-pickup latency 29028ms
     name                                   hz       min       max      mean       p75       p99      p995      p999      rme  samples
   · short polling (pollIntervalMs=50)  0.2290  3,803.77  4,703.52  4,367.70  4,703.52  4,703.52  4,703.52  4,703.52  ±27.95%        3
   · long polling                       0.3497  2,662.15  3,173.08  2,859.75  3,173.08  3,173.08  3,173.08  3,173.08  ±23.84%        3

 BENCH  Summary

  long polling - test/worker-latency.bench.ts > enqueue-to-pickup latency
    1.53x faster than short polling (pollIntervalMs=50)

 PASS  Waiting for file changes...
       press h to show help, press q to quit
```