### PR TITLE
Add shared-secret Bearer token auth for gRPC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.3.14", features = ["derive"] }
+clap = { version = "4.3.14", features = ["derive", "env"] }
 futures = "0.3"
 slatedb = { git = "https://github.com/slatedb/slatedb.git", branch = "main" }
 object_store = { version = "0.12", features = ["gcp"] }

--- a/deploy/local-test/secret.yaml
+++ b/deploy/local-test/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: silo-auth
+  namespace: silo-test
+type: Opaque
+stringData:
+  token: "grpc-auth-token"

--- a/deploy/local-test/statefulset.yaml
+++ b/deploy/local-test/statefulset.yaml
@@ -7,6 +7,7 @@ data:
   config.toml: |
     [server]
     grpc_addr = "0.0.0.0:50051"
+    auth_token = "${SILO_AUTH_TOKEN}"
 
     [logging]
     format = "json"
@@ -99,6 +100,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: SILO_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: silo-auth
+                  key: token
             - name: RUST_LOG
               value: "info,silo::coordination=debug"
           volumeMounts:

--- a/docs/src/content/docs/reference/server-configuration.mdx
+++ b/docs/src/content/docs/reference/server-configuration.mdx
@@ -46,9 +46,36 @@ statement_timeout_ms = 5000
 | `grpc_addr` | string | `"127.0.0.1:7450"` | Address and port for the gRPC server to listen on |
 | `dev_mode` | bool | `false` | Enable development mode features like `ResetShards` RPC. **Never enable in production.** |
 | `statement_timeout_ms` | number | `5000` | Maximum SQL statement execution time in milliseconds. Query execution is aborted when this timeout is hit. Set to `0` to disable statement timeout. |
+| `auth_token` | string | (none) | Shared secret for gRPC authentication. When set, all incoming gRPC requests must include this token as a `Bearer` token in the `authorization` metadata header. When unset (default), authentication is disabled. |
 
 <Aside type="danger">
 `dev_mode` allows destructive operations like resetting shard data. Only enable this for local development and testing.
+</Aside>
+
+### gRPC Authentication
+
+Silo supports optional shared-secret authentication for gRPC requests. When `auth_token` is set in the `[server]` section, all incoming RPCs must include an `authorization: Bearer <token>` metadata header matching the configured value. Requests without a valid token are rejected with `UNAUTHENTICATED`.
+
+When `auth_token` is not set (the default), authentication is disabled and all clients can connect freely.
+
+```toml
+[server]
+grpc_addr = "0.0.0.0:7450"
+auth_token = "${SILO_AUTH_TOKEN}"
+```
+
+When authentication is enabled, node-to-node cluster communication and WebUI remote queries automatically use the configured token. External clients (workers, `siloctl`) must provide the token themselves.
+
+**`siloctl`** supports the token via the `--auth-token` flag or the `SILO_AUTH_TOKEN` environment variable:
+
+```bash
+siloctl --auth-token <token> cluster info
+# or
+SILO_AUTH_TOKEN=<token> siloctl cluster info
+```
+
+<Aside>
+The gRPC health check and server reflection services are **not** wrapped in authentication. This ensures Kubernetes liveness/readiness probes and debugging tools like `grpcurl list` continue to work without credentials.
 </Aside>
 
 ---

--- a/example_configs/k8s-gcs.toml
+++ b/example_configs/k8s-gcs.toml
@@ -9,6 +9,10 @@
 [server]
 # Bind to all interfaces on port 7450
 grpc_addr = "0.0.0.0:7450"
+# Shared secret for gRPC authentication (optional).
+# When set, all incoming gRPC requests must include this as a Bearer token.
+# Workers must be configured with the same token.
+# auth_token = "${SILO_AUTH_TOKEN}"
 
 [coordination]
 backend = "k8s"

--- a/nix/modules/docker.nix
+++ b/nix/modules/docker.nix
@@ -29,7 +29,8 @@
         devEnv = pkgs.buildEnv {
           name = "silo-dev-env";
           paths = [
-            self'.packages.silo
+            # use debug silo for faster builds
+            self'.packages.silo-debug
             pkgs.cacert
             # Shell and core utilities
             pkgs.bashInteractive

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -49,15 +49,29 @@
       
       # Build dependencies separately for caching
       cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-      
+
       # Main package
       silo = craneLib.buildPackage (commonArgs // {
         inherit cargoArtifacts;
         doCheck = false; # Tests require external services, CI runs them separately
       });
+
+      # Debug build (fast to compile, no optimizations)
+      debugArgs = {
+        inherit src;
+        strictDeps = true;
+        nativeBuildInputs = [ pkgs.protobuf pkgs.flatbuffers ];
+        CARGO_PROFILE = "dev";
+      };
+      cargoArtifactsDebug = craneLib.buildDepsOnly debugArgs;
+      silo-debug = craneLib.buildPackage (debugArgs // {
+        cargoArtifacts = cargoArtifactsDebug;
+        doCheck = false;
+      });
     in
     {
       packages.default = silo;
       packages.silo = silo;
+      packages.silo-debug = silo-debug;
     };
 }

--- a/src/bin/siloctl.rs
+++ b/src/bin/siloctl.rs
@@ -32,6 +32,11 @@ struct Args {
     #[arg(long, global = true)]
     json: bool,
 
+    /// Bearer token for gRPC authentication.
+    /// Can also be set via SILO_AUTH_TOKEN environment variable.
+    #[arg(long, global = true, env = "SILO_AUTH_TOKEN")]
+    auth_token: Option<String>,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -42,6 +47,7 @@ impl Args {
             address: self.address.clone(),
             tenant: self.tenant.clone(),
             json: self.json,
+            auth_token: self.auth_token.clone(),
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -226,6 +226,12 @@ pub struct ServerConfig {
     /// Defaults to 5000ms (5s). Set to 0 to disable statement timeout.
     #[serde(default = "default_statement_timeout_ms")]
     pub statement_timeout_ms: Option<u64>,
+    /// Shared secret for gRPC authentication. When set, all incoming gRPC
+    /// requests must include this token as a Bearer token in the `authorization`
+    /// metadata header. When unset (default), authentication is disabled.
+    /// Supports environment variable expansion, e.g. `${SILO_AUTH_TOKEN}`.
+    #[serde(default)]
+    pub auth_token: Option<String>,
 }
 
 impl Default for ServerConfig {
@@ -234,6 +240,7 @@ impl Default for ServerConfig {
             grpc_addr: default_grpc_addr(),
             dev_mode: false,
             statement_timeout_ms: default_statement_timeout_ms(),
+            auth_token: None,
         }
     }
 }
@@ -523,6 +530,7 @@ impl AppConfig {
                 grpc_addr: default_grpc_addr(),
                 dev_mode: false,
                 statement_timeout_ms: default_statement_timeout_ms(),
+                auth_token: None,
             },
             coordination: CoordinationConfig::default(),
             tenancy: TenancyConfig { enabled: false },

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -2090,15 +2090,23 @@ pub async fn run_webui(
     cfg: AppConfig,
     mut shutdown: broadcast::Receiver<()>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let cluster_client = Arc::new(ClusterClient::new(
+    let cluster_client = Arc::new(ClusterClient::with_config(
         factory.clone(),
         Some(coordinator.clone()),
+        crate::cluster_client::ClientConfig {
+            auth_token: cfg.server.auth_token.clone(),
+            ..Default::default()
+        },
     ));
 
     let query_engine = Arc::new(
-        ClusterQueryEngine::new(factory.clone(), Some(coordinator.clone()))
-            .await
-            .expect("Failed to create cluster query engine"),
+        ClusterQueryEngine::with_auth(
+            factory.clone(),
+            Some(coordinator.clone()),
+            cfg.server.auth_token.clone(),
+        )
+        .await
+        .expect("Failed to create cluster query engine"),
     );
 
     let state = AppState {

--- a/tests/cluster_client_tests.rs
+++ b/tests/cluster_client_tests.rs
@@ -1107,6 +1107,7 @@ async fn create_silo_client_connection_failure() {
         keepalive_timeout: Duration::from_secs(1),
         max_retries: 1,
         retry_backoff_base: Duration::from_millis(10),
+        auth_token: None,
     };
 
     // Try to connect to a port that nothing is listening on

--- a/tests/grpc_auth_tests.rs
+++ b/tests/grpc_auth_tests.rs
@@ -1,0 +1,165 @@
+mod grpc_integration_helpers;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use grpc_integration_helpers::{create_test_factory, shutdown_server};
+use silo::cluster_client::AuthInterceptor;
+use silo::coordination::NoneCoordinator;
+use silo::pb::silo_client::SiloClient;
+use silo::pb::*;
+use silo::server::run_server;
+use silo::settings::AppConfig;
+use tokio::net::TcpListener;
+use tonic_health::pb::HealthCheckRequest;
+use tonic_health::pb::health_client::HealthClient;
+
+/// Helper: start a server with a given auth_token
+async fn start_auth_server(
+    auth_token: Option<String>,
+) -> anyhow::Result<(
+    SocketAddr,
+    tokio::sync::broadcast::Sender<()>,
+    tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>,
+    Arc<silo::factory::ShardFactory>,
+    tempfile::TempDir,
+)> {
+    let (factory, tmp) = create_test_factory().await?;
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
+    let addr = listener.local_addr()?;
+    let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
+
+    let mut cfg = AppConfig::load(None).unwrap();
+    cfg.server.auth_token = auth_token;
+
+    let coordinator = Arc::new(
+        NoneCoordinator::from_factory("test-node", format!("http://{}", addr), factory.clone())
+            .await,
+    );
+
+    let server = tokio::spawn(run_server(
+        listener,
+        factory.clone(),
+        coordinator,
+        cfg,
+        None,
+        shutdown_rx,
+    ));
+
+    Ok((addr, shutdown_tx, server, factory, tmp))
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn auth_unauthenticated_client_rejected() -> anyhow::Result<()> {
+    let (addr, shutdown_tx, server, _factory, _tmp) =
+        start_auth_server(Some("test-secret".to_string())).await?;
+
+    let endpoint = format!("http://{}", addr);
+    let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
+    let mut client = SiloClient::new(channel);
+
+    let result = client.get_cluster_info(GetClusterInfoRequest {}).await;
+
+    assert!(result.is_err());
+    let status = result.unwrap_err();
+    assert_eq!(
+        status.code(),
+        tonic::Code::Unauthenticated,
+        "unauthenticated client should be rejected"
+    );
+
+    shutdown_server(shutdown_tx, server).await?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn auth_wrong_token_rejected() -> anyhow::Result<()> {
+    let (addr, shutdown_tx, server, _factory, _tmp) =
+        start_auth_server(Some("test-secret".to_string())).await?;
+
+    let endpoint = format!("http://{}", addr);
+    let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
+    let interceptor = AuthInterceptor::new(Some("wrong-token".to_string()));
+    let mut client = SiloClient::with_interceptor(channel, interceptor);
+
+    let result = client.get_cluster_info(GetClusterInfoRequest {}).await;
+
+    assert!(result.is_err());
+    let status = result.unwrap_err();
+    assert_eq!(
+        status.code(),
+        tonic::Code::Unauthenticated,
+        "client with wrong token should be rejected"
+    );
+
+    shutdown_server(shutdown_tx, server).await?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn auth_correct_token_succeeds() -> anyhow::Result<()> {
+    let (addr, shutdown_tx, server, _factory, _tmp) =
+        start_auth_server(Some("test-secret".to_string())).await?;
+
+    let endpoint = format!("http://{}", addr);
+    let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
+    let interceptor = AuthInterceptor::new(Some("test-secret".to_string()));
+    let mut client = SiloClient::with_interceptor(channel, interceptor);
+
+    let result = client.get_cluster_info(GetClusterInfoRequest {}).await;
+
+    assert!(
+        result.is_ok(),
+        "client with correct token should succeed: {:?}",
+        result.err()
+    );
+
+    shutdown_server(shutdown_tx, server).await?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn auth_disabled_allows_unauthenticated() -> anyhow::Result<()> {
+    let (addr, shutdown_tx, server, _factory, _tmp) = start_auth_server(None).await?;
+
+    let endpoint = format!("http://{}", addr);
+    let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
+    let mut client = SiloClient::new(channel);
+
+    let result = client.get_cluster_info(GetClusterInfoRequest {}).await;
+
+    assert!(
+        result.is_ok(),
+        "unauthenticated client should work when auth is disabled: {:?}",
+        result.err()
+    );
+
+    shutdown_server(shutdown_tx, server).await?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn auth_health_check_bypasses_auth() -> anyhow::Result<()> {
+    let (addr, shutdown_tx, server, _factory, _tmp) =
+        start_auth_server(Some("test-secret".to_string())).await?;
+
+    let endpoint = format!("http://{}", addr);
+    let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
+    let mut health_client = HealthClient::new(channel);
+
+    let resp = health_client
+        .check(HealthCheckRequest {
+            service: "".to_string(),
+        })
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        resp.status,
+        tonic_health::pb::health_check_response::ServingStatus::Serving as i32,
+        "health check should bypass auth"
+    );
+
+    shutdown_server(shutdown_tx, server).await?;
+    Ok(())
+}

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -27,6 +27,7 @@ fn opts_for_addr(addr: &std::net::SocketAddr) -> GlobalOptions {
         address: format!("http://{}", addr),
         tenant: None,
         json: false,
+        auth_token: None,
     }
 }
 
@@ -35,6 +36,7 @@ fn opts_for_addr_json(addr: &std::net::SocketAddr) -> GlobalOptions {
         address: format!("http://{}", addr),
         tenant: None,
         json: true,
+        auth_token: None,
     }
 }
 
@@ -737,6 +739,7 @@ async fn siloctl_connection_error() -> anyhow::Result<()> {
         address: "http://127.0.0.1:59999".to_string(),
         tenant: None,
         json: false,
+        auth_token: None,
     };
     let mut output = Vec::new();
     let result = siloctl::cluster_info(&opts, &mut output).await;

--- a/tests/turmoil_runner/helpers.rs
+++ b/tests/turmoil_runner/helpers.rs
@@ -308,6 +308,7 @@ pub async fn setup_server(port: u16) -> turmoil::Result<()> {
             grpc_addr: format!("0.0.0.0:{}", port),
             dev_mode: false,
             statement_timeout_ms: Some(5_000),
+            auth_token: None,
         },
         coordination: silo::settings::CoordinationConfig::default(),
         tenancy: silo::settings::TenancyConfig { enabled: false },

--- a/tests/turmoil_runner/scenarios/k8s_coordination.rs
+++ b/tests/turmoil_runner/scenarios/k8s_coordination.rs
@@ -187,6 +187,7 @@ async fn setup_node_server(
             grpc_addr: format!("0.0.0.0:{}", port),
             dev_mode: false,
             statement_timeout_ms: Some(5_000),
+            auth_token: None,
         },
         coordination: silo::settings::CoordinationConfig::default(),
         tenancy: silo::settings::TenancyConfig { enabled: true },

--- a/tests/turmoil_runner/scenarios/k8s_permanent_leases.rs
+++ b/tests/turmoil_runner/scenarios/k8s_permanent_leases.rs
@@ -127,6 +127,7 @@ async fn setup_node_server(
             grpc_addr: format!("0.0.0.0:{}", port),
             dev_mode: false,
             statement_timeout_ms: Some(5_000),
+            auth_token: None,
         },
         coordination: silo::settings::CoordinationConfig::default(),
         tenancy: silo::settings::TenancyConfig { enabled: true },

--- a/tests/turmoil_runner/scenarios/k8s_shard_splits.rs
+++ b/tests/turmoil_runner/scenarios/k8s_shard_splits.rs
@@ -182,6 +182,7 @@ async fn setup_node_server(
             grpc_addr: format!("0.0.0.0:{}", port),
             dev_mode: false,
             statement_timeout_ms: Some(5_000),
+            auth_token: None,
         },
         coordination: silo::settings::CoordinationConfig::default(),
         tenancy: silo::settings::TenancyConfig { enabled: true },


### PR DESCRIPTION
## Summary

- Add optional `auth_token` field to `ServerConfig` — when set, a server-side interceptor rejects any gRPC request missing a valid `authorization: Bearer <token>` metadata header. Health check and reflection services remain unauthenticated so k8s probes and debugging tools still work.
- Add `AuthInterceptor` on the client side (`cluster_client.rs`, `cluster_query.rs`) so that node-to-node and WebUI remote calls automatically include the token when configured.
- Add `--auth-token` global flag to `siloctl` (also settable via `SILO_AUTH_TOKEN` env var) so operators can run commands against authenticated production clusters.
- Add `token` support for non-TLS connections in the TypeScript client (previously only worked with TLS).
- Add gRPC auth secret and wiring for the local OrbStack k8s test deployment.
- Auth is **off by default** (`auth_token` defaults to `None`); existing configs and tests are unaffected.
- Uses dev/debug cargo profile for ci and orbstack now

## Changes

| File | Change |
|------|--------|
| `src/settings.rs` | Add `auth_token: Option<String>` to `ServerConfig` |
| `src/server.rs` | Server-side interceptor validates `authorization: Bearer <token>` |
| `src/cluster_client.rs` | `AuthInterceptor` struct, `InterceptedSiloClient` type alias, `auth_token` on `ClientConfig` |
| `src/cluster_query.rs` | Thread auth token through remote SQL query path |
| `src/webui.rs` | Pass auth token to `ClusterClient` and `ClusterQueryEngine` |
| `src/siloctl.rs` | Add `auth_token` to `GlobalOptions`, wire into `connect()` |
| `src/bin/siloctl.rs` | Add `--auth-token` CLI flag with `SILO_AUTH_TOKEN` env var support |
| `Cargo.toml` | Enable clap `env` feature for env var support |
| `typescript_client/src/client.ts` | Fix `token` option for non-TLS connections via `RpcInterceptor` |
| `example_configs/k8s-gcs.toml` | Add commented `auth_token` example |
| `deploy/local-test/secret.yaml` | New k8s Secret with gRPC auth token |
| `deploy/local-test/statefulset.yaml` | Wire `SILO_AUTH_TOKEN` env var from secret into config |
| `tests/grpc_auth_tests.rs` | 5 new integration tests |

## Usage

**Server config** (`k8s-gcs.toml`):
```toml
[server]
auth_token = "${SILO_AUTH_TOKEN}"
```

**siloctl**:
```sh
siloctl --auth-token <token> cluster info
# or
SILO_AUTH_TOKEN=<token> siloctl cluster info
```

**TypeScript client**:
```ts
const client = new SiloGRPCClient({
  servers: "silo:50051",
  token: "my-secret-token",
  useTls: false,  // token now works with non-TLS too
});
```

## Manual testing (tophat)

Deployed to local OrbStack k8s cluster with gRPC auth enabled, then verified:

1. **grpcurl**: Port-forwarded to the silo service and called `GetClusterInfo` with no auth — received `UNAUTHENTICATED: missing authorization header`. Retried with `-H "authorization: Bearer grpc-auth-token"` — succeeded and returned full cluster info.

2. **TypeScript worker**: Ran a script that creates a `SiloGRPCClient` without a token — `refreshTopology()` fails with "Failed to refresh cluster topology from any server". Then created a client with `token: "grpc-auth-token"`, enqueued a job, started a `SiloWorker`, and the job was successfully picked up and processed.

3. **siloctl**: Ran `siloctl --address http://localhost:50051 cluster info` without auth — received `Unauthenticated: missing authorization header`. Ran with `--auth-token grpc-auth-token` — succeeded. Also verified `SILO_AUTH_TOKEN=grpc-auth-token siloctl cluster info` works via env var.

## Test plan

- [x] 5 new integration tests in `tests/grpc_auth_tests.rs`:
  - Unauthenticated client rejected when auth is enabled
  - Wrong token rejected
  - Correct token accepted
  - Unauthenticated client works when auth is disabled (no regression)
  - Health check bypasses auth
- [x] All existing Rust test suites pass (cluster_client, siloctl, webui, grpc_*, turmoil)
- [x] All 197 TypeScript client integration tests pass unchanged
- [x] Manual tophat against local OrbStack k8s deployment (see above)