### PR TITLE
Fix DST failures and remove redundant db.flush() calls

### DIFF
--- a/.ai/skills/fix-dst/SKILL.md
+++ b/.ai/skills/fix-dst/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: fix-dst
+description: |
+  Reviews the latest DST simulation failures in Github Actions fixes them locally
+
+  Use this skill when the user wants to fix remote DST failures discovered by CI DST runs
+---
+
+Use the `gh` CLI to identify the most recent build for the current branch of the `simulation-testing` github actions workflow. Retrieve the action logs and review the list of failed seeds at the end of the log. Identify the failed scenarios and reproduce the failure locally -- it should be fully deterministic and fail in the same way locally as it did in CI. Create a todo for each seed, and debug. Then, fix each failure, validating each one as you go. Report back to the user with what was fixed and how.

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -361,15 +361,13 @@ impl JobStoreShard {
     }
 
     /// Complete an enqueue after successful write/commit and DST event emission.
-    /// Flushes to disk, logs grants, and wakes up the broker.
+    /// Logs grants and wakes up the broker.
     pub(crate) async fn finish_enqueue(
         &self,
         job_id: &str,
         start_at_ms: i64,
         grants: &[(String, String)],
     ) -> Result<(), JobStoreShardError> {
-        self.db.flush().await?;
-
         for (queue, task_id) in grants {
             let span = info_span!("concurrency.grant", queue = %queue, task_id = %task_id, job_id = %job_id, attempt = 1u32, source = "immediate");
             let _g = span.enter();

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -206,7 +206,6 @@ impl JobStoreShard {
         batch.delete(&lease_key);
 
         self.db.write(batch).await?;
-        self.db.flush().await?;
 
         tracing::debug!(
             queue_key = %queue_key,
@@ -310,7 +309,6 @@ impl JobStoreShard {
         batch.delete(&lease_key);
 
         self.db.write(batch).await?;
-        self.db.flush().await?;
 
         if has_waiters {
             tracing::warn!(

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -502,7 +502,6 @@ impl JobStoreShard {
             let mut batch = WriteBatch::new();
             batch.delete(&lease_key);
             self.db.write(batch).await?;
-            self.db.flush().await?;
             return Ok(());
         };
 
@@ -521,7 +520,6 @@ impl JobStoreShard {
         batch.delete(&lease_key);
 
         self.db.write(batch).await?;
-        self.db.flush().await?;
 
         tracing::error!(
             tenant = %tenant,

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -557,7 +557,6 @@ impl JobStoreShard {
         }
 
         self.db.write(batch).await?;
-        self.db.flush().await?;
 
         Ok(())
     }

--- a/tests/turmoil_runner/scenarios/k8s_shard_splits.rs
+++ b/tests/turmoil_runner/scenarios/k8s_shard_splits.rs
@@ -1479,6 +1479,7 @@ pub fn run() {
                 // 2. When a shard splits, SlateDB clones all data to both children
                 // 3. Nodes watch the shard map and immediately reconcile when splits occur
                 // 4. The tenant routing ensures the job is found in the correct child shard
+                // 5. Post-split cleanup removes data from the wrong child shard
                 assert_eq!(
                     completed, enqueued,
                     "All jobs should complete: completed={}, enqueued={}, rate={:.1}%",


### PR DESCRIPTION
## Summary

- **Fix phantom enqueue bug**: `finish_enqueue` called `db.flush()` after data was already committed with `await_durable=true`. If the flush failed (e.g. shard closing during rebalancing), it propagated as an enqueue error even though the job was already durable — causing `completed > enqueued` in k8s_shard_splits DST tests.
- **Fix high_message_loss worker exhaustion**: Worker used a fixed 50-iteration loop and reconnected on every single gRPC failure (~12s cost under 15% loss). Changed to an indefinite loop with reconnection only after 3 consecutive failures.
- **Remove all redundant `db.flush()` calls**: With WAL enabled, `db.write()` uses `WriteOptions::default()` which has `await_durable=true`, meaning data is already persisted to object storage via the WAL before the write returns. The subsequent `flush()` calls were no-ops on an empty WAL buffer. The only remaining `flush()` is in `factory.rs` before checkpoint creation, where it's legitimately needed.

## Test plan

- [x] All 5 originally-failing DST seeds pass
- [x] 30-seed DST fuzz passes (all scenarios including k8s_shard_splits and high_message_loss)
- [x] 20-seed DST fuzz passes after removing remaining redundant flushes
- [x] Full `cargo test` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)