### PR TITLE
Three query performance optimizations: status-index routing, batch cap, range scans

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -77,6 +77,16 @@ pub fn job_status_key(tenant: &str, job_id: &str) -> Vec<u8> {
     encode_with_prefix(prefix::JOB_STATUS, &(tenant, job_id))
 }
 
+/// Prefix for scanning all status records for a tenant.
+pub fn job_status_prefix(tenant: &str) -> Vec<u8> {
+    encode_with_prefix(prefix::JOB_STATUS, &(tenant,))
+}
+
+/// Prefix for scanning all status records across all tenants.
+pub fn jobs_status_prefix() -> Vec<u8> {
+    vec![prefix::JOB_STATUS]
+}
+
 /// Parsed job status key components (same structure as job info).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedJobStatusKey {


### PR DESCRIPTION
## Summary

- **Opt 1 — Route empty-projection FullScans through status/time index**: `analyze_projection` no longer requires `need_status_index_fields` to activate the status-index fast path. `COUNT(*)` and id-only projections now read 50-byte index entries instead of 500–2000 byte `job_info` KVs. Expected: `total_count` 1863ms → ~800ms, `tenant_count` 276ms → ~119ms.

- **Opt 2 — Cap point-lookup batch size at 256**: `stream_via_job_pairs` fetches at most 256 jobs per batch so DataFusion can stop early after receiving enough rows for a `LIMIT` clause. Full scans pay nearly the same total I/O (more, smaller batches). Expected: `large_tenant_failed_page LIMIT 20`: 454ms → ~16ms.

- **Opt 3 — Combined range scans for FullScan + need_job_info**: New `scan_jobs_with_views` / `scan_all_jobs_with_views` read `job_info` values during iteration (no discard+refetch). New `scan_jobs_status_records` / `scan_all_jobs_status_records` replace 79K+ random status point-lookups with a single sequential range scan. Both run concurrently via `tokio::join!`. Expected: `large_tenant_recent ORDER BY enqueue_time`: 4593ms → ~360ms (12.7×).

## Files changed
- `src/keys.rs` — add `job_status_prefix`, `jobs_status_prefix`
- `src/job_store_shard/scan.rs` — add 4 value-reading range-scan methods
- `src/query.rs` — restructure `stream_via_job_pairs` fast paths

## Test plan
- [ ] All query tests pass (`query_tests`, `query_waiting_tests`, `cluster_query_tests`)
- [ ] Full CI test suite passes
- [ ] `query_profile` benchmark shows improvements vs main baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)