### PR TITLE
Fix duplicate concurrency holders during retry scheduling

### DIFF
--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -512,6 +512,7 @@ impl JobStoreShard {
                             now_ms,
                             held_queues: held_queues.clone(),
                             task_group: check_task_group,
+                            skip_try_reserve: false,
                         },
                     )
                     .await?;

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -216,6 +216,7 @@ impl JobStoreShard {
                         now_ms,
                         held_queues: Vec::new(),
                         task_group: &params.task_group,
+                        skip_try_reserve: false,
                     },
                 )
                 .await?;


### PR DESCRIPTION
## Summary

- When a job with concurrency limits fails and schedules a retry, the old holder was not released from the in-memory map before `enqueue_limit_task_at_index` ran. With `max_concurrency > 1`, `try_reserve` could immediately grant the retry task a slot while the old holder still existed, causing the same job to hold duplicate concurrency slots (violating `oneLeasePerJob`).
- Fix: release old holders via `release_reservation` (in-memory only) before retry scheduling, with the DST release event emitted as a pending event tied to the batch's `write_op`. On batch failure, `restore_holder` reverts in-memory state and `cancel_write` removes the pending events.
- Adds two new unit tests exercising retry with `max_concurrency > 1` (spare capacity and concurrent jobs), a previously untested code path.

## Test plan

- [x] Chaos DST seed 2477657861 (originally failing) passes
- [x] k8s_shard_splits DST seed 480954020 passes
- [x] 20 random chaos DST seeds pass
- [x] All 16 concurrency unit tests pass (including 2 new ones)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)