### PR TITLE
Add positional bind params to Query RPC and TypeScript client

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -44,6 +44,8 @@ fn main() {
         .arg(out_dir.as_os_str())
         .arg("schema/internal_storage.fbs")
         .status()
-        .expect("failed to run flatc - ensure flatbuffers is installed (available via nix devshell)");
+        .expect(
+            "failed to run flatc - ensure flatbuffers is installed (available via nix devshell)",
+        );
     assert!(flatc_status.success(), "flatc failed to compile schema");
 }

--- a/docs/src/content/docs/guides/querying.mdx
+++ b/docs/src/content/docs/guides/querying.mdx
@@ -41,6 +41,21 @@ for (const row of typed.rows) {
 
 The second argument is the tenant used for routing the query to the correct shard. If you're not using multi-tenancy, you can omit it.
 
+You can also pass positional bind parameters as a third argument. Placeholders use `$1`, `$2`, ... and are matched by position.
+
+```typescript
+const tenant = "customer-123";
+const minPriority = 10;
+
+const result = await client.query(
+  "SELECT id, priority FROM jobs WHERE tenant = $1 AND priority >= $2 ORDER BY priority ASC LIMIT 25",
+  tenant,
+  [tenant, minPriority]
+);
+```
+
+Supported bind parameter types in the TypeScript client are `boolean`, `number`, `string`, `Uint8Array`, and `null`.
+
 The result includes:
 - `columns` — schema information (`name` and `dataType` for each column)
 - `rows` — deserialized JavaScript objects, one per row

--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -350,12 +350,28 @@ message HeartbeatResponse {
   optional int64 cancelled_at_ms = 2; // Unix timestamp (ms) when cancellation was requested, if cancelled.
 }
 
+message QueryNull {}
+
+// A single bind parameter value for SQL query placeholders.
+message QueryParameter {
+  oneof value {
+    bool bool_value = 1;
+    int64 int64_value = 2;
+    uint64 uint64_value = 3;
+    double float64_value = 4;
+    string string_value = 5;
+    bytes bytes_value = 6;
+    QueryNull null_value = 7;
+  }
+}
+
 // Request to execute an arbitrary SQL query against shard data.
 // Useful for ad-hoc inspection and debugging.
 message QueryRequest {
   string shard = 1;          // Shard ID (UUID) to query.
   string sql = 2;            // SQL query string.
   optional string tenant = 3; // Tenant ID to scope results, if multi-tenancy is enabled.
+  repeated QueryParameter parameters = 4; // Optional SQL bind parameters (`$1`, `$2`, ...).
 }
 
 // Metadata about a column in query results.
@@ -377,6 +393,7 @@ message QueryArrowRequest {
   string shard = 1;          // Shard ID (UUID) to query.
   string sql = 2;            // SQL query string.
   optional string tenant = 3; // Tenant ID to scope results, if multi-tenancy is enabled.
+  repeated QueryParameter parameters = 4; // Optional SQL bind parameters (`$1`, `$2`, ...).
 }
 
 // Arrow IPC encoded message. Part of a streaming response.

--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -461,6 +461,7 @@ impl ClusterClient {
             shard: shard_id.to_string(),
             sql: sql.to_string(),
             tenant: None,
+            parameters: vec![],
         };
 
         let response = match client.query(request).await {

--- a/src/cluster_query.rs
+++ b/src/cluster_query.rs
@@ -618,6 +618,7 @@ async fn query_remote_shard_batches(
             shard: shard_id.to_string(),
             sql: sql.clone(),
             tenant: None,
+            parameters: vec![],
         };
 
         let response = match client.query_arrow(request).await {

--- a/src/siloctl.rs
+++ b/src/siloctl.rs
@@ -433,6 +433,7 @@ pub async fn query<W: Write>(
             shard: shard.to_string(),
             sql: sql.to_string(),
             tenant: opts.tenant.clone(),
+            parameters: vec![],
         })
         .await?
         .into_inner();

--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -415,6 +415,7 @@ async fn grpc_server_reset_shards_works_in_dev_mode() -> anyhow::Result<()> {
                 shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
                 sql: "SELECT COUNT(*) as count FROM jobs".to_string(),
                 tenant: None,
+                parameters: vec![],
             })
             .await?
             .into_inner();
@@ -435,6 +436,7 @@ async fn grpc_server_reset_shards_works_in_dev_mode() -> anyhow::Result<()> {
                 shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
                 sql: "SELECT COUNT(*) as count FROM jobs".to_string(),
                 tenant: None,
+                parameters: vec![],
             })
             .await?
             .into_inner();
@@ -782,6 +784,7 @@ async fn grpc_server_reset_shards_clears_fs_backend_data() -> anyhow::Result<()>
                 shard: test_shard_id.to_string(),
                 sql: "SELECT COUNT(*) as count FROM jobs".to_string(),
                 tenant: None,
+                parameters: vec![],
             })
             .await?
             .into_inner();
@@ -848,6 +851,7 @@ async fn grpc_server_reset_shards_clears_fs_backend_data() -> anyhow::Result<()>
                 shard: test_shard_id.to_string(),
                 sql: "SELECT COUNT(*) as count FROM jobs".to_string(),
                 tenant: None,
+                parameters: vec![],
             })
             .await?
             .into_inner();
@@ -868,6 +872,7 @@ async fn grpc_server_reset_shards_clears_fs_backend_data() -> anyhow::Result<()>
                 shard: test_shard_id.to_string(),
                 sql: "SELECT COUNT(*) as count FROM jobs".to_string(),
                 tenant: None,
+                parameters: vec![],
             })
             .await?
             .into_inner();
@@ -963,6 +968,7 @@ async fn grpc_server_reset_shards_with_relative_path() -> anyhow::Result<()> {
                 shard: test_shard_id.to_string(),
                 sql: "SELECT COUNT(*) as count FROM jobs".to_string(),
                 tenant: None,
+                parameters: vec![],
             })
             .await?
             .into_inner();
@@ -995,6 +1001,7 @@ async fn grpc_server_reset_shards_with_relative_path() -> anyhow::Result<()> {
                 shard: test_shard_id.to_string(),
                 sql: "SELECT COUNT(*) as count FROM jobs".to_string(),
                 tenant: None,
+                parameters: vec![],
             })
             .await?
             .into_inner();
@@ -1090,6 +1097,7 @@ async fn grpc_server_reset_shards_clears_memory_backend_data() -> anyhow::Result
                 shard: test_shard_id.to_string(),
                 sql: "SELECT COUNT(*) as count FROM jobs".to_string(),
                 tenant: None,
+                parameters: vec![],
             })
             .await?
             .into_inner();
@@ -1110,6 +1118,7 @@ async fn grpc_server_reset_shards_clears_memory_backend_data() -> anyhow::Result
                 shard: test_shard_id.to_string(),
                 sql: "SELECT COUNT(*) as count FROM jobs".to_string(),
                 tenant: None,
+                parameters: vec![],
             })
             .await?
             .into_inner();
@@ -1282,6 +1291,7 @@ async fn grpc_server_reset_shards_immediately_available_production_path() -> any
                 shard: shard_id.clone(),
                 sql: "SELECT COUNT(*) as count FROM jobs".to_string(),
                 tenant: None,
+                parameters: vec![],
             })
             .await?
             .into_inner();
@@ -1378,6 +1388,7 @@ async fn grpc_server_reset_shards_multiple_resets_immediately_available() -> any
                     shard: shard_id.clone(),
                     sql: "SELECT COUNT(*) as count FROM jobs".to_string(),
                     tenant: None,
+                    parameters: vec![],
                 })
                 .await?
                 .into_inner();

--- a/tests/server_split_paused_tests.rs
+++ b/tests/server_split_paused_tests.rs
@@ -374,6 +374,7 @@ async fn query_returns_unavailable_when_shard_paused() {
     let req = Request::new(QueryRequest {
         shard: shard_id.to_string(),
         tenant: None,
+        parameters: vec![],
         sql: "SELECT * FROM jobs LIMIT 10".to_string(),
     });
 
@@ -393,6 +394,7 @@ async fn query_returns_unavailable_when_shard_paused() {
     let req = Request::new(QueryRequest {
         shard: shard_id.to_string(),
         tenant: None,
+        parameters: vec![],
         sql: "SELECT * FROM jobs LIMIT 10".to_string(),
     });
 

--- a/tests/turmoil_runner/helpers.rs
+++ b/tests/turmoil_runner/helpers.rs
@@ -1615,6 +1615,7 @@ pub async fn verify_server_invariants(
             shard: shard.to_string(),
             sql: job_status_query.to_string(),
             tenant: None,
+            parameters: vec![],
         }))
         .await
     {
@@ -1650,6 +1651,7 @@ pub async fn verify_server_invariants(
             shard: shard.to_string(),
             sql: holder_query.to_string(),
             tenant: None,
+            parameters: vec![],
         }))
         .await
     {
@@ -1682,6 +1684,7 @@ pub async fn verify_server_invariants(
             shard: shard.to_string(),
             sql: requester_query.to_string(),
             tenant: None,
+            parameters: vec![],
         }))
         .await
     {
@@ -1721,6 +1724,7 @@ pub async fn verify_server_invariants(
             shard: shard.to_string(),
             sql: terminal_with_holders_query.to_string(),
             tenant: None,
+            parameters: vec![],
         }))
         .await
     {

--- a/tests/turmoil_runner/scenarios/concurrent_grant_race.rs
+++ b/tests/turmoil_runner/scenarios/concurrent_grant_race.rs
@@ -19,9 +19,9 @@
 
 use crate::helpers::{
     AttemptStatus, ConcurrencyLimit, EnqueueRequest, GetJobRequest, HashMap, InvariantTracker,
-    JobStatus, LeaseTasksRequest, Limit, ReportOutcomeRequest, SerializedBytes,
-    SiloClient, TEST_SHARD_ID, connect_to_server, get_seed, limit, report_outcome_request,
-    run_scenario_impl, serialized_bytes, setup_server, turmoil_connector,
+    JobStatus, LeaseTasksRequest, Limit, ReportOutcomeRequest, SerializedBytes, SiloClient,
+    TEST_SHARD_ID, connect_to_server, get_seed, limit, report_outcome_request, run_scenario_impl,
+    serialized_bytes, setup_server, turmoil_connector,
 };
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -151,20 +151,18 @@ pub fn run() {
                                     .report_outcome(tonic::Request::new(ReportOutcomeRequest {
                                         shard: TEST_SHARD_ID.to_string(),
                                         task_id: task.id.clone(),
-                                        outcome: Some(
-                                            report_outcome_request::Outcome::Success(
-                                                SerializedBytes {
-                                                    encoding: Some(
-                                                        serialized_bytes::Encoding::Msgpack(
-                                                            rmp_serde::to_vec(
-                                                                &serde_json::json!("done"),
-                                                            )
-                                                            .unwrap(),
-                                                        ),
+                                        outcome: Some(report_outcome_request::Outcome::Success(
+                                            SerializedBytes {
+                                                encoding: Some(
+                                                    serialized_bytes::Encoding::Msgpack(
+                                                        rmp_serde::to_vec(&serde_json::json!(
+                                                            "done"
+                                                        ))
+                                                        .unwrap(),
                                                     ),
-                                                },
-                                            ),
-                                        ),
+                                                ),
+                                            },
+                                        )),
                                     }))
                                     .await
                                 {

--- a/typescript_client/src/index.ts
+++ b/typescript_client/src/index.ts
@@ -49,6 +49,7 @@ export {
   type ShardInfoWithRange,
   type QueryResult,
   type QueryColumnInfo,
+  type QueryBindParameter,
 } from "./client";
 export {
   SiloWorker,

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -933,6 +933,66 @@ export interface HeartbeatResponse {
     cancelledAtMs?: bigint; // Unix timestamp (ms) when cancellation was requested, if cancelled.
 }
 /**
+ * @generated from protobuf message silo.v1.QueryNull
+ */
+export interface QueryNull {
+}
+/**
+ * A single bind parameter value for SQL query placeholders.
+ *
+ * @generated from protobuf message silo.v1.QueryParameter
+ */
+export interface QueryParameter {
+    /**
+     * @generated from protobuf oneof: value
+     */
+    value: {
+        oneofKind: "boolValue";
+        /**
+         * @generated from protobuf field: bool bool_value = 1
+         */
+        boolValue: boolean;
+    } | {
+        oneofKind: "int64Value";
+        /**
+         * @generated from protobuf field: int64 int64_value = 2
+         */
+        int64Value: bigint;
+    } | {
+        oneofKind: "uint64Value";
+        /**
+         * @generated from protobuf field: uint64 uint64_value = 3
+         */
+        uint64Value: bigint;
+    } | {
+        oneofKind: "float64Value";
+        /**
+         * @generated from protobuf field: double float64_value = 4
+         */
+        float64Value: number;
+    } | {
+        oneofKind: "stringValue";
+        /**
+         * @generated from protobuf field: string string_value = 5
+         */
+        stringValue: string;
+    } | {
+        oneofKind: "bytesValue";
+        /**
+         * @generated from protobuf field: bytes bytes_value = 6
+         */
+        bytesValue: Uint8Array;
+    } | {
+        oneofKind: "nullValue";
+        /**
+         * @generated from protobuf field: silo.v1.QueryNull null_value = 7
+         */
+        nullValue: QueryNull;
+    } | {
+        oneofKind: undefined;
+    };
+}
+/**
  * Request to execute an arbitrary SQL query against shard data.
  * Useful for ad-hoc inspection and debugging.
  *
@@ -951,6 +1011,10 @@ export interface QueryRequest {
      * @generated from protobuf field: optional string tenant = 3
      */
     tenant?: string; // Tenant ID to scope results, if multi-tenancy is enabled.
+    /**
+     * @generated from protobuf field: repeated silo.v1.QueryParameter parameters = 4
+     */
+    parameters: QueryParameter[]; // Optional SQL bind parameters (`$1`, `$2`, ...).
 }
 /**
  * Metadata about a column in query results.
@@ -1005,6 +1069,10 @@ export interface QueryArrowRequest {
      * @generated from protobuf field: optional string tenant = 3
      */
     tenant?: string; // Tenant ID to scope results, if multi-tenancy is enabled.
+    /**
+     * @generated from protobuf field: repeated silo.v1.QueryParameter parameters = 4
+     */
+    parameters: QueryParameter[]; // Optional SQL bind parameters (`$1`, `$2`, ...).
 }
 /**
  * Arrow IPC encoded message. Part of a streaming response.
@@ -4365,18 +4433,168 @@ class HeartbeatResponse$Type extends MessageType<HeartbeatResponse> {
  */
 export const HeartbeatResponse = new HeartbeatResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class QueryNull$Type extends MessageType<QueryNull> {
+    constructor() {
+        super("silo.v1.QueryNull", []);
+    }
+    create(value?: PartialMessage<QueryNull>): QueryNull {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<QueryNull>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: QueryNull): QueryNull {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: QueryNull, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.QueryNull
+ */
+export const QueryNull = new QueryNull$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class QueryParameter$Type extends MessageType<QueryParameter> {
+    constructor() {
+        super("silo.v1.QueryParameter", [
+            { no: 1, name: "bool_value", kind: "scalar", oneof: "value", T: 8 /*ScalarType.BOOL*/ },
+            { no: 2, name: "int64_value", kind: "scalar", oneof: "value", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 3, name: "uint64_value", kind: "scalar", oneof: "value", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 4, name: "float64_value", kind: "scalar", oneof: "value", T: 1 /*ScalarType.DOUBLE*/ },
+            { no: 5, name: "string_value", kind: "scalar", oneof: "value", T: 9 /*ScalarType.STRING*/ },
+            { no: 6, name: "bytes_value", kind: "scalar", oneof: "value", T: 12 /*ScalarType.BYTES*/ },
+            { no: 7, name: "null_value", kind: "message", oneof: "value", T: () => QueryNull }
+        ]);
+    }
+    create(value?: PartialMessage<QueryParameter>): QueryParameter {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.value = { oneofKind: undefined };
+        if (value !== undefined)
+            reflectionMergePartial<QueryParameter>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: QueryParameter): QueryParameter {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* bool bool_value */ 1:
+                    message.value = {
+                        oneofKind: "boolValue",
+                        boolValue: reader.bool()
+                    };
+                    break;
+                case /* int64 int64_value */ 2:
+                    message.value = {
+                        oneofKind: "int64Value",
+                        int64Value: reader.int64().toBigInt()
+                    };
+                    break;
+                case /* uint64 uint64_value */ 3:
+                    message.value = {
+                        oneofKind: "uint64Value",
+                        uint64Value: reader.uint64().toBigInt()
+                    };
+                    break;
+                case /* double float64_value */ 4:
+                    message.value = {
+                        oneofKind: "float64Value",
+                        float64Value: reader.double()
+                    };
+                    break;
+                case /* string string_value */ 5:
+                    message.value = {
+                        oneofKind: "stringValue",
+                        stringValue: reader.string()
+                    };
+                    break;
+                case /* bytes bytes_value */ 6:
+                    message.value = {
+                        oneofKind: "bytesValue",
+                        bytesValue: reader.bytes()
+                    };
+                    break;
+                case /* silo.v1.QueryNull null_value */ 7:
+                    message.value = {
+                        oneofKind: "nullValue",
+                        nullValue: QueryNull.internalBinaryRead(reader, reader.uint32(), options, (message.value as any).nullValue)
+                    };
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: QueryParameter, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* bool bool_value = 1; */
+        if (message.value.oneofKind === "boolValue")
+            writer.tag(1, WireType.Varint).bool(message.value.boolValue);
+        /* int64 int64_value = 2; */
+        if (message.value.oneofKind === "int64Value")
+            writer.tag(2, WireType.Varint).int64(message.value.int64Value);
+        /* uint64 uint64_value = 3; */
+        if (message.value.oneofKind === "uint64Value")
+            writer.tag(3, WireType.Varint).uint64(message.value.uint64Value);
+        /* double float64_value = 4; */
+        if (message.value.oneofKind === "float64Value")
+            writer.tag(4, WireType.Bit64).double(message.value.float64Value);
+        /* string string_value = 5; */
+        if (message.value.oneofKind === "stringValue")
+            writer.tag(5, WireType.LengthDelimited).string(message.value.stringValue);
+        /* bytes bytes_value = 6; */
+        if (message.value.oneofKind === "bytesValue")
+            writer.tag(6, WireType.LengthDelimited).bytes(message.value.bytesValue);
+        /* silo.v1.QueryNull null_value = 7; */
+        if (message.value.oneofKind === "nullValue")
+            QueryNull.internalBinaryWrite(message.value.nullValue, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.QueryParameter
+ */
+export const QueryParameter = new QueryParameter$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class QueryRequest$Type extends MessageType<QueryRequest> {
     constructor() {
         super("silo.v1.QueryRequest", [
             { no: 1, name: "shard", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "sql", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "tenant", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+            { no: 3, name: "tenant", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "parameters", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => QueryParameter }
         ]);
     }
     create(value?: PartialMessage<QueryRequest>): QueryRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.shard = "";
         message.sql = "";
+        message.parameters = [];
         if (value !== undefined)
             reflectionMergePartial<QueryRequest>(this, message, value);
         return message;
@@ -4394,6 +4612,9 @@ class QueryRequest$Type extends MessageType<QueryRequest> {
                     break;
                 case /* optional string tenant */ 3:
                     message.tenant = reader.string();
+                    break;
+                case /* repeated silo.v1.QueryParameter parameters */ 4:
+                    message.parameters.push(QueryParameter.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -4416,6 +4637,9 @@ class QueryRequest$Type extends MessageType<QueryRequest> {
         /* optional string tenant = 3; */
         if (message.tenant !== undefined)
             writer.tag(3, WireType.LengthDelimited).string(message.tenant);
+        /* repeated silo.v1.QueryParameter parameters = 4; */
+        for (let i = 0; i < message.parameters.length; i++)
+            QueryParameter.internalBinaryWrite(message.parameters[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -4550,13 +4774,15 @@ class QueryArrowRequest$Type extends MessageType<QueryArrowRequest> {
         super("silo.v1.QueryArrowRequest", [
             { no: 1, name: "shard", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "sql", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "tenant", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+            { no: 3, name: "tenant", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "parameters", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => QueryParameter }
         ]);
     }
     create(value?: PartialMessage<QueryArrowRequest>): QueryArrowRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.shard = "";
         message.sql = "";
+        message.parameters = [];
         if (value !== undefined)
             reflectionMergePartial<QueryArrowRequest>(this, message, value);
         return message;
@@ -4574,6 +4800,9 @@ class QueryArrowRequest$Type extends MessageType<QueryArrowRequest> {
                     break;
                 case /* optional string tenant */ 3:
                     message.tenant = reader.string();
+                    break;
+                case /* repeated silo.v1.QueryParameter parameters */ 4:
+                    message.parameters.push(QueryParameter.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -4596,6 +4825,9 @@ class QueryArrowRequest$Type extends MessageType<QueryArrowRequest> {
         /* optional string tenant = 3; */
         if (message.tenant !== undefined)
             writer.tag(3, WireType.LengthDelimited).string(message.tenant);
+        /* repeated silo.v1.QueryParameter parameters = 4; */
+        for (let i = 0; i < message.parameters.length; i++)
+            QueryParameter.internalBinaryWrite(message.parameters[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);


### PR DESCRIPTION
## Summary
- add positional SQL bind parameter support to Query and QueryArrow RPCs
- remove named parameter support and flatten proto shape to repeated `QueryParameter`
- apply DataFusion `with_param_values` in server query execution path
- update Rust callsites/tests and regenerate TypeScript protobuf bindings
- extend TS client `query(...)` to accept positional bind parameters
- add one TS integration test for positional bind parameters

## Validation
- `cargo test -q --no-run`
- `cargo test --test query_tests sql_bind_ -q`
- `cargo test --test grpc_query_tests bind_parameter -q`
- `cd typescript_client && pnpm typecheck`
- `cd typescript_client && RUN_INTEGRATION=true pnpm exec vitest run test/client-integration.test.ts -t "queries with positional bind parameters"`
