### PR TITLE
Use biased select! to fix DST non-determinism

### DIFF
--- a/src/coordination/etcd.rs
+++ b/src/coordination/etcd.rs
@@ -208,6 +208,7 @@ impl EtcdCoordinator {
 
             loop {
                 tokio::select! {
+                    biased;
                     _ = keepalive_timer.tick() => {
                         if *shutdown_rx.borrow() { break; }
                         // Send keepalive for membership lease

--- a/src/coordination/k8s.rs
+++ b/src/coordination/k8s.rs
@@ -341,6 +341,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
 
         loop {
             tokio::select! {
+                biased;
                 _ = shutdown_rx.changed() => {
                     if *shutdown_rx.borrow() {
                         debug!(node_id = %self.base.node_id, "membership watcher shutting down");
@@ -404,6 +405,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
 
         loop {
             tokio::select! {
+                biased;
                 _ = shutdown_rx.changed() => {
                     if *shutdown_rx.borrow() {
                         debug!(node_id = %self.base.node_id, "shard map watcher shutting down");
@@ -475,6 +477,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
 
         loop {
             tokio::select! {
+                biased;
                 _ = shutdown_rx.changed() => {
                     if *shutdown_rx.borrow() {
                         debug!(node_id = %self.base.node_id, "shard lease watcher shutting down");

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -288,8 +288,9 @@ impl<T> ShardGuardContext<T> {
     pub async fn wait_for_change(&self) {
         let mut shutdown_rx = self.shutdown.clone();
         tokio::select! {
-            _ = self.notify.notified() => {}
+            biased;
             _ = shutdown_rx.changed() => {}
+            _ = self.notify.notified() => {}
         }
     }
 

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -404,6 +404,7 @@ impl JobStoreShard {
 
             loop {
                 tokio::select! {
+                    biased;
                     _ = cancellation.cancelled() => {
                         tracing::debug!(
                             shard = %shard_name,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1779,6 +1779,8 @@ where
         let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
         loop {
             tokio::select! {
+                biased;
+                _ = tick_rx.recv() => { break; }
                 _ = interval.tick() => {
                     let instances = reaper_factory.instances();
 
@@ -1798,7 +1800,6 @@ where
                         }
                     }
                 }
-                _ = tick_rx.recv() => { break; }
             }
         }
     });

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -286,10 +286,11 @@ impl TaskBroker {
                 let delay = tokio::time::sleep(Duration::from_millis(sleep_ms));
                 tokio::pin!(delay);
                 tokio::select! {
-                    _ = &mut delay => {},
+                    biased;
                     _ = broker.notify.notified() => {
                         debug!("broker woken by notification");
                     }
+                    _ = &mut delay => {},
                 }
             }
         });


### PR DESCRIPTION
## Summary
- Add `biased;` to all `tokio::select!` calls to eliminate non-determinism in DST
- `tokio::select!` without `biased;` uses `thread_rng_n()` to randomly pick branch polling order. When two branches are simultaneously Ready, this random choice cascades through subsequent select! calls on the same host, shifting the shared FastRand state
- Branch ordering adjusted to prioritize shutdown/cancellation signals first

## Test plan
- [x] Seed 1792998142: 15/15 passes (was failing ~60-75%)
- [x] Seed 2933754683: 10/10 passes
- [x] Seed 2129858497: 10/10 passes
- [x] All 30 other DST scenarios pass
- [x] Core unit tests pass
- [x] Clippy clean
- [ ] CI passes
- [ ] Simulation Testing workflow (1000 seeds)
- [ ] Simulation Testing workflow (20000 seeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)