### PR TITLE
Add result field to GetJobResponse

### DIFF
--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -158,6 +158,7 @@ message GetJobResponse {
   repeated JobAttempt attempts = 10;     // All attempts for this job. Only populated if include_attempts was true in the request.
   optional int64 next_attempt_starts_after_ms = 11; // Unix timestamp (ms) when the next attempt will start. Present for scheduled jobs, absent for running or terminal jobs.
   string task_group = 12;                // Task group this job's tasks are enqueued into.
+  optional SerializedBytes result = 13;  // Result data from the last attempt, if the job succeeded.
 }
 
 // Request to get the result of a completed job.

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -510,6 +510,8 @@ export interface Job<Payload = unknown, Result = unknown> {
   nextAttemptStartsAfterMs?: bigint;
   /** Task group the job belongs to */
   taskGroup: string;
+  /** Result data from the last attempt, if the job succeeded */
+  result?: Result;
 }
 
 /** Possible job statuses */
@@ -1544,6 +1546,14 @@ export class SiloGRPCClient {
             response.attempts.length > 0 ? response.attempts.map(protoAttemptToPublic) : undefined,
           nextAttemptStartsAfterMs: response.nextAttemptStartsAfterMs,
           taskGroup: response.taskGroup,
+          result: response.result
+            ? decodeBytes(
+                response.result.encoding.oneofKind === "msgpack"
+                  ? response.result.encoding.msgpack
+                  : undefined,
+                "result",
+              )
+            : undefined,
         };
       });
     } catch (error) {

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -382,6 +382,10 @@ export interface GetJobResponse {
      * @generated from protobuf field: string task_group = 12
      */
     taskGroup: string; // Task group this job's tasks are enqueued into.
+    /**
+     * @generated from protobuf field: optional silo.v1.SerializedBytes result = 13
+     */
+    result?: SerializedBytes; // Result data from the last attempt, if the job succeeded.
 }
 /**
  * Request to get the result of a completed job.
@@ -2569,7 +2573,8 @@ class GetJobResponse$Type extends MessageType<GetJobResponse> {
             { no: 9, name: "status_changed_at_ms", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 10, name: "attempts", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => JobAttempt },
             { no: 11, name: "next_attempt_starts_after_ms", kind: "scalar", opt: true, T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
-            { no: 12, name: "task_group", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 12, name: "task_group", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 13, name: "result", kind: "message", T: () => SerializedBytes }
         ]);
     }
     create(value?: PartialMessage<GetJobResponse>): GetJobResponse {
@@ -2627,6 +2632,9 @@ class GetJobResponse$Type extends MessageType<GetJobResponse> {
                     break;
                 case /* string task_group */ 12:
                     message.taskGroup = reader.string();
+                    break;
+                case /* optional silo.v1.SerializedBytes result */ 13:
+                    message.result = SerializedBytes.internalBinaryRead(reader, reader.uint32(), options, message.result);
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -2692,6 +2700,9 @@ class GetJobResponse$Type extends MessageType<GetJobResponse> {
         /* string task_group = 12; */
         if (message.taskGroup !== "")
             writer.tag(12, WireType.LengthDelimited).string(message.taskGroup);
+        /* optional silo.v1.SerializedBytes result = 13; */
+        if (message.result)
+            SerializedBytes.internalBinaryWrite(message.result, writer.tag(13, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);


### PR DESCRIPTION
## Summary
- Adds an optional `result` field to the `GetJobResponse` proto message, populated for succeeded jobs
- When `include_attempts` is true, the result is extracted from the already-loaded attempts
- When `include_attempts` is false, the latest attempt is queried to get the result
- Updates the TypeScript client's `Job` interface and `getJob` mapping to expose the new field

## Test plan
- [x] Added 3 Rust gRPC tests: result without attempts, result with attempts, no result for failed jobs
- [x] Added 2 TypeScript integration tests: result for succeeded jobs, no result for failed jobs
- [x] All existing grpc_job_tests pass (17/17)
- [x] TypeScript unit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)