### PR TITLE
Add lazy topology auto-refresh to TypeScript client

### DIFF
--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -1076,6 +1076,12 @@ export class SiloGRPCClient {
   /** @internal Array of shards sorted by rangeStart for efficient lookup */
   private _shards: ShardInfoWithRange[] = [];
 
+  /** @internal Whether topology has been successfully loaded at least once */
+  private _topologyReady: boolean = false;
+
+  /** @internal In-flight topology refresh promise for deduplication */
+  private _pendingTopologyRefresh: Promise<void> | null = null;
+
   /** @internal */
   private _topologyRefreshInterval: ReturnType<typeof setInterval> | null = null;
   /** Counter for round-robin server selection */
@@ -1347,6 +1353,24 @@ export class SiloGRPCClient {
   }
 
   /**
+   * Ensure topology has been loaded, triggering a lazy refresh if needed.
+   * Multiple concurrent callers will share the same in-flight refresh.
+   * @internal
+   */
+  private async _ensureTopology(): Promise<void> {
+    if (this._topologyReady) {
+      return;
+    }
+    if (this._pendingTopologyRefresh) {
+      return this._pendingTopologyRefresh;
+    }
+    this._pendingTopologyRefresh = this.refreshTopology().finally(() => {
+      this._pendingTopologyRefresh = null;
+    });
+    return this._pendingTopologyRefresh;
+  }
+
+  /**
    * Execute an operation with retry logic for wrong shard errors.
    * @internal
    */
@@ -1354,6 +1378,7 @@ export class SiloGRPCClient {
     tenant: string | undefined,
     operation: (client: SiloClient, shard: string) => Promise<T>,
   ): Promise<T> {
+    await this._ensureTopology();
     let lastError: unknown;
     let delay = this._wrongShardRetryDelayMs;
     let { client, shard } = this._getClientForTenant(tenant);
@@ -1435,6 +1460,7 @@ export class SiloGRPCClient {
         // Sort shards by rangeStart for efficient binary search lookup
         shards.sort((a, b) => a.rangeStart.localeCompare(b.rangeStart));
         this._shards = shards;
+        this._topologyReady = true;
 
         return; // Success
       } catch {
@@ -2104,6 +2130,11 @@ export class SiloGRPCClient {
         const call = conn.client.resetShards({}, this._rpcOptions());
         await call.response;
       }
+
+      // Clear topology state so the next operation triggers a lazy refresh
+      this._shardToServer.clear();
+      this._shards = [];
+      this._topologyReady = false;
     } catch (error) {
       throwMappedRpcError(error, { operation: "resetShards" });
     }

--- a/typescript_client/test/shard-routing.test.ts
+++ b/typescript_client/test/shard-routing.test.ts
@@ -308,6 +308,7 @@ describe("Shard Routing", () => {
         },
       ];
       (c as any)._shardToServer.set("00000000-0000-0000-0000-000000000001", "localhost:7450");
+      (c as any)._topologyReady = true;
     };
 
     beforeEach(() => {
@@ -529,6 +530,159 @@ describe("Shard Routing", () => {
         expect(handle.id).toBe("job-abc");
         expect(refreshSpy).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe("Lazy topology auto-refresh", () => {
+    let client: SiloGRPCClient;
+
+    afterEach(() => {
+      client.close();
+    });
+
+    // Helper: create a client and mock getClusterInfo to return a single shard
+    const setupClientWithMockTopology = () => {
+      client = new SiloGRPCClient({
+        servers: "localhost:7450",
+        useTls: false,
+        shardRouting: {
+          topologyRefreshIntervalMs: 0,
+        },
+      });
+
+      const mockGetClusterInfo = vi.fn().mockReturnValue({
+        response: Promise.resolve({
+          numShards: 1,
+          shardOwners: [
+            {
+              shardId: "00000000-0000-0000-0000-000000000001",
+              grpcAddr: "localhost:7450",
+              nodeId: "node-1",
+              rangeStart: "",
+              rangeEnd: "",
+            },
+          ],
+          thisNodeId: "node-1",
+          thisGrpcAddr: "localhost:7450",
+        }),
+      });
+
+      const mockEnqueue = vi.fn().mockReturnValue({
+        response: Promise.resolve({ id: "job-123" }),
+      });
+
+      const connections = (client as any)._connections as Map<string, any>;
+      const conn = connections.values().next().value;
+      conn.client.getClusterInfo = mockGetClusterInfo;
+      conn.client.enqueue = mockEnqueue;
+
+      return { mockGetClusterInfo, mockEnqueue };
+    };
+
+    it("auto-refreshes topology on first enqueue if refreshTopology() was never called", async () => {
+      const { mockGetClusterInfo, mockEnqueue } = setupClientWithMockTopology();
+
+      // Don't call refreshTopology() - just call enqueue directly
+      const handle = await client.enqueue({
+        tenant: "test-tenant",
+        payload: { test: true },
+        taskGroup: "default",
+      });
+
+      expect(handle.id).toBe("job-123");
+      // Should have called getClusterInfo to auto-discover topology
+      expect(mockGetClusterInfo).toHaveBeenCalled();
+      expect(mockEnqueue).toHaveBeenCalled();
+    });
+
+    it("does not re-fetch topology if it was already loaded", async () => {
+      const { mockGetClusterInfo, mockEnqueue } = setupClientWithMockTopology();
+
+      // Explicitly refresh topology first
+      await client.refreshTopology();
+      expect(mockGetClusterInfo).toHaveBeenCalledTimes(1);
+
+      // Now enqueue should not trigger another refresh
+      await client.enqueue({
+        tenant: "test-tenant",
+        payload: { test: true },
+        taskGroup: "default",
+      });
+
+      expect(mockGetClusterInfo).toHaveBeenCalledTimes(1);
+      expect(mockEnqueue).toHaveBeenCalled();
+    });
+
+    it("deduplicates concurrent topology refreshes", async () => {
+      const { mockGetClusterInfo } = setupClientWithMockTopology();
+
+      const mockEnqueue = vi.fn().mockReturnValue({
+        response: Promise.resolve({ id: "job-concurrent" }),
+      });
+      const connections = (client as any)._connections as Map<string, any>;
+      const conn = connections.values().next().value;
+      conn.client.enqueue = mockEnqueue;
+
+      // Launch 5 concurrent enqueues without having called refreshTopology
+      const promises = Array.from({ length: 5 }, (_, i) =>
+        client.enqueue({
+          tenant: "test-tenant",
+          payload: { index: i },
+          taskGroup: "default",
+        }),
+      );
+
+      const results = await Promise.all(promises);
+
+      // All should succeed
+      expect(results).toHaveLength(5);
+      for (const handle of results) {
+        expect(handle.id).toBe("job-concurrent");
+      }
+
+      // getClusterInfo should have been called exactly once (deduped)
+      expect(mockGetClusterInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it("resetShards puts client back into lazy-refresh mode", async () => {
+      const { mockGetClusterInfo } = setupClientWithMockTopology();
+
+      const mockEnqueue = vi.fn().mockReturnValue({
+        response: Promise.resolve({ id: "job-after-reset" }),
+      });
+      const mockResetShards = vi.fn().mockReturnValue({
+        response: Promise.resolve({}),
+      });
+
+      const connections = (client as any)._connections as Map<string, any>;
+      const conn = connections.values().next().value;
+      conn.client.enqueue = mockEnqueue;
+      conn.client.resetShards = mockResetShards;
+
+      // First, refresh topology and do an enqueue
+      await client.refreshTopology();
+      expect(mockGetClusterInfo).toHaveBeenCalledTimes(1);
+
+      await client.enqueue({
+        tenant: "test-tenant",
+        payload: { test: true },
+        taskGroup: "default",
+      });
+      // No additional refresh needed
+      expect(mockGetClusterInfo).toHaveBeenCalledTimes(1);
+
+      // Now reset shards - this should clear topology state
+      await client.resetShards();
+
+      // Next enqueue should trigger a new topology refresh
+      await client.enqueue({
+        tenant: "test-tenant",
+        payload: { test: true },
+        taskGroup: "default",
+      });
+
+      // Should have refreshed topology again
+      expect(mockGetClusterInfo).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Operations like `enqueue()` now automatically trigger a topology refresh if `refreshTopology()` was never called, removing the need for explicit initialization before using the client
- Multiple concurrent calls that trigger a lazy refresh are deduplicated into a single `GetClusterInfo` RPC call, avoiding spamming the cluster at process startup
- `resetShards()` now clears the topology state, putting the client back into lazy-refresh mode so the next operation re-discovers the topology

## Test plan
- [x] Added unit test: auto-refreshes topology on first enqueue without explicit `refreshTopology()`
- [x] Added unit test: skips refresh if topology was already loaded
- [x] Added unit test: 5 concurrent enqueues produce only 1 `GetClusterInfo` call (deduplication)
- [x] Added unit test: `resetShards()` puts client back into lazy-refresh mode
- [x] All existing shard-routing, client, and worker unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)