### PR TITLE
Switch tenant sharding from lexicographic ranges to hash-based

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5445,6 +5445,7 @@ dependencies = [
  "urlencoding",
  "usdt",
  "uuid",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -7117,6 +7118,12 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ flate2 = "1"
 urlencoding = "2"
 storekey = { version = "0.11", features = ["storekey-derive"] }
 hex = "0.4"
+xxhash-rust = { version = "0.8", features = ["xxh64"] }
 
 [features]
 default = ["k8s"]

--- a/docs/src/content/docs/introduction.md
+++ b/docs/src/content/docs/introduction.md
@@ -38,11 +38,11 @@ A **task group** determines which workers process a job. Workers poll for tasks 
 
 ### Tenants
 
-A **tenant** is an isolation boundary for job data. All data for a tenant lives on a single shard, enabling fast local transactions. Tenants can be very high cardinality (millions), but each individual tenant is bounded by a single shard's throughput (roughly 4,000 jobs/second).
+A **tenant** is an isolation boundary for job data. All data for a tenant lives on a single shard, enabling fast local transactions. Tenants are routed to shards using hash-based routing (XXH64), which distributes tenants uniformly across the hash space regardless of naming patterns. Tenants can be very high cardinality (millions), but each individual tenant is bounded by a single shard's throughput (roughly 4,000 jobs/second).
 
 ### Shards
 
-Silo partitions data across **shards**. Each shard is backed by its own SlateDB instance in object storage. Shards are assigned to compute nodes, and can be split dynamically as load grows. Shard ownership is coordinated via etcd or Kubernetes.
+Silo partitions data across **shards**. Each shard owns a range of the 64-bit hash space. When a job is enqueued for a tenant, Silo hashes the tenant ID (XXH64) and routes it to the shard whose range contains that hash. Shards are backed by their own SlateDB instance in object storage, assigned to compute nodes, and can be split dynamically as load grows. Shard ownership is coordinated via etcd or Kubernetes.
 
 ### Workers
 
@@ -51,7 +51,7 @@ Silo partitions data across **shards**. Each shard is backed by its own SlateDB 
 ## How It Works
 
 1. Your application **enqueues** a job by calling Silo's gRPC API with a payload and task group.
-2. Silo stores the job in the appropriate shard (based on tenant) and makes it available for dequeue.
+2. Silo hashes the tenant ID and stores the job in the appropriate shard, making it available for dequeue.
 3. A **worker** polling that task group leases the task and processes it.
 4. The worker **reports the outcome** (success with optional result, or failure) back to Silo.
 5. On failure, Silo automatically retries according to the job's retry policy.

--- a/src/bin/silo-bench.rs
+++ b/src/bin/silo-bench.rs
@@ -252,10 +252,8 @@ async fn worker_loop(
                             if client.handle_routing_error(&e, &task_shard).await.is_some() {
                                 // Retry once with updated routing
                                 if let Ok(mut retry_client) = client.client_for_shard(&task_shard) {
-                                    let retry_req = make_success_outcome_request(
-                                        task_shard,
-                                        task.id.clone(),
-                                    );
+                                    let retry_req =
+                                        make_success_outcome_request(task_shard, task.id.clone());
                                     match retry_client.report_outcome(retry_req).await {
                                         Ok(_) => {
                                             completed_count.fetch_add(1, Ordering::Relaxed);
@@ -352,8 +350,7 @@ async fn enqueuer_loop(
                 }
                 Err(e) => {
                     if retries < MAX_ROUTING_RETRIES
-                        && let Some(needs_backoff) =
-                            client.handle_routing_error(&e, &shard).await
+                        && let Some(needs_backoff) = client.handle_routing_error(&e, &shard).await
                     {
                         retries += 1;
                         if needs_backoff {

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -157,7 +157,7 @@ impl ConcurrencyCounts {
             };
 
             // Filter by shard range - only hydrate holders for tenants in this shard
-            if !range.contains(&parsed.tenant) {
+            if !range.contains_tenant(&parsed.tenant) {
                 tracing::debug!(
                     tenant = %parsed.tenant,
                     queue = %parsed.queue,
@@ -665,7 +665,7 @@ impl ConcurrencyManager {
             };
 
             // Only process requests for tenants in our range
-            if !range.contains(&parsed.tenant) {
+            if !range.contains_tenant(&parsed.tenant) {
                 continue;
             }
 

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -252,7 +252,7 @@ impl JobStoreShard {
             progress.keys_scanned += 1;
 
             if let Some(tenant) = extract_tenant(&kv.key, &kv.value)
-                && !range.contains(&tenant)
+                && !range.contains_tenant(&tenant)
             {
                 batch.delete(&kv.key);
                 batch_count += 1;

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -117,7 +117,7 @@ impl JobStoreShard {
                 // Tasks for tenants outside the range are defunct (from before a split)
                 let task_tenant = decoded.tenant();
 
-                if !shard_range.contains(task_tenant) {
+                if !shard_range.contains_tenant(task_tenant) {
                     // Task is for a tenant outside our range - delete and skip
                     state.batch.delete(&entry.key);
                     state.ack_deleted(&entry.key);

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -385,7 +385,7 @@ impl JobStoreShard {
             // Check if lease's tenant is within shard range
             let lease_tenant = decoded.tenant();
 
-            if !shard_range.contains(lease_tenant) {
+            if !shard_range.contains_tenant(lease_tenant) {
                 // Lease is for a tenant outside our range - mark for deletion
                 debug!(
                     key = ?kv.key,

--- a/src/routing_client.rs
+++ b/src/routing_client.rs
@@ -46,11 +46,16 @@ pub struct ClusterTopology {
 
 impl ClusterTopology {
     /// Find the shard that owns the given tenant ID based on shard ranges.
+    ///
+    /// Hashes the tenant ID with the same algorithm used by the server
+    /// and matches against hash-space range boundaries.
     pub fn shard_for_tenant(&self, tenant_id: &str) -> Option<&ShardOwnerInfo> {
+        let hashed = crate::shard_range::hash_tenant(tenant_id);
         self.shard_owners.iter().find(|owner| {
             let after_start =
-                owner.range_start.is_empty() || tenant_id >= owner.range_start.as_str();
-            let before_end = owner.range_end.is_empty() || tenant_id < owner.range_end.as_str();
+                owner.range_start.is_empty() || hashed.as_str() >= owner.range_start.as_str();
+            let before_end =
+                owner.range_end.is_empty() || hashed.as_str() < owner.range_end.as_str();
             after_start && before_end
         })
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -712,7 +712,7 @@ impl SiloService {
         };
 
         // Validate tenant_id is within the shard's range
-        if !shard_info.range.contains(tenant_id) {
+        if !shard_info.contains(tenant_id) {
             tracing::warn!(
                 shard_id = %shard_id,
                 tenant_id = %tenant_id,

--- a/src/shard_range.rs
+++ b/src/shard_range.rs
@@ -198,9 +198,9 @@ impl ShardRange {
     /// Compute the numeric midpoint of this hash-space range for auto-split.
     ///
     /// Interprets the range boundaries as 16-character hex-encoded u64 values
-    /// and returns the midpoint as a 16-character hex string.
+    /// and returns the midpoint as a u64.
     /// Returns None if the range is too small to split.
-    pub fn midpoint(&self) -> Option<String> {
+    pub fn midpoint(&self) -> Option<u64> {
         let start_val: u64 = if self.start.is_empty() {
             0
         } else {
@@ -217,8 +217,7 @@ impl ShardRange {
             return None;
         }
 
-        let mid = start_val + (end_val - start_val) / 2;
-        Some(format!("{:016x}", mid))
+        Some(start_val + (end_val - start_val) / 2)
     }
 }
 
@@ -419,22 +418,20 @@ impl ShardMap {
             // Single shard covers entire keyspace
             shards.push(ShardInfo::new(ShardId::new(), ShardRange::full()));
         } else {
-            // Divide keyspace into equal ranges
-            // We use a simple approach: divide into ranges based on first character
-            // For better distribution, we create ranges using hex boundaries
+            // Divide the u64 hash keyspace into equal ranges
             let boundaries = compute_range_boundaries(shard_count);
 
             for i in 0..shard_count as usize {
                 let start = if i == 0 {
                     String::new() // Unbounded start
                 } else {
-                    boundaries[i - 1].clone()
+                    format_hash_boundary(boundaries[i - 1])
                 };
 
                 let end = if i == shard_count as usize - 1 {
                     String::new() // Unbounded end
                 } else {
-                    boundaries[i].clone()
+                    format_hash_boundary(boundaries[i])
                 };
 
                 shards.push(ShardInfo::new(ShardId::new(), ShardRange::new(start, end)));
@@ -676,11 +673,16 @@ pub enum ShardMapError {
     SplitAlreadyInProgress(ShardId),
 }
 
+/// Format a u64 hash-space value as a 16-character hex string for use in shard ranges.
+pub fn format_hash_boundary(val: u64) -> String {
+    format!("{:016x}", val)
+}
+
 /// Compute evenly-spaced range boundaries for the given shard count.
 ///
-/// Returns `shard_count - 1` boundary strings that divide the u64 hash
-/// keyspace into equal-sized partitions, formatted as 16-character hex strings.
-fn compute_range_boundaries(shard_count: u32) -> Vec<String> {
+/// Returns `shard_count - 1` boundary values that divide the u64 hash
+/// keyspace into equal-sized partitions.
+fn compute_range_boundaries(shard_count: u32) -> Vec<u64> {
     if shard_count <= 1 {
         return Vec::new();
     }
@@ -690,7 +692,7 @@ fn compute_range_boundaries(shard_count: u32) -> Vec<String> {
 
     for i in 1..shard_count {
         let boundary = (i as u128 * space / shard_count as u128) as u64;
-        boundaries.push(format!("{:016x}", boundary));
+        boundaries.push(boundary);
     }
 
     boundaries

--- a/src/shard_range.rs
+++ b/src/shard_range.rs
@@ -1,14 +1,35 @@
-//! Range-based shard coordination types.
+//! Hash-based shard coordination types.
 //!
-//! This module defines the core data structures for range-based sharding,
-//! where the tenant_id keyspace is split into lexicographical ranges,
-//! each owned by a shard with a unique UUID identity.
+//! This module defines the core data structures for hash-based sharding,
+//! where tenant IDs are hashed (FNV-1a) into a uniform keyspace and then
+//! assigned to shards via lexicographical ranges over the hex-encoded hash.
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use uuid::Uuid;
 
 use crate::coordination::SplitPhase;
+
+/// Hash a tenant ID to a 16-character hex string using FNV-1a with
+/// splitmix64 finalization for strong avalanche properties.
+///
+/// This ensures uniform distribution across the shard keyspace regardless
+/// of the structure of tenant ID strings (e.g. shared prefixes like "env-").
+pub fn hash_tenant(tenant_id: &str) -> String {
+    // FNV-1a accumulation
+    let mut hash: u64 = 0xcbf29ce484222325; // FNV-1a offset basis
+    for byte in tenant_id.as_bytes() {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3); // FNV-1a prime
+    }
+    // splitmix64 finalization — ensures full avalanche even for similar inputs
+    hash ^= hash >> 30;
+    hash = hash.wrapping_mul(0xbf58476d1ce4e5b9);
+    hash ^= hash >> 27;
+    hash = hash.wrapping_mul(0x94d049bb133111eb);
+    hash ^= hash >> 31;
+    format!("{:016x}", hash)
+}
 
 /// A unique identifier for a shard.
 ///
@@ -69,13 +90,14 @@ impl From<ShardId> for Uuid {
     }
 }
 
-/// A lexicographical range of tenant IDs owned by a shard.
+/// A range in the hash keyspace owned by a shard.
 ///
 /// Ranges are defined as `[start, end)` where:
 /// - `start` is inclusive (empty string means unbounded start, i.e., from the beginning)
 /// - `end` is exclusive (empty string means unbounded end, i.e., to infinity)
 ///
-/// Tenant IDs are compared lexicographically (byte-by-byte string comparison).
+/// Boundaries are 16-character hex-encoded u64 hash values.
+/// Use `contains_tenant` (which hashes the tenant ID first) for tenant lookups.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ShardRange {
     /// Inclusive start of the range. Empty string means unbounded (from beginning).
@@ -112,6 +134,14 @@ impl ShardRange {
         let before_end = self.end.is_empty() || tenant_id < self.end.as_str();
 
         after_start && before_end
+    }
+
+    /// Check if this range contains the hash of the given tenant ID.
+    ///
+    /// Hashes the tenant ID with FNV-1a and checks if the result falls
+    /// within this range's bounds.
+    pub fn contains_tenant(&self, tenant_id: &str) -> bool {
+        self.contains(&hash_tenant(tenant_id))
     }
 
     /// Check if this range is unbounded at the start.
@@ -177,81 +207,30 @@ impl ShardRange {
         Ok((left, right))
     }
 
-    /// Compute the lexicographic midpoint of this range for auto-split.
+    /// Compute the numeric midpoint of this hash-space range for auto-split.
     ///
-    /// Returns None if the range cannot be split (e.g., single character range).
+    /// Interprets the range boundaries as 16-character hex-encoded u64 values
+    /// and returns the midpoint as a 16-character hex string.
+    /// Returns None if the range is too small to split.
     pub fn midpoint(&self) -> Option<String> {
-        // For unbounded ranges, we need to pick reasonable bounds
-        let effective_start = if self.start.is_empty() {
-            "0".to_string()
+        let start_val: u64 = if self.start.is_empty() {
+            0
         } else {
-            self.start.clone()
+            u64::from_str_radix(&self.start, 16).ok()?
         };
 
-        let effective_end = if self.end.is_empty() {
-            // Use a reasonably high value (all 'z's)
-            "zzzzzzzz".to_string()
+        let end_val: u64 = if self.end.is_empty() {
+            u64::MAX
         } else {
-            self.end.clone()
+            u64::from_str_radix(&self.end, 16).ok()?
         };
 
-        // Simple midpoint: take first char of start, compute midpoint with first char of end
-        // This is a simplified approach; a production system might use more sophisticated logic
-        if effective_start >= effective_end {
+        if end_val <= start_val + 1 {
             return None;
         }
 
-        // Binary search through the string space
-        let start_bytes = effective_start.as_bytes();
-        let end_bytes = effective_end.as_bytes();
-
-        // Find the first differing position
-        let min_len = start_bytes.len().min(end_bytes.len());
-        let mut diff_pos = 0;
-        while diff_pos < min_len && start_bytes[diff_pos] == end_bytes[diff_pos] {
-            diff_pos += 1;
-        }
-
-        if diff_pos == min_len {
-            // One is a prefix of the other
-            if start_bytes.len() < end_bytes.len() {
-                // Start is shorter; extend start with a character that keeps us below end.
-                // Since start is a prefix of end, start + C < end when C < end_bytes[diff_pos].
-                let end_char_at_diff = end_bytes[diff_pos];
-                if end_char_at_diff >= 2 {
-                    let mid_char = end_char_at_diff / 2;
-                    let mut mid = effective_start.clone();
-                    mid.push(mid_char as char);
-                    return Some(mid);
-                }
-            }
-            return None;
-        }
-
-        // Compute midpoint at the differing position
-        let start_char = start_bytes[diff_pos];
-        let end_char = end_bytes[diff_pos];
-
-        if end_char <= start_char + 1 {
-            // Too close to split at this level, extend
-            let mut mid = String::from_utf8_lossy(&start_bytes[..=diff_pos]).to_string();
-            mid.push('~'); // High ASCII value
-            if mid.as_str() > effective_start.as_str() && mid.as_str() < effective_end.as_str() {
-                return Some(mid);
-            }
-            return None;
-        }
-
-        let mid_char = start_char + (end_char - start_char) / 2;
-        let mut result = String::from_utf8_lossy(&start_bytes[..diff_pos]).to_string();
-        result.push(mid_char as char);
-
-        // Validate the result
-        if result.as_str() > effective_start.as_str() && result.as_str() < effective_end.as_str() {
-            Some(result)
-        } else {
-            None
-        }
+        let mid = start_val + (end_val - start_val) / 2;
+        Some(format!("{:016x}", mid))
     }
 }
 
@@ -341,8 +320,10 @@ impl ShardInfo {
     }
 
     /// Check if this shard's range contains the given tenant ID.
+    ///
+    /// Hashes the tenant ID before checking the range.
     pub fn contains(&self, tenant_id: &str) -> bool {
-        self.range.contains(tenant_id)
+        self.range.contains_tenant(tenant_id)
     }
 }
 
@@ -434,9 +415,9 @@ impl ShardMap {
 
     /// Create an initial shard map with the given number of shards.
     ///
-    /// Divides the keyspace evenly among shards using hex prefixes.
-    /// For example, with 16 shards, each shard owns 1/16th of the keyspace
-    /// based on the first hex digit of the tenant ID hash.
+    /// Divides the u64 hash keyspace evenly among shards.
+    /// Tenant IDs are hashed with FNV-1a before lookup, so the
+    /// boundaries are 16-character hex strings in hash space.
     pub fn create_initial(shard_count: u32) -> Result<Self, ShardMapError> {
         if shard_count == 0 {
             return Err(ShardMapError::InvalidShardCount(
@@ -498,7 +479,7 @@ impl ShardMap {
 
     /// Find the shard that owns the given tenant ID.
     ///
-    /// Uses binary search for efficient lookup.
+    /// Hashes the tenant ID with FNV-1a and uses binary search for efficient lookup.
     /// Returns None if the map is empty or the tenant ID doesn't fall in any range
     /// (which should not happen in a valid map).
     pub fn shard_for_tenant(&self, tenant_id: &str) -> Option<&ShardInfo> {
@@ -506,25 +487,23 @@ impl ShardMap {
             return None;
         }
 
-        // Binary search to find the shard whose range contains this tenant
-        // We search for the rightmost shard where start <= tenant_id
+        let hashed = hash_tenant(tenant_id);
+        let hashed_str = hashed.as_str();
+
+        // Binary search to find the shard whose range contains this tenant's hash
         let idx = self.shards.partition_point(|shard| {
-            // For unbounded start (empty string), it's always <= tenant_id
-            shard.range.start.is_empty() || shard.range.start.as_str() <= tenant_id
+            shard.range.start.is_empty() || shard.range.start.as_str() <= hashed_str
         });
 
-        // partition_point returns the index where we'd insert, so we need idx - 1
         if idx == 0 {
-            // tenant_id is before all shards - check first shard
-            // This can happen if first shard has unbounded start
-            if self.shards[0].range.contains(tenant_id) {
+            if self.shards[0].range.contains(hashed_str) {
                 return Some(&self.shards[0]);
             }
             return None;
         }
 
         let candidate = &self.shards[idx - 1];
-        if candidate.range.contains(tenant_id) {
+        if candidate.range.contains(hashed_str) {
             Some(candidate)
         } else {
             None
@@ -711,40 +690,19 @@ pub enum ShardMapError {
 
 /// Compute evenly-spaced range boundaries for the given shard count.
 ///
-/// Returns `shard_count - 1` boundary strings that divide the keyspace.
-/// Uses a simple hex-based scheme for predictable distribution.
+/// Returns `shard_count - 1` boundary strings that divide the u64 hash
+/// keyspace into equal-sized partitions, formatted as 16-character hex strings.
 fn compute_range_boundaries(shard_count: u32) -> Vec<String> {
     if shard_count <= 1 {
         return Vec::new();
     }
 
     let mut boundaries = Vec::with_capacity((shard_count - 1) as usize);
+    let space: u128 = 1u128 << 64; // 2^64
 
-    // We'll use a simple scheme based on hex characters
-    // For up to 16 shards, we use single hex digits
-    // For more, we use multi-character boundaries
-    if shard_count <= 16 {
-        // Use hex digits 0-f to create boundaries
-        let hex_chars: Vec<char> = "0123456789abcdef".chars().collect();
-        let step = 16 / shard_count;
-        for i in 1..shard_count {
-            let idx = (i * step) as usize;
-            if idx < hex_chars.len() {
-                boundaries.push(hex_chars[idx].to_string());
-            }
-        }
-    } else if shard_count <= 256 {
-        // Use two hex digits
-        for i in 1..shard_count {
-            let boundary = (i * 256 / shard_count) as u8;
-            boundaries.push(format!("{:02x}", boundary));
-        }
-    } else {
-        // Use four hex digits for larger shard counts
-        for i in 1..shard_count {
-            let boundary = (i as u64 * 65536 / shard_count as u64) as u16;
-            boundaries.push(format!("{:04x}", boundary));
-        }
+    for i in 1..shard_count {
+        let boundary = (i as u128 * space / shard_count as u128) as u64;
+        boundaries.push(format!("{:016x}", boundary));
     }
 
     boundaries

--- a/src/shard_range.rs
+++ b/src/shard_range.rs
@@ -1,7 +1,7 @@
 //! Hash-based shard coordination types.
 //!
 //! This module defines the core data structures for hash-based sharding,
-//! where tenant IDs are hashed (FNV-1a) into a uniform keyspace and then
+//! where tenant IDs are hashed (XXH64) into a uniform keyspace and then
 //! assigned to shards via lexicographical ranges over the hex-encoded hash.
 
 use serde::{Deserialize, Serialize};
@@ -10,24 +10,12 @@ use uuid::Uuid;
 
 use crate::coordination::SplitPhase;
 
-/// Hash a tenant ID to a 16-character hex string using FNV-1a with
-/// splitmix64 finalization for strong avalanche properties.
+/// Hash a tenant ID to a 16-character hex string using XXH64 (seed 0).
 ///
 /// This ensures uniform distribution across the shard keyspace regardless
 /// of the structure of tenant ID strings (e.g. shared prefixes like "env-").
 pub fn hash_tenant(tenant_id: &str) -> String {
-    // FNV-1a accumulation
-    let mut hash: u64 = 0xcbf29ce484222325; // FNV-1a offset basis
-    for byte in tenant_id.as_bytes() {
-        hash ^= *byte as u64;
-        hash = hash.wrapping_mul(0x100000001b3); // FNV-1a prime
-    }
-    // splitmix64 finalization — ensures full avalanche even for similar inputs
-    hash ^= hash >> 30;
-    hash = hash.wrapping_mul(0xbf58476d1ce4e5b9);
-    hash ^= hash >> 27;
-    hash = hash.wrapping_mul(0x94d049bb133111eb);
-    hash ^= hash >> 31;
+    let hash = xxhash_rust::xxh64::xxh64(tenant_id.as_bytes(), 0);
     format!("{:016x}", hash)
 }
 
@@ -138,7 +126,7 @@ impl ShardRange {
 
     /// Check if this range contains the hash of the given tenant ID.
     ///
-    /// Hashes the tenant ID with FNV-1a and checks if the result falls
+    /// Hashes the tenant ID with XXH64 and checks if the result falls
     /// within this range's bounds.
     pub fn contains_tenant(&self, tenant_id: &str) -> bool {
         self.contains(&hash_tenant(tenant_id))
@@ -416,7 +404,7 @@ impl ShardMap {
     /// Create an initial shard map with the given number of shards.
     ///
     /// Divides the u64 hash keyspace evenly among shards.
-    /// Tenant IDs are hashed with FNV-1a before lookup, so the
+    /// Tenant IDs are hashed with XXH64 before lookup, so the
     /// boundaries are 16-character hex strings in hash space.
     pub fn create_initial(shard_count: u32) -> Result<Self, ShardMapError> {
         if shard_count == 0 {
@@ -479,7 +467,7 @@ impl ShardMap {
 
     /// Find the shard that owns the given tenant ID.
     ///
-    /// Hashes the tenant ID with FNV-1a and uses binary search for efficient lookup.
+    /// Hashes the tenant ID with XXH64 and uses binary search for efficient lookup.
     /// Returns None if the map is empty or the tenant ID doesn't fall in any range
     /// (which should not happen in a valid map).
     pub fn shard_for_tenant(&self, tenant_id: &str) -> Option<&ShardInfo> {

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -178,7 +178,7 @@ impl TaskBroker {
             // Check if task's tenant is within shard range
             let task_tenant = decoded.tenant();
 
-            if !self.range.contains(task_tenant) {
+            if !self.range.contains_tenant(task_tenant) {
                 // Task is for a tenant outside our range - mark for deletion
                 defunct_keys.push(kv.key.to_vec());
                 debug!(

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -2007,7 +2007,9 @@ async fn shard_split_handler(
         // Auto-compute midpoint from shard range
         if let Ok(shard_map) = state.coordinator.get_shard_map().await {
             if let Some(info) = shard_map.get_shard(&parsed_shard_id) {
-                info.range.midpoint()
+                info.range
+                    .midpoint()
+                    .map(crate::shard_range::format_hash_boundary)
             } else {
                 None
             }

--- a/tests/bench_routing_tests.rs
+++ b/tests/bench_routing_tests.rs
@@ -4,6 +4,7 @@ use grpc_integration_helpers::{setup_multi_shard_server, shutdown_server};
 use silo::pb::silo_client::SiloClient;
 use silo::pb::*;
 use silo::settings::AppConfig;
+use silo::shard_range::hash_tenant;
 
 /// This test reproduces the silo-bench routing bug: when the bench tool discovers
 /// cluster topology, it ignores the shard range information and picks a random shard
@@ -52,21 +53,23 @@ async fn bench_tenant_routing_with_shard_ranges() -> anyhow::Result<()> {
         // The bench tenants: "bench-0", "bench-1", "bench-2", "bench-3"
         let tenants = vec!["bench-0", "bench-1", "bench-2", "bench-3"];
 
-        // For each tenant, find the shard that owns it by checking ranges
+        // For each tenant, find the shard that owns it by hashing the tenant
+        // and checking against the hash-space range boundaries.
         // This is what silo-bench SHOULD do (but didn't before the fix)
         for tenant in &tenants {
+            let hashed = hash_tenant(tenant);
             let owning_shard = cluster_info
                 .shard_owners
                 .iter()
                 .find(|owner| {
                     let after_start =
-                        owner.range_start.is_empty() || *tenant >= owner.range_start.as_str();
+                        owner.range_start.is_empty() || hashed.as_str() >= owner.range_start.as_str();
                     let before_end =
-                        owner.range_end.is_empty() || *tenant < owner.range_end.as_str();
+                        owner.range_end.is_empty() || hashed.as_str() < owner.range_end.as_str();
                     after_start && before_end
                 })
                 .unwrap_or_else(|| {
-                    panic!("tenant '{}' should be owned by some shard", tenant)
+                    panic!("tenant '{}' (hash '{}') should be owned by some shard", tenant, hashed)
                 });
 
             // Enqueue to the correct shard -- this should succeed
@@ -103,12 +106,13 @@ async fn bench_tenant_routing_with_shard_ranges() -> anyhow::Result<()> {
         // Now demonstrate the bug: if we pick the WRONG shard for a tenant,
         // the server rejects it with FailedPrecondition
         let first_shard = &cluster_info.shard_owners[0];
-        // Find a tenant NOT in the first shard's range
+        // Find a tenant NOT in the first shard's range (using hashed comparison)
         let wrong_tenant = tenants.iter().find(|tenant| {
+            let hashed = hash_tenant(tenant);
             let after_start =
-                first_shard.range_start.is_empty() || **tenant >= first_shard.range_start.as_str();
+                first_shard.range_start.is_empty() || hashed.as_str() >= first_shard.range_start.as_str();
             let before_end =
-                first_shard.range_end.is_empty() || **tenant < first_shard.range_end.as_str();
+                first_shard.range_end.is_empty() || hashed.as_str() < first_shard.range_end.as_str();
             !(after_start && before_end)
         });
 

--- a/tests/cleanup_reacquire_tests.rs
+++ b/tests/cleanup_reacquire_tests.rs
@@ -18,6 +18,13 @@ use silo::settings::{Backend, DatabaseConfig};
 use silo::shard_range::ShardRange;
 use std::sync::Arc;
 
+/// Hash-space boundary for cleanup tests.
+/// Tenants whose XXH64 hash < this value are "in range"; others are "out of range".
+///
+/// In range  (hash < 8000): bbb(3a4f), xxx(3c37), zzz(6d85), zulu(774a), yankee(2197)
+/// Out of range (hash >= 8000): aaa(ae01), ccc(8ed4), yyy(ed58), alpha(c758), beta(f5ee)
+const RANGE_BOUNDARY: &str = "8000000000000000";
+
 /// Helper to enqueue jobs for multiple tenants
 async fn enqueue_jobs_for_tenants(shard: &JobStoreShard, tenants: &[&str], jobs_per_tenant: usize) {
     for tenant in tenants {
@@ -47,7 +54,7 @@ async fn background_cleanup_spawns_when_cleanup_pending() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().to_string_lossy().to_string();
     let rate_limiter = MockGubernatorClient::new_arc();
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     // First, create a shard and set it up with pending cleanup
     {
@@ -64,8 +71,9 @@ async fn background_cleanup_spawns_when_cleanup_pending() {
             .await
             .expect("open shard");
 
-        // Enqueue jobs for tenants inside and outside the range
-        enqueue_jobs_for_tenants(&shard, &["aaa", "bbb", "zzz"], 3).await;
+        // Enqueue jobs for tenants inside and outside the hash-space range
+        // bbb(3a) and zzz(6d) are in range; aaa(ae) is out of range
+        enqueue_jobs_for_tenants(&shard, &["bbb", "zzz", "aaa"], 3).await;
         shard.db().flush().await.unwrap();
 
         // Set status to CleanupPending (simulating a split child)
@@ -107,7 +115,7 @@ async fn background_cleanup_spawns_when_cleanup_pending() {
         let remaining_jobs = count_job_info_keys(shard.db()).await;
         assert_eq!(
             remaining_jobs, 6,
-            "should have 6 jobs (aaa=3 + bbb=3), zzz should be cleaned up"
+            "should have 6 jobs (bbb=3 + zzz=3), aaa should be cleaned up"
         );
 
         // Verify cleanup status is now CompactionDone
@@ -128,7 +136,7 @@ async fn background_cleanup_resumes_when_cleanup_was_running() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().to_string_lossy().to_string();
     let rate_limiter = MockGubernatorClient::new_arc();
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     // First, create a shard and simulate interrupted cleanup
     {
@@ -145,8 +153,8 @@ async fn background_cleanup_resumes_when_cleanup_was_running() {
             .await
             .expect("open shard");
 
-        // Enqueue jobs
-        enqueue_jobs_for_tenants(&shard, &["aaa", "zzz"], 5).await;
+        // Enqueue jobs: zzz(6d) is in range, aaa(ae) is out
+        enqueue_jobs_for_tenants(&shard, &["zzz", "aaa"], 5).await;
         shard.db().flush().await.unwrap();
 
         // Set status to CleanupRunning (simulating an interrupted cleanup)
@@ -182,7 +190,7 @@ async fn background_cleanup_resumes_when_cleanup_was_running() {
 
         // Verify cleanup completed
         let remaining_jobs = count_job_info_keys(shard.db()).await;
-        assert_eq!(remaining_jobs, 5, "should have 5 jobs (aaa only)");
+        assert_eq!(remaining_jobs, 5, "should have 5 jobs (zzz only)");
 
         let status = shard.get_cleanup_status().await.expect("get status");
         assert_eq!(status, SplitCleanupStatus::CompactionDone);
@@ -197,7 +205,7 @@ async fn background_cleanup_runs_compaction_when_cleanup_done() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().to_string_lossy().to_string();
     let rate_limiter = MockGubernatorClient::new_arc();
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     // First, create a shard with CleanupDone status
     {
@@ -262,7 +270,7 @@ async fn no_cleanup_when_already_complete() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().to_string_lossy().to_string();
     let rate_limiter = MockGubernatorClient::new_arc();
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     // Create a shard with CompactionDone status (default)
     {
@@ -330,7 +338,7 @@ async fn cleanup_cancelled_on_shard_close() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().to_string_lossy().to_string();
     let rate_limiter = MockGubernatorClient::new_arc();
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     // Create shard with lots of data to make cleanup take longer
     let cfg = DatabaseConfig {
@@ -390,7 +398,7 @@ async fn cleanup_progress_saved_on_cancellation() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().to_string_lossy().to_string();
     let rate_limiter = MockGubernatorClient::new_arc();
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     let cfg = DatabaseConfig {
         name: "test".to_string(),
@@ -407,8 +415,8 @@ async fn cleanup_progress_saved_on_cancellation() {
             .await
             .expect("open shard");
 
-        // Enqueue jobs
-        for tenant in ["aaa", "zzz", "yyy", "xxx"] {
+        // Enqueue jobs: zzz(6d) is in range; aaa(ae), yyy(ed), ccc(8e) are out
+        for tenant in ["zzz", "aaa", "yyy", "ccc"] {
             enqueue_jobs_for_tenants(&shard, &[tenant], 10).await;
         }
         shard.db().flush().await.unwrap();
@@ -469,9 +477,9 @@ async fn cleanup_progress_saved_on_cancellation() {
 
         shard.db().flush().await.unwrap();
 
-        // Only aaa jobs should remain
+        // Only zzz jobs should remain (in range)
         let remaining_jobs = count_job_info_keys(shard.db()).await;
-        assert_eq!(remaining_jobs, 10, "only aaa jobs should remain");
+        assert_eq!(remaining_jobs, 10, "only zzz jobs should remain");
 
         shard.close().await.expect("close shard");
     }
@@ -483,7 +491,7 @@ async fn cleanup_result_indicates_cancellation() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().to_string_lossy().to_string();
     let rate_limiter = MockGubernatorClient::new_arc();
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     let cfg = DatabaseConfig {
         name: "test".to_string(),
@@ -498,8 +506,8 @@ async fn cleanup_result_indicates_cancellation() {
         .await
         .expect("open shard");
 
-    // Enqueue jobs
-    enqueue_jobs_for_tenants(&shard, &["aaa", "zzz"], 30).await;
+    // Enqueue jobs: zzz(6d) in range, aaa(ae) out
+    enqueue_jobs_for_tenants(&shard, &["zzz", "aaa"], 30).await;
     shard.db().flush().await.unwrap();
 
     // Set status to CleanupPending
@@ -548,7 +556,7 @@ async fn cleanup_handles_multiple_close_calls() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().to_string_lossy().to_string();
     let rate_limiter = MockGubernatorClient::new_arc();
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     let cfg = DatabaseConfig {
         name: "test".to_string(),
@@ -589,7 +597,7 @@ async fn full_reacquisition_cycle_triggers_cleanup() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().to_string_lossy().to_string();
     let rate_limiter = MockGubernatorClient::new_arc();
-    let range = ShardRange::new("", "mmm"); // Only tenants < "mmm"
+    let range = ShardRange::new("", RANGE_BOUNDARY); // Only tenants < "mmm"
 
     let cfg = DatabaseConfig {
         name: "test".to_string(),
@@ -606,8 +614,9 @@ async fn full_reacquisition_cycle_triggers_cleanup() {
             .await
             .expect("open shard");
 
-        // Enqueue jobs for various tenants
-        enqueue_jobs_for_tenants(&shard, &["alpha", "beta", "zulu", "yankee"], 5).await;
+        // Enqueue jobs: yankee(21) and zulu(77) are in range;
+        // alpha(c7) and beta(f5) are out of range
+        enqueue_jobs_for_tenants(&shard, &["yankee", "zulu", "alpha", "beta"], 5).await;
         shard.db().flush().await.unwrap();
 
         // Verify all jobs exist
@@ -638,15 +647,15 @@ async fn full_reacquisition_cycle_triggers_cleanup() {
         shard.db().flush().await.unwrap();
 
         // Verify cleanup happened
+        let yankee_jobs = count_job_info_keys_for_tenant(shard.db(), "yankee").await;
+        let zulu_jobs = count_job_info_keys_for_tenant(shard.db(), "zulu").await;
         let alpha_jobs = count_job_info_keys_for_tenant(shard.db(), "alpha").await;
         let beta_jobs = count_job_info_keys_for_tenant(shard.db(), "beta").await;
-        let zulu_jobs = count_job_info_keys_for_tenant(shard.db(), "zulu").await;
-        let yankee_jobs = count_job_info_keys_for_tenant(shard.db(), "yankee").await;
 
-        assert_eq!(alpha_jobs, 5, "alpha (in range) should be kept");
-        assert_eq!(beta_jobs, 5, "beta (in range) should be kept");
-        assert_eq!(zulu_jobs, 0, "zulu (out of range) should be cleaned");
-        assert_eq!(yankee_jobs, 0, "yankee (out of range) should be cleaned");
+        assert_eq!(yankee_jobs, 5, "yankee (in range) should be kept");
+        assert_eq!(zulu_jobs, 5, "zulu (in range) should be kept");
+        assert_eq!(alpha_jobs, 0, "alpha (out of range) should be cleaned");
+        assert_eq!(beta_jobs, 0, "beta (out of range) should be cleaned");
 
         // Verify final status
         let status = shard.get_cleanup_status().await.expect("get status");
@@ -684,7 +693,7 @@ async fn interrupted_cleanup_resumes_on_reacquisition() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().to_string_lossy().to_string();
     let rate_limiter = MockGubernatorClient::new_arc();
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     let cfg = DatabaseConfig {
         name: "test".to_string(),
@@ -701,8 +710,8 @@ async fn interrupted_cleanup_resumes_on_reacquisition() {
             .await
             .expect("open shard");
 
-        // Enqueue jobs
-        enqueue_jobs_for_tenants(&shard, &["aaa", "zzz"], 15).await;
+        // Enqueue jobs: zzz(6d) in range, aaa(ae) out
+        enqueue_jobs_for_tenants(&shard, &["zzz", "aaa"], 15).await;
         shard.db().flush().await.unwrap();
 
         shard
@@ -742,7 +751,7 @@ async fn interrupted_cleanup_resumes_on_reacquisition() {
         assert_eq!(status, SplitCleanupStatus::CompactionDone);
 
         let remaining = count_job_info_keys(shard.db()).await;
-        assert_eq!(remaining, 15, "only aaa jobs should remain");
+        assert_eq!(remaining, 15, "only zzz jobs should remain");
 
         shard.close().await.expect("close shard");
     }

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -471,9 +471,18 @@ async fn execute_split_completes_full_cycle() {
 
     let splitter = ShardSplitter::new(Arc::new(c1.clone()));
 
+    // Compute midpoint of the shard's range for a balanced split
+    let shard_map = c1.get_shard_map().await.expect("get shard map");
+    let split_point = shard_map
+        .get_shard(&shard_id)
+        .unwrap()
+        .range
+        .midpoint()
+        .unwrap();
+
     // Request and execute the split
     let split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, split_point.clone())
         .await
         .expect("request split should succeed");
 
@@ -519,11 +528,14 @@ async fn execute_split_completes_full_cycle() {
     assert_eq!(left_info.parent_shard_id, Some(shard_id));
     assert_eq!(right_info.parent_shard_id, Some(shard_id));
 
-    // Tenant routing should work correctly
-    let tenant_a = shard_map.shard_for_tenant("a").unwrap();
-    let tenant_z = shard_map.shard_for_tenant("z").unwrap();
-    assert_eq!(tenant_a.id, split.left_child_id);
-    assert_eq!(tenant_z.id, split.right_child_id);
+    // Tenant routing should work correctly — all tenants route to one of the children
+    for tenant in ["a", "m", "z", "env-123"] {
+        let routed = shard_map.shard_for_tenant(tenant).unwrap();
+        assert!(
+            routed.id == split.left_child_id || routed.id == split.right_child_id,
+            "tenant should route to one of the children"
+        );
+    }
 
     c1.shutdown().await.unwrap();
     let _ = h1.abort();
@@ -747,9 +759,17 @@ async fn sequential_splits_work_correctly() {
 
     let splitter = ShardSplitter::new(Arc::new(c1.clone()));
 
-    // First split at "m"
+    // First split at midpoint
+    let shard_map = c1.get_shard_map().await.expect("get shard map");
+    let split_point1 = shard_map
+        .get_shard(&shard_id)
+        .unwrap()
+        .range
+        .midpoint()
+        .unwrap();
+
     let split1 = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, split_point1)
         .await
         .expect("first split request");
     splitter
@@ -761,10 +781,16 @@ async fn sequential_splits_work_correctly() {
     let shard_map = c1.get_shard_map().await.expect("get shard map");
     assert_eq!(shard_map.len(), 2);
 
-    // Second split: split the left child at "g"
+    // Second split: split the left child at its midpoint
     let left_child_id = split1.left_child_id;
+    let split_point2 = shard_map
+        .get_shard(&left_child_id)
+        .unwrap()
+        .range
+        .midpoint()
+        .unwrap();
     let split2 = splitter
-        .request_split(left_child_id, "g".to_string())
+        .request_split(left_child_id, split_point2)
         .await
         .expect("second split request");
     splitter
@@ -776,14 +802,20 @@ async fn sequential_splits_work_correctly() {
     let shard_map = c1.get_shard_map().await.expect("get shard map");
     assert_eq!(shard_map.len(), 3);
 
-    // Verify tenant routing after both splits
-    let tenant_a = shard_map.shard_for_tenant("a").unwrap();
-    let tenant_h = shard_map.shard_for_tenant("h").unwrap();
-    let tenant_z = shard_map.shard_for_tenant("z").unwrap();
-
-    assert_eq!(tenant_a.id, split2.left_child_id);
-    assert_eq!(tenant_h.id, split2.right_child_id);
-    assert_eq!(tenant_z.id, split1.right_child_id);
+    // Verify tenant routing works — all tenants route to one of the three shards
+    let valid_ids = [
+        split2.left_child_id,
+        split2.right_child_id,
+        split1.right_child_id,
+    ];
+    for tenant in ["a", "h", "z", "env-123"] {
+        let routed = shard_map.shard_for_tenant(tenant).unwrap();
+        assert!(
+            valid_ids.contains(&routed.id),
+            "tenant '{}' should route to one of the three shards",
+            tenant
+        );
+    }
 
     c1.shutdown().await.unwrap();
     let _ = h1.abort();
@@ -1340,7 +1372,7 @@ mod splitter_unit_tests {
         let shard_id = shard_map.lock().await.shard_ids()[0];
 
         // Should fail because we don't own the shard
-        // Use "2" as the split point since shard 0 covers "" to "4" with 4 shards
+        // Use "2" as the split point (valid within shard 0's hash-space range)
         let result = splitter.request_split(shard_id, "2".to_string()).await;
         assert!(matches!(result, Err(CoordinationError::NotShardOwner(_))));
 

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -473,12 +473,14 @@ async fn execute_split_completes_full_cycle() {
 
     // Compute midpoint of the shard's range for a balanced split
     let shard_map = c1.get_shard_map().await.expect("get shard map");
-    let split_point = shard_map
-        .get_shard(&shard_id)
-        .unwrap()
-        .range
-        .midpoint()
-        .unwrap();
+    let split_point = silo::shard_range::format_hash_boundary(
+        shard_map
+            .get_shard(&shard_id)
+            .unwrap()
+            .range
+            .midpoint()
+            .unwrap(),
+    );
 
     // Request and execute the split
     let split = splitter
@@ -761,12 +763,14 @@ async fn sequential_splits_work_correctly() {
 
     // First split at midpoint
     let shard_map = c1.get_shard_map().await.expect("get shard map");
-    let split_point1 = shard_map
-        .get_shard(&shard_id)
-        .unwrap()
-        .range
-        .midpoint()
-        .unwrap();
+    let split_point1 = silo::shard_range::format_hash_boundary(
+        shard_map
+            .get_shard(&shard_id)
+            .unwrap()
+            .range
+            .midpoint()
+            .unwrap(),
+    );
 
     let split1 = splitter
         .request_split(shard_id, split_point1)
@@ -783,12 +787,14 @@ async fn sequential_splits_work_correctly() {
 
     // Second split: split the left child at its midpoint
     let left_child_id = split1.left_child_id;
-    let split_point2 = shard_map
-        .get_shard(&left_child_id)
-        .unwrap()
-        .range
-        .midpoint()
-        .unwrap();
+    let split_point2 = silo::shard_range::format_hash_boundary(
+        shard_map
+            .get_shard(&left_child_id)
+            .unwrap()
+            .range
+            .midpoint()
+            .unwrap(),
+    );
     let split2 = splitter
         .request_split(left_child_id, split_point2)
         .await
@@ -880,10 +886,12 @@ async fn split_in_multi_node_cluster() {
     let shard_info = shard_map
         .get_shard(&shard_to_split)
         .expect("find shard in map");
-    let split_point = shard_info
-        .range
-        .midpoint()
-        .expect("shard range should have a midpoint");
+    let split_point = silo::shard_range::format_hash_boundary(
+        shard_info
+            .range
+            .midpoint()
+            .expect("shard range should have a midpoint"),
+    );
 
     // Create splitter and split the shard
 

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -1281,7 +1281,9 @@ async fn etcd_request_split_fails_if_not_owner() {
     // Create splitter for c2 and try to split a shard owned by c1
     let splitter2 = ShardSplitter::new(c2.clone());
 
-    let result = splitter2.request_split(c1_shard, "8000000000000000".to_string()).await;
+    let result = splitter2
+        .request_split(c1_shard, "8000000000000000".to_string())
+        .await;
     assert!(
         matches!(result, Err(CoordinationError::NotShardOwner(_))),
         "should fail with NotShardOwner, got: {:?}",
@@ -1320,7 +1322,9 @@ async fn etcd_request_split_fails_if_already_in_progress() {
         .expect("first request_split should succeed");
 
     // Second split request should fail
-    let result = splitter.request_split(shard_id, "4000000000000000".to_string()).await;
+    let result = splitter
+        .request_split(shard_id, "4000000000000000".to_string())
+        .await;
     assert!(
         matches!(result, Err(CoordinationError::SplitAlreadyInProgress(_))),
         "should fail with SplitAlreadyInProgress, got: {:?}",

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -1619,9 +1619,17 @@ async fn etcd_sequential_splits_work_correctly() {
     // Create splitter
     let splitter = ShardSplitter::new(coord.clone());
 
-    // First split at "m"
+    // First split at midpoint
+    let shard_map = coord.get_shard_map().await.unwrap();
+    let split_point1 = shard_map
+        .get_shard(&shard_id)
+        .unwrap()
+        .range
+        .midpoint()
+        .unwrap();
+
     let split1 = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, split_point1)
         .await
         .expect("first request_split");
     splitter
@@ -1632,10 +1640,16 @@ async fn etcd_sequential_splits_work_correctly() {
     let shard_map = coord.get_shard_map().await.unwrap();
     assert_eq!(shard_map.len(), 2);
 
-    // Second split: split left child at "g"
+    // Second split: split left child at its midpoint
     let left_child_id = split1.left_child_id;
+    let split_point2 = shard_map
+        .get_shard(&left_child_id)
+        .unwrap()
+        .range
+        .midpoint()
+        .unwrap();
     let split2 = splitter
-        .request_split(left_child_id, "g".to_string())
+        .request_split(left_child_id, split_point2)
         .await
         .expect("second request_split");
     splitter
@@ -1646,14 +1660,20 @@ async fn etcd_sequential_splits_work_correctly() {
     let shard_map = coord.get_shard_map().await.unwrap();
     assert_eq!(shard_map.len(), 3);
 
-    // Verify tenant routing
-    let tenant_a = shard_map.shard_for_tenant("a").unwrap();
-    let tenant_h = shard_map.shard_for_tenant("h").unwrap();
-    let tenant_z = shard_map.shard_for_tenant("z").unwrap();
-
-    assert_eq!(tenant_a.id, split2.left_child_id);
-    assert_eq!(tenant_h.id, split2.right_child_id);
-    assert_eq!(tenant_z.id, split1.right_child_id);
+    // Verify tenant routing — all tenants route to one of the three shards
+    let valid_ids = [
+        split2.left_child_id,
+        split2.right_child_id,
+        split1.right_child_id,
+    ];
+    for tenant in ["a", "h", "z", "env-123"] {
+        let routed = shard_map.shard_for_tenant(tenant).unwrap();
+        assert!(
+            valid_ids.contains(&routed.id),
+            "tenant '{}' should route to one of the three shards",
+            tenant
+        );
+    }
 
     coord.shutdown().await.unwrap();
     handle.abort();

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -1199,8 +1199,8 @@ async fn etcd_request_split_creates_split_record() {
     assert!(!owned.is_empty(), "should own at least one shard");
     let shard_id = owned[0];
 
-    // Use a simple split point - with 1 shard the range is unbounded so "m" is valid
-    let split_point = "m".to_string();
+    // Use hash-space midpoint as split point
+    let split_point = "8000000000000000".to_string();
 
     // Create splitter
     let splitter = ShardSplitter::new(coord.clone());
@@ -1281,7 +1281,7 @@ async fn etcd_request_split_fails_if_not_owner() {
     // Create splitter for c2 and try to split a shard owned by c1
     let splitter2 = ShardSplitter::new(c2.clone());
 
-    let result = splitter2.request_split(c1_shard, "mmmmm".to_string()).await;
+    let result = splitter2.request_split(c1_shard, "8000000000000000".to_string()).await;
     assert!(
         matches!(result, Err(CoordinationError::NotShardOwner(_))),
         "should fail with NotShardOwner, got: {:?}",
@@ -1315,12 +1315,12 @@ async fn etcd_request_split_fails_if_already_in_progress() {
 
     // First split request should succeed
     let _split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("first request_split should succeed");
 
     // Second split request should fail
-    let result = splitter.request_split(shard_id, "n".to_string()).await;
+    let result = splitter.request_split(shard_id, "4000000000000000".to_string()).await;
     assert!(
         matches!(result, Err(CoordinationError::SplitAlreadyInProgress(_))),
         "should fail with SplitAlreadyInProgress, got: {:?}",
@@ -1360,7 +1360,7 @@ async fn etcd_is_shard_paused_returns_correct_values() {
 
     // Request a split - still not paused in SplitRequested phase
     let _split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split should succeed");
 
@@ -1400,7 +1400,7 @@ async fn etcd_split_state_persists_across_restart() {
     let splitter1 = ShardSplitter::new(c1.clone());
 
     let split = splitter1
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split should succeed");
 
@@ -1442,7 +1442,7 @@ async fn etcd_split_state_persists_across_restart() {
     );
     let status = status.unwrap();
     assert_eq!(status.parent_shard_id, shard_id);
-    assert_eq!(status.split_point, "m");
+    assert_eq!(status.split_point, "8000000000000000");
     assert_eq!(status.left_child_id, split.left_child_id);
     assert_eq!(status.right_child_id, split.right_child_id);
 
@@ -1471,7 +1471,7 @@ async fn etcd_execute_split_completes_full_cycle() {
 
     // Request and execute the split
     let split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split should succeed");
 
@@ -1567,7 +1567,7 @@ async fn etcd_execute_split_resumes_from_partial_state() {
 
     // Request and advance to SplitPausing
     let split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split");
     splitter
@@ -1804,7 +1804,7 @@ async fn etcd_crash_recovery_early_phase_abandons_split() {
     let splitter1 = ShardSplitter::new(c1.clone());
 
     let _split = splitter1
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split");
     splitter1
@@ -1890,7 +1890,7 @@ async fn etcd_crash_recovery_cloning_phase_abandons_split() {
     let splitter1 = ShardSplitter::new(c1.clone());
 
     let _split = splitter1
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split");
 
@@ -2007,7 +2007,7 @@ async fn etcd_grpc_request_split_executes_to_completion() {
     let response = client
         .request_split(silo::pb::RequestSplitRequest {
             shard_id: shard_id.to_string(),
-            split_point: "m".to_string(),
+            split_point: "8000000000000000".to_string(),
         })
         .await
         .expect("request_split gRPC call should succeed");

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -1736,10 +1736,12 @@ async fn etcd_split_in_multi_node_cluster() {
     let shard_info = shard_map
         .get_shard(&shard_to_split)
         .expect("find shard in map");
-    let split_point = shard_info
-        .range
-        .midpoint()
-        .expect("shard range should have a midpoint");
+    let split_point = silo::shard_range::format_hash_boundary(
+        shard_info
+            .range
+            .midpoint()
+            .expect("shard range should have a midpoint"),
+    );
 
     // Create splitter and split the shard
     let splitter = ShardSplitter::new(splitter_coord.clone());

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -1619,14 +1619,10 @@ async fn etcd_sequential_splits_work_correctly() {
     // Create splitter
     let splitter = ShardSplitter::new(coord.clone());
 
-    // First split at midpoint
+    // First split: midpoint minus an offset (not exactly at the midpoint)
     let shard_map = coord.get_shard_map().await.unwrap();
-    let split_point1 = shard_map
-        .get_shard(&shard_id)
-        .unwrap()
-        .range
-        .midpoint()
-        .unwrap();
+    let mid1: u64 = u64::MAX / 2;
+    let split_point1 = format!("{:016x}", mid1 - 0x0100000000000000);
 
     let split1 = splitter
         .request_split(shard_id, split_point1)
@@ -1640,14 +1636,11 @@ async fn etcd_sequential_splits_work_correctly() {
     let shard_map = coord.get_shard_map().await.unwrap();
     assert_eq!(shard_map.len(), 2);
 
-    // Second split: split left child at its midpoint
+    // Second split: split left child at midpoint plus an offset
     let left_child_id = split1.left_child_id;
-    let split_point2 = shard_map
-        .get_shard(&left_child_id)
-        .unwrap()
-        .range
-        .midpoint()
-        .unwrap();
+    let left_range = &shard_map.get_shard(&left_child_id).unwrap().range;
+    let left_end = u64::from_str_radix(&left_range.end, 16).unwrap();
+    let split_point2 = format!("{:016x}", left_end / 2 + 0x0080000000000000);
     let split2 = splitter
         .request_split(left_child_id, split_point2)
         .await

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -2619,8 +2619,8 @@ async fn k8s_request_split_creates_split_record() {
     assert!(!owned.is_empty(), "should own at least one shard");
     let shard_id = owned[0];
 
-    // Use a simple split point - with 1 shard the range is unbounded so "m" is valid
-    let split_point = "m".to_string();
+    // Use hash-space midpoint as split point
+    let split_point = "8000000000000000".to_string();
 
     // Create splitter
 
@@ -2726,7 +2726,7 @@ async fn k8s_request_split_fails_if_not_owner() {
     };
 
     let result = non_owner_splitter
-        .request_split(target_shard, "mmmmm".to_string())
+        .request_split(target_shard, "8000000000000000".to_string())
         .await;
     assert!(
         matches!(result, Err(CoordinationError::NotShardOwner(_))),
@@ -2768,12 +2768,12 @@ async fn k8s_request_split_fails_if_already_in_progress() {
 
     // First split request should succeed
     let _split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("first request_split should succeed");
 
     // Second split request should fail
-    let result = splitter.request_split(shard_id, "n".to_string()).await;
+    let result = splitter.request_split(shard_id, "4000000000000000".to_string()).await;
     assert!(
         matches!(result, Err(CoordinationError::SplitAlreadyInProgress(_))),
         "should fail with SplitAlreadyInProgress, got: {:?}",
@@ -2869,7 +2869,7 @@ async fn k8s_is_shard_paused_returns_correct_values() {
 
     // Request a split - still not paused in SplitRequested phase
     let _split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split should succeed");
 
@@ -2912,7 +2912,7 @@ async fn k8s_split_state_persists_across_restart() {
     let splitter1 = ShardSplitter::new(c1.clone());
 
     let split = splitter1
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split should succeed");
 
@@ -2955,7 +2955,7 @@ async fn k8s_split_state_persists_across_restart() {
     );
     let status = status.unwrap();
     assert_eq!(status.parent_shard_id, shard_id);
-    assert_eq!(status.split_point, "m");
+    assert_eq!(status.split_point, "8000000000000000");
     assert_eq!(status.left_child_id, split.left_child_id);
     assert_eq!(status.right_child_id, split.right_child_id);
 
@@ -3028,7 +3028,7 @@ async fn k8s_execute_split_completes_full_cycle() {
 
     // Request and execute the split
     let split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split should succeed");
 
@@ -3101,7 +3101,7 @@ async fn k8s_shard_paused_during_split_execution() {
 
     // Request split but don't execute
     let _split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split");
 
@@ -3198,7 +3198,7 @@ async fn k8s_execute_split_resumes_from_partial_state() {
 
     // Request and advance to SplitPausing
     let split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split");
     splitter
@@ -3435,7 +3435,7 @@ async fn k8s_crash_recovery_early_phase_abandons_split() {
     let splitter1 = ShardSplitter::new(c1.clone());
 
     let _split = splitter1
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split");
     splitter1
@@ -3552,7 +3552,7 @@ async fn k8s_child_shards_acquired_via_watch_after_split() {
     // Perform the split
     let splitter = ShardSplitter::new(splitter_coord.clone());
     let split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split");
     splitter
@@ -3663,10 +3663,10 @@ async fn k8s_child_shards_usable_after_split() {
         "job should exist in parent before split"
     );
 
-    // Perform the split at "m"
+    // Perform the split at hash-space midpoint
     let splitter = ShardSplitter::new(coord.clone());
     let split = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split");
 
@@ -3683,36 +3683,40 @@ async fn k8s_child_shards_usable_after_split() {
     assert!(right_shard.is_some(), "right child shard should be open");
 
     let _left_shard = left_shard.unwrap();
-    let right_shard = right_shard.unwrap();
+    let _right_shard = right_shard.unwrap();
 
     // Verify the ranges are correct
     let shard_map = coord.get_shard_map().await.unwrap();
     let left_info = shard_map.get_shard(&split.left_child_id).unwrap();
     let right_info = shard_map.get_shard(&split.right_child_id).unwrap();
 
-    // Left child should have range up to "m"
+    // Left child should have range up to the split point
     assert!(
-        left_info.range.end == "m",
+        left_info.range.end == "8000000000000000",
         "left child should have end bound at split point"
     );
 
-    // Right child should have range starting at "m"
+    // Right child should have range starting at the split point
     assert!(
-        right_info.range.start == "m",
+        right_info.range.start == "8000000000000000",
         "right child should have start bound at split point"
     );
 
-    // Verify jobs are accessible in one of the child shards
-    // (depends on which range the tenant falls into)
-    // Since tenant "test-tenant" > "m", it should be in the right child
-    let right_job_status = right_shard.get_job_status(tenant, "job-0").await;
+    // Verify jobs are accessible in the correct child shard based on tenant hash
+    let routed = shard_map.shard_for_tenant(tenant).unwrap();
+    let target_shard = if routed.id == split.left_child_id {
+        factory.get(&split.left_child_id).unwrap()
+    } else {
+        factory.get(&split.right_child_id).unwrap()
+    };
+    let job_status = target_shard.get_job_status(tenant, "job-0").await;
     assert!(
-        right_job_status.is_ok() && right_job_status.unwrap().is_some(),
+        job_status.is_ok() && job_status.unwrap().is_some(),
         "jobs should be accessible in the correct child shard after split"
     );
 
     // Verify dequeue works on child shards (tests TaskBroker is functional)
-    let dequeue_result = right_shard.dequeue("test-worker", "default", 10).await;
+    let dequeue_result = target_shard.dequeue("test-worker", "default", 10).await;
     assert!(dequeue_result.is_ok(), "dequeue should work on child shard");
 
     coord.shutdown().await.unwrap();
@@ -3750,7 +3754,7 @@ async fn k8s_crash_recovery_cloning_phase_abandons_split() {
     let splitter1 = ShardSplitter::new(c1.clone());
 
     let _split = splitter1
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split");
 

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -3376,10 +3376,12 @@ async fn k8s_split_in_multi_node_cluster() {
     let shard_info = shard_map
         .get_shard(&shard_to_split)
         .expect("find shard in map");
-    let split_point = shard_info
-        .range
-        .midpoint()
-        .expect("shard range should have a midpoint");
+    let split_point = silo::shard_range::format_hash_boundary(
+        shard_info
+            .range
+            .midpoint()
+            .expect("shard range should have a midpoint"),
+    );
 
     // Create splitter for the coordinator that owns the shard and split it
     let splitter = ShardSplitter::new(splitter_coord.clone());

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -2773,7 +2773,9 @@ async fn k8s_request_split_fails_if_already_in_progress() {
         .expect("first request_split should succeed");
 
     // Second split request should fail
-    let result = splitter.request_split(shard_id, "4000000000000000".to_string()).await;
+    let result = splitter
+        .request_split(shard_id, "4000000000000000".to_string())
+        .await;
     assert!(
         matches!(result, Err(CoordinationError::SplitAlreadyInProgress(_))),
         "should fail with SplitAlreadyInProgress, got: {:?}",

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -4815,7 +4815,9 @@ async fn k8s_crash_restart_reclaims_and_opens_shards() {
 async fn k8s_hash_ring_divergence_on_restart() {
     let prefix = unique_prefix();
     let namespace = get_namespace();
-    let num_shards: u32 = 8;
+    // Use 32 shards to ensure both nodes get some via rendezvous hashing.
+    // With 8 shards the probability of all going to one node is (0.5)^8 ≈ 0.4%.
+    let num_shards: u32 = 32;
 
     // Start A and B, let them partition shards
     let (ca, ha) = start_coordinator!(

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -3257,9 +3257,17 @@ async fn k8s_sequential_splits_work_correctly() {
 
     let splitter = ShardSplitter::new(coord.clone());
 
-    // First split at "m"
+    // First split at midpoint
+    let shard_map = coord.get_shard_map().await.unwrap();
+    let split_point1 = shard_map
+        .get_shard(&shard_id)
+        .unwrap()
+        .range
+        .midpoint()
+        .unwrap();
+
     let split1 = splitter
-        .request_split(shard_id, "m".to_string())
+        .request_split(shard_id, split_point1)
         .await
         .expect("first request_split");
     splitter
@@ -3270,10 +3278,16 @@ async fn k8s_sequential_splits_work_correctly() {
     let shard_map = coord.get_shard_map().await.unwrap();
     assert_eq!(shard_map.len(), 2);
 
-    // Second split: split left child at "g"
+    // Second split: split left child at its midpoint
     let left_child_id = split1.left_child_id;
+    let split_point2 = shard_map
+        .get_shard(&left_child_id)
+        .unwrap()
+        .range
+        .midpoint()
+        .unwrap();
     let split2 = splitter
-        .request_split(left_child_id, "g".to_string())
+        .request_split(left_child_id, split_point2)
         .await
         .expect("second request_split");
     splitter
@@ -3284,14 +3298,20 @@ async fn k8s_sequential_splits_work_correctly() {
     let shard_map = coord.get_shard_map().await.unwrap();
     assert_eq!(shard_map.len(), 3);
 
-    // Verify tenant routing
-    let tenant_a = shard_map.shard_for_tenant("a").unwrap();
-    let tenant_h = shard_map.shard_for_tenant("h").unwrap();
-    let tenant_z = shard_map.shard_for_tenant("z").unwrap();
-
-    assert_eq!(tenant_a.id, split2.left_child_id);
-    assert_eq!(tenant_h.id, split2.right_child_id);
-    assert_eq!(tenant_z.id, split1.right_child_id);
+    // Verify tenant routing — all tenants route to one of the three shards
+    let valid_ids = [
+        split2.left_child_id,
+        split2.right_child_id,
+        split1.right_child_id,
+    ];
+    for tenant in ["a", "h", "z", "env-123"] {
+        let routed = shard_map.shard_for_tenant(tenant).unwrap();
+        assert!(
+            valid_ids.contains(&routed.id),
+            "tenant '{}' should route to one of the three shards",
+            tenant
+        );
+    }
 
     coord.shutdown().await.unwrap();
     handle.abort();

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -3257,14 +3257,10 @@ async fn k8s_sequential_splits_work_correctly() {
 
     let splitter = ShardSplitter::new(coord.clone());
 
-    // First split at midpoint
+    // First split: midpoint minus an offset (not exactly at the midpoint)
     let shard_map = coord.get_shard_map().await.unwrap();
-    let split_point1 = shard_map
-        .get_shard(&shard_id)
-        .unwrap()
-        .range
-        .midpoint()
-        .unwrap();
+    let mid1: u64 = u64::MAX / 2;
+    let split_point1 = format!("{:016x}", mid1 - 0x0100000000000000);
 
     let split1 = splitter
         .request_split(shard_id, split_point1)
@@ -3278,14 +3274,11 @@ async fn k8s_sequential_splits_work_correctly() {
     let shard_map = coord.get_shard_map().await.unwrap();
     assert_eq!(shard_map.len(), 2);
 
-    // Second split: split left child at its midpoint
+    // Second split: split left child at midpoint plus an offset
     let left_child_id = split1.left_child_id;
-    let split_point2 = shard_map
-        .get_shard(&left_child_id)
-        .unwrap()
-        .range
-        .midpoint()
-        .unwrap();
+    let left_range = &shard_map.get_shard(&left_child_id).unwrap().range;
+    let left_end = u64::from_str_radix(&left_range.end, 16).unwrap();
+    let split_point2 = format!("{:016x}", left_end / 2 + 0x0080000000000000);
     let split2 = splitter
         .request_split(left_child_id, split_point2)
         .await

--- a/tests/shard_cleanup_tests.rs
+++ b/tests/shard_cleanup_tests.rs
@@ -81,8 +81,14 @@ async fn cleanup_removes_keys_outside_range() {
     let yyy_jobs = count_job_info_keys_for_tenant(shard.db(), "yyy").await;
 
     assert_eq!(bbb_jobs, 2, "bbb jobs should remain (hash in range)");
-    assert_eq!(aaa_jobs, 0, "aaa jobs should be deleted (hash out of range)");
-    assert_eq!(yyy_jobs, 0, "yyy jobs should be deleted (hash out of range)");
+    assert_eq!(
+        aaa_jobs, 0,
+        "aaa jobs should be deleted (hash out of range)"
+    );
+    assert_eq!(
+        yyy_jobs, 0,
+        "yyy jobs should be deleted (hash out of range)"
+    );
 }
 
 #[silo::test]
@@ -152,8 +158,14 @@ async fn cleanup_handles_right_child_range() {
     let aaa_jobs = count_job_info_keys_for_tenant(shard.db(), "aaa").await;
     let ccc_jobs = count_job_info_keys_for_tenant(shard.db(), "ccc").await;
 
-    assert_eq!(bbb_jobs, 0, "bbb jobs should be deleted (hash out of range)");
-    assert_eq!(zzz_jobs, 0, "zzz jobs should be deleted (hash out of range)");
+    assert_eq!(
+        bbb_jobs, 0,
+        "bbb jobs should be deleted (hash out of range)"
+    );
+    assert_eq!(
+        zzz_jobs, 0,
+        "zzz jobs should be deleted (hash out of range)"
+    );
     assert_eq!(aaa_jobs, 2, "aaa jobs should remain (hash in range)");
     assert_eq!(ccc_jobs, 2, "ccc jobs should remain (hash in range)");
 }

--- a/tests/shard_cleanup_tests.rs
+++ b/tests/shard_cleanup_tests.rs
@@ -6,6 +6,9 @@ use test_helpers::{
 
 use silo::shard_range::ShardRange;
 
+/// Boundary at the midpoint of the u64 hash space, encoded as a 16-char hex string.
+const RANGE_BOUNDARY: &str = "8000000000000000";
+
 /// Helper to enqueue jobs for multiple tenants
 async fn enqueue_jobs_for_tenants(
     shard: &silo::job_store_shard::JobStoreShard,
@@ -37,18 +40,18 @@ async fn enqueue_jobs_for_tenants(
 async fn cleanup_removes_keys_outside_range() {
     let (_tmp, shard) = open_temp_shard().await;
 
-    // Enqueue jobs for tenants a, m, and z
-    // After split at "m", left shard gets [, m) and right shard gets [m, )
-    enqueue_jobs_for_tenants(&shard, &["aaa", "bbb", "lll", "mmm", "nnn", "zzz"], 2).await;
+    // Enqueue jobs for 6 tenants: 3 whose hashes fall in [, 8000) and 3 outside.
+    // IN  range: bbb(3a4f), mmm(0489), nnn(02ff)
+    // OUT range: aaa(ae01), lll(d389), yyy(ed58)
+    enqueue_jobs_for_tenants(&shard, &["aaa", "bbb", "lll", "mmm", "nnn", "yyy"], 2).await;
     shard.db().flush().await.unwrap();
 
     // Verify jobs exist for all tenants before cleanup
     let count_before = count_job_info_keys(shard.db()).await;
     assert_eq!(count_before, 12); // 6 tenants * 2 jobs
 
-    // Simulate this shard becoming the LEFT child after a split at "m"
-    // Left child should have range [, m) - keeps tenants < "m"
-    let left_range = ShardRange::new("", "mmm"); // Exclusive end
+    // Simulate this shard becoming the LEFT child after a split at the hash midpoint
+    let left_range = ShardRange::new("", RANGE_BOUNDARY);
 
     // Run cleanup to remove keys outside range
     let result = shard
@@ -64,8 +67,8 @@ async fn cleanup_removes_keys_outside_range() {
     shard.db().flush().await.unwrap();
 
     // Verify only left-range tenants remain
-    // aaa, bbb, lll should remain (3 tenants * 2 jobs = 6)
-    // mmm, nnn, zzz should be deleted
+    // bbb, mmm, nnn should remain (3 tenants * 2 jobs = 6)
+    // aaa, lll, yyy should be deleted
     let count_after = count_job_info_keys(shard.db()).await;
     assert_eq!(
         count_after, 6,
@@ -73,20 +76,21 @@ async fn cleanup_removes_keys_outside_range() {
     );
 
     // Verify specific tenants
+    let bbb_jobs = count_job_info_keys_for_tenant(shard.db(), "bbb").await;
     let aaa_jobs = count_job_info_keys_for_tenant(shard.db(), "aaa").await;
-    let mmm_jobs = count_job_info_keys_for_tenant(shard.db(), "mmm").await;
-    let zzz_jobs = count_job_info_keys_for_tenant(shard.db(), "zzz").await;
+    let yyy_jobs = count_job_info_keys_for_tenant(shard.db(), "yyy").await;
 
-    assert_eq!(aaa_jobs, 2, "aaa jobs should remain");
-    assert_eq!(mmm_jobs, 0, "mmm jobs should be deleted");
-    assert_eq!(zzz_jobs, 0, "zzz jobs should be deleted");
+    assert_eq!(bbb_jobs, 2, "bbb jobs should remain (hash in range)");
+    assert_eq!(aaa_jobs, 0, "aaa jobs should be deleted (hash out of range)");
+    assert_eq!(yyy_jobs, 0, "yyy jobs should be deleted (hash out of range)");
 }
 
 #[silo::test]
 async fn cleanup_removes_status_and_index_keys() {
     let (_tmp, shard) = open_temp_shard().await;
 
-    // Enqueue jobs for tenants on both sides of a split point
+    // Enqueue jobs for tenants on both sides of the hash boundary
+    // zzz(6d85) is IN range [, 8000), aaa(ae01) is OUT
     enqueue_jobs_for_tenants(&shard, &["aaa", "zzz"], 3).await;
     shard.db().flush().await.unwrap();
 
@@ -98,8 +102,8 @@ async fn cleanup_removes_status_and_index_keys() {
     let idx_before = count_status_time_index_keys(shard.db()).await;
     assert_eq!(idx_before, 6);
 
-    // Run cleanup for LEFT child range (tenants < "mmm")
-    let left_range = ShardRange::new("", "mmm");
+    // Run cleanup for LEFT child range
+    let left_range = ShardRange::new("", RANGE_BOUNDARY);
     let result = shard
         .after_split_cleanup_defunct_data(&left_range, 10)
         .await
@@ -108,26 +112,28 @@ async fn cleanup_removes_status_and_index_keys() {
     assert!(result.complete);
     shard.db().flush().await.unwrap();
 
-    // Verify only aaa tenant keys remain
+    // Verify only zzz tenant keys remain (hash 6d85 is in range)
     let status_after = count_job_status_keys(shard.db()).await;
-    assert_eq!(status_after, 3, "only aaa status records should remain");
+    assert_eq!(status_after, 3, "only zzz status records should remain");
 
     // Note: we can't easily filter status index by tenant with binary keys without
     // adding more helper functions, so just verify total count decreased
     let idx_after = count_status_time_index_keys(shard.db()).await;
-    assert_eq!(idx_after, 3, "only aaa index records should remain");
+    assert_eq!(idx_after, 3, "only zzz index records should remain");
 }
 
 #[silo::test]
 async fn cleanup_handles_right_child_range() {
     let (_tmp, shard) = open_temp_shard().await;
 
-    // Enqueue jobs for tenants on both sides of a split point
-    enqueue_jobs_for_tenants(&shard, &["aaa", "bbb", "mmm", "nnn", "zzz"], 2).await;
+    // Enqueue jobs for tenants on both sides of the hash boundary
+    // IN  right range [8000, ""): aaa(ae01), ccc(8ed4), yyy(ed58)
+    // OUT right range (hash < 8000): bbb(3a4f), zzz(6d85)
+    enqueue_jobs_for_tenants(&shard, &["aaa", "bbb", "ccc", "yyy", "zzz"], 2).await;
     shard.db().flush().await.unwrap();
 
-    // Run cleanup for RIGHT child range (tenants >= "mmm")
-    let right_range = ShardRange::new("mmm", ""); // Unbounded end
+    // Run cleanup for RIGHT child range
+    let right_range = ShardRange::new(RANGE_BOUNDARY, "");
     let result = shard
         .after_split_cleanup_defunct_data(&right_range, 10)
         .await
@@ -136,20 +142,20 @@ async fn cleanup_handles_right_child_range() {
     assert!(result.complete);
     shard.db().flush().await.unwrap();
 
-    // Verify only right-range tenants remain (mmm, nnn, zzz)
+    // Verify only right-range tenants remain (aaa, ccc, yyy)
     let count_after = count_job_info_keys(shard.db()).await;
     assert_eq!(count_after, 6, "should have 6 job records (3 tenants * 2)");
 
     // Verify specific tenants
-    let aaa_jobs = count_job_info_keys_for_tenant(shard.db(), "aaa").await;
     let bbb_jobs = count_job_info_keys_for_tenant(shard.db(), "bbb").await;
-    let mmm_jobs = count_job_info_keys_for_tenant(shard.db(), "mmm").await;
     let zzz_jobs = count_job_info_keys_for_tenant(shard.db(), "zzz").await;
+    let aaa_jobs = count_job_info_keys_for_tenant(shard.db(), "aaa").await;
+    let ccc_jobs = count_job_info_keys_for_tenant(shard.db(), "ccc").await;
 
-    assert_eq!(aaa_jobs, 0, "aaa jobs should be deleted");
-    assert_eq!(bbb_jobs, 0, "bbb jobs should be deleted");
-    assert_eq!(mmm_jobs, 2, "mmm jobs should remain");
-    assert_eq!(zzz_jobs, 2, "zzz jobs should remain");
+    assert_eq!(bbb_jobs, 0, "bbb jobs should be deleted (hash out of range)");
+    assert_eq!(zzz_jobs, 0, "zzz jobs should be deleted (hash out of range)");
+    assert_eq!(aaa_jobs, 2, "aaa jobs should remain (hash in range)");
+    assert_eq!(ccc_jobs, 2, "ccc jobs should remain (hash in range)");
 }
 
 #[silo::test]
@@ -159,7 +165,7 @@ async fn cleanup_is_idempotent() {
     enqueue_jobs_for_tenants(&shard, &["aaa", "zzz"], 3).await;
     shard.db().flush().await.unwrap();
 
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     // First cleanup
     let result1 = shard
@@ -197,7 +203,7 @@ async fn cleanup_progress_tracks_work() {
     enqueue_jobs_for_tenants(&shard, &["aaa", "bbb", "mmm", "nnn"], 5).await;
     shard.db().flush().await.unwrap();
 
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     // Before cleanup, no pending work
     let pending_before = shard
@@ -230,7 +236,7 @@ async fn full_compaction_clears_cleanup_progress() {
     enqueue_jobs_for_tenants(&shard, &["aaa", "zzz"], 2).await;
     shard.db().flush().await.unwrap();
 
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     // Run cleanup
     let result = shard
@@ -268,7 +274,7 @@ async fn full_compaction_clears_cleanup_progress() {
 async fn cleanup_empty_shard_succeeds() {
     let (_tmp, shard) = open_temp_shard().await;
 
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     let result = shard
         .after_split_cleanup_defunct_data(&range, 10)
@@ -339,9 +345,9 @@ async fn cleanup_handles_escaped_tenant_ids() {
     }
     shard.db().flush().await.unwrap();
 
-    // Use a range that should include "normal-tenant" but exclude the others
-    // The escaped versions sort differently than unescaped
-    let range = ShardRange::new("normal", "normz");
+    // Use a hash-space range that includes normal-tenant(7ab0) but excludes
+    // tenant/with/slashes(0fdd) and tenant%with%percent(dfa4)
+    let range = ShardRange::new("7000000000000000", "8000000000000000");
 
     let result = shard
         .after_split_cleanup_defunct_data(&range, 10)
@@ -433,7 +439,7 @@ async fn cleanup_sets_status_to_running_then_done() {
         .await
         .expect("set cleanup pending");
 
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     // Run cleanup (this should set status to CleanupRunning, then CleanupDone)
     let result = shard
@@ -513,7 +519,7 @@ async fn reopening_shard_after_cleanup_preserves_status() {
             .expect("set cleanup pending");
 
         // Run cleanup
-        let range = ShardRange::new("", "mmm");
+        let range = ShardRange::new("", RANGE_BOUNDARY);
         let result = shard
             .after_split_cleanup_defunct_data(&range, 10)
             .await
@@ -706,7 +712,7 @@ async fn cleanup_completed_at_only_set_on_actual_completion() {
     );
 
     // Run cleanup
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
     shard
         .after_split_cleanup_defunct_data(&range, 10)
         .await

--- a/tests/shard_split_tests.rs
+++ b/tests/shard_split_tests.rs
@@ -163,7 +163,8 @@ fn shard_range_split_children_contain_correct_tenants() {
 
 #[test]
 fn shard_range_midpoint_basic() {
-    let range = ShardRange::new("a", "z");
+    // Use hex-encoded hash-space boundaries
+    let range = ShardRange::new("2000000000000000", "a000000000000000");
     let midpoint = range.midpoint();
 
     // Midpoint should exist
@@ -174,8 +175,9 @@ fn shard_range_midpoint_basic() {
     assert!(range.contains(&mid));
 
     // Midpoint should be strictly between start and end
-    assert!(mid.as_str() > "a");
-    assert!(mid.as_str() < "z");
+    assert!(mid.as_str() > "2000000000000000");
+    assert!(mid.as_str() < "a000000000000000");
+    assert_eq!(mid, "6000000000000000");
 }
 
 #[test]
@@ -190,7 +192,7 @@ fn shard_range_midpoint_full_range() {
 
 #[test]
 fn shard_range_midpoint_can_be_used_for_split() {
-    let range = ShardRange::new("abc", "xyz");
+    let range = ShardRange::new("1000000000000000", "f000000000000000");
     if let Some(mid) = range.midpoint() {
         let result = range.split(&mid);
         assert!(result.is_ok(), "midpoint should be valid for splitting");
@@ -219,12 +221,12 @@ fn shard_range_midpoint_all_32_shard_ranges() {
 }
 
 #[test]
-fn shard_range_midpoint_prefix_with_low_boundary() {
-    // Regression: ["0", "08") failed when midpoint appended 'M' > '8'
-    let range = ShardRange::new("0", "08");
+fn shard_range_midpoint_small_range() {
+    let range = ShardRange::new("0000000000000000", "0800000000000000");
     let mid = range.midpoint().expect("should have a midpoint");
-    assert!(mid.as_str() > "0");
-    assert!(mid.as_str() < "08");
+    assert!(mid.as_str() > "0000000000000000");
+    assert!(mid.as_str() < "0800000000000000");
+    assert_eq!(mid, "0400000000000000");
 }
 
 #[test]
@@ -248,11 +250,19 @@ fn shard_map_split_shard_basic() {
     let original_shard_id = map.shards()[0].id;
     let original_version = map.version;
 
+    // Use the midpoint of the full hash-space range as split point
+    let split_point = map.shards()[0].range.midpoint().unwrap();
+
     let left_child_id = ShardId::new();
     let right_child_id = ShardId::new();
 
     let (left, right) = map
-        .split_shard(&original_shard_id, "m", left_child_id, right_child_id)
+        .split_shard(
+            &original_shard_id,
+            &split_point,
+            left_child_id,
+            right_child_id,
+        )
         .expect("split should succeed");
 
     // Map should now have 2 shards
@@ -270,8 +280,8 @@ fn shard_map_split_shard_basic() {
 
     // Children should have correct ranges
     assert!(left.range.is_start_unbounded());
-    assert_eq!(left.range.end, "m");
-    assert_eq!(right.range.start, "m");
+    assert_eq!(left.range.end, split_point);
+    assert_eq!(right.range.start, split_point);
     assert!(right.range.is_end_unbounded());
 
     // [SILO-COORD-INV-3] Children should be contiguous
@@ -287,13 +297,14 @@ fn shard_map_split_preserves_keyspace_coverage() {
     let mut map = ShardMap::create_initial(1).expect("create initial map");
     let shard_id = map.shards()[0].id;
 
-    map.split_shard(&shard_id, "tenant-500", ShardId::new(), ShardId::new())
+    let split_point = map.shards()[0].range.midpoint().unwrap();
+    map.split_shard(&shard_id, &split_point, ShardId::new(), ShardId::new())
         .expect("split should succeed");
 
     // [SILO-COORD-INV-2] Map should still be valid (full coverage)
     map.validate().expect("map should be valid after split");
 
-    // Should be able to find shards for all tenants
+    // Should be able to find shards for all tenants (hashes distribute across both halves)
     assert!(map.shard_for_tenant("a").is_some());
     assert!(map.shard_for_tenant("tenant-100").is_some());
     assert!(map.shard_for_tenant("tenant-500").is_some());
@@ -303,27 +314,35 @@ fn shard_map_split_preserves_keyspace_coverage() {
 
 #[test]
 fn shard_map_split_tenant_routing() {
+    use silo::shard_range::hash_tenant;
+
     let mut map = ShardMap::create_initial(1).expect("create initial map");
     let shard_id = map.shards()[0].id;
     let left_id = ShardId::new();
     let right_id = ShardId::new();
 
-    map.split_shard(&shard_id, "m", left_id, right_id)
+    let split_point = map.shards()[0].range.midpoint().unwrap();
+    map.split_shard(&shard_id, &split_point, left_id, right_id)
         .expect("split should succeed");
 
-    // Tenants before split point should route to left child
-    let shard_for_a = map.shard_for_tenant("a").unwrap();
-    assert_eq!(shard_for_a.id, left_id);
-
-    let shard_for_l = map.shard_for_tenant("l").unwrap();
-    assert_eq!(shard_for_l.id, left_id);
-
-    // Tenants at or after split point should route to right child
-    let shard_for_m = map.shard_for_tenant("m").unwrap();
-    assert_eq!(shard_for_m.id, right_id);
-
-    let shard_for_z = map.shard_for_tenant("z").unwrap();
-    assert_eq!(shard_for_z.id, right_id);
+    // Every tenant should route to one of the two children based on its hash
+    for tenant in ["a", "m", "z", "env-123", "tenant-456"] {
+        let shard = map.shard_for_tenant(tenant).unwrap();
+        let hashed = hash_tenant(tenant);
+        if hashed.as_str() < split_point.as_str() {
+            assert_eq!(
+                shard.id, left_id,
+                "tenant '{}' (hash {}) should route to left",
+                tenant, hashed
+            );
+        } else {
+            assert_eq!(
+                shard.id, right_id,
+                "tenant '{}' (hash {}) should route to right",
+                tenant, hashed
+            );
+        }
+    }
 }
 
 #[test]
@@ -339,41 +358,46 @@ fn shard_map_split_shard_not_found() {
 fn shard_map_split_invalid_split_point() {
     let mut map = ShardMap::create_initial(2).expect("create initial map with 2 shards");
 
-    // Find a shard that doesn't cover "m"
-    let shard_id = map
-        .shards()
-        .iter()
-        .find(|s| !s.range.contains("m"))
-        .map(|s| s.id);
-    if let Some(id) = shard_id {
-        let result = map.split_shard(&id, "m", ShardId::new(), ShardId::new());
-        assert!(matches!(result, Err(ShardMapError::InvalidSplitPoint(_))));
-    }
+    // Use a hash-space value that falls in the first shard's range as split point
+    // for the second shard — this should fail
+    let first_shard_mid = map.shards()[0].range.midpoint().unwrap();
+    let second_shard_id = map.shards()[1].id;
+
+    let result = map.split_shard(
+        &second_shard_id,
+        &first_shard_mid,
+        ShardId::new(),
+        ShardId::new(),
+    );
+    assert!(matches!(result, Err(ShardMapError::InvalidSplitPoint(_))));
 }
 
 #[test]
 fn shard_map_sequential_splits() {
     let mut map = ShardMap::create_initial(1).expect("create initial map");
 
-    // First split
+    // First split at midpoint of full range
     let shard_id = map.shards()[0].id;
+    let split1 = map.shards()[0].range.midpoint().unwrap();
     let left1 = ShardId::new();
     let right1 = ShardId::new();
-    map.split_shard(&shard_id, "m", left1, right1)
+    map.split_shard(&shard_id, &split1, left1, right1)
         .expect("first split should succeed");
     assert_eq!(map.len(), 2);
 
-    // Second split on left child
+    // Second split on left child at its midpoint
+    let split2 = map.get_shard(&left1).unwrap().range.midpoint().unwrap();
     let left2 = ShardId::new();
     let right2 = ShardId::new();
-    map.split_shard(&left1, "g", left2, right2)
+    map.split_shard(&left1, &split2, left2, right2)
         .expect("second split should succeed");
     assert_eq!(map.len(), 3);
 
-    // Third split on right child of first split
+    // Third split on right child of first split at its midpoint
+    let split3 = map.get_shard(&right1).unwrap().range.midpoint().unwrap();
     let left3 = ShardId::new();
     let right3 = ShardId::new();
-    map.split_shard(&right1, "t", left3, right3)
+    map.split_shard(&right1, &split3, left3, right3)
         .expect("third split should succeed");
     assert_eq!(map.len(), 4);
 
@@ -381,11 +405,14 @@ fn shard_map_sequential_splits() {
     map.validate()
         .expect("map should be valid after multiple splits");
 
-    // All tenants should route correctly
-    assert_eq!(map.shard_for_tenant("a").unwrap().id, left2);
-    assert_eq!(map.shard_for_tenant("h").unwrap().id, right2);
-    assert_eq!(map.shard_for_tenant("n").unwrap().id, left3);
-    assert_eq!(map.shard_for_tenant("z").unwrap().id, right3);
+    // All tenants should still route to some shard
+    for tenant in ["a", "h", "n", "z", "env-123", "tenant-999"] {
+        assert!(
+            map.shard_for_tenant(tenant).is_some(),
+            "tenant '{}' should map to a shard",
+            tenant
+        );
+    }
 }
 
 #[test]

--- a/tests/shard_split_tests.rs
+++ b/tests/shard_split_tests.rs
@@ -1,5 +1,7 @@
 use silo::coordination::{SplitCleanupStatus, SplitPhase};
-use silo::shard_range::{ShardId, ShardInfo, ShardMap, ShardMapError, ShardRange, SplitInProgress};
+use silo::shard_range::{
+    ShardId, ShardInfo, ShardMap, ShardMapError, ShardRange, SplitInProgress, format_hash_boundary,
+};
 
 #[test]
 fn cleanup_status_default_is_compaction_done() {
@@ -170,14 +172,15 @@ fn shard_range_midpoint_basic() {
     // Midpoint should exist
     assert!(midpoint.is_some());
     let mid = midpoint.unwrap();
+    let mid_hex = format_hash_boundary(mid);
 
     // Midpoint should be within range
-    assert!(range.contains(&mid));
+    assert!(range.contains(&mid_hex));
 
     // Midpoint should be strictly between start and end
-    assert!(mid.as_str() > "2000000000000000");
-    assert!(mid.as_str() < "a000000000000000");
-    assert_eq!(mid, "6000000000000000");
+    assert!(mid > 0x2000000000000000);
+    assert!(mid < 0xa000000000000000);
+    assert_eq!(mid, 0x6000000000000000);
 }
 
 #[test]
@@ -186,15 +189,16 @@ fn shard_range_midpoint_full_range() {
     let midpoint = range.midpoint();
 
     assert!(midpoint.is_some());
-    let mid = midpoint.unwrap();
-    assert!(range.contains(&mid));
+    let mid_hex = format_hash_boundary(midpoint.unwrap());
+    assert!(range.contains(&mid_hex));
 }
 
 #[test]
 fn shard_range_midpoint_can_be_used_for_split() {
     let range = ShardRange::new("1000000000000000", "f000000000000000");
     if let Some(mid) = range.midpoint() {
-        let result = range.split(&mid);
+        let mid_hex = format_hash_boundary(mid);
+        let result = range.split(&mid_hex);
         assert!(result.is_ok(), "midpoint should be valid for splitting");
 
         let (left, right) = result.unwrap();
@@ -211,10 +215,11 @@ fn shard_range_midpoint_all_32_shard_ranges() {
             .range
             .midpoint()
             .unwrap_or_else(|| panic!("range {} should have a midpoint", shard_info.range));
+        let mid_hex = format_hash_boundary(mid);
         assert!(
-            shard_info.range.contains(&mid),
-            "midpoint {:?} should be within range {}",
-            mid,
+            shard_info.range.contains(&mid_hex),
+            "midpoint {} should be within range {}",
+            mid_hex,
             shard_info.range
         );
     }
@@ -224,9 +229,9 @@ fn shard_range_midpoint_all_32_shard_ranges() {
 fn shard_range_midpoint_small_range() {
     let range = ShardRange::new("0000000000000000", "0800000000000000");
     let mid = range.midpoint().expect("should have a midpoint");
-    assert!(mid.as_str() > "0000000000000000");
-    assert!(mid.as_str() < "0800000000000000");
-    assert_eq!(mid, "0400000000000000");
+    assert!(mid > 0x0000000000000000);
+    assert!(mid < 0x0800000000000000);
+    assert_eq!(mid, 0x0400000000000000);
 }
 
 #[test]
@@ -251,7 +256,7 @@ fn shard_map_split_shard_basic() {
     let original_version = map.version;
 
     // Use the midpoint of the full hash-space range as split point
-    let split_point = map.shards()[0].range.midpoint().unwrap();
+    let split_point = format_hash_boundary(map.shards()[0].range.midpoint().unwrap());
 
     let left_child_id = ShardId::new();
     let right_child_id = ShardId::new();
@@ -297,7 +302,7 @@ fn shard_map_split_preserves_keyspace_coverage() {
     let mut map = ShardMap::create_initial(1).expect("create initial map");
     let shard_id = map.shards()[0].id;
 
-    let split_point = map.shards()[0].range.midpoint().unwrap();
+    let split_point = format_hash_boundary(map.shards()[0].range.midpoint().unwrap());
     map.split_shard(&shard_id, &split_point, ShardId::new(), ShardId::new())
         .expect("split should succeed");
 
@@ -321,7 +326,7 @@ fn shard_map_split_tenant_routing() {
     let left_id = ShardId::new();
     let right_id = ShardId::new();
 
-    let split_point = map.shards()[0].range.midpoint().unwrap();
+    let split_point = format_hash_boundary(map.shards()[0].range.midpoint().unwrap());
     map.split_shard(&shard_id, &split_point, left_id, right_id)
         .expect("split should succeed");
 
@@ -360,7 +365,7 @@ fn shard_map_split_invalid_split_point() {
 
     // Use a hash-space value that falls in the first shard's range as split point
     // for the second shard — this should fail
-    let first_shard_mid = map.shards()[0].range.midpoint().unwrap();
+    let first_shard_mid = format_hash_boundary(map.shards()[0].range.midpoint().unwrap());
     let second_shard_id = map.shards()[1].id;
 
     let result = map.split_shard(
@@ -378,7 +383,7 @@ fn shard_map_sequential_splits() {
 
     // First split at midpoint of full range
     let shard_id = map.shards()[0].id;
-    let split1 = map.shards()[0].range.midpoint().unwrap();
+    let split1 = format_hash_boundary(map.shards()[0].range.midpoint().unwrap());
     let left1 = ShardId::new();
     let right1 = ShardId::new();
     map.split_shard(&shard_id, &split1, left1, right1)
@@ -386,7 +391,7 @@ fn shard_map_sequential_splits() {
     assert_eq!(map.len(), 2);
 
     // Second split on left child at its midpoint
-    let split2 = map.get_shard(&left1).unwrap().range.midpoint().unwrap();
+    let split2 = format_hash_boundary(map.get_shard(&left1).unwrap().range.midpoint().unwrap());
     let left2 = ShardId::new();
     let right2 = ShardId::new();
     map.split_shard(&left1, &split2, left2, right2)
@@ -394,7 +399,7 @@ fn shard_map_sequential_splits() {
     assert_eq!(map.len(), 3);
 
     // Third split on right child of first split at its midpoint
-    let split3 = map.get_shard(&right1).unwrap().range.midpoint().unwrap();
+    let split3 = format_hash_boundary(map.get_shard(&right1).unwrap().range.midpoint().unwrap());
     let left3 = ShardId::new();
     let right3 = ShardId::new();
     map.split_shard(&right1, &split3, left3, right3)

--- a/tests/split_aware_processing_tests.rs
+++ b/tests/split_aware_processing_tests.rs
@@ -16,6 +16,9 @@ use test_helpers::{
 
 use silo::shard_range::ShardRange;
 
+/// Boundary at the midpoint of the u64 hash space, encoded as a 16-char hex string.
+const RANGE_BOUNDARY: &str = "8000000000000000";
+
 /// Helper to enqueue jobs for multiple tenants
 async fn enqueue_jobs_for_tenants(
     shard: &silo::job_store_shard::JobStoreShard,
@@ -49,16 +52,18 @@ async fn enqueue_jobs_for_tenants(
 async fn cleanup_removes_tasks_outside_range() {
     let (_tmp, shard) = open_temp_shard().await;
 
-    // Enqueue jobs for tenants across a potential split point
-    enqueue_jobs_for_tenants(&shard, &["aaa", "mmm", "zzz"], 2, "default").await;
+    // Enqueue jobs for tenants across the hash boundary
+    // IN  range [, 8000): bbb(3a4f)
+    // OUT range: aaa(ae01), yyy(ed58)
+    enqueue_jobs_for_tenants(&shard, &["aaa", "bbb", "yyy"], 2, "default").await;
     shard.db().flush().await.unwrap();
 
     // Verify tasks exist for all tenants
     let task_count_before = count_task_keys(shard.db()).await;
     assert_eq!(task_count_before, 6); // 3 tenants * 2 jobs
 
-    // Run cleanup with range that only includes tenants < "mmm"
-    let cleanup_range = ShardRange::new("", "mmm");
+    // Run cleanup with range that only includes tenants whose hash < 8000
+    let cleanup_range = ShardRange::new("", RANGE_BOUNDARY);
     let result = shard
         .after_split_cleanup_defunct_data(&cleanup_range, 100)
         .await
@@ -66,11 +71,11 @@ async fn cleanup_removes_tasks_outside_range() {
 
     shard.db().flush().await.unwrap();
 
-    // Tasks for mmm and zzz should be deleted
+    // Tasks for aaa and yyy should be deleted (hashes out of range)
     let task_count_after = count_task_keys(shard.db()).await;
     assert_eq!(
         task_count_after, 2,
-        "only aaa tasks should remain (2 tasks)"
+        "only bbb tasks should remain (2 tasks)"
     );
     assert!(result.keys_deleted > 0, "should have deleted some keys");
 }
@@ -80,12 +85,13 @@ async fn cleanup_removes_tasks_outside_range() {
 async fn cleanup_preserves_tasks_within_range() {
     let (_tmp, shard) = open_temp_shard().await;
 
-    // Enqueue jobs only for tenants within a specific range
-    enqueue_jobs_for_tenants(&shard, &["abc", "def", "ghi"], 2, "default").await;
+    // Enqueue jobs only for tenants whose hashes are all within [, 8000)
+    // bbb(3a4f), mmm(0489), zzz(6d85) — all IN range
+    enqueue_jobs_for_tenants(&shard, &["bbb", "mmm", "zzz"], 2, "default").await;
     shard.db().flush().await.unwrap();
 
-    // Run cleanup with a range that includes all these tenants
-    let cleanup_range = ShardRange::new("a", "n");
+    // Run cleanup with range that includes all these tenants
+    let cleanup_range = ShardRange::new("", RANGE_BOUNDARY);
     let result = shard
         .after_split_cleanup_defunct_data(&cleanup_range, 100)
         .await
@@ -116,11 +122,11 @@ async fn dequeue_works_with_full_range() {
 /// Shard opened with restricted range only processes tasks within that range
 #[silo::test]
 async fn shard_with_restricted_range_only_processes_within_range() {
-    // Open shard with range that only includes tenants < "ccc"
-    let (_tmp, shard) = open_temp_shard_with_range(ShardRange::new("", "ccc")).await;
+    // Open shard with range [, 8000) — only tenants whose hashes fall in this range
+    let (_tmp, shard) = open_temp_shard_with_range(ShardRange::new("", RANGE_BOUNDARY)).await;
 
-    // Enqueue jobs only for tenants within the range
-    enqueue_jobs_for_tenants(&shard, &["aaa", "bbb"], 2, "default").await;
+    // Enqueue jobs for tenants within the range: bbb(3a4f), mmm(0489) — both IN
+    enqueue_jobs_for_tenants(&shard, &["bbb", "mmm"], 2, "default").await;
     shard.db().flush().await.unwrap();
 
     // All tasks should be present and processable
@@ -128,15 +134,15 @@ async fn shard_with_restricted_range_only_processes_within_range() {
     assert_eq!(
         result.tasks.len(),
         4,
-        "should get all 4 tasks for aaa and bbb"
+        "should get all 4 tasks for bbb and mmm"
     );
 
     // Verify the returned tasks are for the correct tenants
     for task in &result.tasks {
         let tid = task.tenant_id();
         assert!(
-            tid == "aaa" || tid == "bbb",
-            "task tenant should be aaa or bbb, got {}",
+            tid == "bbb" || tid == "mmm",
+            "task tenant should be bbb or mmm, got {}",
             tid
         );
     }
@@ -148,7 +154,8 @@ async fn cleanup_removes_leases_outside_range() {
     let (_tmp, shard) = open_temp_shard().await;
 
     // Enqueue and dequeue jobs to create leases
-    enqueue_jobs_for_tenants(&shard, &["aaa", "zzz"], 1, "default").await;
+    // bbb(3a4f) IN range [, 8000), aaa(ae01) OUT
+    enqueue_jobs_for_tenants(&shard, &["aaa", "bbb"], 1, "default").await;
     shard.db().flush().await.unwrap();
 
     let result = shard.dequeue("worker-1", "default", 10).await.unwrap();
@@ -159,19 +166,19 @@ async fn cleanup_removes_leases_outside_range() {
     let lease_count_before = count_lease_keys(shard.db()).await;
     assert_eq!(lease_count_before, 2, "should have 2 leases");
 
-    // Run cleanup with range that only includes aaa
-    let cleanup_range = ShardRange::new("", "b");
+    // Run cleanup with range [, 8000) — keeps bbb, removes aaa
+    let cleanup_range = ShardRange::new("", RANGE_BOUNDARY);
     shard
         .after_split_cleanup_defunct_data(&cleanup_range, 100)
         .await
         .expect("cleanup should succeed");
     shard.db().flush().await.unwrap();
 
-    // The zzz lease should be deleted
+    // The aaa lease should be deleted (hash out of range)
     let lease_count_after = count_lease_keys(shard.db()).await;
     assert_eq!(
         lease_count_after, 1,
-        "should have 1 lease remaining (aaa only)"
+        "should have 1 lease remaining (bbb only)"
     );
 }
 
@@ -181,6 +188,8 @@ async fn post_split_cleanup_left_child() {
     let (_tmp, shard) = open_temp_shard().await;
 
     // Simulate parent shard with jobs for multiple tenants
+    // IN  range [, 8000): delta(21c5), gamma(7707)
+    // OUT range: alpha(c758), beta(f5ee), epsilon(a64f)
     enqueue_jobs_for_tenants(
         &shard,
         &["alpha", "beta", "gamma", "delta", "epsilon"],
@@ -194,29 +203,26 @@ async fn post_split_cleanup_left_child() {
     let job_count = count_job_info_keys(shard.db()).await;
     assert_eq!(job_count, 10); // 5 tenants * 2 jobs
 
-    // Run cleanup as if this is the LEFT child after split at "delta"
-    // Left child gets tenants < "delta": alpha, beta (not gamma which comes after delta alphabetically)
-    // Wait, alphabetically: alpha < beta < delta < epsilon < gamma
-    // So tenants < "delta" are: alpha, beta
-    let cleanup_range = ShardRange::new("", "delta");
+    // Run cleanup as the LEFT child with range [, 8000)
+    let cleanup_range = ShardRange::new("", RANGE_BOUNDARY);
     shard
         .after_split_cleanup_defunct_data(&cleanup_range, 100)
         .await
         .expect("cleanup should succeed");
     shard.db().flush().await.unwrap();
 
-    // Jobs for delta, epsilon, gamma should be deleted
+    // Jobs for alpha, beta, epsilon should be deleted (hashes out of range)
     let job_count_after = count_job_info_keys(shard.db()).await;
     assert_eq!(
         job_count_after, 4,
-        "should have 4 jobs remaining (alpha=2, beta=2)"
+        "should have 4 jobs remaining (delta=2, gamma=2)"
     );
 
-    // Tasks for delta, epsilon, gamma should also be deleted
+    // Tasks for alpha, beta, epsilon should also be deleted
     let task_count_after = count_task_keys(shard.db()).await;
     assert_eq!(
         task_count_after, 4,
-        "should have 4 tasks remaining (alpha=2, beta=2)"
+        "should have 4 tasks remaining (delta=2, gamma=2)"
     );
 }
 
@@ -226,31 +232,31 @@ async fn post_split_cleanup_right_child() {
     let (_tmp, shard) = open_temp_shard().await;
 
     // Simulate parent shard with jobs for multiple tenants
-    // Note: alphabetically aaa < bbb < mmm < nnn < zzz
-    enqueue_jobs_for_tenants(&shard, &["aaa", "bbb", "mmm", "nnn", "zzz"], 2, "default").await;
+    // IN  right range [8000, ""): aaa(ae01), ccc(8ed4), yyy(ed58)
+    // OUT right range (hash < 8000): bbb(3a4f), zzz(6d85)
+    enqueue_jobs_for_tenants(&shard, &["aaa", "bbb", "ccc", "yyy", "zzz"], 2, "default").await;
     shard.db().flush().await.unwrap();
 
-    // Run cleanup as if this is the RIGHT child after split at "mmm"
-    // Right child gets tenants >= "mmm": mmm, nnn, zzz
-    let cleanup_range = ShardRange::new("mmm", "");
+    // Run cleanup as the RIGHT child with range [8000, "")
+    let cleanup_range = ShardRange::new(RANGE_BOUNDARY, "");
     shard
         .after_split_cleanup_defunct_data(&cleanup_range, 100)
         .await
         .expect("cleanup should succeed");
     shard.db().flush().await.unwrap();
 
-    // Jobs for aaa, bbb should be deleted
+    // Jobs for bbb, zzz should be deleted (hashes out of range)
     let job_count_after = count_job_info_keys(shard.db()).await;
     assert_eq!(
         job_count_after, 6,
-        "should have 6 jobs remaining (mmm=2, nnn=2, zzz=2)"
+        "should have 6 jobs remaining (aaa=2, ccc=2, yyy=2)"
     );
 
-    // Tasks for aaa, bbb should also be deleted
+    // Tasks for bbb, zzz should also be deleted
     let task_count_after = count_task_keys(shard.db()).await;
     assert_eq!(
         task_count_after, 6,
-        "should have 6 tasks remaining (mmm=2, nnn=2, zzz=2)"
+        "should have 6 tasks remaining (aaa=2, ccc=2, yyy=2)"
     );
 }
 
@@ -259,12 +265,12 @@ async fn post_split_cleanup_right_child() {
 async fn can_process_jobs_during_cleanup() {
     use silo::coordination::SplitCleanupStatus;
 
-    // Open shard with full range initially
-    let (_tmp, shard) = open_temp_shard_with_range(ShardRange::new("", "mmm")).await;
+    // Open shard with restricted range [, 8000)
+    let (_tmp, shard) = open_temp_shard_with_range(ShardRange::new("", RANGE_BOUNDARY)).await;
 
-    // Enqueue jobs for tenants inside and outside the range
-    // "aaa" and "bbb" are inside range, "zzz" would be outside
-    enqueue_jobs_for_tenants(&shard, &["aaa", "bbb"], 3, "default").await;
+    // Enqueue jobs for tenants inside the range
+    // bbb(3a4f) and mmm(0489) are inside range [, 8000)
+    enqueue_jobs_for_tenants(&shard, &["bbb", "mmm"], 3, "default").await;
     shard.db().flush().await.unwrap();
 
     // Set status to CleanupRunning (simulating cleanup in progress)
@@ -278,14 +284,14 @@ async fn can_process_jobs_during_cleanup() {
     assert_eq!(
         result.tasks.len(),
         6,
-        "should dequeue all 6 jobs (aaa=3 + bbb=3)"
+        "should dequeue all 6 jobs (bbb=3 + mmm=3)"
     );
 
     // All dequeued tasks should be for tenants within range
     for task in &result.tasks {
         let tid = task.tenant_id();
         assert!(
-            tid == "aaa" || tid == "bbb",
+            tid == "bbb" || tid == "mmm",
             "task tenant should be within range, got {}",
             tid
         );
@@ -297,10 +303,10 @@ async fn can_process_jobs_during_cleanup() {
 async fn can_enqueue_and_process_during_cleanup() {
     use silo::coordination::SplitCleanupStatus;
 
-    let (_tmp, shard) = open_temp_shard_with_range(ShardRange::new("", "mmm")).await;
+    let (_tmp, shard) = open_temp_shard_with_range(ShardRange::new("", RANGE_BOUNDARY)).await;
 
-    // Enqueue initial jobs
-    enqueue_jobs_for_tenants(&shard, &["aaa"], 2, "default").await;
+    // Enqueue initial jobs for an in-range tenant: nnn(02ff) IN
+    enqueue_jobs_for_tenants(&shard, &["nnn"], 2, "default").await;
     shard.db().flush().await.unwrap();
 
     // Set status to CleanupRunning
@@ -309,7 +315,7 @@ async fn can_enqueue_and_process_during_cleanup() {
         .await
         .expect("set cleanup running");
 
-    // Enqueue more jobs during "cleanup"
+    // Enqueue more jobs during "cleanup" for another in-range tenant: bbb(3a4f) IN
     enqueue_jobs_for_tenants(&shard, &["bbb"], 2, "default").await;
     shard.db().flush().await.unwrap();
 
@@ -318,17 +324,17 @@ async fn can_enqueue_and_process_during_cleanup() {
     assert_eq!(result.tasks.len(), 4, "should dequeue all 4 jobs");
 
     // Verify both tenants are represented
-    let aaa_count = result
+    let nnn_count = result
         .tasks
         .iter()
-        .filter(|t| t.tenant_id() == "aaa")
+        .filter(|t| t.tenant_id() == "nnn")
         .count();
     let bbb_count = result
         .tasks
         .iter()
         .filter(|t| t.tenant_id() == "bbb")
         .count();
-    assert_eq!(aaa_count, 2, "should have 2 aaa tasks");
+    assert_eq!(nnn_count, 2, "should have 2 nnn tasks");
     assert_eq!(bbb_count, 2, "should have 2 bbb tasks");
 }
 
@@ -339,12 +345,14 @@ async fn cleanup_concurrent_with_job_processing() {
     let shard = std::sync::Arc::new(shard);
 
     // Enqueue jobs for multiple tenants (some inside, some outside the cleanup range)
+    // IN  range [, 8000): bbb(3a4f), zzz(6d85)
+    // OUT range: aaa(ae01)
     enqueue_jobs_for_tenants(&shard, &["aaa", "bbb", "zzz"], 3, "default").await;
     shard.db().flush().await.unwrap();
 
-    let cleanup_range = ShardRange::new("", "mmm");
+    let cleanup_range = ShardRange::new("", RANGE_BOUNDARY);
 
-    // Dequeue jobs for tenant "aaa" before cleanup
+    // Dequeue some jobs before cleanup
     let result1 = shard.dequeue("worker-1", "default", 3).await.unwrap();
     assert!(!result1.tasks.is_empty(), "should get some tasks");
 
@@ -355,27 +363,27 @@ async fn cleanup_concurrent_with_job_processing() {
         .expect("cleanup should succeed");
 
     assert!(cleanup_result.complete);
-    // zzz keys should be deleted
+    // aaa keys should be deleted (hash out of range)
     assert!(cleanup_result.keys_deleted > 0);
 
     shard.db().flush().await.unwrap();
 
-    // Dequeue remaining jobs - should only get jobs for aaa and bbb
+    // Dequeue remaining jobs - should only get jobs for bbb and zzz
     let result2 = shard.dequeue("worker-2", "default", 20).await.unwrap();
 
     // Verify all dequeued tasks are for tenants within the cleanup range
     for task in &result2.tasks {
         let tid = task.tenant_id();
         assert!(
-            tid == "aaa" || tid == "bbb",
+            tid == "bbb" || tid == "zzz",
             "after cleanup, tasks should only be for tenants in range, got {}",
             tid
         );
     }
 
-    // Verify zzz jobs are gone
-    let zzz_jobs = count_job_info_keys_for_tenant(shard.db(), "zzz").await;
-    assert_eq!(zzz_jobs, 0, "zzz jobs should be cleaned up");
+    // Verify aaa jobs are gone
+    let aaa_jobs = count_job_info_keys_for_tenant(shard.db(), "aaa").await;
+    assert_eq!(aaa_jobs, 0, "aaa jobs should be cleaned up");
 }
 
 // After a shard split, cleanup runs asynchronously in the background.
@@ -453,11 +461,11 @@ async fn create_shard_with_uncleaned_data(
 /// Dequeue should NOT return tasks for out-of-range tenants, even before cleanup
 #[silo::test]
 async fn dequeue_ignores_uncleaned_out_of_range_tasks() {
-    let range = ShardRange::new("", "mmm"); // Only tenants < "mmm"
+    let range = ShardRange::new("", RANGE_BOUNDARY);
     let (_tmp, shard) = create_shard_with_uncleaned_data(
         range,
-        &["aaa", "bbb"], // in-range
-        &["zzz", "yyy"], // out-of-range (uncleaned)
+        &["bbb", "zzz"], // in-range: bbb(3a4f), zzz(6d85)
+        &["aaa", "yyy"], // out-of-range: aaa(ae01), yyy(ed58)
         3,
     )
     .await;
@@ -472,13 +480,13 @@ async fn dequeue_ignores_uncleaned_out_of_range_tasks() {
     // Dequeue should ONLY return in-range tasks
     let result = shard.dequeue("worker-1", "default", 100).await.unwrap();
 
-    // Should only get tasks for aaa and bbb (6 total), NOT zzz or yyy
+    // Should only get tasks for bbb and zzz (6 total), NOT aaa or yyy
     assert_eq!(result.tasks.len(), 6, "should only dequeue in-range tasks");
 
     for task in &result.tasks {
         let tid = task.tenant_id();
         assert!(
-            tid == "aaa" || tid == "bbb",
+            tid == "bbb" || tid == "zzz",
             "dequeue returned out-of-range tenant task: {}",
             tid
         );
@@ -488,8 +496,8 @@ async fn dequeue_ignores_uncleaned_out_of_range_tasks() {
 /// Scan/query operations should respect shard range with uncleaned data present
 #[silo::test]
 async fn scan_jobs_ignores_uncleaned_out_of_range_jobs() {
-    let range = ShardRange::new("", "mmm");
-    let (_tmp, shard) = create_shard_with_uncleaned_data(range, &["aaa", "bbb"], &["zzz"], 2).await;
+    let range = ShardRange::new("", RANGE_BOUNDARY);
+    let (_tmp, shard) = create_shard_with_uncleaned_data(range, &["bbb", "zzz"], &["aaa"], 2).await;
 
     // Verify uncleaned data exists
     let all_jobs = count_job_info_keys(shard.db()).await;
@@ -499,25 +507,25 @@ async fn scan_jobs_ignores_uncleaned_out_of_range_jobs() {
     );
 
     // scan_jobs for in-range tenant should work
-    let aaa_jobs = shard.scan_jobs("aaa", Some(100)).await.unwrap();
-    assert_eq!(aaa_jobs.len(), 2, "should find 2 aaa jobs");
+    let bbb_jobs = shard.scan_jobs("bbb", Some(100)).await.unwrap();
+    assert_eq!(bbb_jobs.len(), 2, "should find 2 bbb jobs");
 
     // scan_jobs for out-of-range tenant - the data exists but shouldn't be accessible
     // Note: scan_jobs doesn't filter by range, it just scans by tenant
     // This is OK because the tenant explicitly requested their own data
-    let zzz_jobs = shard.scan_jobs("zzz", Some(100)).await.unwrap();
+    let aaa_jobs = shard.scan_jobs("aaa", Some(100)).await.unwrap();
     // This will return results since scan_jobs is tenant-specific
     // The important thing is dequeue and other operations filter correctly
-    assert_eq!(zzz_jobs.len(), 2, "scan_jobs returns tenant's own data");
+    assert_eq!(aaa_jobs.len(), 2, "scan_jobs returns tenant's own data");
 }
 
 /// Enqueue should work for in-range tenants even with uncleaned data present
 #[silo::test]
 async fn enqueue_works_with_uncleaned_data_present() {
-    let range = ShardRange::new("", "mmm");
-    let (_tmp, shard) = create_shard_with_uncleaned_data(range, &["aaa"], &["zzz"], 2).await;
+    let range = ShardRange::new("", RANGE_BOUNDARY);
+    let (_tmp, shard) = create_shard_with_uncleaned_data(range, &["zzz"], &["aaa"], 2).await;
 
-    // Enqueue a new job for an in-range tenant
+    // Enqueue a new job for an in-range tenant: bbb(3a4f) IN
     let payload = msgpack_payload(&serde_json::json!({"new": true}));
     let job_id = shard
         .enqueue(
@@ -540,7 +548,7 @@ async fn enqueue_works_with_uncleaned_data_present() {
     // The new job should be dequeue-able along with the original in-range jobs
     let dequeue_result = shard.dequeue("worker-1", "default", 100).await.unwrap();
 
-    // Should have 3 in-range tasks: 2 from aaa + 1 new from bbb
+    // Should have 3 in-range tasks: 2 from zzz + 1 new from bbb
     assert_eq!(
         dequeue_result.tasks.len(),
         3,
@@ -556,7 +564,7 @@ async fn enqueue_works_with_uncleaned_data_present() {
     // Verify all dequeued tasks are in-range
     for task in &dequeue_result.tasks {
         assert!(
-            task.tenant_id() == "aaa" || task.tenant_id() == "bbb",
+            task.tenant_id() == "zzz" || task.tenant_id() == "bbb",
             "should only dequeue in-range tasks, got {}",
             task.tenant_id()
         );
@@ -568,14 +576,14 @@ async fn enqueue_works_with_uncleaned_data_present() {
 async fn job_completion_works_with_uncleaned_data() {
     use silo::job_attempt::AttemptOutcome;
 
-    let range = ShardRange::new("", "mmm");
-    let (_tmp, shard) = create_shard_with_uncleaned_data(range, &["aaa"], &["zzz"], 2).await;
+    let range = ShardRange::new("", RANGE_BOUNDARY);
+    let (_tmp, shard) = create_shard_with_uncleaned_data(range, &["zzz"], &["aaa"], 2).await;
 
-    // Dequeue an in-range job
+    // Dequeue an in-range job: zzz(6d85) is IN range [, 8000)
     let result = shard.dequeue("worker-1", "default", 1).await.unwrap();
     assert_eq!(result.tasks.len(), 1);
     let task = &result.tasks[0];
-    assert_eq!(task.tenant_id(), "aaa", "should dequeue in-range tenant");
+    assert_eq!(task.tenant_id(), "zzz", "should dequeue in-range tenant");
 
     // Complete the job
     let complete_result = shard
@@ -602,7 +610,7 @@ async fn concurrency_hydration_ignores_uncleaned_holders() {
 
     let tmp = tempfile::tempdir().unwrap();
     let rate_limiter = MockGubernatorClient::new_arc();
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
 
     let cfg = DatabaseConfig {
         name: "test".to_string(),
@@ -614,13 +622,14 @@ async fn concurrency_hydration_ignores_uncleaned_holders() {
     };
 
     // Phase 1: Create jobs with concurrency limits for both in-range and out-of-range tenants
+    // zzz(6d85) IN range [, 8000), aaa(ae01) OUT
     {
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, ShardRange::full())
             .await
             .expect("open shard");
 
         // Create jobs with concurrency limits
-        for tenant in ["aaa", "zzz"] {
+        for tenant in ["zzz", "aaa"] {
             let payload = msgpack_payload(&serde_json::json!({}));
             let limits = vec![Limit::Concurrency(ConcurrencyLimit {
                 key: "shared-queue".to_string(),
@@ -649,10 +658,10 @@ async fn concurrency_hydration_ignores_uncleaned_holders() {
         shard.db().flush().await.unwrap();
 
         // Verify holders exist for both tenants
-        let aaa_holders = count_concurrency_holders_for_tenant(shard.db(), "aaa").await;
         let zzz_holders = count_concurrency_holders_for_tenant(shard.db(), "zzz").await;
-        assert!(aaa_holders > 0, "aaa should have holders");
+        let aaa_holders = count_concurrency_holders_for_tenant(shard.db(), "aaa").await;
         assert!(zzz_holders > 0, "zzz should have holders");
+        assert!(aaa_holders > 0, "aaa should have holders");
 
         shard.close().await.unwrap();
     }
@@ -663,18 +672,18 @@ async fn concurrency_hydration_ignores_uncleaned_holders() {
             .await
             .expect("reopen with restricted range");
 
-        // The zzz holder records still exist in the DB (uncleaned)
-        let zzz_holders = count_concurrency_holders_for_tenant(shard.db(), "zzz").await;
+        // The aaa holder records still exist in the DB (uncleaned)
+        let aaa_holders = count_concurrency_holders_for_tenant(shard.db(), "aaa").await;
         assert!(
-            zzz_holders > 0,
-            "uncleaned zzz holders should still be in DB"
+            aaa_holders > 0,
+            "uncleaned aaa holders should still be in DB"
         );
 
         // But when we try to get a new concurrency ticket, the in-memory count
         // should only reflect in-range tenants (verified by hydration filtering)
         // We can't directly inspect in-memory counts, but we can verify behavior:
-        // If a job needs a ticket on "shared-queue" with limit 1, and zzz is holding one,
-        // an in-range job should still be able to get a ticket (because zzz is filtered)
+        // If a job needs a ticket on "shared-queue" with limit 1, and aaa is holding one,
+        // an in-range job should still be able to get a ticket (because aaa is filtered)
 
         // This is implicitly tested by the dequeue working correctly above
         shard.close().await.unwrap();
@@ -687,9 +696,9 @@ async fn processing_continues_during_active_cleanup() {
     use silo::coordination::SplitCleanupStatus;
     use std::sync::Arc;
 
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
     let (_tmp, shard) =
-        create_shard_with_uncleaned_data(range.clone(), &["aaa", "bbb"], &["zzz", "yyy"], 5).await;
+        create_shard_with_uncleaned_data(range.clone(), &["bbb", "zzz"], &["aaa", "yyy"], 5).await;
     let shard = Arc::new(shard);
 
     // Set status to indicate cleanup is running
@@ -714,11 +723,11 @@ async fn processing_continues_during_active_cleanup() {
     assert_eq!(
         result.tasks.len(),
         10,
-        "should dequeue all in-range tasks (aaa=5, bbb=5)"
+        "should dequeue all in-range tasks (bbb=5, zzz=5)"
     );
     for task in &result.tasks {
         assert!(
-            task.tenant_id() == "aaa" || task.tenant_id() == "bbb",
+            task.tenant_id() == "bbb" || task.tenant_id() == "zzz",
             "should only get in-range tasks during cleanup"
         );
     }
@@ -731,12 +740,12 @@ async fn processing_continues_during_active_cleanup() {
 /// Verify all dequeue operations filter by range, not just the first batch
 #[silo::test]
 async fn repeated_dequeue_consistently_filters_out_of_range() {
-    let range = ShardRange::new("", "mmm");
+    let range = ShardRange::new("", RANGE_BOUNDARY);
     let (_tmp, shard) = create_shard_with_uncleaned_data(
         range,
-        &["aaa"],
-        &["zzz"],
-        10, // More jobs to ensure multiple dequeue calls
+        &["zzz"], // zzz(6d85) IN range [, 8000)
+        &["aaa"], // aaa(ae01) OUT
+        10,       // More jobs to ensure multiple dequeue calls
     )
     .await;
 
@@ -746,7 +755,7 @@ async fn repeated_dequeue_consistently_filters_out_of_range() {
         for task in &result.tasks {
             assert_eq!(
                 task.tenant_id(),
-                "aaa",
+                "zzz",
                 "every dequeue batch should only return in-range tasks"
             );
         }
@@ -762,10 +771,10 @@ async fn lease_operations_handle_cleanup_gracefully() {
 
     let (_tmp, shard) = open_temp_shard().await;
 
-    // Enqueue jobs for a tenant that will be outside cleanup range
-    enqueue_jobs_for_tenants(&shard, &["zzz"], 1, "default").await;
-    // Also enqueue jobs within range
+    // Enqueue jobs for a tenant that will be outside cleanup range: aaa(ae01) OUT
     enqueue_jobs_for_tenants(&shard, &["aaa"], 1, "default").await;
+    // Also enqueue jobs within range: zzz(6d85) IN [, 8000)
+    enqueue_jobs_for_tenants(&shard, &["zzz"], 1, "default").await;
     shard.db().flush().await.unwrap();
 
     // Dequeue all tasks (this creates leases)
@@ -773,8 +782,8 @@ async fn lease_operations_handle_cleanup_gracefully() {
     assert_eq!(dequeue_result.tasks.len(), 2);
     shard.db().flush().await.unwrap();
 
-    // Run cleanup for range that excludes "zzz"
-    let cleanup_range = ShardRange::new("", "mmm");
+    // Run cleanup for range that excludes "aaa"
+    let cleanup_range = ShardRange::new("", RANGE_BOUNDARY);
     let cleanup_result = shard
         .after_split_cleanup_defunct_data(&cleanup_range, 100)
         .await
@@ -783,17 +792,17 @@ async fn lease_operations_handle_cleanup_gracefully() {
     assert!(cleanup_result.complete);
     shard.db().flush().await.unwrap();
 
-    // Find the "aaa" task and complete its lease - this should work
-    let aaa_task = dequeue_result
+    // Find the "zzz" task and complete its lease - this should work (in range)
+    let zzz_task = dequeue_result
         .tasks
         .iter()
-        .find(|t| t.tenant_id() == "aaa")
-        .expect("should have aaa task");
+        .find(|t| t.tenant_id() == "zzz")
+        .expect("should have zzz task");
 
-    // Completing the lease for aaa should work fine
+    // Completing the lease for zzz should work fine
     let complete_result = shard
         .report_attempt_outcome(
-            aaa_task.attempt().task_id(),
+            zzz_task.attempt().task_id(),
             AttemptOutcome::Success { result: vec![] },
         )
         .await;
@@ -803,24 +812,24 @@ async fn lease_operations_handle_cleanup_gracefully() {
         "completing lease for in-range task should succeed"
     );
 
-    // The zzz task's lease was deleted by cleanup, so operations on it
+    // The aaa task's lease was deleted by cleanup, so operations on it
     // will fail with lease not found - this is expected behavior
-    let zzz_task = dequeue_result
+    let aaa_task = dequeue_result
         .tasks
         .iter()
-        .find(|t| t.tenant_id() == "zzz")
-        .expect("should have zzz task");
+        .find(|t| t.tenant_id() == "aaa")
+        .expect("should have aaa task");
 
-    let zzz_result = shard
+    let aaa_result = shard
         .report_attempt_outcome(
-            zzz_task.attempt().task_id(),
+            aaa_task.attempt().task_id(),
             AttemptOutcome::Success { result: vec![] },
         )
         .await;
 
-    // The zzz lease was deleted by cleanup, so this should fail
+    // The aaa lease was deleted by cleanup, so this should fail
     assert!(
-        zzz_result.is_err(),
+        aaa_result.is_err(),
         "completing lease for out-of-range task should fail after cleanup"
     );
 }

--- a/tests/tenant_shard_distribution_tests.rs
+++ b/tests/tenant_shard_distribution_tests.rs
@@ -1,115 +1,15 @@
-use std::collections::HashSet;
-
 use silo::shard_range::ShardMap;
 
-/// Demonstrates that hash-based sharding distributes env-XXXXXXXXXX tenants
-/// across multiple shards, avoiding the hotspot that occurred with
-/// lexicographic range-based sharding.
+/// Verifies that the same tenant always maps to the same shard (determinism)
+/// and that every tenant maps to some shard (full coverage).
+///
+/// Distribution quality is guaranteed by XXH64 (via the xxhash-rust crate)
+/// and doesn't need to be tested here.
 #[silo::test]
-fn env_tenants_with_10_digit_ids_spread_across_shards() {
-    // Test across multiple shard counts that are realistic for production
-    for shard_count in [2, 4, 8, 16] {
-        let map = ShardMap::create_initial(shard_count).unwrap();
-
-        // Generate a variety of env-XXXXXXXXXX tenant keys
-        let tenants: Vec<String> = vec![
-            "env-1000000000".to_string(),
-            "env-1000000001".to_string(),
-            "env-1234567890".to_string(),
-            "env-2000000000".to_string(),
-            "env-5555555555".to_string(),
-            "env-9999999999".to_string(),
-            "env-0000000001".to_string(),
-            "env-4294967296".to_string(), // 2^32
-        ];
-
-        let mut shard_ids = HashSet::new();
-        for tenant in &tenants {
-            let shard = map
-                .shard_for_tenant(tenant)
-                .unwrap_or_else(|| panic!("tenant '{}' should map to a shard", tenant));
-            shard_ids.insert(shard.id);
-        }
-
-        assert!(
-            shard_ids.len() > 1,
-            "With {} shards, env-XXXXXXXXXX tenants should spread across multiple shards, \
-             but they all landed on {} shard(s)",
-            shard_count,
-            shard_ids.len(),
-        );
-    }
-}
-
-/// Shows that with many tenants, hash-based sharding distributes them well
-/// across all available shards.
-#[silo::test]
-fn env_tenants_spread_across_shards_with_many_tenants() {
-    let shard_count = 16;
-    let map = ShardMap::create_initial(shard_count).unwrap();
-
-    let mut shard_ids = HashSet::new();
-    // Generate 1000 different env- tenant keys
-    for i in 1_000_000_000u64..1_000_001_000u64 {
-        let tenant = format!("env-{}", i);
-        let shard = map.shard_for_tenant(&tenant).unwrap();
-        shard_ids.insert(shard.id);
-    }
-
-    assert!(
-        shard_ids.len() >= shard_count as usize - 1,
-        "1000 env- tenants should spread across nearly all {} shards, \
-         but only hit {} shards",
-        shard_count,
-        shard_ids.len()
-    );
-}
-
-/// Confirms that both env- prefixed tenants and diverse tenants distribute
-/// across shards, since hashing eliminates prefix-based clustering.
-#[silo::test]
-fn both_env_and_diverse_tenants_spread_across_shards() {
+fn routing_is_deterministic_and_complete() {
     let map = ShardMap::create_initial(16).unwrap();
 
-    // Diverse tenants spread across shards
-    let diverse_tenants = vec![
-        "0-tenant", "1-tenant", "2-tenant", "3-tenant", "4-tenant", "5-tenant", "6-tenant",
-        "7-tenant", "8-tenant", "9-tenant", "a-tenant", "b-tenant", "c-tenant", "d-tenant",
-        "e-tenant", "f-tenant",
-    ];
-
-    let mut diverse_shard_ids = HashSet::new();
-    for tenant in &diverse_tenants {
-        let shard = map.shard_for_tenant(tenant).unwrap();
-        diverse_shard_ids.insert(shard.id);
-    }
-
-    // env- tenants also spread across shards (use more tenants for statistical reliability)
-    let env_tenants: Vec<String> = (0..100).map(|i| format!("env-{:010}", i)).collect();
-    let mut env_shard_ids = HashSet::new();
-    for tenant in &env_tenants {
-        let shard = map.shard_for_tenant(tenant).unwrap();
-        env_shard_ids.insert(shard.id);
-    }
-
-    assert!(
-        diverse_shard_ids.len() > 1,
-        "Diverse tenants should spread across multiple shards, got {}",
-        diverse_shard_ids.len()
-    );
-    assert!(
-        env_shard_ids.len() > 1,
-        "env- tenants should spread across multiple shards, got {}",
-        env_shard_ids.len()
-    );
-}
-
-/// Verifies that the same tenant always maps to the same shard (determinism).
-#[silo::test]
-fn hash_based_sharding_is_deterministic() {
-    let map = ShardMap::create_initial(16).unwrap();
-
-    for tenant in ["env-1234567890", "env-0000000001", "tenant-abc", "foo"] {
+    for tenant in ["env-1234567890", "env-0000000001", "tenant-abc", "foo", ""] {
         let shard1 = map.shard_for_tenant(tenant).unwrap();
         let shard2 = map.shard_for_tenant(tenant).unwrap();
         assert_eq!(

--- a/tests/tenant_shard_distribution_tests.rs
+++ b/tests/tenant_shard_distribution_tests.rs
@@ -2,14 +2,11 @@ use std::collections::HashSet;
 
 use silo::shard_range::ShardMap;
 
-/// Demonstrates that all tenants with the format "env-XXXXXXXXXX" (env- followed by a
-/// 10-digit number, matching Gadget's environment ID tenant keys) land on the same shard
-/// because silo uses lexicographic range-based sharding on the raw tenant string.
-///
-/// Since all these tenants share the "env-" prefix, they cluster in the same region of the
-/// keyspace and will always be assigned to whichever shard's range covers that prefix.
+/// Demonstrates that hash-based sharding distributes env-XXXXXXXXXX tenants
+/// across multiple shards, avoiding the hotspot that occurred with
+/// lexicographic range-based sharding.
 #[silo::test]
-fn all_env_tenants_with_10_digit_ids_land_on_same_shard() {
+fn env_tenants_with_10_digit_ids_spread_across_shards() {
     // Test across multiple shard counts that are realistic for production
     for shard_count in [2, 4, 8, 16] {
         let map = ShardMap::create_initial(shard_count).unwrap();
@@ -34,27 +31,22 @@ fn all_env_tenants_with_10_digit_ids_land_on_same_shard() {
             shard_ids.insert(shard.id);
         }
 
-        assert_eq!(
-            shard_ids.len(),
-            1,
-            "With {} shards, all env-XXXXXXXXXX tenants should land on the same shard, \
-             but they were distributed across {} shards. \
-             Shard ranges: {:?}",
+        assert!(
+            shard_ids.len() > 1,
+            "With {} shards, env-XXXXXXXXXX tenants should spread across multiple shards, \
+             but they all landed on {} shard(s)",
             shard_count,
             shard_ids.len(),
-            map.shards()
-                .iter()
-                .map(|s| format!("{}: {}", s.id, s.range))
-                .collect::<Vec<_>>()
         );
     }
 }
 
-/// Shows that even with many more tenants, they all still land on the same shard
-/// because the discriminating part (the numeric ID) comes after the shared "env-" prefix.
+/// Shows that with many tenants, hash-based sharding distributes them well
+/// across all available shards.
 #[silo::test]
-fn env_tenants_do_not_spread_across_shards_even_with_many_tenants() {
-    let map = ShardMap::create_initial(16).unwrap();
+fn env_tenants_spread_across_shards_with_many_tenants() {
+    let shard_count = 16;
+    let map = ShardMap::create_initial(shard_count).unwrap();
 
     let mut shard_ids = HashSet::new();
     // Generate 1000 different env- tenant keys
@@ -64,45 +56,19 @@ fn env_tenants_do_not_spread_across_shards_even_with_many_tenants() {
         shard_ids.insert(shard.id);
     }
 
-    assert_eq!(
-        shard_ids.len(),
-        1,
-        "All 1000 env- tenants should land on the same shard with 16 shards, \
-         but they were distributed across {} shards",
+    assert!(
+        shard_ids.len() >= shard_count as usize - 1,
+        "1000 env- tenants should spread across nearly all {} shards, \
+         but only hit {} shards",
+        shard_count,
         shard_ids.len()
     );
 }
 
-/// Confirms the root cause: the "env-" prefix falls entirely within one shard range
-/// because range boundaries are hex characters (0-9, a-f) and "e" < "env-" < "f".
+/// Confirms that both env- prefixed tenants and diverse tenants distribute
+/// across shards, since hashing eliminates prefix-based clustering.
 #[silo::test]
-fn env_prefix_falls_in_single_range_because_boundaries_are_hex() {
-    let map = ShardMap::create_initial(16).unwrap();
-
-    // Find which shard owns "env-" prefixed tenants
-    let shard = map.shard_for_tenant("env-1234567890").unwrap();
-
-    // The shard range should contain the entire "env-" prefix space
-    // since all env-XXXXXXXXXX strings are lexicographically between "e" and "f"
-    let range = &shard.range;
-
-    // Verify: the range start is <= "e" and the range end is >= "f" (or unbounded)
-    // meaning all "env-*" strings fall within this single range
-    let start_covers = range.start.is_empty() || range.start.as_str() <= "e";
-    let end_covers = range.end.is_empty() || range.end.as_str() > "env-9999999999";
-
-    assert!(
-        start_covers && end_covers,
-        "Expected a single shard range to cover all env- tenants. \
-         Range: {}, start_covers: {}, end_covers: {}",
-        range, start_covers, end_covers
-    );
-}
-
-/// Contrasts env- tenants with tenants that have diverse prefixes to show that
-/// diverse prefixes DO spread across shards, while env- does not.
-#[silo::test]
-fn diverse_tenant_prefixes_spread_across_shards_but_env_does_not() {
+fn both_env_and_diverse_tenants_spread_across_shards() {
     let map = ShardMap::create_initial(16).unwrap();
 
     // Diverse tenants spread across shards
@@ -118,8 +84,8 @@ fn diverse_tenant_prefixes_spread_across_shards_but_env_does_not() {
         diverse_shard_ids.insert(shard.id);
     }
 
-    // env- tenants all on one shard
-    let env_tenants: Vec<String> = (0..16).map(|i| format!("env-{:010}", i)).collect();
+    // env- tenants also spread across shards (use more tenants for statistical reliability)
+    let env_tenants: Vec<String> = (0..100).map(|i| format!("env-{:010}", i)).collect();
     let mut env_shard_ids = HashSet::new();
     for tenant in &env_tenants {
         let shard = map.shard_for_tenant(tenant).unwrap();
@@ -131,10 +97,25 @@ fn diverse_tenant_prefixes_spread_across_shards_but_env_does_not() {
         "Diverse tenants should spread across multiple shards, got {}",
         diverse_shard_ids.len()
     );
-    assert_eq!(
-        env_shard_ids.len(),
-        1,
-        "All env- tenants should land on exactly 1 shard, got {}",
+    assert!(
+        env_shard_ids.len() > 1,
+        "env- tenants should spread across multiple shards, got {}",
         env_shard_ids.len()
     );
+}
+
+/// Verifies that the same tenant always maps to the same shard (determinism).
+#[silo::test]
+fn hash_based_sharding_is_deterministic() {
+    let map = ShardMap::create_initial(16).unwrap();
+
+    for tenant in ["env-1234567890", "env-0000000001", "tenant-abc", "foo"] {
+        let shard1 = map.shard_for_tenant(tenant).unwrap();
+        let shard2 = map.shard_for_tenant(tenant).unwrap();
+        assert_eq!(
+            shard1.id, shard2.id,
+            "tenant '{}' should always map to the same shard",
+            tenant
+        );
+    }
 }

--- a/tests/tenant_shard_distribution_tests.rs
+++ b/tests/tenant_shard_distribution_tests.rs
@@ -1,4 +1,4 @@
-use silo::shard_range::ShardMap;
+use silo::shard_range::{ShardId, ShardInfo, ShardMap, ShardRange, hash_tenant};
 
 /// Verifies that the same tenant always maps to the same shard (determinism)
 /// and that every tenant maps to some shard (full coverage).
@@ -18,4 +18,63 @@ fn routing_is_deterministic_and_complete() {
             tenant
         );
     }
+}
+
+/// A single-tenant shard can be created by using a range that contains exactly
+/// one hash value: [hash, hash+1). This is useful for isolating a large tenant
+/// onto its own shard.
+#[silo::test]
+fn single_tenant_shard_isolates_one_tenant() {
+    let big_tenant = "env-42940";
+    let hash = hash_tenant(big_tenant);
+    let hash_val = u64::from_str_radix(&hash, 16).unwrap();
+
+    // Build a 3-shard map: [0, hash), [hash, hash+1), [hash+1, MAX]
+    // The middle shard contains exactly one hash value — the big tenant's.
+    let shard_before = ShardInfo::new(ShardId::new(), ShardRange::new("", &hash));
+    let shard_isolated = ShardInfo::new(
+        ShardId::new(),
+        ShardRange::new(&hash, format!("{:016x}", hash_val + 1)),
+    );
+    let shard_after = ShardInfo::new(
+        ShardId::new(),
+        ShardRange::new(format!("{:016x}", hash_val + 1), ""),
+    );
+
+    let isolated_id = shard_isolated.id.clone();
+    let map = ShardMap::from_shards(vec![shard_before, shard_isolated, shard_after]);
+
+    // The big tenant must route to the isolated shard
+    let routed = map.shard_for_tenant(big_tenant).unwrap();
+    assert_eq!(
+        routed.id, isolated_id,
+        "big tenant should land on isolated shard"
+    );
+
+    // Other tenants must NOT route to the isolated shard
+    for other in [
+        "env-other-1",
+        "env-other-2",
+        "tenant-small",
+        "foo",
+        "bar",
+        "zzz",
+    ] {
+        let routed = map.shard_for_tenant(other).unwrap();
+        assert_ne!(
+            routed.id, isolated_id,
+            "tenant '{}' should not land on the isolated shard",
+            other
+        );
+    }
+
+    // The isolated shard's range cannot be split further (too narrow)
+    assert!(
+        map.get_shard(&isolated_id)
+            .unwrap()
+            .range
+            .midpoint()
+            .is_none(),
+        "single-hash range should not be splittable"
+    );
 }

--- a/tests/tenant_shard_distribution_tests.rs
+++ b/tests/tenant_shard_distribution_tests.rs
@@ -1,0 +1,140 @@
+use std::collections::HashSet;
+
+use silo::shard_range::ShardMap;
+
+/// Demonstrates that all tenants with the format "env-XXXXXXXXXX" (env- followed by a
+/// 10-digit number, matching Gadget's environment ID tenant keys) land on the same shard
+/// because silo uses lexicographic range-based sharding on the raw tenant string.
+///
+/// Since all these tenants share the "env-" prefix, they cluster in the same region of the
+/// keyspace and will always be assigned to whichever shard's range covers that prefix.
+#[silo::test]
+fn all_env_tenants_with_10_digit_ids_land_on_same_shard() {
+    // Test across multiple shard counts that are realistic for production
+    for shard_count in [2, 4, 8, 16] {
+        let map = ShardMap::create_initial(shard_count).unwrap();
+
+        // Generate a variety of env-XXXXXXXXXX tenant keys
+        let tenants: Vec<String> = vec![
+            "env-1000000000".to_string(),
+            "env-1000000001".to_string(),
+            "env-1234567890".to_string(),
+            "env-2000000000".to_string(),
+            "env-5555555555".to_string(),
+            "env-9999999999".to_string(),
+            "env-0000000001".to_string(),
+            "env-4294967296".to_string(), // 2^32
+        ];
+
+        let mut shard_ids = HashSet::new();
+        for tenant in &tenants {
+            let shard = map
+                .shard_for_tenant(tenant)
+                .unwrap_or_else(|| panic!("tenant '{}' should map to a shard", tenant));
+            shard_ids.insert(shard.id);
+        }
+
+        assert_eq!(
+            shard_ids.len(),
+            1,
+            "With {} shards, all env-XXXXXXXXXX tenants should land on the same shard, \
+             but they were distributed across {} shards. \
+             Shard ranges: {:?}",
+            shard_count,
+            shard_ids.len(),
+            map.shards()
+                .iter()
+                .map(|s| format!("{}: {}", s.id, s.range))
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+/// Shows that even with many more tenants, they all still land on the same shard
+/// because the discriminating part (the numeric ID) comes after the shared "env-" prefix.
+#[silo::test]
+fn env_tenants_do_not_spread_across_shards_even_with_many_tenants() {
+    let map = ShardMap::create_initial(16).unwrap();
+
+    let mut shard_ids = HashSet::new();
+    // Generate 1000 different env- tenant keys
+    for i in 1_000_000_000u64..1_000_001_000u64 {
+        let tenant = format!("env-{}", i);
+        let shard = map.shard_for_tenant(&tenant).unwrap();
+        shard_ids.insert(shard.id);
+    }
+
+    assert_eq!(
+        shard_ids.len(),
+        1,
+        "All 1000 env- tenants should land on the same shard with 16 shards, \
+         but they were distributed across {} shards",
+        shard_ids.len()
+    );
+}
+
+/// Confirms the root cause: the "env-" prefix falls entirely within one shard range
+/// because range boundaries are hex characters (0-9, a-f) and "e" < "env-" < "f".
+#[silo::test]
+fn env_prefix_falls_in_single_range_because_boundaries_are_hex() {
+    let map = ShardMap::create_initial(16).unwrap();
+
+    // Find which shard owns "env-" prefixed tenants
+    let shard = map.shard_for_tenant("env-1234567890").unwrap();
+
+    // The shard range should contain the entire "env-" prefix space
+    // since all env-XXXXXXXXXX strings are lexicographically between "e" and "f"
+    let range = &shard.range;
+
+    // Verify: the range start is <= "e" and the range end is >= "f" (or unbounded)
+    // meaning all "env-*" strings fall within this single range
+    let start_covers = range.start.is_empty() || range.start.as_str() <= "e";
+    let end_covers = range.end.is_empty() || range.end.as_str() > "env-9999999999";
+
+    assert!(
+        start_covers && end_covers,
+        "Expected a single shard range to cover all env- tenants. \
+         Range: {}, start_covers: {}, end_covers: {}",
+        range, start_covers, end_covers
+    );
+}
+
+/// Contrasts env- tenants with tenants that have diverse prefixes to show that
+/// diverse prefixes DO spread across shards, while env- does not.
+#[silo::test]
+fn diverse_tenant_prefixes_spread_across_shards_but_env_does_not() {
+    let map = ShardMap::create_initial(16).unwrap();
+
+    // Diverse tenants spread across shards
+    let diverse_tenants = vec![
+        "0-tenant", "1-tenant", "2-tenant", "3-tenant", "4-tenant", "5-tenant", "6-tenant",
+        "7-tenant", "8-tenant", "9-tenant", "a-tenant", "b-tenant", "c-tenant", "d-tenant",
+        "e-tenant", "f-tenant",
+    ];
+
+    let mut diverse_shard_ids = HashSet::new();
+    for tenant in &diverse_tenants {
+        let shard = map.shard_for_tenant(tenant).unwrap();
+        diverse_shard_ids.insert(shard.id);
+    }
+
+    // env- tenants all on one shard
+    let env_tenants: Vec<String> = (0..16).map(|i| format!("env-{:010}", i)).collect();
+    let mut env_shard_ids = HashSet::new();
+    for tenant in &env_tenants {
+        let shard = map.shard_for_tenant(tenant).unwrap();
+        env_shard_ids.insert(shard.id);
+    }
+
+    assert!(
+        diverse_shard_ids.len() > 1,
+        "Diverse tenants should spread across multiple shards, got {}",
+        diverse_shard_ids.len()
+    );
+    assert_eq!(
+        env_shard_ids.len(),
+        1,
+        "All env- tenants should land on exactly 1 shard, got {}",
+        env_shard_ids.len()
+    );
+}

--- a/typescript_client/package.json
+++ b/typescript_client/package.json
@@ -33,7 +33,8 @@
     "@protobuf-ts/runtime-rpc": "^2.9.4",
     "msgpackr": "^1.11.2",
     "p-queue": "6.6.2",
-    "serialize-error": "7.0.1"
+    "serialize-error": "7.0.1",
+    "xxhash-wasm": "^1.1.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",

--- a/typescript_client/pnpm-lock.yaml
+++ b/typescript_client/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       serialize-error:
         specifier: 7.0.1
         version: 7.0.1
+      xxhash-wasm:
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
@@ -1520,6 +1523,9 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xxhash-wasm@1.1.0:
+    resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2848,6 +2854,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
 

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -277,25 +277,23 @@ export function hashTenant(tenantId: string): string {
 }
 
 /**
- * Find the shard that owns a given tenant ID using hash-based range lookup.
- * The tenant ID is hashed before comparing against shard range boundaries.
+ * Find the shard whose range contains the given key using lexicographic comparison.
+ * The key should already be in hash space (use hashTenant() first for tenant IDs).
  * Shards should be sorted by rangeStart for efficient binary search.
- * @param tenantId The tenant identifier
+ * @param key The hash-space key to look up
  * @param shards Array of shards sorted by rangeStart
  * @returns The shard info, or undefined if no shard found
  */
 export function shardForTenant(
-  tenantId: string,
+  key: string,
   shards: ShardInfoWithRange[],
 ): ShardInfoWithRange | undefined {
   if (shards.length === 0) {
     return undefined;
   }
 
-  const hashed = hashTenant(tenantId);
-
-  // Binary search to find the shard whose range contains the tenant hash
-  // We're looking for the last shard where rangeStart <= hashed
+  // Binary search to find the shard whose range contains the key
+  // We're looking for the last shard where rangeStart <= key
   let left = 0;
   let right = shards.length - 1;
   let result: ShardInfoWithRange | undefined = undefined;
@@ -304,23 +302,23 @@ export function shardForTenant(
     const mid = Math.floor((left + right) / 2);
     const shard = shards[mid];
 
-    // Check if hashed >= rangeStart (empty rangeStart means -infinity)
-    const afterStart = shard.rangeStart === "" || hashed >= shard.rangeStart;
+    // Check if key >= rangeStart (empty rangeStart means -infinity)
+    const afterStart = shard.rangeStart === "" || key >= shard.rangeStart;
 
     if (afterStart) {
-      // This shard's rangeStart is <= hashed, could be a candidate
+      // This shard's rangeStart is <= key, could be a candidate
       result = shard;
       left = mid + 1; // Look for a shard with a later rangeStart
     } else {
-      right = mid - 1; // rangeStart > hashed, look earlier
+      right = mid - 1; // rangeStart > key, look earlier
     }
   }
 
-  // Verify the tenant hash is within the range (before rangeEnd)
+  // Verify the key is within the range (before rangeEnd)
   if (result) {
-    const beforeEnd = result.rangeEnd === "" || hashed < result.rangeEnd;
+    const beforeEnd = result.rangeEnd === "" || key < result.rangeEnd;
     if (!beforeEnd) {
-      // The hash is >= rangeEnd, so it's not in this shard's range
+      // The key is >= rangeEnd, so it's not in this shard's range
       // This shouldn't happen if shards cover the full keyspace
       return undefined;
     }
@@ -1315,7 +1313,8 @@ export class SiloGRPCClient {
     if (this._shards.length === 0) {
       throw new Error("Cluster topology not discovered yet. Call refreshTopology() first.");
     }
-    const shardInfo = shardForTenant(tenantId, this._shards);
+    const hashed = hashTenant(tenantId);
+    const shardInfo = shardForTenant(hashed, this._shards);
     if (!shardInfo) {
       throw new Error(`No shard found for tenant "${tenantId}". This indicates a topology error.`);
     }

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -250,7 +250,35 @@ export interface ShardInfoWithRange {
 }
 
 /**
- * Find the shard that owns a given tenant ID using range-based lookup.
+ * Hash a tenant ID to a 16-character hex string using FNV-1a with
+ * splitmix64 finalization. Must match the Rust `hash_tenant` implementation
+ * in `src/shard_range.rs` exactly.
+ */
+export function hashTenant(tenantId: string): string {
+  const MASK = 0xffffffffffffffffn;
+  const FNV_OFFSET = 0xcbf29ce484222325n;
+  const FNV_PRIME = 0x100000001b3n;
+
+  // FNV-1a accumulation
+  let hash = FNV_OFFSET;
+  for (let i = 0; i < tenantId.length; i++) {
+    hash ^= BigInt(tenantId.charCodeAt(i));
+    hash = (hash * FNV_PRIME) & MASK;
+  }
+
+  // splitmix64 finalization
+  hash ^= hash >> 30n;
+  hash = (hash * 0xbf58476d1ce4e5b9n) & MASK;
+  hash ^= hash >> 27n;
+  hash = (hash * 0x94d049bb133111ebn) & MASK;
+  hash ^= hash >> 31n;
+
+  return hash.toString(16).padStart(16, "0");
+}
+
+/**
+ * Find the shard that owns a given tenant ID using hash-based range lookup.
+ * The tenant ID is hashed before comparing against shard range boundaries.
  * Shards should be sorted by rangeStart for efficient binary search.
  * @param tenantId The tenant identifier
  * @param shards Array of shards sorted by rangeStart
@@ -264,8 +292,10 @@ export function shardForTenant(
     return undefined;
   }
 
-  // Binary search to find the shard whose range contains the tenant
-  // We're looking for the last shard where rangeStart <= tenantId
+  const hashed = hashTenant(tenantId);
+
+  // Binary search to find the shard whose range contains the tenant hash
+  // We're looking for the last shard where rangeStart <= hashed
   let left = 0;
   let right = shards.length - 1;
   let result: ShardInfoWithRange | undefined = undefined;
@@ -274,23 +304,23 @@ export function shardForTenant(
     const mid = Math.floor((left + right) / 2);
     const shard = shards[mid];
 
-    // Check if tenantId >= rangeStart (empty rangeStart means -infinity)
-    const afterStart = shard.rangeStart === "" || tenantId >= shard.rangeStart;
+    // Check if hashed >= rangeStart (empty rangeStart means -infinity)
+    const afterStart = shard.rangeStart === "" || hashed >= shard.rangeStart;
 
     if (afterStart) {
-      // This shard's rangeStart is <= tenantId, could be a candidate
+      // This shard's rangeStart is <= hashed, could be a candidate
       result = shard;
       left = mid + 1; // Look for a shard with a later rangeStart
     } else {
-      right = mid - 1; // rangeStart > tenantId, look earlier
+      right = mid - 1; // rangeStart > hashed, look earlier
     }
   }
 
-  // Verify the tenant is within the range (before rangeEnd)
+  // Verify the tenant hash is within the range (before rangeEnd)
   if (result) {
-    const beforeEnd = result.rangeEnd === "" || tenantId < result.rangeEnd;
+    const beforeEnd = result.rangeEnd === "" || hashed < result.rangeEnd;
     if (!beforeEnd) {
-      // The tenant is >= rangeEnd, so it's not in this shard's range
+      // The hash is >= rangeEnd, so it's not in this shard's range
       // This shouldn't happen if shards cover the full keyspace
       return undefined;
     }

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -1,3 +1,4 @@
+import xxhashInit from "xxhash-wasm";
 import type { ClientOptions } from "@grpc/grpc-js";
 import { ChannelCredentials, credentials, Metadata } from "@grpc/grpc-js";
 import { GrpcTransport } from "@protobuf-ts/grpc-transport";
@@ -250,30 +251,32 @@ export interface ShardInfoWithRange {
 }
 
 /**
- * Hash a tenant ID to a 16-character hex string using FNV-1a with
- * splitmix64 finalization. Must match the Rust `hash_tenant` implementation
- * in `src/shard_range.rs` exactly.
+ * Initialize the XXH64 hasher (loads WASM). Must be awaited before calling
+ * hashTenant(). The SiloGRPCClient handles this automatically; only needed
+ * when using hashTenant() directly.
+ */
+let _h64: ((input: string, seed?: bigint) => bigint) | undefined;
+let _initPromise: Promise<void> | undefined;
+
+export function initHasher(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = xxhashInit().then((api) => {
+      _h64 = api.h64;
+    });
+  }
+  return _initPromise;
+}
+
+/**
+ * Hash a tenant ID to a 16-character hex string using XXH64 (seed 0).
+ * Must match the Rust `hash_tenant` implementation in `src/shard_range.rs`.
+ * Call and await initHasher() before first use.
  */
 export function hashTenant(tenantId: string): string {
-  const MASK = 0xffffffffffffffffn;
-  const FNV_OFFSET = 0xcbf29ce484222325n;
-  const FNV_PRIME = 0x100000001b3n;
-
-  // FNV-1a accumulation
-  let hash = FNV_OFFSET;
-  for (let i = 0; i < tenantId.length; i++) {
-    hash ^= BigInt(tenantId.charCodeAt(i));
-    hash = (hash * FNV_PRIME) & MASK;
+  if (!_h64) {
+    throw new Error("XXH64 hasher not initialized. Call and await initHasher() first.");
   }
-
-  // splitmix64 finalization
-  hash ^= hash >> 30n;
-  hash = (hash * 0xbf58476d1ce4e5b9n) & MASK;
-  hash ^= hash >> 27n;
-  hash = (hash * 0x94d049bb133111ebn) & MASK;
-  hash ^= hash >> 31n;
-
-  return hash.toString(16).padStart(16, "0");
+  return _h64(tenantId).toString(16).padStart(16, "0");
 }
 
 /**
@@ -1387,6 +1390,7 @@ export class SiloGRPCClient {
    * @internal
    */
   private async _ensureTopology(): Promise<void> {
+    await initHasher();
     if (this._topologyReady) {
       return;
     }

--- a/typescript_client/src/index.ts
+++ b/typescript_client/src/index.ts
@@ -16,6 +16,8 @@ export {
   SiloResourceExhaustedError,
   SiloUnavailableError,
   SiloDeadlineExceededError,
+  initHasher,
+  hashTenant,
   shardForTenant,
   GubernatorAlgorithm,
   GubernatorBehavior,

--- a/typescript_client/test/shard-routing.test.ts
+++ b/typescript_client/test/shard-routing.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { SiloGRPCClient, shardForTenant, hashTenant, type ShardInfoWithRange } from "../src/client";
+import { SiloGRPCClient, shardForTenant, hashTenant, initHasher, type ShardInfoWithRange } from "../src/client";
 import { RpcError } from "@protobuf-ts/runtime-rpc";
 
 describe("Shard Routing", () => {
+  beforeAll(() => initHasher());
+
   describe("hashTenant", () => {
     it("returns a 16-character hex string", () => {
       const hash = hashTenant("test-tenant");

--- a/typescript_client/test/shard-routing.test.ts
+++ b/typescript_client/test/shard-routing.test.ts
@@ -23,18 +23,16 @@ describe("Shard Routing", () => {
     });
   });
 
-  describe("shardForTenant hash-based lookup", () => {
-    it("routes tenant to correct shard based on hash", () => {
-      // Use hash-space boundaries (16-char hex)
+  describe("shardForTenant lexicographic lookup (expects hash-space keys)", () => {
+    it("finds correct shard for key in range", () => {
       const shards: ShardInfoWithRange[] = [
         { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "8000000000000000" },
         { shardId: "shard-2", serverAddr: "server-b:7450", rangeStart: "8000000000000000", rangeEnd: "" },
       ];
 
-      // Every tenant should land on one of the two shards
-      const result = shardForTenant("test-tenant", shards);
-      expect(result).toBeDefined();
-      expect(["shard-1", "shard-2"]).toContain(result?.shardId);
+      // Keys in hash space — direct lexicographic comparison
+      expect(shardForTenant("3000000000000000", shards)?.shardId).toBe("shard-1");
+      expect(shardForTenant("a000000000000000", shards)?.shardId).toBe("shard-2");
     });
 
     it("handles single full-range shard", () => {
@@ -42,14 +40,14 @@ describe("Shard Routing", () => {
         { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "" },
       ];
 
-      expect(shardForTenant("any-tenant", shards)?.shardId).toBe("shard-1");
+      expect(shardForTenant("anything", shards)?.shardId).toBe("shard-1");
     });
 
     it("returns undefined for empty shards array", () => {
-      expect(shardForTenant("tenant", [])).toBeUndefined();
+      expect(shardForTenant("key", [])).toBeUndefined();
     });
 
-    it("handles multiple shard ranges in hash space", () => {
+    it("handles multiple shard ranges", () => {
       const shards: ShardInfoWithRange[] = [
         { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "4000000000000000" },
         { shardId: "shard-2", serverAddr: "server-b:7450", rangeStart: "4000000000000000", rangeEnd: "8000000000000000" },
@@ -57,23 +55,29 @@ describe("Shard Routing", () => {
         { shardId: "shard-4", serverAddr: "server-b:7450", rangeStart: "c000000000000000", rangeEnd: "" },
       ];
 
-      // All tenants should route to exactly one shard
-      for (const tenant of ["tenant-1", "tenant-2", "env-123", "zebra", "apple"]) {
-        const result = shardForTenant(tenant, shards);
-        expect(result).toBeDefined();
-        expect(["shard-1", "shard-2", "shard-3", "shard-4"]).toContain(result?.shardId);
-      }
+      expect(shardForTenant("1000000000000000", shards)?.shardId).toBe("shard-1");
+      expect(shardForTenant("5000000000000000", shards)?.shardId).toBe("shard-2");
+      expect(shardForTenant("9000000000000000", shards)?.shardId).toBe("shard-3");
+      expect(shardForTenant("d000000000000000", shards)?.shardId).toBe("shard-4");
     });
 
-    it("same tenant always routes to same shard", () => {
+    it("end-to-end: hashTenant + shardForTenant routes tenants correctly", () => {
       const shards: ShardInfoWithRange[] = [
         { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "8000000000000000" },
         { shardId: "shard-2", serverAddr: "server-b:7450", rangeStart: "8000000000000000", rangeEnd: "" },
       ];
 
-      const result1 = shardForTenant("my-tenant", shards);
-      const result2 = shardForTenant("my-tenant", shards);
-      expect(result1?.shardId).toBe(result2?.shardId);
+      // Hash first, then look up — this is what _resolveShard does
+      for (const tenant of ["test-tenant", "env-123", "bench-0"]) {
+        const result = shardForTenant(hashTenant(tenant), shards);
+        expect(result).toBeDefined();
+        expect(["shard-1", "shard-2"]).toContain(result?.shardId);
+      }
+
+      // Same tenant always routes to same shard
+      const r1 = shardForTenant(hashTenant("my-tenant"), shards);
+      const r2 = shardForTenant(hashTenant("my-tenant"), shards);
+      expect(r1?.shardId).toBe(r2?.shardId);
     });
   });
 

--- a/typescript_client/test/shard-routing.test.ts
+++ b/typescript_client/test/shard-routing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
 import { SiloGRPCClient, shardForTenant, hashTenant, initHasher, type ShardInfoWithRange } from "../src/client";
 import { RpcError } from "@protobuf-ts/runtime-rpc";
 

--- a/typescript_client/test/shard-routing.test.ts
+++ b/typescript_client/test/shard-routing.test.ts
@@ -1,22 +1,43 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { SiloGRPCClient, shardForTenant, type ShardInfoWithRange } from "../src/client";
+import { SiloGRPCClient, shardForTenant, hashTenant, type ShardInfoWithRange } from "../src/client";
 import { RpcError } from "@protobuf-ts/runtime-rpc";
 
 describe("Shard Routing", () => {
-  describe("shardForTenant range-based lookup", () => {
-    it("finds correct shard for tenant in range", () => {
-      const shards: ShardInfoWithRange[] = [
-        { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "m" },
-        { shardId: "shard-2", serverAddr: "server-b:7450", rangeStart: "m", rangeEnd: "" },
-      ];
-
-      // "apple" comes before "m"
-      expect(shardForTenant("apple", shards)?.shardId).toBe("shard-1");
-      // "zebra" comes after "m"
-      expect(shardForTenant("zebra", shards)?.shardId).toBe("shard-2");
+  describe("hashTenant", () => {
+    it("returns a 16-character hex string", () => {
+      const hash = hashTenant("test-tenant");
+      expect(hash).toMatch(/^[0-9a-f]{16}$/);
     });
 
-    it("handles empty rangeStart (no lower bound)", () => {
+    it("is deterministic", () => {
+      expect(hashTenant("tenant-1")).toBe(hashTenant("tenant-1"));
+    });
+
+    it("distributes env- tenants across different first hex digits", () => {
+      const firstDigits = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        firstDigits.add(hashTenant(`env-${i}`)[0]);
+      }
+      // With good hashing, 100 env- tenants should hit many different first digits
+      expect(firstDigits.size).toBeGreaterThan(8);
+    });
+  });
+
+  describe("shardForTenant hash-based lookup", () => {
+    it("routes tenant to correct shard based on hash", () => {
+      // Use hash-space boundaries (16-char hex)
+      const shards: ShardInfoWithRange[] = [
+        { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "8000000000000000" },
+        { shardId: "shard-2", serverAddr: "server-b:7450", rangeStart: "8000000000000000", rangeEnd: "" },
+      ];
+
+      // Every tenant should land on one of the two shards
+      const result = shardForTenant("test-tenant", shards);
+      expect(result).toBeDefined();
+      expect(["shard-1", "shard-2"]).toContain(result?.shardId);
+    });
+
+    it("handles single full-range shard", () => {
       const shards: ShardInfoWithRange[] = [
         { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "" },
       ];
@@ -24,30 +45,35 @@ describe("Shard Routing", () => {
       expect(shardForTenant("any-tenant", shards)?.shardId).toBe("shard-1");
     });
 
-    it("handles empty rangeEnd (no upper bound)", () => {
-      const shards: ShardInfoWithRange[] = [
-        { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "a", rangeEnd: "" },
-      ];
-
-      expect(shardForTenant("zebra", shards)?.shardId).toBe("shard-1");
-    });
-
     it("returns undefined for empty shards array", () => {
       expect(shardForTenant("tenant", [])).toBeUndefined();
     });
 
-    it("handles multiple shard ranges", () => {
+    it("handles multiple shard ranges in hash space", () => {
       const shards: ShardInfoWithRange[] = [
-        { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "4" },
-        { shardId: "shard-2", serverAddr: "server-b:7450", rangeStart: "4", rangeEnd: "8" },
-        { shardId: "shard-3", serverAddr: "server-a:7450", rangeStart: "8", rangeEnd: "c" },
-        { shardId: "shard-4", serverAddr: "server-b:7450", rangeStart: "c", rangeEnd: "" },
+        { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "4000000000000000" },
+        { shardId: "shard-2", serverAddr: "server-b:7450", rangeStart: "4000000000000000", rangeEnd: "8000000000000000" },
+        { shardId: "shard-3", serverAddr: "server-a:7450", rangeStart: "8000000000000000", rangeEnd: "c000000000000000" },
+        { shardId: "shard-4", serverAddr: "server-b:7450", rangeStart: "c000000000000000", rangeEnd: "" },
       ];
 
-      expect(shardForTenant("1", shards)?.shardId).toBe("shard-1");
-      expect(shardForTenant("5", shards)?.shardId).toBe("shard-2");
-      expect(shardForTenant("9", shards)?.shardId).toBe("shard-3");
-      expect(shardForTenant("d", shards)?.shardId).toBe("shard-4");
+      // All tenants should route to exactly one shard
+      for (const tenant of ["tenant-1", "tenant-2", "env-123", "zebra", "apple"]) {
+        const result = shardForTenant(tenant, shards);
+        expect(result).toBeDefined();
+        expect(["shard-1", "shard-2", "shard-3", "shard-4"]).toContain(result?.shardId);
+      }
+    });
+
+    it("same tenant always routes to same shard", () => {
+      const shards: ShardInfoWithRange[] = [
+        { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "8000000000000000" },
+        { shardId: "shard-2", serverAddr: "server-b:7450", rangeStart: "8000000000000000", rangeEnd: "" },
+      ];
+
+      const result1 = shardForTenant("my-tenant", shards);
+      const result2 = shardForTenant("my-tenant", shards);
+      expect(result1?.shardId).toBe(result2?.shardId);
     });
   });
 
@@ -78,27 +104,27 @@ describe("Shard Routing", () => {
               grpcAddr: "server-a:7450",
               nodeId: "node-a",
               rangeStart: "",
-              rangeEnd: "4",
+              rangeEnd: "4000000000000000",
             },
             {
               shardId: "00000000-0000-0000-0000-000000000002",
               grpcAddr: "server-b:7450",
               nodeId: "node-b",
-              rangeStart: "4",
-              rangeEnd: "8",
+              rangeStart: "4000000000000000",
+              rangeEnd: "8000000000000000",
             },
             {
               shardId: "00000000-0000-0000-0000-000000000003",
               grpcAddr: "server-a:7450",
               nodeId: "node-a",
-              rangeStart: "8",
-              rangeEnd: "c",
+              rangeStart: "8000000000000000",
+              rangeEnd: "c000000000000000",
             },
             {
               shardId: "00000000-0000-0000-0000-000000000004",
               grpcAddr: "server-b:7450",
               nodeId: "node-b",
-              rangeStart: "c",
+              rangeStart: "c000000000000000",
               rangeEnd: "",
             },
           ],
@@ -139,13 +165,13 @@ describe("Shard Routing", () => {
               grpcAddr: "server-x:7450",
               nodeId: "node-x",
               rangeStart: "",
-              rangeEnd: "m",
+              rangeEnd: "8000000000000000",
             },
             {
               shardId: "00000000-0000-0000-0000-000000000002",
               grpcAddr: "server-y:7450",
               nodeId: "node-y",
-              rangeStart: "m",
+              rangeStart: "8000000000000000",
               rangeEnd: "",
             },
           ],


### PR DESCRIPTION
## Summary

Tenant IDs are now hashed before shard assignment, preventing hotspots where tenants with shared prefixes (e.g. all `env-*` tenants) cluster on a single shard.

- **Hash algorithm**: XXH64 via `xxhash-rust` (Rust) and `xxhash-wasm` (TypeScript) — a well-known, fast non-cryptographic hash with excellent avalanche properties. Using crate/npm packages on both sides means we don't maintain our own hash implementation.
- **Raw keys preserved**: The tenant key itself is still stored everywhere (shard databases, logs, gRPC requests). Hashing only happens at routing time to decide which shard owns a tenant. This means a marginal increase in CPU for hashing on each request, but we get to see raw tenant keys in logs and storage.
- **Range boundaries**: Shard ranges are now evenly-spaced 16-char hex strings in the u64 hash space. Midpoint computation is numeric (u64 arithmetic) rather than the old string-based approach.

## Test plan
- [x] All shard range, split, and coordination tests pass with hash-space boundaries
- [x] Cross-language hash parity verified (Rust and TypeScript produce identical XXH64 outputs)
- [x] etcd and k8s sequential split tests use offset split points (not exact midpoints)
- [x] Determinism test verifies same tenant always maps to same shard