### PR TITLE
Add per-queue requester counter and optimize COUNT(*) queries

### DIFF
--- a/benches/query_performance.rs
+++ b/benches/query_performance.rs
@@ -110,6 +110,107 @@ async fn main() {
     run_tenant_queries(&engine, small_tenant).await;
     println!();
 
+    // --- Queue Count Queries ---
+    println!(
+        "--- Queue Count Queries (deep-queue: {} holders + {} waiters) ---",
+        DEEP_QUEUE_HOLDERS, DEEP_QUEUE_WAITERS
+    );
+
+    let r = bench_query(
+        &engine,
+        "count_all_holders",
+        "SELECT COUNT(*) FROM queues WHERE entry_type = 'holder'",
+    )
+    .await;
+    r.print();
+
+    let r = bench_query(
+        &engine,
+        "count_all_requesters",
+        "SELECT COUNT(*) FROM queues WHERE entry_type = 'requester'",
+    )
+    .await;
+    r.print();
+
+    let r = bench_query(
+        &engine,
+        "count_holders_by_tenant",
+        &format!(
+            "SELECT COUNT(*) FROM queues WHERE tenant = '{}' AND entry_type = 'holder'",
+            BENCH_DEEP_QUEUE_TENANT
+        ),
+    )
+    .await;
+    r.print();
+
+    let r = bench_query(
+        &engine,
+        "count_requesters_by_tenant",
+        &format!(
+            "SELECT COUNT(*) FROM queues WHERE tenant = '{}' AND entry_type = 'requester'",
+            BENCH_DEEP_QUEUE_TENANT
+        ),
+    )
+    .await;
+    r.print();
+
+    let r = bench_query(
+        &engine,
+        "count_holders_by_queue",
+        &format!(
+            "SELECT COUNT(*) FROM queues WHERE tenant = '{}' AND queue_name = '{}' AND entry_type = 'holder'",
+            BENCH_DEEP_QUEUE_TENANT, DEEP_QUEUE_KEY
+        ),
+    )
+    .await;
+    r.print();
+
+    let r = bench_query(
+        &engine,
+        "count_requesters_by_queue",
+        &format!(
+            "SELECT COUNT(*) FROM queues WHERE tenant = '{}' AND queue_name = '{}' AND entry_type = 'requester'",
+            BENCH_DEEP_QUEUE_TENANT, DEEP_QUEUE_KEY
+        ),
+    )
+    .await;
+    r.print();
+
+    let r = bench_query(
+        &engine,
+        "queue_breakdown",
+        &format!(
+            "SELECT queue_name, entry_type, COUNT(*) FROM queues WHERE tenant = '{}' GROUP BY queue_name, entry_type",
+            BENCH_DEEP_QUEUE_TENANT
+        ),
+    )
+    .await;
+    r.print();
+
+    let r = bench_query(
+        &engine,
+        "list_holders_for_queue",
+        &format!(
+            "SELECT * FROM queues WHERE tenant = '{}' AND queue_name = '{}' AND entry_type = 'holder'",
+            BENCH_DEEP_QUEUE_TENANT, DEEP_QUEUE_KEY
+        ),
+    )
+    .await;
+    r.print();
+
+    let r = bench_query(
+        &engine,
+        "first_page_requesters",
+        &format!(
+            "SELECT * FROM queues WHERE tenant = '{}' AND queue_name = '{}' AND entry_type = 'requester' LIMIT 20",
+            BENCH_DEEP_QUEUE_TENANT, DEEP_QUEUE_KEY
+        ),
+    )
+    .await;
+    r.print();
+
+    println!();
+
     shard.close().await.expect("close shard");
     println!("Done.");
 }

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -43,6 +43,7 @@ use std::sync::{Arc, Mutex};
 use slatedb::config::WriteOptions;
 use slatedb::{Db, DbIterator, WriteBatch};
 
+use crate::job_store_shard::counters::encode_counter;
 use crate::job_store_shard::helpers::WriteBatcher;
 
 use crate::codec::{
@@ -54,9 +55,9 @@ use crate::job::{ConcurrencyLimit, JobStatusKind, JobView, Limit};
 use crate::job_store_shard::helpers::decode_job_status_owned;
 use crate::keys::{
     concurrency_counts_key, concurrency_holder_key, concurrency_holders_queue_prefix,
-    concurrency_request_key, concurrency_request_prefix, concurrency_requests_prefix, end_bound,
-    floating_limit_state_key, job_status_key, parse_concurrency_holder_key,
-    parse_concurrency_request_key, task_key,
+    concurrency_request_key, concurrency_request_prefix, concurrency_requester_counter_key,
+    concurrency_requests_prefix, end_bound, floating_limit_state_key, job_status_key,
+    parse_concurrency_holder_key, parse_concurrency_request_key, task_key,
 };
 use crate::shard_range::ShardRange;
 use crate::task::{ConcurrencyAction, HolderRecord, Task};
@@ -763,7 +764,12 @@ impl ConcurrencyManager {
                             || status.current_attempt != Some(attempt_number) =>
                     {
                         // [SILO-GRANT-6] Drop stale request key without granting work.
-                        let _ = db.delete(&kv.key).await;
+                        if delete_stale_request(db, &kv.key, tenant, queue)
+                            .await
+                            .is_err()
+                        {
+                            continue;
+                        }
                         tracing::debug!(
                             job_id = %job_id_str,
                             queue = %queue,
@@ -776,7 +782,12 @@ impl ConcurrencyManager {
                     }
                     Ok(_) => {}
                     Err(_) => {
-                        let _ = db.delete(&kv.key).await;
+                        if delete_stale_request(db, &kv.key, tenant, queue)
+                            .await
+                            .is_err()
+                        {
+                            continue;
+                        }
                         tracing::warn!(
                             job_id = %job_id_str,
                             queue = %queue,
@@ -786,7 +797,12 @@ impl ConcurrencyManager {
                     }
                 },
                 Ok(None) => {
-                    let _ = db.delete(&kv.key).await;
+                    if delete_stale_request(db, &kv.key, tenant, queue)
+                        .await
+                        .is_err()
+                    {
+                        continue;
+                    }
                     tracing::debug!(
                         job_id = %job_id_str,
                         queue = %queue,
@@ -879,6 +895,12 @@ impl ConcurrencyManager {
                 &tval,
             );
             batch.delete(&kv.key);
+
+            // Decrement the per-queue requester counter (request converted to holder)
+            batch.merge(
+                concurrency_requester_counter_key(tenant, queue),
+                encode_counter(-1),
+            );
 
             // Commit with durability
             if let Err(e) = db
@@ -984,5 +1006,32 @@ fn append_request_edits<W: WriteBatcher>(
         &suffix,
     );
     writer.put(&req_key, &action_val)?;
+
+    // Increment the per-queue requester counter
+    let counter_key = concurrency_requester_counter_key(tenant, queue);
+    writer.merge(&counter_key, encode_counter(1))?;
+
+    Ok(())
+}
+
+/// Atomically delete a stale concurrency request key and decrement the per-queue
+/// requester counter. Used by the grant scanner when it discovers requests for
+/// jobs that are no longer in the expected state.
+async fn delete_stale_request(
+    db: &Db,
+    request_key: &[u8],
+    tenant: &str,
+    queue: &str,
+) -> Result<(), slatedb::Error> {
+    let mut batch = WriteBatch::new();
+    batch.delete(request_key);
+    batch.merge(
+        concurrency_requester_counter_key(tenant, queue),
+        encode_counter(-1),
+    );
+    if let Err(e) = db.write(batch).await {
+        tracing::warn!(error = %e, "grant scanner: failed to delete stale request");
+        return Err(e);
+    }
     Ok(())
 }

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -4,13 +4,14 @@ use slatedb::{DbIterator, IsolationLevel};
 
 use crate::codec::{decode_cancellation_at_ms, decode_task, encode_job_cancellation};
 use crate::job::{JobCancellation, JobStatus, JobStatusKind, JobView, Limit};
+use crate::job_store_shard::counters::encode_counter;
 use crate::job_store_shard::helpers::{
     TxnWriter, decode_job_status_owned, now_epoch_ms, retry_on_txn_conflict,
 };
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
-    concurrency_holder_key, concurrency_request_job_prefix, end_bound, job_cancelled_key,
-    job_info_key, job_status_key, task_key,
+    concurrency_holder_key, concurrency_request_job_prefix, concurrency_requester_counter_key,
+    end_bound, job_cancelled_key, job_info_key, job_status_key, task_key,
 };
 use crate::task::Task;
 
@@ -284,17 +285,25 @@ impl JobStoreShard {
         let end = end_bound(&prefix);
         let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(prefix..end).await?;
 
-        let mut deleted_any = false;
+        let mut deleted_count: i64 = 0;
         while let Some(kv) = iter.next().await? {
             txn.delete(&kv.key)?;
-            deleted_any = true;
+            deleted_count += 1;
             tracing::debug!(
                 job_id = %job_id,
                 queue = %queue_key,
                 "cancel: deleted concurrency request for cancelled job"
             );
         }
-        Ok(deleted_any)
+
+        if deleted_count > 0 {
+            // Decrement the per-queue requester counter
+            let counter_key = concurrency_requester_counter_key(tenant, queue_key);
+            txn.merge(&counter_key, encode_counter(-deleted_count))?;
+            txn.unmark_write([counter_key.as_slice()])?;
+        }
+
+        Ok(deleted_count > 0)
     }
 
     /// Check if a job has been cancelled.

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -9,9 +9,9 @@
 use crate::coordination::SplitCleanupStatus;
 use crate::keys::{
     self, end_bound, parse_attempt_key, parse_concurrency_holder_key,
-    parse_concurrency_request_key, parse_floating_limit_key, parse_job_cancelled_key,
-    parse_job_info_key, parse_job_status_key, parse_metadata_index_key,
-    parse_status_time_index_key, tasks_prefix,
+    parse_concurrency_request_key, parse_concurrency_requester_counter_key,
+    parse_floating_limit_key, parse_job_cancelled_key, parse_job_info_key, parse_job_status_key,
+    parse_metadata_index_key, parse_status_time_index_key, tasks_prefix,
 };
 use crate::shard_range::ShardRange;
 use slatedb::WriteBatch;
@@ -165,6 +165,11 @@ impl JobStoreShard {
             (
                 vec![prefix::FLOATING_LIMIT],
                 Box::new(|key, _| parse_floating_limit_key(key).map(|p| p.tenant)),
+            ),
+            // Concurrency requester counter keys (0xF7)
+            (
+                vec![prefix::COUNTER_CONCURRENCY_REQUESTERS],
+                Box::new(|key, _| parse_concurrency_requester_counter_key(key).map(|p| p.tenant)),
             ),
             // Task keys - tenant is in the value, not the key
             (

--- a/src/job_store_shard/counters.rs
+++ b/src/job_store_shard/counters.rs
@@ -21,7 +21,10 @@ use slatedb::{MergeOperator, MergeOperatorError};
 
 use crate::job_store_shard::helpers::WriteBatcher;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
-use crate::keys::{shard_completed_jobs_counter_key, shard_total_jobs_counter_key};
+use crate::keys::{
+    concurrency_requester_counter_key, shard_completed_jobs_counter_key,
+    shard_total_jobs_counter_key,
+};
 
 /// Shard job counters returned by get_counters.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -157,5 +160,18 @@ impl JobStoreShard {
         let key = shard_completed_jobs_counter_key();
         writer.merge(&key, encode_counter(-1))?;
         Ok(())
+    }
+
+    /// Get the current concurrency requester count for a specific tenant/queue.
+    pub async fn get_concurrency_requester_count(
+        &self,
+        tenant: &str,
+        queue: &str,
+    ) -> Result<i64, JobStoreShardError> {
+        let key = concurrency_requester_counter_key(tenant, queue);
+        match self.db.get(&key).await? {
+            Some(bytes) => Ok(decode_counter(&bytes)),
+            None => Ok(0),
+        }
     }
 }

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -1,7 +1,7 @@
 //! Job store shard - a single shard of the distributed job storage system.
 mod cancel;
 mod cleanup;
-mod counters;
+pub(crate) mod counters;
 mod dequeue;
 mod enqueue;
 mod expedite;

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -31,6 +31,7 @@ pub(crate) mod prefix {
     pub const CLEANUP_STATUS: u8 = 0xF4;
     pub const SHARD_CREATED_AT: u8 = 0xF5;
     pub const CLEANUP_COMPLETED_AT: u8 = 0xF6;
+    pub const COUNTER_CONCURRENCY_REQUESTERS: u8 = 0xF7;
 }
 
 /// Encode a key with its namespace prefix.
@@ -565,6 +566,30 @@ pub fn shard_created_at_key() -> Vec<u8> {
 /// Only set after a split cleanup finishes.
 pub fn cleanup_completed_at_key() -> Vec<u8> {
     vec![prefix::CLEANUP_COMPLETED_AT]
+}
+
+/// Key for the per-queue concurrency requester counter.
+/// Tracks the number of pending concurrency requests for a specific tenant/queue.
+pub fn concurrency_requester_counter_key(tenant: &str, queue: &str) -> Vec<u8> {
+    encode_with_prefix(prefix::COUNTER_CONCURRENCY_REQUESTERS, &(tenant, queue))
+}
+
+/// Parsed concurrency requester counter key components.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedConcurrencyRequesterCounterKey {
+    pub tenant: String,
+    pub queue: String,
+}
+
+/// Parse a concurrency requester counter key back to its components.
+pub fn parse_concurrency_requester_counter_key(
+    key: &[u8],
+) -> Option<ParsedConcurrencyRequesterCounterKey> {
+    if key.first() != Some(&prefix::COUNTER_CONCURRENCY_REQUESTERS) {
+        return None;
+    }
+    let (tenant, queue): (String, String) = decode(&key[1..]).ok()?;
+    Some(ParsedConcurrencyRequesterCounterKey { tenant, queue })
 }
 
 /// Construct a composite key for in-memory concurrency queue tracking.

--- a/src/query.rs
+++ b/src/query.rs
@@ -1171,6 +1171,62 @@ fn make_empty_projection_batch(projection: &SchemaRef, row_count: usize) -> DfRe
     .map_err(|e| DataFusionError::Execution(e.to_string()))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QueueRequesterFastPathProjection {
+    Empty,
+    ConstantColumns,
+}
+
+fn queue_requester_fast_path_projection(
+    projection: &SchemaRef,
+) -> Option<QueueRequesterFastPathProjection> {
+    if projection.fields().is_empty() {
+        return Some(QueueRequesterFastPathProjection::Empty);
+    }
+
+    projection
+        .fields()
+        .iter()
+        .all(|field| {
+            matches!(
+                field.name().as_str(),
+                "shard_id" | "tenant" | "queue_name" | "entry_type"
+            )
+        })
+        .then_some(QueueRequesterFastPathProjection::ConstantColumns)
+}
+
+fn make_queue_constant_projection_batch(
+    projection: &SchemaRef,
+    shard_id: &str,
+    tenant: &str,
+    queue: &str,
+    entry_type: &str,
+    row_count: usize,
+) -> DfResult<RecordBatch> {
+    if projection.fields().is_empty() {
+        return make_empty_projection_batch(projection, row_count);
+    }
+
+    let mut cols: Vec<ArrayRef> = Vec::with_capacity(projection.fields().len());
+    for field in projection.fields() {
+        match field.name().as_str() {
+            "shard_id" => cols.push(Arc::new(StringArray::from(vec![shard_id; row_count]))),
+            "tenant" => cols.push(Arc::new(StringArray::from(vec![tenant; row_count]))),
+            "queue_name" => cols.push(Arc::new(StringArray::from(vec![queue; row_count]))),
+            "entry_type" => cols.push(Arc::new(StringArray::from(vec![entry_type; row_count]))),
+            other => {
+                return Err(DataFusionError::Execution(format!(
+                    "requester fast path does not support projection column {other}"
+                )));
+            }
+        }
+    }
+
+    RecordBatch::try_new(Arc::clone(projection), cols)
+        .map_err(|e| DataFusionError::Execution(e.to_string()))
+}
+
 /// Scanner for the queues table - reads concurrency queue data from a single shard.
 pub struct QueuesScanner {
     pub(crate) shard: Arc<JobStoreShard>,
@@ -1221,18 +1277,20 @@ impl Scan for QueuesScanner {
     fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
         let mut tenant = None;
         let mut queue = None;
+        let mut entry_type = None;
         for f in filters {
             if let Some((col, val)) = parse_eq_filter(f) {
                 match col.as_str() {
                     "tenant" => tenant = Some(val),
                     "queue_name" => queue = Some(val),
+                    "entry_type" => entry_type = Some(val),
                     _ => {}
                 }
             }
         }
         format!(
-            "queues[tenant={:?}, queue={:?}], limit={:?}",
-            tenant, queue, limit
+            "queues[tenant={:?}, queue={:?}, entry_type={:?}], limit={:?}",
+            tenant, queue, entry_type, limit
         )
     }
 
@@ -1243,18 +1301,135 @@ impl Scan for QueuesScanner {
         batch_size: usize,
         limit: Option<usize>,
     ) -> SendableRecordBatchStream {
-        // Parse filters for tenant and queue_name
+        // Parse filters for tenant, queue_name, and entry_type
         let mut tenant_filter: Option<String> = None;
         let mut queue_filter: Option<String> = None;
+        let mut entry_type_filter: Option<String> = None;
         for f in filters {
             if let Some((col, val)) = parse_eq_filter(f) {
                 match col.as_str() {
                     "tenant" => tenant_filter = Some(val),
                     "queue_name" => queue_filter = Some(val),
+                    "entry_type" => entry_type_filter = Some(val),
                     _ => {}
                 }
             }
         }
+
+        // Fast path: requester-only scans for a specific tenant + queue.
+        // Filtered COUNT(*) keeps the filter columns projected because FilterExec stays above
+        // our scan, so support both the empty projection and constant-column variants.
+        if let Some(fast_path_projection) = queue_requester_fast_path_projection(&projection)
+            && let Some(ref tenant) = tenant_filter
+            && let Some(ref queue) = queue_filter
+            && entry_type_filter.as_deref() == Some("requester")
+        {
+            let tenant = tenant.clone();
+            let queue = queue.clone();
+            let shard = Arc::clone(&self.shard);
+            let proj_for_stream = Arc::clone(&projection);
+            let (tx, rx) = mpsc::channel::<DfResult<RecordBatch>>(2);
+            tokio::spawn(async move {
+                let db = shard.db();
+                let counter_key = crate::keys::concurrency_requester_counter_key(&tenant, &queue);
+                let count = match db.get(&counter_key).await {
+                    Ok(Some(bytes)) => {
+                        crate::job_store_shard::counters::decode_counter(&bytes).max(0) as usize
+                    }
+                    Ok(None) => {
+                        let prefix = crate::keys::concurrency_request_prefix(&tenant, &queue);
+                        let end = crate::keys::end_bound(&prefix);
+                        let mut iter = match db.scan::<Vec<u8>, _>(prefix..=end).await {
+                            Ok(iter) => iter,
+                            Err(e) => {
+                                let _ = tx
+                                    .send(Err(DataFusionError::Execution(e.to_string())))
+                                    .await;
+                                return;
+                            }
+                        };
+
+                        let mut scanned_count: usize = 0;
+                        loop {
+                            match iter.next().await {
+                                Ok(Some(kv)) => {
+                                    if crate::keys::parse_concurrency_request_key(&kv.key).is_some()
+                                    {
+                                        scanned_count += 1;
+                                    }
+                                }
+                                Ok(None) => break,
+                                Err(e) => {
+                                    let _ = tx
+                                        .send(Err(DataFusionError::Execution(e.to_string())))
+                                        .await;
+                                    return;
+                                }
+                            }
+                        }
+                        scanned_count
+                    }
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(DataFusionError::Execution(format!(
+                                "failed to read requester counter: {e}"
+                            ))))
+                            .await;
+                        return;
+                    }
+                };
+
+                match fast_path_projection {
+                    QueueRequesterFastPathProjection::Empty => {
+                        let batch = make_empty_projection_batch(&proj_for_stream, count);
+                        let _ = tx.send(batch).await;
+                    }
+                    QueueRequesterFastPathProjection::ConstantColumns => {
+                        let batch_rows = batch_size.max(1);
+                        let shard_id = shard.name().to_string();
+                        let mut remaining = count;
+
+                        loop {
+                            let rows = remaining.min(batch_rows);
+                            if remaining == 0 && rows == 0 {
+                                let batch = make_queue_constant_projection_batch(
+                                    &proj_for_stream,
+                                    &shard_id,
+                                    &tenant,
+                                    &queue,
+                                    "requester",
+                                    0,
+                                );
+                                let _ = tx.send(batch).await;
+                                break;
+                            }
+
+                            let batch = make_queue_constant_projection_batch(
+                                &proj_for_stream,
+                                &shard_id,
+                                &tenant,
+                                &queue,
+                                "requester",
+                                rows,
+                            );
+                            if tx.send(batch).await.is_err() {
+                                break;
+                            }
+
+                            remaining -= rows;
+                            if remaining == 0 {
+                                break;
+                            }
+                        }
+                    }
+                }
+            });
+            return Box::pin(RecordBatchStreamAdapter::new(
+                Arc::clone(&projection),
+                ReceiverStream::new(rx).map(|r| r),
+            ));
+        }
+
         let (tx, rx) = mpsc::channel::<DfResult<RecordBatch>>(2);
         let shard = Arc::clone(&self.shard);
         let proj_for_stream = Arc::clone(&projection);

--- a/tests/concurrency_requester_counter_tests.rs
+++ b/tests/concurrency_requester_counter_tests.rs
@@ -1,0 +1,581 @@
+mod test_helpers;
+
+use std::sync::Arc;
+
+use silo::codec::encode_concurrency_action;
+use silo::job::{ConcurrencyLimit, Limit};
+use silo::job_attempt::AttemptOutcome;
+use silo::keys::concurrency_request_key;
+use silo::keys::concurrency_requester_counter_key;
+use silo::query::ShardQueryEngine;
+use silo::task::ConcurrencyAction;
+use test_helpers::*;
+
+#[silo::test]
+async fn requester_counter_tracks_enqueue_and_grant() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "counter-q".to_string();
+
+    // First job takes the single slot (holder, no request)
+    shard
+        .enqueue(
+            "-",
+            Some("job-1".to_string()),
+            10,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue1");
+    let tasks = shard.dequeue("w", "default", 1).await.expect("deq1").tasks;
+    assert_eq!(tasks.len(), 1);
+    let t1_id = tasks[0].attempt().task_id().to_string();
+
+    // Counter should be 0 (no requesters yet)
+    let count = shard
+        .get_concurrency_requester_count("-", &queue)
+        .await
+        .expect("get counter");
+    assert_eq!(count, 0, "no requesters after first job gets holder");
+
+    // Second job should become a requester (queue full)
+    shard
+        .enqueue(
+            "-",
+            Some("job-2".to_string()),
+            10,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue2");
+
+    let count = shard
+        .get_concurrency_requester_count("-", &queue)
+        .await
+        .expect("get counter");
+    assert_eq!(count, 1, "one requester after second enqueue");
+
+    // Third job should also become a requester
+    shard
+        .enqueue(
+            "-",
+            Some("job-3".to_string()),
+            10,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 3})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue3");
+
+    let count = shard
+        .get_concurrency_requester_count("-", &queue)
+        .await
+        .expect("get counter");
+    assert_eq!(count, 2, "two requesters after third enqueue");
+
+    // Complete first task; this should trigger grant and decrement counter
+    shard
+        .report_attempt_outcome(&t1_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report");
+
+    // Poll until counter decrements (grant happens async)
+    let final_count = poll_until(
+        || async {
+            shard
+                .get_concurrency_requester_count("-", &queue)
+                .await
+                .unwrap_or(99)
+        },
+        |c| *c == 1,
+        5000,
+    )
+    .await;
+    assert_eq!(final_count, 1, "counter should decrement after grant");
+}
+
+#[silo::test]
+async fn requester_counter_tracks_cancel() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "cancel-counter-q".to_string();
+
+    // First job takes the slot
+    shard
+        .enqueue(
+            "-",
+            Some("holder-job".to_string()),
+            10,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue holder");
+    let tasks = shard.dequeue("w", "default", 1).await.expect("deq").tasks;
+    assert_eq!(tasks.len(), 1);
+
+    // Second job becomes a requester
+    let waiter_id = shard
+        .enqueue(
+            "-",
+            Some("waiter-job".to_string()),
+            10,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue waiter");
+
+    let count = shard
+        .get_concurrency_requester_count("-", &queue)
+        .await
+        .expect("get counter");
+    assert_eq!(count, 1, "one requester before cancel");
+
+    // Cancel the waiting job
+    shard
+        .cancel_job("-", &waiter_id)
+        .await
+        .expect("cancel waiter");
+
+    let count = shard
+        .get_concurrency_requester_count("-", &queue)
+        .await
+        .expect("get counter after cancel");
+    assert_eq!(count, 0, "counter should be 0 after cancelling requester");
+}
+
+#[silo::test]
+async fn query_count_requesters_uses_counter() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "query-counter-q".to_string();
+
+    // First job takes slot
+    shard
+        .enqueue(
+            "-",
+            Some("holder-job".to_string()),
+            10,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue holder");
+    shard.dequeue("w", "default", 1).await.expect("deq");
+
+    // Enqueue 5 waiters
+    for i in 0..5 {
+        shard
+            .enqueue(
+                "-",
+                Some(format!("waiter-{}", i)),
+                10,
+                now,
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({})),
+                vec![Limit::Concurrency(ConcurrencyLimit {
+                    key: queue.clone(),
+                    max_concurrency: 1,
+                })],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue waiter");
+    }
+
+    // Query using COUNT(*) with entry_type = 'requester'
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT COUNT(*) FROM queues WHERE tenant = '-' AND queue_name = 'query-counter-q' AND entry_type = 'requester'")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    assert!(!batches.is_empty());
+    let count_col = batches[0].column(0);
+    let count_arr = count_col
+        .as_any()
+        .downcast_ref::<datafusion::arrow::array::Int64Array>()
+        .expect("count column");
+    assert_eq!(count_arr.value(0), 5, "COUNT(*) should return 5 requesters");
+
+    // Also verify holder count query still works (not optimized, goes through scan)
+    let batches = sql
+        .sql("SELECT COUNT(*) FROM queues WHERE tenant = '-' AND queue_name = 'query-counter-q' AND entry_type = 'holder'")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    let count_col = batches[0].column(0);
+    let count_arr = count_col
+        .as_any()
+        .downcast_ref::<datafusion::arrow::array::Int64Array>()
+        .expect("count column");
+    assert_eq!(count_arr.value(0), 1, "COUNT(*) should return 1 holder");
+
+    // Verify total count (no entry_type filter) still works correctly
+    let batches = sql
+        .sql("SELECT COUNT(*) FROM queues WHERE tenant = '-' AND queue_name = 'query-counter-q'")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    let count_col = batches[0].column(0);
+    let count_arr = count_col
+        .as_any()
+        .downcast_ref::<datafusion::arrow::array::Int64Array>()
+        .expect("count column");
+    assert_eq!(
+        count_arr.value(0),
+        6,
+        "COUNT(*) without entry_type should return all entries"
+    );
+}
+
+/// Helper: write a fake concurrency request key and bump the requester counter.
+/// The request references a job that does NOT exist in the DB, so the grant scanner
+/// will treat it as stale (missing job status) and clean it up.
+async fn inject_fake_request(
+    shard: &silo::job_store_shard::JobStoreShard,
+    tenant: &str,
+    queue: &str,
+    fake_job_id: &str,
+    attempt: u32,
+    start_time_ms: i64,
+) {
+    let db = shard.db();
+    let req_key = concurrency_request_key(
+        tenant,
+        queue,
+        start_time_ms,
+        10,
+        fake_job_id,
+        attempt,
+        "fake0001",
+    );
+    let action = ConcurrencyAction::EnqueueTask {
+        start_time_ms,
+        priority: 10,
+        job_id: fake_job_id.to_string(),
+        attempt_number: attempt,
+        relative_attempt_number: attempt,
+        task_group: "default".to_string(),
+    };
+    let action_val = encode_concurrency_action(&action);
+    db.put(&req_key, &action_val)
+        .await
+        .expect("put fake request");
+
+    // Bump the counter to reflect the injected request
+    let counter_key = concurrency_requester_counter_key(tenant, queue);
+    db.merge(counter_key, 1i64.to_le_bytes())
+        .await
+        .expect("merge counter");
+}
+
+/// The grant scanner should detect and clean up request keys whose job status
+/// is missing (deleted / never existed) and decrement the requester counter.
+#[silo::test]
+async fn requester_counter_decrements_on_stale_request_missing_status() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "stale-missing-q".to_string();
+    let tenant = "-";
+
+    // Job A takes the single slot
+    shard
+        .enqueue(
+            tenant,
+            Some("holder-job".to_string()),
+            10,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue holder");
+    let tasks = shard.dequeue("w", "default", 1).await.expect("deq").tasks;
+    assert_eq!(tasks.len(), 1);
+    let holder_task_id = tasks[0].attempt().task_id().to_string();
+
+    // Inject a fake request for a job that doesn't exist
+    inject_fake_request(&shard, tenant, &queue, "ghost-job", 1, now).await;
+
+    let count = shard
+        .get_concurrency_requester_count(tenant, &queue)
+        .await
+        .expect("counter");
+    assert_eq!(count, 1, "counter should reflect the injected fake request");
+
+    // Complete the holder to trigger the grant scanner
+    shard
+        .report_attempt_outcome(&holder_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report");
+
+    // The grant scanner should find the fake request, see no job status, delete it,
+    // and decrement the counter.
+    let final_count = poll_until(
+        || async {
+            shard
+                .get_concurrency_requester_count(tenant, &queue)
+                .await
+                .unwrap_or(99)
+        },
+        |c| *c == 0,
+        5000,
+    )
+    .await;
+    assert_eq!(
+        final_count, 0,
+        "counter should be 0 after stale request cleanup"
+    );
+
+    // The stale request key should have been deleted
+    let remaining_requests = count_concurrency_requests(shard.db()).await;
+    assert_eq!(remaining_requests, 0, "stale request key should be deleted");
+}
+
+/// The grant scanner should detect and clean up request keys for jobs whose
+/// status has changed away from Scheduled (e.g. to Failed), and decrement the
+/// requester counter.
+#[silo::test]
+async fn requester_counter_decrements_on_stale_request_wrong_status() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "stale-status-q".to_string();
+    let tenant = "-";
+
+    // Job A takes the single slot
+    shard
+        .enqueue(
+            tenant,
+            Some("holder-a".to_string()),
+            10,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue holder A");
+    let tasks = shard.dequeue("w", "default", 1).await.expect("deq A").tasks;
+    assert_eq!(tasks.len(), 1);
+    let holder_a_task = tasks[0].attempt().task_id().to_string();
+
+    // Job B enqueues and becomes a real requester (queue full)
+    shard
+        .enqueue(
+            tenant,
+            Some("job-b".to_string()),
+            10,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue B");
+
+    assert_eq!(
+        shard
+            .get_concurrency_requester_count(tenant, &queue)
+            .await
+            .expect("counter"),
+        1,
+        "one real requester"
+    );
+
+    // Cancel job B — this cleans up its request key and decrements the counter
+    shard.cancel_job(tenant, "job-b").await.expect("cancel B");
+
+    assert_eq!(
+        shard
+            .get_concurrency_requester_count(tenant, &queue)
+            .await
+            .expect("counter"),
+        0,
+        "counter 0 after cancel"
+    );
+
+    // Now inject a fake request that references a job whose status is not Scheduled.
+    // We use "job-b" which we just cancelled — its status is now Cancelled.
+    inject_fake_request(&shard, tenant, &queue, "job-b", 99, now).await;
+
+    assert_eq!(
+        shard
+            .get_concurrency_requester_count(tenant, &queue)
+            .await
+            .expect("counter"),
+        1,
+        "counter reflects injected stale request"
+    );
+
+    // Complete holder A to trigger the grant scanner
+    shard
+        .report_attempt_outcome(&holder_a_task, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report A");
+
+    // The grant scanner should find the stale request for job-b (status=Cancelled,
+    // attempt mismatch), delete it, and decrement the counter.
+    let final_count = poll_until(
+        || async {
+            shard
+                .get_concurrency_requester_count(tenant, &queue)
+                .await
+                .unwrap_or(99)
+        },
+        |c| *c == 0,
+        5000,
+    )
+    .await;
+    assert_eq!(
+        final_count, 0,
+        "counter should be 0 after stale request cleanup"
+    );
+
+    let remaining_requests = count_concurrency_requests(shard.db()).await;
+    assert_eq!(remaining_requests, 0, "stale request key should be deleted");
+}
+
+/// When multiple stale requests exist, the grant scanner should clean them all up
+/// and decrement the counter by the correct total amount.
+#[silo::test]
+async fn requester_counter_decrements_for_multiple_stale_requests() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "stale-multi-q".to_string();
+    let tenant = "-";
+
+    // Job A takes the single slot
+    shard
+        .enqueue(
+            tenant,
+            Some("holder-job".to_string()),
+            10,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue holder");
+    let tasks = shard.dequeue("w", "default", 1).await.expect("deq").tasks;
+    assert_eq!(tasks.len(), 1);
+    let holder_task_id = tasks[0].attempt().task_id().to_string();
+
+    // Inject 3 fake requests for non-existent jobs
+    for i in 0..3 {
+        inject_fake_request(&shard, tenant, &queue, &format!("ghost-{i}"), 1, now).await;
+    }
+
+    assert_eq!(
+        shard
+            .get_concurrency_requester_count(tenant, &queue)
+            .await
+            .expect("counter"),
+        3,
+        "counter should reflect 3 injected fake requests"
+    );
+
+    // Complete the holder to trigger grant scanner
+    shard
+        .report_attempt_outcome(&holder_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report");
+
+    // All stale requests should be cleaned up
+    let final_count = poll_until(
+        || async {
+            shard
+                .get_concurrency_requester_count(tenant, &queue)
+                .await
+                .unwrap_or(99)
+        },
+        |c| *c == 0,
+        5000,
+    )
+    .await;
+    assert_eq!(
+        final_count, 0,
+        "counter should be 0 after all stale requests cleaned"
+    );
+
+    let remaining_requests = count_concurrency_requests(shard.db()).await;
+    assert_eq!(
+        remaining_requests, 0,
+        "all stale request keys should be deleted"
+    );
+}

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use datafusion::arrow::array::{Array, Int64Array, StringArray};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::ScalarValue;
+use datafusion::physical_plan::ExecutionPlan;
 use silo::job_store_shard::JobStoreShard;
 use silo::query::ShardQueryEngine;
 use test_helpers::*;
@@ -1337,6 +1338,29 @@ async fn query_queue_names(sql: &ShardQueryEngine, query: &str) -> Vec<String> {
     extract_string_column(&batches, 0)
 }
 
+fn find_plan_schema_fields(
+    plan: &Arc<dyn ExecutionPlan>,
+    target_name: &str,
+) -> Option<Vec<String>> {
+    if plan.name() == target_name {
+        return Some(
+            plan.schema()
+                .fields()
+                .iter()
+                .map(|field| field.name().to_string())
+                .collect(),
+        );
+    }
+
+    for child in plan.children() {
+        if let Some(fields) = find_plan_schema_fields(child, target_name) {
+            return Some(fields);
+        }
+    }
+
+    None
+}
+
 #[silo::test]
 async fn queues_table_exists() {
     let (_tmp, shard) = open_temp_shard().await;
@@ -1678,6 +1702,46 @@ async fn queues_table_count_aggregate() {
         .downcast_ref::<datafusion::arrow::array::Int64Array>()
         .expect("count column");
     assert_eq!(count_arr.value(0), 3);
+}
+
+#[silo::test]
+async fn queues_count_plan_uses_empty_scan_projection_without_filters() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+
+    let plan = sql
+        .get_physical_plan("SELECT COUNT(*) FROM queues")
+        .await
+        .expect("plan");
+
+    let fields =
+        find_plan_schema_fields(&plan, "SiloExecutionPlan").expect("SiloExecutionPlan fields");
+    assert!(
+        fields.is_empty(),
+        "COUNT(*) without filters should let the scan use an empty projection, got {:?}",
+        fields
+    );
+}
+
+#[silo::test]
+async fn queues_requester_count_plan_projects_filter_columns() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+
+    let plan = sql
+        .get_physical_plan(
+            "SELECT COUNT(*) FROM queues WHERE tenant = '-' AND queue_name = 'q' AND entry_type = 'requester'",
+        )
+        .await
+        .expect("plan");
+
+    let fields =
+        find_plan_schema_fields(&plan, "SiloExecutionPlan").expect("SiloExecutionPlan fields");
+    assert_eq!(
+        fields,
+        vec!["tenant", "queue_name", "entry_type"],
+        "Filtered requester COUNT(*) should keep the filter columns in the scan projection"
+    );
 }
 
 #[silo::test]


### PR DESCRIPTION
## Summary

- Adds a durable per-queue counter (`0xF7` prefix) tracking pending concurrency requesters using SlateDB's merge operator
- Short-circuits `COUNT(*) FROM queues WHERE tenant = ? AND queue_name = ? AND entry_type = 'requester'` with an O(1) point read instead of scanning 20K+ request keys
- All request create/delete paths atomically update the counter (enqueue, grant, cancel, stale cleanup)
- Counter keys are cleaned up during post-split shard cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)