### PR TITLE
Add public getters for SiloWorker configuration

### DIFF
--- a/typescript_client/src/worker.ts
+++ b/typescript_client/src/worker.ts
@@ -274,6 +274,55 @@ export class SiloWorker<
   }
 
   /**
+   * The unique identifier for this worker.
+   */
+  public get workerId(): string {
+    return this._workerId;
+  }
+
+  /**
+   * The task group this worker polls for tasks from.
+   */
+  public get taskGroup(): string {
+    return this._taskGroup;
+  }
+
+  /**
+   * The number of concurrent poll calls configured.
+   */
+  public get concurrentPollers(): number {
+    return this._concurrentPollers;
+  }
+
+  /**
+   * The maximum number of tasks that can execute simultaneously.
+   */
+  public get maxConcurrentTasks(): number {
+    return this._maxConcurrentTasks;
+  }
+
+  /**
+   * The number of tasks requested per poll call.
+   */
+  public get tasksPerPoll(): number {
+    return this._tasksPerPoll;
+  }
+
+  /**
+   * The interval in ms between poll attempts.
+   */
+  public get pollIntervalMs(): number {
+    return this._pollIntervalMs;
+  }
+
+  /**
+   * The interval in ms between heartbeats for running tasks.
+   */
+  public get heartbeatIntervalMs(): number {
+    return this._heartbeatIntervalMs;
+  }
+
+  /**
    * Whether the worker is currently running.
    */
   public get isRunning(): boolean {

--- a/typescript_client/test/worker.test.ts
+++ b/typescript_client/test/worker.test.ts
@@ -72,6 +72,13 @@ describe("SiloWorker", () => {
 
       expect(worker.isRunning).toBe(false);
       expect(worker.activeTasks).toBe(0);
+      expect(worker.workerId).toBe("test-worker");
+      expect(worker.taskGroup).toBe("default");
+      expect(worker.concurrentPollers).toBe(1);
+      expect(worker.maxConcurrentTasks).toBe(10);
+      expect(worker.tasksPerPoll).toBe(5);
+      expect(worker.pollIntervalMs).toBe(1000);
+      expect(worker.heartbeatIntervalMs).toBe(5000);
     });
 
     it("creates a worker with custom options", () => {
@@ -94,6 +101,13 @@ describe("SiloWorker", () => {
       });
 
       expect(worker.isRunning).toBe(false);
+      expect(worker.workerId).toBe("test-worker");
+      expect(worker.taskGroup).toBe("default");
+      expect(worker.concurrentPollers).toBe(3);
+      expect(worker.maxConcurrentTasks).toBe(20);
+      expect(worker.tasksPerPoll).toBe(5);
+      expect(worker.pollIntervalMs).toBe(500);
+      expect(worker.heartbeatIntervalMs).toBe(2000);
     });
   });
 


### PR DESCRIPTION
## Summary
- Expose `workerId`, `taskGroup`, `concurrentPollers`, `maxConcurrentTasks`, `tasksPerPoll`, `pollIntervalMs`, and `heartbeatIntervalMs` as read-only getters on `SiloWorker` for introspection
- Add regression tests asserting both default and custom values

## Test plan
- [x] Existing worker unit tests pass
- [x] New getter assertions added to constructor tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)