### PR TITLE
Use Prometheus counters for SlateDB counter-type metrics

### DIFF
--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -88,11 +88,9 @@ Concurrency limits control how many jobs with the same concurrency key can run s
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `silo_concurrency_holders` | Gauge | `tenant`, `queue` | Active concurrency ticket holders per queue |
 | `silo_concurrency_tickets_granted_total` | Counter | - | Total concurrency tickets granted |
 
 **Key insights:**
-- `silo_concurrency_holders` at limit indicates jobs are waiting for capacity
 - Track `silo_concurrency_tickets_granted_total` rate to understand throughput through limited queues
 
 ### gRPC Metrics

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -22,8 +22,9 @@
 //! metrics.jobs_enqueued.with_label_values(&["0", "default"]).inc();
 //! ```
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use axum::{Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
 use prometheus::{
@@ -71,24 +72,30 @@ pub struct Metrics {
     task_leases_active: GaugeVec,
 
     // Concurrency metrics
-    concurrency_holders: GaugeVec,
     concurrency_tickets_granted: Counter,
 
-    // SlateDB storage metrics (per-shard)
-    slatedb_get_requests: GaugeVec,
-    slatedb_scan_requests: GaugeVec,
-    slatedb_write_ops: GaugeVec,
-    slatedb_write_batch_count: GaugeVec,
-    slatedb_backpressure_count: GaugeVec,
+    // SlateDB storage counters (per-shard, monotonically increasing in SlateDB)
+    slatedb_get_requests: CounterVec,
+    slatedb_scan_requests: CounterVec,
+    slatedb_write_ops: CounterVec,
+    slatedb_write_batch_count: CounterVec,
+    slatedb_backpressure_count: CounterVec,
+    slatedb_wal_buffer_flushes: CounterVec,
+    slatedb_immutable_memtable_flushes: CounterVec,
+    slatedb_sst_filter_positives: CounterVec,
+    slatedb_sst_filter_negatives: CounterVec,
+    slatedb_sst_filter_false_positives: CounterVec,
+    slatedb_bytes_compacted: CounterVec,
+
+    // SlateDB storage gauges (per-shard, point-in-time values)
     slatedb_wal_buffer_estimated_bytes: GaugeVec,
-    slatedb_wal_buffer_flushes: GaugeVec,
-    slatedb_immutable_memtable_flushes: GaugeVec,
-    slatedb_sst_filter_positives: GaugeVec,
-    slatedb_sst_filter_negatives: GaugeVec,
-    slatedb_sst_filter_false_positives: GaugeVec,
-    slatedb_bytes_compacted: GaugeVec,
     slatedb_running_compactions: GaugeVec,
     slatedb_last_compaction_ts_sec: GaugeVec,
+
+    /// Tracks previous SlateDB counter values per (stat_name, shard) for delta computation.
+    /// SlateDB exposes counters as absolute values via `stat.get()`, but Prometheus counters
+    /// only support `inc_by(delta)`, so we compute deltas between polls.
+    slatedb_prev_values: Arc<Mutex<HashMap<(String, String), f64>>>,
 }
 
 impl Metrics {
@@ -191,13 +198,6 @@ impl Metrics {
             .dec();
     }
 
-    /// Update concurrency holders count for a queue.
-    pub fn set_concurrency_holders(&self, tenant: &str, queue: &str, count: u64) {
-        self.concurrency_holders
-            .with_label_values(&[tenant, queue])
-            .set(count as f64);
-    }
-
     /// Record a concurrency ticket being granted.
     pub fn record_concurrency_ticket_granted(&self) {
         self.concurrency_tickets_granted.inc();
@@ -206,10 +206,11 @@ impl Metrics {
     /// Update SlateDB storage metrics from a shard's StatRegistry.
     ///
     /// Call this periodically (e.g., every second) to sync SlateDB's internal
-    /// statistics to Prometheus gauges.
+    /// statistics to Prometheus metrics. Counter-type stats are tracked via deltas
+    /// since Prometheus counters only support `inc_by()`, not `set()`.
     pub fn update_slatedb_stats(&self, shard: &str, stats: &Arc<StatRegistry>) {
-        let mappings: &[(&str, &GaugeVec)] = &[
-            // DB stats
+        // Counter-type stats: monotonically increasing in SlateDB
+        let counter_mappings: &[(&str, &CounterVec)] = &[
             (slatedb::db_stats::GET_REQUESTS, &self.slatedb_get_requests),
             (
                 slatedb::db_stats::SCAN_REQUESTS,
@@ -223,10 +224,6 @@ impl Metrics {
             (
                 slatedb::db_stats::BACKPRESSURE_COUNT,
                 &self.slatedb_backpressure_count,
-            ),
-            (
-                slatedb::db_stats::WAL_BUFFER_ESTIMATED_BYTES,
-                &self.slatedb_wal_buffer_estimated_bytes,
             ),
             (
                 slatedb::db_stats::WAL_BUFFER_FLUSHES,
@@ -248,8 +245,15 @@ impl Metrics {
                 slatedb::db_stats::SST_FILTER_FALSE_POSITIVES,
                 &self.slatedb_sst_filter_false_positives,
             ),
-            // Compactor stats (string literals - constants not exported in slatedb 0.10)
             ("compactor/bytes_compacted", &self.slatedb_bytes_compacted),
+        ];
+
+        // Gauge-type stats: point-in-time values
+        let gauge_mappings: &[(&str, &GaugeVec)] = &[
+            (
+                slatedb::db_stats::WAL_BUFFER_ESTIMATED_BYTES,
+                &self.slatedb_wal_buffer_estimated_bytes,
+            ),
             (
                 "compactor/running_compactions",
                 &self.slatedb_running_compactions,
@@ -260,7 +264,21 @@ impl Metrics {
             ),
         ];
 
-        for (stat_name, gauge) in mappings {
+        let mut prev_values = self.slatedb_prev_values.lock().expect("lock poisoned");
+
+        for (stat_name, counter) in counter_mappings {
+            if let Some(stat) = stats.lookup(stat_name) {
+                let current = stat.get() as f64;
+                let key = (stat_name.to_string(), shard.to_string());
+                let prev = prev_values.get(&key).copied().unwrap_or(0.0);
+                if current > prev {
+                    counter.with_label_values(&[shard]).inc_by(current - prev);
+                }
+                prev_values.insert(key, current);
+            }
+        }
+
+        for (stat_name, gauge) in gauge_mappings {
             if let Some(stat) = stats.lookup(stat_name) {
                 gauge.with_label_values(&[shard]).set(stat.get() as f64);
             }
@@ -419,17 +437,6 @@ pub fn init() -> anyhow::Result<Metrics> {
     );
 
     // Concurrency metrics
-    let concurrency_holders = register(
-        &registry,
-        GaugeVec::new(
-            Opts::new(
-                "silo_concurrency_holders",
-                "Number of active concurrency ticket holders per queue",
-            ),
-            &["tenant", "queue"],
-        )?,
-    );
-
     let concurrency_tickets_granted = register(
         &registry,
         Counter::new(
@@ -438,10 +445,10 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
-    // SlateDB storage metrics
+    // SlateDB storage counters (monotonically increasing in SlateDB)
     let slatedb_get_requests = register(
         &registry,
-        GaugeVec::new(
+        CounterVec::new(
             Opts::new(
                 "silo_slatedb_get_requests_total",
                 "Total number of GET (read) requests to SlateDB",
@@ -452,7 +459,7 @@ pub fn init() -> anyhow::Result<Metrics> {
 
     let slatedb_scan_requests = register(
         &registry,
-        GaugeVec::new(
+        CounterVec::new(
             Opts::new(
                 "silo_slatedb_scan_requests_total",
                 "Total number of scan (range query) requests to SlateDB",
@@ -463,7 +470,7 @@ pub fn init() -> anyhow::Result<Metrics> {
 
     let slatedb_write_ops = register(
         &registry,
-        GaugeVec::new(
+        CounterVec::new(
             Opts::new(
                 "silo_slatedb_write_ops_total",
                 "Total number of individual write operations to SlateDB",
@@ -474,7 +481,7 @@ pub fn init() -> anyhow::Result<Metrics> {
 
     let slatedb_write_batch_count = register(
         &registry,
-        GaugeVec::new(
+        CounterVec::new(
             Opts::new(
                 "silo_slatedb_write_batch_count_total",
                 "Total number of write batches to SlateDB",
@@ -485,7 +492,7 @@ pub fn init() -> anyhow::Result<Metrics> {
 
     let slatedb_backpressure_count = register(
         &registry,
-        GaugeVec::new(
+        CounterVec::new(
             Opts::new(
                 "silo_slatedb_backpressure_count_total",
                 "Number of times writes were blocked by back-pressure in SlateDB",
@@ -494,20 +501,9 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
-    let slatedb_wal_buffer_estimated_bytes = register(
-        &registry,
-        GaugeVec::new(
-            Opts::new(
-                "silo_slatedb_wal_buffer_estimated_bytes",
-                "Estimated bytes buffered in the SlateDB WAL buffer",
-            ),
-            &["shard"],
-        )?,
-    );
-
     let slatedb_wal_buffer_flushes = register(
         &registry,
-        GaugeVec::new(
+        CounterVec::new(
             Opts::new(
                 "silo_slatedb_wal_buffer_flushes_total",
                 "Total number of WAL buffer flushes in SlateDB",
@@ -518,7 +514,7 @@ pub fn init() -> anyhow::Result<Metrics> {
 
     let slatedb_immutable_memtable_flushes = register(
         &registry,
-        GaugeVec::new(
+        CounterVec::new(
             Opts::new(
                 "silo_slatedb_immutable_memtable_flushes_total",
                 "Total number of immutable memtable flushes to SSTs in SlateDB",
@@ -529,7 +525,7 @@ pub fn init() -> anyhow::Result<Metrics> {
 
     let slatedb_sst_filter_positives = register(
         &registry,
-        GaugeVec::new(
+        CounterVec::new(
             Opts::new(
                 "silo_slatedb_sst_filter_positives_total",
                 "Total SST filter true positives (key exists, filter says yes)",
@@ -540,7 +536,7 @@ pub fn init() -> anyhow::Result<Metrics> {
 
     let slatedb_sst_filter_negatives = register(
         &registry,
-        GaugeVec::new(
+        CounterVec::new(
             Opts::new(
                 "silo_slatedb_sst_filter_negatives_total",
                 "Total SST filter true negatives (key absent, filter says no)",
@@ -551,7 +547,7 @@ pub fn init() -> anyhow::Result<Metrics> {
 
     let slatedb_sst_filter_false_positives = register(
         &registry,
-        GaugeVec::new(
+        CounterVec::new(
             Opts::new(
                 "silo_slatedb_sst_filter_false_positives_total",
                 "Total SST filter false positives (key absent, but filter said yes)",
@@ -562,10 +558,22 @@ pub fn init() -> anyhow::Result<Metrics> {
 
     let slatedb_bytes_compacted = register(
         &registry,
-        GaugeVec::new(
+        CounterVec::new(
             Opts::new(
                 "silo_slatedb_bytes_compacted_total",
                 "Total number of bytes compacted by SlateDB compactor",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    // SlateDB storage gauges (point-in-time values)
+    let slatedb_wal_buffer_estimated_bytes = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_slatedb_wal_buffer_estimated_bytes",
+                "Estimated bytes buffered in the SlateDB WAL buffer",
             ),
             &["shard"],
         )?,
@@ -608,22 +616,22 @@ pub fn init() -> anyhow::Result<Metrics> {
         broker_inflight_size,
         broker_scan_duration,
         task_leases_active,
-        concurrency_holders,
         concurrency_tickets_granted,
         slatedb_get_requests,
         slatedb_scan_requests,
         slatedb_write_ops,
         slatedb_write_batch_count,
         slatedb_backpressure_count,
-        slatedb_wal_buffer_estimated_bytes,
         slatedb_wal_buffer_flushes,
         slatedb_immutable_memtable_flushes,
         slatedb_sst_filter_positives,
         slatedb_sst_filter_negatives,
         slatedb_sst_filter_false_positives,
         slatedb_bytes_compacted,
+        slatedb_wal_buffer_estimated_bytes,
         slatedb_running_compactions,
         slatedb_last_compaction_ts_sec,
+        slatedb_prev_values: Arc::new(Mutex::new(HashMap::new())),
     })
 }
 

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -217,9 +217,6 @@ async fn test_metrics_all_recording_methods() {
     metrics.inc_task_leases_active("0", "default");
     metrics.dec_task_leases_active("0", "default");
 
-    // set_concurrency_holders
-    metrics.set_concurrency_holders("tenant-1", "queue-a", 7);
-
     // record_concurrency_ticket_granted
     metrics.record_concurrency_ticket_granted();
 
@@ -320,18 +317,6 @@ async fn test_metrics_all_recording_methods() {
         leases_line
     );
 
-    // Verify concurrency holders
-    let holders_line = find_line(&[
-        "silo_concurrency_holders",
-        "tenant=\"tenant-1\"",
-        "queue=\"queue-a\"",
-    ]);
-    assert!(
-        holders_line.as_ref().map_or(false, |l| l.ends_with(" 7")),
-        "concurrency holders should be 7, found: {:?}",
-        holders_line
-    );
-
     // Verify concurrency tickets granted
     assert!(
         body_str.contains("silo_concurrency_tickets_granted_total 1"),
@@ -347,7 +332,7 @@ async fn test_metrics_all_recording_methods() {
 
 #[silo::test]
 async fn test_metrics_slatedb_stats() {
-    let (metrics, app) = create_metrics_router();
+    let (metrics, _app) = create_metrics_router();
 
     // Create a real SlateDB to get a StatRegistry with actual stats
     let tmpdir = tempfile::tempdir().unwrap();
@@ -366,27 +351,182 @@ async fn test_metrics_slatedb_stats() {
     let stat_registry = db.metrics();
     metrics.update_slatedb_stats("0", &stat_registry);
 
-    let request = Request::builder()
-        .method("GET")
-        .uri("/metrics")
-        .body(Body::empty())
-        .unwrap();
+    let body_str = gather_metrics_text(&metrics);
 
-    let response = app.oneshot(request).await.unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body = response.into_body().collect().await.unwrap().to_bytes();
-    let body_str = String::from_utf8_lossy(&body);
-
-    // Verify SlateDB metrics are present
+    // Counter-type metrics should be emitted as TYPE counter
     assert!(
-        body_str.contains("silo_slatedb_write_ops_total"),
-        "should contain slatedb write ops metric"
+        body_str.contains("# TYPE silo_slatedb_write_ops_total counter"),
+        "write_ops should be a counter type"
     );
     assert!(
-        body_str.contains("silo_slatedb_get_requests_total"),
-        "should contain slatedb get requests metric"
+        body_str.contains("# TYPE silo_slatedb_get_requests_total counter"),
+        "get_requests should be a counter type"
+    );
+    assert!(
+        body_str.contains("# TYPE silo_slatedb_write_batch_count_total counter"),
+        "write_batch_count should be a counter type"
+    );
+
+    // Gauge-type metrics should be emitted as TYPE gauge
+    assert!(
+        body_str.contains("# TYPE silo_slatedb_wal_buffer_estimated_bytes gauge"),
+        "wal_buffer_estimated_bytes should be a gauge type"
+    );
+    assert!(
+        body_str.contains("# TYPE silo_slatedb_running_compactions gauge"),
+        "running_compactions should be a gauge type"
+    );
+
+    // Verify counter values are non-zero after writes and reads
+    let find_line = |substrings: &[&str]| -> Option<String> {
+        body_str
+            .lines()
+            .find(|l| substrings.iter().all(|s| l.contains(s)))
+            .map(|s| s.to_string())
+    };
+
+    let write_ops_line = find_line(&["silo_slatedb_write_ops_total", "shard=\"0\""]);
+    assert!(
+        write_ops_line
+            .as_ref()
+            .map_or(false, |l| !l.ends_with(" 0")),
+        "write_ops counter should be > 0 after puts, found: {:?}",
+        write_ops_line
+    );
+
+    let get_requests_line = find_line(&["silo_slatedb_get_requests_total", "shard=\"0\""]);
+    assert!(
+        get_requests_line
+            .as_ref()
+            .map_or(false, |l| !l.ends_with(" 0")),
+        "get_requests counter should be > 0 after get, found: {:?}",
+        get_requests_line
     );
 
     db.close().await.unwrap();
+}
+
+#[silo::test]
+async fn test_metrics_slatedb_counter_delta_tracking() {
+    let (metrics, _app) = create_metrics_router();
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let object_store = std::sync::Arc::new(
+        object_store::local::LocalFileSystem::new_with_prefix(tmpdir.path()).unwrap(),
+    );
+    let db = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store)
+        .await
+        .unwrap();
+
+    // First batch of writes
+    db.put(b"key1", b"value1").await.unwrap();
+    let stat_registry = db.metrics();
+    metrics.update_slatedb_stats("0", &stat_registry);
+
+    let body1 = gather_metrics_text(&metrics);
+    let write_ops_1 =
+        extract_metric_value(&body1, &["silo_slatedb_write_ops_total", "shard=\"0\""]);
+    assert!(write_ops_1 > 0.0, "write_ops should be > 0 after first put");
+
+    // Second batch of writes — delta tracking should accumulate, not reset
+    db.put(b"key2", b"value2").await.unwrap();
+    db.put(b"key3", b"value3").await.unwrap();
+    metrics.update_slatedb_stats("0", &stat_registry);
+
+    let body2 = gather_metrics_text(&metrics);
+    let write_ops_2 =
+        extract_metric_value(&body2, &["silo_slatedb_write_ops_total", "shard=\"0\""]);
+    assert!(
+        write_ops_2 > write_ops_1,
+        "write_ops should increase after more puts: {} -> {}",
+        write_ops_1,
+        write_ops_2
+    );
+
+    // Calling update again without new writes should not change the counter
+    metrics.update_slatedb_stats("0", &stat_registry);
+    let body3 = gather_metrics_text(&metrics);
+    let write_ops_3 =
+        extract_metric_value(&body3, &["silo_slatedb_write_ops_total", "shard=\"0\""]);
+    assert_eq!(
+        write_ops_2, write_ops_3,
+        "write_ops should not change when no new writes occurred"
+    );
+
+    db.close().await.unwrap();
+}
+
+#[silo::test]
+async fn test_metrics_slatedb_multiple_shards() {
+    let (metrics, _app) = create_metrics_router();
+
+    let tmpdir1 = tempfile::tempdir().unwrap();
+    let object_store1 = std::sync::Arc::new(
+        object_store::local::LocalFileSystem::new_with_prefix(tmpdir1.path()).unwrap(),
+    );
+    let db1 = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store1)
+        .await
+        .unwrap();
+
+    let tmpdir2 = tempfile::tempdir().unwrap();
+    let object_store2 = std::sync::Arc::new(
+        object_store::local::LocalFileSystem::new_with_prefix(tmpdir2.path()).unwrap(),
+    );
+    let db2 = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store2)
+        .await
+        .unwrap();
+
+    // Write different amounts to each shard
+    db1.put(b"a", b"1").await.unwrap();
+    db2.put(b"b", b"2").await.unwrap();
+    db2.put(b"c", b"3").await.unwrap();
+
+    metrics.update_slatedb_stats("shard-a", &db1.metrics());
+    metrics.update_slatedb_stats("shard-b", &db2.metrics());
+
+    let body = gather_metrics_text(&metrics);
+    let shard_a_writes = extract_metric_value(
+        &body,
+        &["silo_slatedb_write_ops_total", "shard=\"shard-a\""],
+    );
+    let shard_b_writes = extract_metric_value(
+        &body,
+        &["silo_slatedb_write_ops_total", "shard=\"shard-b\""],
+    );
+
+    assert!(shard_a_writes > 0.0, "shard-a should have writes");
+    assert!(shard_b_writes > 0.0, "shard-b should have writes");
+    assert!(
+        shard_b_writes > shard_a_writes,
+        "shard-b should have more writes than shard-a: {} vs {}",
+        shard_b_writes,
+        shard_a_writes
+    );
+
+    db1.close().await.unwrap();
+    db2.close().await.unwrap();
+}
+
+/// Gather metrics text from the Prometheus registry.
+fn gather_metrics_text(metrics: &metrics::Metrics) -> String {
+    use prometheus::{Encoder, TextEncoder};
+    let encoder = TextEncoder::new();
+    let metric_families = metrics.registry().gather();
+    let mut buffer = Vec::new();
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+    String::from_utf8(buffer).unwrap()
+}
+
+/// Extract a numeric metric value from Prometheus text output, finding the line
+/// that contains all given substrings.
+fn extract_metric_value(body: &str, substrings: &[&str]) -> f64 {
+    let line = body
+        .lines()
+        .find(|l| !l.starts_with('#') && substrings.iter().all(|s| l.contains(s)))
+        .unwrap_or_else(|| panic!("metric line not found for substrings {:?}", substrings));
+    line.rsplit_once(' ')
+        .unwrap_or_else(|| panic!("no space-separated value in line: {}", line))
+        .1
+        .parse::<f64>()
+        .unwrap_or_else(|_| panic!("failed to parse metric value from line: {}", line))
 }


### PR DESCRIPTION
## Summary
- Changed 11 SlateDB metrics from Prometheus `GaugeVec` to `CounterVec` to match their monotonically-increasing semantics in SlateDB (get_requests, scan_requests, write_ops, write_batch_count, backpressure_count, wal_buffer_flushes, immutable_memtable_flushes, sst_filter_positives/negatives/false_positives, bytes_compacted)
- Added delta tracking (`slatedb_prev_values` HashMap) since Prometheus counters only support `inc_by()`, not `set()`, and SlateDB exposes absolute values
- Kept 3 metrics as gauges where correct: `wal_buffer_estimated_bytes`, `running_compactions`, `last_compaction_ts_seconds`
- Removed unused `concurrency_holders` metric (was never set from production code)
- Added tests for counter TYPE annotation, delta accumulation across polls, and multi-shard independence

## Test plan
- [x] `cargo test --test metrics_tests` — all 7 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)