### PR TITLE
Add RoutingClient with topology refresh and redirect handling

### DIFF
--- a/src/bin/silo-bench.rs
+++ b/src/bin/silo-bench.rs
@@ -11,14 +11,13 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use clap::Parser;
 use rand::Rng;
 use silo::pb::report_outcome_request::Outcome;
-use silo::pb::silo_client::SiloClient;
 use silo::pb::{
-    ConcurrencyLimit, EnqueueRequest, GetClusterInfoRequest, LeaseTasksRequest, Limit,
-    ReportOutcomeRequest, SerializedBytes, serialized_bytes,
+    ConcurrencyLimit, EnqueueRequest, LeaseTasksRequest, Limit, ReportOutcomeRequest,
+    SerializedBytes, serialized_bytes,
 };
+use silo::routing_client::RoutingClient;
 use silo::settings::LogFormat;
 use silo::trace;
-use tonic::transport::Channel;
 use tracing::{error, info, warn};
 
 #[derive(Parser, Debug)]
@@ -84,106 +83,6 @@ fn now_ms() -> i64 {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_millis() as i64
-}
-
-/// Ensure an address has the http:// scheme prefix
-fn ensure_http_scheme(addr: &str) -> String {
-    if addr.starts_with("http://") || addr.starts_with("https://") {
-        addr.to_string()
-    } else {
-        format!("http://{}", addr)
-    }
-}
-
-async fn connect(address: &str) -> anyhow::Result<SiloClient<Channel>> {
-    let url = ensure_http_scheme(address);
-    let channel = Channel::from_shared(url)?.connect().await?;
-    Ok(SiloClient::new(channel))
-}
-
-/// Discover cluster topology by calling GetClusterInfo
-async fn discover_cluster(address: &str) -> anyhow::Result<ClusterInfo> {
-    let mut client = connect(address).await?;
-    let response = client
-        .get_cluster_info(GetClusterInfoRequest {})
-        .await?
-        .into_inner();
-
-    let num_shards = response.num_shards;
-    let shard_owners: Vec<ShardOwnerInfo> = response
-        .shard_owners
-        .into_iter()
-        .map(|owner| ShardOwnerInfo {
-            shard_id: owner.shard_id,
-            grpc_addr: owner.grpc_addr,
-            node_id: owner.node_id,
-            range_start: owner.range_start,
-            range_end: owner.range_end,
-        })
-        .collect();
-
-    Ok(ClusterInfo {
-        num_shards,
-        shard_owners,
-        this_node_id: response.this_node_id,
-        this_grpc_addr: response.this_grpc_addr,
-    })
-}
-
-#[derive(Debug, Clone)]
-struct ShardOwnerInfo {
-    shard_id: String,
-    grpc_addr: String,
-    #[allow(dead_code)]
-    node_id: String,
-    range_start: String,
-    range_end: String,
-}
-
-#[derive(Debug, Clone)]
-struct ClusterInfo {
-    num_shards: u32,
-    shard_owners: Vec<ShardOwnerInfo>,
-    this_node_id: String,
-    this_grpc_addr: String,
-}
-
-impl ClusterInfo {
-    /// Get a random shard ID
-    fn random_shard(&self) -> &str {
-        let idx = rand::rng().random_range(0..self.shard_owners.len());
-        &self.shard_owners[idx].shard_id
-    }
-
-    /// Get the address of the server owning a specific shard
-    fn address_for_shard(&self, shard_id: &str) -> Option<&str> {
-        self.shard_owners
-            .iter()
-            .find(|owner| owner.shard_id == shard_id)
-            .map(|owner| owner.grpc_addr.as_str())
-    }
-
-    /// Find the shard that owns the given tenant ID based on shard ranges.
-    fn shard_for_tenant(&self, tenant_id: &str) -> Option<&ShardOwnerInfo> {
-        self.shard_owners.iter().find(|owner| {
-            let after_start =
-                owner.range_start.is_empty() || tenant_id >= owner.range_start.as_str();
-            let before_end = owner.range_end.is_empty() || tenant_id < owner.range_end.as_str();
-            after_start && before_end
-        })
-    }
-
-    /// Get all unique server addresses in the cluster
-    fn all_addresses(&self) -> Vec<String> {
-        let mut addrs: Vec<String> = self
-            .shard_owners
-            .iter()
-            .map(|owner| owner.grpc_addr.clone())
-            .collect();
-        addrs.sort();
-        addrs.dedup();
-        addrs
-    }
 }
 
 /// Handles weighted tenant selection for distributing jobs across tenants.
@@ -275,11 +174,27 @@ impl TenantSelector {
     }
 }
 
+/// Maximum number of retries for wrong-shard routing errors per request.
+const MAX_ROUTING_RETRIES: u32 = 3;
+
+/// Pre-serialized empty success payload, shared across all outcome reports.
+fn make_success_outcome_request(shard: String, task_id: String) -> ReportOutcomeRequest {
+    ReportOutcomeRequest {
+        shard,
+        task_id,
+        outcome: Some(Outcome::Success(SerializedBytes {
+            encoding: Some(serialized_bytes::Encoding::Msgpack(
+                rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
+            )),
+        })),
+    }
+}
+
 /// Worker task that polls for tasks from random shards and reports success outcomes.
 /// Workers lease tasks from all tenants and report outcomes without specifying a tenant
 /// (the server determines the tenant from the task_id).
 async fn worker_loop(
-    cluster_info: Arc<ClusterInfo>,
+    client: Arc<RoutingClient>,
     worker_id: String,
     max_tasks: u32,
     running: Arc<AtomicBool>,
@@ -287,58 +202,18 @@ async fn worker_loop(
     poll_count: Arc<AtomicU64>,
     empty_poll_count: Arc<AtomicU64>,
 ) {
-    // Create connections to all servers in the cluster
-    let mut connections: std::collections::HashMap<String, SiloClient<Channel>> =
-        std::collections::HashMap::new();
-
-    for addr in cluster_info.all_addresses() {
-        match connect(&addr).await {
-            Ok(client) => {
-                connections.insert(addr, client);
-            }
-            Err(e) => {
-                error!(worker_id = %worker_id, address = %addr, error = %e, "Worker failed to connect");
-            }
-        }
-    }
-
-    if connections.is_empty() {
-        error!(worker_id = %worker_id, "Worker has no active connections, exiting");
-        return;
-    }
-
     while running.load(Ordering::Relaxed) {
-        // Pick a random shard
-        let shard = cluster_info.random_shard();
-
-        // Find the server owning this shard
-        let addr = match cluster_info.address_for_shard(shard) {
-            Some(addr) => addr.to_string(),
-            None => {
-                // Fallback: use any available connection
-                connections.keys().next().unwrap().clone()
-            }
-        };
-
-        let client = match connections.get_mut(&addr) {
-            Some(c) => c,
-            None => {
-                // Try to reconnect
-                match connect(&addr).await {
-                    Ok(c) => {
-                        connections.insert(addr.clone(), c);
-                        connections.get_mut(&addr).unwrap()
-                    }
-                    Err(_) => {
-                        tokio::time::sleep(Duration::from_millis(10)).await;
-                        continue;
-                    }
-                }
+        let (mut silo_client, shard) = match client.client_for_random_shard() {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!(worker_id = %worker_id, error = %e, "Worker failed to get client");
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                continue;
             }
         };
 
         let request = LeaseTasksRequest {
-            shard: Some(shard.to_string()),
+            shard: Some(shard.clone()),
             worker_id: worker_id.clone(),
             max_tasks,
             task_group: "default".to_string(),
@@ -346,7 +221,8 @@ async fn worker_loop(
 
         poll_count.fetch_add(1, Ordering::Relaxed);
 
-        match client.lease_tasks(request).await {
+        let result = silo_client.lease_tasks(request).await;
+        match result {
             Ok(response) => {
                 let tasks = response.into_inner().tasks;
                 if tasks.is_empty() {
@@ -357,36 +233,39 @@ async fn worker_loop(
                 }
 
                 for task in tasks {
-                    // Report success immediately (simulating instant task execution)
                     let task_shard = task.shard.clone();
-                    let task_addr = cluster_info
-                        .address_for_shard(&task_shard)
-                        .map(|a| a.to_string())
-                        .unwrap_or_else(|| addr.clone());
 
-                    // Determine which address to use for reporting - prefer task_addr if we have a connection
-                    let report_addr = if connections.contains_key(&task_addr) {
-                        task_addr
-                    } else {
-                        addr.clone()
+                    let mut report_client = match client.client_for_shard(&task_shard) {
+                        Ok(c) => c,
+                        Err(_) => silo_client.clone(),
                     };
 
-                    let outcome_request = ReportOutcomeRequest {
-                        shard: task_shard,
-                        task_id: task.id.clone(),
-                        outcome: Some(Outcome::Success(SerializedBytes {
-                            encoding: Some(serialized_bytes::Encoding::Msgpack(
-                                rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
-                            )),
-                        })),
-                    };
+                    let outcome_request =
+                        make_success_outcome_request(task_shard.clone(), task.id.clone());
 
-                    if let Some(report_client) = connections.get_mut(&report_addr) {
-                        match report_client.report_outcome(outcome_request).await {
-                            Ok(_) => {
-                                completed_count.fetch_add(1, Ordering::Relaxed);
-                            }
-                            Err(e) => {
+                    match report_client.report_outcome(outcome_request).await {
+                        Ok(_) => {
+                            completed_count.fetch_add(1, Ordering::Relaxed);
+                        }
+                        Err(e) => {
+                            // Try handling routing error for outcome reporting
+                            if client.handle_routing_error(&e, &task_shard).await.is_some() {
+                                // Retry once with updated routing
+                                if let Ok(mut retry_client) = client.client_for_shard(&task_shard) {
+                                    let retry_req = make_success_outcome_request(
+                                        task_shard,
+                                        task.id.clone(),
+                                    );
+                                    match retry_client.report_outcome(retry_req).await {
+                                        Ok(_) => {
+                                            completed_count.fetch_add(1, Ordering::Relaxed);
+                                        }
+                                        Err(e) => {
+                                            warn!(worker_id = %worker_id, error = %e, "Worker failed to report outcome after retry");
+                                        }
+                                    }
+                                }
+                            } else {
                                 warn!(worker_id = %worker_id, error = %e, "Worker failed to report outcome");
                             }
                         }
@@ -394,6 +273,13 @@ async fn worker_loop(
                 }
             }
             Err(e) => {
+                // Handle routing errors for lease_tasks
+                if let Some(needs_backoff) = client.handle_routing_error(&e, &shard).await {
+                    if needs_backoff {
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                    continue;
+                }
                 warn!(worker_id = %worker_id, error = %e, "Worker poll failed");
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
@@ -401,9 +287,9 @@ async fn worker_loop(
     }
 }
 
-/// Enqueuer task that continuously enqueues tasks to random shards
+/// Enqueuer task that continuously enqueues tasks to the correct shards.
 async fn enqueuer_loop(
-    cluster_info: Arc<ClusterInfo>,
+    client: Arc<RoutingClient>,
     enqueuer_id: String,
     concurrency_key: String,
     max_concurrency: u32,
@@ -411,105 +297,74 @@ async fn enqueuer_loop(
     enqueued_count: Arc<AtomicU64>,
     tenant_selector: Arc<TenantSelector>,
 ) {
-    // Create connections to all servers in the cluster
-    let mut connections: std::collections::HashMap<String, SiloClient<Channel>> =
-        std::collections::HashMap::new();
-
-    for addr in cluster_info.all_addresses() {
-        match connect(&addr).await {
-            Ok(client) => {
-                connections.insert(addr, client);
-            }
-            Err(e) => {
-                error!(enqueuer_id = %enqueuer_id, address = %addr, error = %e, "Enqueuer failed to connect");
-            }
-        }
-    }
-
-    if connections.is_empty() {
-        error!(enqueuer_id = %enqueuer_id, "Enqueuer has no active connections, exiting");
-        return;
-    }
-
     let mut job_counter = 0u64;
 
     while running.load(Ordering::Relaxed) {
-        // Select a tenant first, then route to the correct shard
         let tenant = tenant_selector.select().to_string();
 
-        // Find the shard that owns this tenant based on range information
-        let shard = match cluster_info.shard_for_tenant(&tenant) {
-            Some(owner) => owner.shard_id.clone(),
-            None => {
-                warn!(enqueuer_id = %enqueuer_id, tenant = %tenant, "No shard found for tenant");
-                tokio::time::sleep(Duration::from_millis(10)).await;
-                continue;
-            }
-        };
-
-        // Find the server owning this shard
-        let addr = match cluster_info.address_for_shard(&shard) {
-            Some(addr) => addr.to_string(),
-            None => {
-                // Fallback: use any available connection
-                connections.keys().next().unwrap().clone()
-            }
-        };
-
-        let client = match connections.get_mut(&addr) {
-            Some(c) => c,
-            None => {
-                // Try to reconnect
-                match connect(&addr).await {
-                    Ok(c) => {
-                        connections.insert(addr.clone(), c);
-                        connections.get_mut(&addr).unwrap()
-                    }
-                    Err(_) => {
-                        tokio::time::sleep(Duration::from_millis(10)).await;
-                        continue;
-                    }
-                }
-            }
-        };
-
+        // Serialize payload once outside the retry loop
         let payload = serde_json::json!({
             "enqueuer": enqueuer_id,
             "job": job_counter,
             "tenant": tenant,
             "timestamp": now_ms(),
         });
+        let payload_bytes = rmp_serde::to_vec(&payload).unwrap();
+        let priority = (job_counter % 100) as u32;
+        let start_at_ms = now_ms();
 
-        let request = EnqueueRequest {
-            shard: shard.to_string(),
-            id: String::new(), // Let server generate ID
-            priority: (job_counter % 100) as u32,
-            start_at_ms: now_ms(),
-            retry_policy: None,
-            payload: Some(SerializedBytes {
-                encoding: Some(serialized_bytes::Encoding::Msgpack(
-                    rmp_serde::to_vec(&payload).unwrap(),
-                )),
-            }),
-            limits: vec![Limit {
-                limit: Some(silo::pb::limit::Limit::Concurrency(ConcurrencyLimit {
-                    key: concurrency_key.clone(),
-                    max_concurrency,
-                })),
-            }],
-            tenant: Some(tenant),
-            metadata: Default::default(),
-            task_group: "default".to_string(),
-        };
+        let mut retries = 0u32;
+        loop {
+            let (mut silo_client, shard) = match client.client_for_tenant(&tenant) {
+                Ok(pair) => pair,
+                Err(e) => {
+                    warn!(enqueuer_id = %enqueuer_id, tenant = %tenant, error = %e, "No shard for tenant");
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    break;
+                }
+            };
 
-        match client.enqueue(request).await {
-            Ok(_) => {
-                enqueued_count.fetch_add(1, Ordering::Relaxed);
-                job_counter = job_counter.wrapping_add(1);
-            }
-            Err(e) => {
-                warn!(enqueuer_id = %enqueuer_id, error = %e, "Enqueuer failed to enqueue");
-                tokio::time::sleep(Duration::from_millis(10)).await;
+            let request = EnqueueRequest {
+                shard: shard.clone(),
+                id: String::new(),
+                priority,
+                start_at_ms,
+                retry_policy: None,
+                payload: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(payload_bytes.clone())),
+                }),
+                limits: vec![Limit {
+                    limit: Some(silo::pb::limit::Limit::Concurrency(ConcurrencyLimit {
+                        key: concurrency_key.clone(),
+                        max_concurrency,
+                    })),
+                }],
+                tenant: Some(tenant.clone()),
+                metadata: Default::default(),
+                task_group: "default".to_string(),
+            };
+
+            match silo_client.enqueue(request).await {
+                Ok(_) => {
+                    enqueued_count.fetch_add(1, Ordering::Relaxed);
+                    job_counter = job_counter.wrapping_add(1);
+                    break;
+                }
+                Err(e) => {
+                    if retries < MAX_ROUTING_RETRIES
+                        && let Some(needs_backoff) =
+                            client.handle_routing_error(&e, &shard).await
+                    {
+                        retries += 1;
+                        if needs_backoff {
+                            tokio::time::sleep(Duration::from_millis(50)).await;
+                        }
+                        continue; // retry with updated routing
+                    }
+                    warn!(enqueuer_id = %enqueuer_id, error = %e, "Enqueuer failed to enqueue");
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    break;
+                }
             }
         }
 
@@ -564,16 +419,18 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // Discover cluster topology
+    // Discover cluster topology and create shared client
     info!("Discovering cluster topology...");
-    let cluster_info = discover_cluster(&args.address).await?;
+    let client = RoutingClient::discover(&args.address).await?;
+
+    let topo = client.topology();
     info!(
-        node_id = %cluster_info.this_node_id,
-        grpc_addr = %cluster_info.this_grpc_addr,
+        node_id = %topo.this_node_id,
+        grpc_addr = %topo.this_grpc_addr,
         "Connected to node"
     );
-    info!(num_shards = cluster_info.num_shards, "Cluster shard count");
-    for owner in &cluster_info.shard_owners {
+    info!(num_shards = topo.num_shards, "Cluster shard count");
+    for owner in &topo.shard_owners {
         let range_display = format!(
             "[{}, {})",
             if owner.range_start.is_empty() {
@@ -595,11 +452,11 @@ async fn main() -> anyhow::Result<()> {
             "Shard owner"
         );
     }
-    info!(servers = ?cluster_info.all_addresses(), "Unique servers");
+    info!(servers = ?client.all_addresses(), "Unique servers");
 
     // Log tenant-to-shard mapping
     for tenant in tenant_selector.all_tenants() {
-        match cluster_info.shard_for_tenant(tenant) {
+        match topo.shard_for_tenant(tenant) {
             Some(owner) => {
                 info!(
                     tenant = %tenant,
@@ -614,8 +471,6 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    let cluster_info = Arc::new(cluster_info);
-
     // Shared counters
     let running = Arc::new(AtomicBool::new(true));
     let completed_count = Arc::new(AtomicU64::new(0));
@@ -626,7 +481,7 @@ async fn main() -> anyhow::Result<()> {
     // Spawn worker tasks
     let mut handles = Vec::new();
     for i in 0..args.workers {
-        let cluster = cluster_info.clone();
+        let client = client.clone();
         let worker_id = format!("bench-worker-{}", i);
         let running = running.clone();
         let completed = completed_count.clone();
@@ -634,7 +489,7 @@ async fn main() -> anyhow::Result<()> {
         let empty_polls = empty_poll_count.clone();
 
         handles.push(tokio::spawn(worker_loop(
-            cluster,
+            client,
             worker_id,
             args.max_tasks_per_poll,
             running,
@@ -646,7 +501,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Spawn enqueuer tasks
     for i in 0..args.enqueuers {
-        let cluster = cluster_info.clone();
+        let client = client.clone();
         let enqueuer_id = format!("bench-enqueuer-{}", i);
         let running = running.clone();
         let enqueued = enqueued_count.clone();
@@ -655,7 +510,7 @@ async fn main() -> anyhow::Result<()> {
         let selector = tenant_selector.clone();
 
         handles.push(tokio::spawn(enqueuer_loop(
-            cluster,
+            client,
             enqueuer_id,
             concurrency_key,
             max_concurrency,

--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -1,12 +1,27 @@
-//! Cluster client for routing queries to appropriate nodes in a distributed Silo cluster.
+//! Internal cluster client for server-to-server communication within a Silo cluster.
 //!
-//! This module provides a client that can query any shard in the cluster by:
-//! - Querying local shards directly via the ShardFactory
-//! - Making gRPC Query calls to remote nodes for shards they own
+//! [`ClusterClient`] is used by silo server nodes to route operations (queries,
+//! job lookups, cancellations, splits) to the correct peer. It has direct access
+//! to the [`Coordinator`](crate::coordination::Coordinator) and
+//! [`ShardFactory`](crate::factory::ShardFactory), so it always knows the live
+//! topology and can serve local shards without a network hop. It does **not**
+//! need redirect or topology-refresh logic because the coordinator is the source
+//! of truth.
+//!
+//! For external consumers (benchmarks, workers, other services) that connect to
+//! the cluster from outside and need to handle stale topology, see
+//! [`RoutingClient`](crate::routing_client::RoutingClient).
+//!
+//! This module also exports shared connection infrastructure used by both clients:
+//! [`ClientConfig`], [`create_silo_client`], [`create_silo_client_lazy`],
+//! [`ensure_http_scheme`], [`AuthInterceptor`], and [`InterceptedSiloClient`].
 //!
 //! ## Connection Resilience
 //!
-//! The client includes built-in timeout and reconnection logic to handle network failures gracefully. When a connection fails or times out, the client will  automatically invalidate the cached connection and attempt to reconnect on the next request.
+//! The client includes built-in timeout and reconnection logic to handle network
+//! failures gracefully. When a connection fails or times out, the client
+//! automatically invalidates the cached connection and reconnects on the next
+//! request.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -127,24 +142,28 @@ pub fn ensure_http_scheme(addr: &str) -> String {
 }
 
 /// Client-side gRPC interceptor that injects a Bearer auth token into outgoing requests.
-/// When `token` is `None`, this is a no-op pass-through.
+/// When `header_value` is `None`, this is a no-op pass-through.
 #[derive(Clone)]
 pub struct AuthInterceptor {
-    token: Option<String>,
+    header_value: Option<MetadataValue<tonic::metadata::Ascii>>,
 }
 
 impl AuthInterceptor {
     pub fn new(token: Option<String>) -> Self {
-        Self { token }
+        Self {
+            header_value: token.map(|t| {
+                format!("Bearer {}", t)
+                    .parse()
+                    .expect("auth token should be valid ASCII metadata")
+            }),
+        }
     }
 }
 
 impl tonic::service::Interceptor for AuthInterceptor {
     fn call(&mut self, mut req: Request<()>) -> Result<Request<()>, Status> {
-        if let Some(ref token) = self.token {
-            let val: MetadataValue<tonic::metadata::Ascii> =
-                format!("Bearer {}", token).parse().unwrap();
-            req.metadata_mut().insert("authorization", val);
+        if let Some(ref val) = self.header_value {
+            req.metadata_mut().insert("authorization", val.clone());
         }
         Ok(req)
     }
@@ -153,7 +172,34 @@ impl tonic::service::Interceptor for AuthInterceptor {
 /// Type alias for a SiloClient with auth interceptor applied.
 pub type InterceptedSiloClient = SiloClient<InterceptedService<Channel, AuthInterceptor>>;
 
-/// Helper to create a SiloClient with proper timeout and retry configuration.
+/// Create a SiloClient with a lazy (non-blocking) connection.
+///
+/// Returns a client immediately without establishing a TCP connection. The actual
+/// connection is made on the first RPC call, and tonic handles reconnection
+/// automatically. The endpoint is configured with the same timeouts and keepalive
+/// settings from [`ClientConfig`].
+///
+/// This is preferred for connection pools where you want fast client creation
+/// and don't need to verify reachability upfront. For eager connection with
+/// retry logic, use [`create_silo_client`] instead.
+pub fn create_silo_client_lazy(
+    uri: &str,
+    config: &ClientConfig,
+) -> Result<InterceptedSiloClient, ClusterClientError> {
+    let full_uri = ensure_http_scheme(uri);
+
+    let endpoint = config
+        .configure_endpoint(&full_uri)
+        .map_err(|e| ClusterClientError::ConnectionFailed(full_uri.clone(), e.to_string()))?;
+
+    let channel = endpoint.connect_lazy();
+    let interceptor = AuthInterceptor::new(config.auth_token.clone());
+    Ok(SiloClient::with_interceptor(channel, interceptor)
+        .max_decoding_message_size(128 * 1024 * 1024)
+        .max_encoding_message_size(128 * 1024 * 1024))
+}
+
+/// Helper to create a SiloClient with an eager connection and retry logic.
 ///
 /// This function creates a gRPC client with configurable timeouts and automatic retry logic with exponential backoff. Retries are attempted when the initial connection fails.
 ///
@@ -316,7 +362,21 @@ impl ClusterNodeInfo {
     }
 }
 
-/// Client for querying shards across a distributed Silo cluster
+/// Internal server-to-server client for routing operations across a Silo cluster.
+///
+/// This client runs inside silo server nodes and has direct access to the
+/// [`Coordinator`](crate::coordination::Coordinator) for live topology and the
+/// [`ShardFactory`](crate::factory::ShardFactory) for local shard access. It
+/// routes queries, job operations, and split requests to the correct peer node
+/// via gRPC, or handles them locally when the shard is owned by this node.
+///
+/// Because it has the coordinator, it always knows the current shard→node mapping
+/// and does not need redirect handling or topology refresh. Connection failures
+/// are handled by invalidating the cached connection and reconnecting on the next
+/// request.
+///
+/// For external clients that don't have coordinator access, see
+/// [`RoutingClient`](crate::routing_client::RoutingClient).
 pub struct ClusterClient {
     /// Local shard factory for querying local shards
     factory: Arc<ShardFactory>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod keys;
 pub mod metrics;
 pub mod query;
 pub mod retry;
+pub mod routing_client;
 pub mod settings;
 pub mod shard_range;
 pub mod storage;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -264,17 +264,18 @@ impl Metrics {
             ),
         ];
 
-        let mut prev_values = self.slatedb_prev_values.lock().expect("lock poisoned");
-
-        for (stat_name, counter) in counter_mappings {
-            if let Some(stat) = stats.lookup(stat_name) {
-                let current = stat.get() as f64;
-                let key = (stat_name.to_string(), shard.to_string());
-                let prev = prev_values.get(&key).copied().unwrap_or(0.0);
-                if current > prev {
-                    counter.with_label_values(&[shard]).inc_by(current - prev);
+        {
+            let mut prev_values = self.slatedb_prev_values.lock().expect("lock poisoned");
+            for (stat_name, counter) in counter_mappings {
+                if let Some(stat) = stats.lookup(stat_name) {
+                    let current = stat.get() as f64;
+                    let key = (stat_name.to_string(), shard.to_string());
+                    let prev = prev_values.get(&key).copied().unwrap_or(0.0);
+                    if current > prev {
+                        counter.with_label_values(&[shard]).inc_by(current - prev);
+                    }
+                    prev_values.insert(key, current);
                 }
-                prev_values.insert(key, current);
             }
         }
 

--- a/src/routing_client.rs
+++ b/src/routing_client.rs
@@ -1,0 +1,462 @@
+//! Cluster-aware gRPC client for connecting to a silo cluster.
+//!
+//! Handles topology discovery, shard routing, connection pooling, and automatic
+//! retry on wrong-shard errors (NOT_FOUND with redirect metadata or
+//! FailedPrecondition for stale tenant routing).
+//!
+//! This client is designed for external consumers of the silo cluster (benchmarks,
+//! workers, other services) rather than internal node-to-node communication.
+//! Uses the same [`ClientConfig`] and connection infrastructure as the internal
+//! [`ClusterClient`](crate::cluster_client::ClusterClient).
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use dashmap::DashMap;
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
+
+use crate::cluster_client::{
+    ClientConfig, InterceptedSiloClient, create_silo_client_lazy, ensure_http_scheme,
+};
+use crate::pb::GetClusterInfoRequest;
+use crate::server::SHARD_OWNER_ADDR_METADATA_KEY;
+
+/// Information about a shard owner in the cluster.
+#[derive(Debug, Clone)]
+pub struct ShardOwnerInfo {
+    pub shard_id: String,
+    pub grpc_addr: String,
+    pub node_id: String,
+    pub range_start: String,
+    pub range_end: String,
+}
+
+/// Cluster topology snapshot.
+#[derive(Debug, Clone)]
+pub struct ClusterTopology {
+    pub num_shards: u32,
+    pub shard_owners: Vec<ShardOwnerInfo>,
+    pub this_node_id: String,
+    pub this_grpc_addr: String,
+    /// Per-shard address overrides from redirect metadata. These take precedence
+    /// over the topology's address when a server tells us a shard moved.
+    shard_addr_overrides: std::collections::HashMap<String, String>,
+}
+
+impl ClusterTopology {
+    /// Find the shard that owns the given tenant ID based on shard ranges.
+    pub fn shard_for_tenant(&self, tenant_id: &str) -> Option<&ShardOwnerInfo> {
+        self.shard_owners.iter().find(|owner| {
+            let after_start =
+                owner.range_start.is_empty() || tenant_id >= owner.range_start.as_str();
+            let before_end = owner.range_end.is_empty() || tenant_id < owner.range_end.as_str();
+            after_start && before_end
+        })
+    }
+
+    /// Get the effective address for a shard, checking overrides first.
+    pub fn address_for_shard(&self, shard_id: &str) -> Option<&str> {
+        if let Some(addr) = self.shard_addr_overrides.get(shard_id) {
+            return Some(addr.as_str());
+        }
+        self.shard_owners
+            .iter()
+            .find(|owner| owner.shard_id == shard_id)
+            .map(|owner| owner.grpc_addr.as_str())
+    }
+
+    /// Get a random shard ID.
+    pub fn random_shard(&self) -> Option<&str> {
+        if self.shard_owners.is_empty() {
+            return None;
+        }
+        let idx = rand::random_range(0..self.shard_owners.len());
+        Some(&self.shard_owners[idx].shard_id)
+    }
+
+    /// Get all unique server addresses (including overrides).
+    pub fn all_addresses(&self) -> Vec<String> {
+        let mut addrs: Vec<String> = self
+            .shard_owners
+            .iter()
+            .map(|owner| owner.grpc_addr.clone())
+            .chain(self.shard_addr_overrides.values().cloned())
+            .collect();
+        addrs.sort();
+        addrs.dedup();
+        addrs
+    }
+}
+
+/// Result of classifying a gRPC error for retry purposes.
+#[derive(Debug)]
+pub enum ErrorAction {
+    /// Server returned NOT_FOUND with a redirect address for the shard.
+    Redirect { shard_id: String, new_addr: String },
+    /// Server returned FailedPrecondition — tenant not in shard range. Need full topology refresh.
+    RefreshTopology,
+    /// Server returned UNAVAILABLE — shard is temporarily unavailable (split in progress,
+    /// acquisition pending). Caller should retry with backoff.
+    RetryWithBackoff,
+    /// Not a routing error — don't retry.
+    NotRoutingError,
+}
+
+/// Classify a tonic error to determine what retry action to take.
+pub fn classify_error(status: &tonic::Status, shard_id: &str) -> ErrorAction {
+    match status.code() {
+        tonic::Code::NotFound => {
+            // Check for redirect metadata
+            let metadata = status.metadata();
+            if let Some(addr) = metadata.get(SHARD_OWNER_ADDR_METADATA_KEY)
+                && let Ok(addr_str) = addr.to_str()
+            {
+                return ErrorAction::Redirect {
+                    shard_id: shard_id.to_string(),
+                    new_addr: addr_str.to_string(),
+                };
+            }
+            // NOT_FOUND without redirect — could be a deleted shard, refresh topology
+            ErrorAction::RefreshTopology
+        }
+        tonic::Code::FailedPrecondition => {
+            // "tenant X is not within shard Y range Z; refresh topology and retry"
+            ErrorAction::RefreshTopology
+        }
+        tonic::Code::Unavailable => {
+            // Shard is temporarily unavailable: split in progress or acquisition pending.
+            // Retry with backoff — the shard will be ready soon.
+            ErrorAction::RetryWithBackoff
+        }
+        _ => ErrorAction::NotRoutingError,
+    }
+}
+
+/// Cluster-aware client that handles topology changes, redirects, and connection pooling.
+///
+/// Uses the same [`ClientConfig`] and [`create_silo_client_lazy`] connection infrastructure
+/// as the internal [`ClusterClient`](crate::cluster_client::ClusterClient), giving it
+/// proper connect timeouts, keepalive, and auth token support.
+///
+/// Uses `std::sync::RwLock` for the topology since the critical section is tiny
+/// (just reading/cloning small strings) and writes are extremely rare. This avoids
+/// the overhead of `tokio::sync::RwLock` which is designed for holding locks across
+/// await points.
+///
+/// Topology refreshes are coalesced: when multiple concurrent tasks hit routing errors
+/// simultaneously, only one `GetClusterInfo` RPC is made and the others wait for its
+/// result.
+pub struct RoutingClient {
+    topology: RwLock<ClusterTopology>,
+    connections: DashMap<String, InterceptedSiloClient>,
+    /// The original seed addresses used to discover the cluster. These are
+    /// immutable after construction and may include load balancer addresses
+    /// not present in topology responses. Combined with
+    /// `topology.all_addresses()` to form the full set of refresh candidates.
+    seed_addresses: Vec<String>,
+    /// Client configuration for timeouts and connection behavior.
+    config: ClientConfig,
+    /// Mutex to coalesce concurrent topology refreshes. Only one refresh runs at a
+    /// time; other callers wait for the in-flight refresh to complete.
+    refresh_mutex: Mutex<()>,
+    /// Monotonic counter incremented after every completed refresh attempt.
+    refresh_generation: AtomicU64,
+    /// Result of the most recent refresh attempt, used by waiters to reuse the
+    /// in-flight refresh result instead of re-running discovery.
+    last_refresh_succeeded: AtomicBool,
+}
+
+impl RoutingClient {
+    /// Connect to the cluster and discover its topology using default configuration.
+    pub async fn discover(address: &str) -> anyhow::Result<Arc<Self>> {
+        Self::discover_with_config(address, ClientConfig::default()).await
+    }
+
+    /// Connect to the cluster and discover its topology with custom configuration.
+    pub async fn discover_with_config(
+        address: &str,
+        config: ClientConfig,
+    ) -> anyhow::Result<Arc<Self>> {
+        let topology = Self::fetch_topology(address, &config).await?;
+
+        let seed_addresses = vec![ensure_http_scheme(address)];
+
+        let client = Arc::new(Self {
+            topology: RwLock::new(topology),
+            connections: DashMap::new(),
+            seed_addresses,
+            config,
+            refresh_mutex: Mutex::new(()),
+            refresh_generation: AtomicU64::new(0),
+            last_refresh_succeeded: AtomicBool::new(false),
+        });
+
+        // Pre-populate the connection pool for all known servers. Since connections
+        // are lazy, this doesn't establish TCP — it just creates configured endpoints
+        // so the first RPC to each server doesn't need to build them.
+        let addrs = client.all_addresses();
+        for addr in &addrs {
+            if let Err(e) = client.get_or_connect(addr) {
+                warn!(address = %addr, error = %e, "Failed to create endpoint");
+            }
+        }
+
+        Ok(client)
+    }
+
+    /// Fetch topology from a specific server address.
+    async fn fetch_topology(
+        address: &str,
+        config: &ClientConfig,
+    ) -> anyhow::Result<ClusterTopology> {
+        let mut client = create_silo_client_lazy(address, config)?;
+
+        let response = client
+            .get_cluster_info(GetClusterInfoRequest {})
+            .await?
+            .into_inner();
+
+        let shard_owners: Vec<ShardOwnerInfo> = response
+            .shard_owners
+            .into_iter()
+            .map(|owner| ShardOwnerInfo {
+                shard_id: owner.shard_id,
+                grpc_addr: owner.grpc_addr,
+                node_id: owner.node_id,
+                range_start: owner.range_start,
+                range_end: owner.range_end,
+            })
+            .collect();
+
+        Ok(ClusterTopology {
+            num_shards: response.num_shards,
+            shard_owners,
+            this_node_id: response.this_node_id,
+            this_grpc_addr: response.this_grpc_addr,
+            shard_addr_overrides: std::collections::HashMap::new(),
+        })
+    }
+
+    /// Get a client and shard ID for the given tenant.
+    /// Returns (client, shard_id).
+    pub fn client_for_tenant(
+        &self,
+        tenant: &str,
+    ) -> anyhow::Result<(InterceptedSiloClient, String)> {
+        let (shard_id, addr) = {
+            let topo = self.topology.read().expect("topology lock poisoned");
+            let owner = topo
+                .shard_for_tenant(tenant)
+                .ok_or_else(|| anyhow::anyhow!("no shard found for tenant '{}'", tenant))?;
+            let shard_id = owner.shard_id.clone();
+            let addr = topo
+                .address_for_shard(&shard_id)
+                .unwrap_or(&owner.grpc_addr)
+                .to_string();
+            (shard_id, addr)
+        };
+
+        let client = self.get_or_connect(&addr)?;
+        Ok((client, shard_id))
+    }
+
+    /// Get a client for a random shard (used by workers).
+    /// Returns (client, shard_id).
+    pub fn client_for_random_shard(&self) -> anyhow::Result<(InterceptedSiloClient, String)> {
+        let (shard_id, addr) = {
+            let topo = self.topology.read().expect("topology lock poisoned");
+            let shard_id = topo
+                .random_shard()
+                .ok_or_else(|| anyhow::anyhow!("no shards available in topology"))?
+                .to_string();
+            let addr = topo
+                .address_for_shard(&shard_id)
+                .ok_or_else(|| anyhow::anyhow!("no address for shard '{}'", shard_id))?
+                .to_string();
+            (shard_id, addr)
+        };
+
+        let client = self.get_or_connect(&addr)?;
+        Ok((client, shard_id))
+    }
+
+    /// Get a client for a specific shard (used for report_outcome).
+    pub fn client_for_shard(&self, shard_id: &str) -> anyhow::Result<InterceptedSiloClient> {
+        let addr = {
+            let topo = self.topology.read().expect("topology lock poisoned");
+            topo.address_for_shard(shard_id)
+                .ok_or_else(|| anyhow::anyhow!("no address for shard '{}'", shard_id))?
+                .to_string()
+        };
+
+        self.get_or_connect(&addr)
+    }
+
+    /// Handle a routing error by updating internal state.
+    ///
+    /// Returns `Some(true)` if the caller should retry with backoff (e.g., shard
+    /// temporarily unavailable), `Some(false)` if the caller should retry
+    /// immediately (e.g., topology refreshed or redirect applied), or `None` if
+    /// the error is not a routing error and should not be retried.
+    pub async fn handle_routing_error(
+        &self,
+        status: &tonic::Status,
+        shard_id: &str,
+    ) -> Option<bool> {
+        match classify_error(status, shard_id) {
+            ErrorAction::Redirect { shard_id, new_addr } => {
+                let new_addr = ensure_http_scheme(&new_addr);
+                info!(
+                    shard_id = %shard_id,
+                    new_addr = %new_addr,
+                    "Shard redirected to new address"
+                );
+                // Update the override in topology. This also makes the address
+                // available to `refresh_topology_once` via `topology.all_addresses()`.
+                {
+                    let mut topo = self.topology.write().expect("topology lock poisoned");
+                    topo.shard_addr_overrides.insert(shard_id, new_addr);
+                }
+                Some(false)
+            }
+            ErrorAction::RefreshTopology => {
+                info!("Routing error detected, refreshing topology");
+                if self.refresh_topology().await {
+                    Some(false)
+                } else {
+                    None
+                }
+            }
+            ErrorAction::RetryWithBackoff => {
+                // UNAVAILABLE — shard temporarily down (split/acquisition). Just signal
+                // the caller to retry with backoff; no topology change needed.
+                debug!("Shard temporarily unavailable, retrying with backoff");
+                Some(true)
+            }
+            ErrorAction::NotRoutingError => None,
+        }
+    }
+
+    /// Invalidate the cached connection for the given address, forcing a fresh
+    /// lazy channel to be created on the next request. Call this after transport-level
+    /// errors to recover from broken connections.
+    pub fn invalidate_connection(&self, addr: &str) {
+        let addr = ensure_http_scheme(addr);
+        if self.connections.remove(&addr).is_some() {
+            debug!(addr = %addr, "invalidated cached connection");
+        }
+    }
+
+    /// Refresh the cluster topology by contacting any available server.
+    /// Returns true if the refresh succeeded.
+    ///
+    /// Coalesced: if multiple tasks call this concurrently, only one
+    /// `GetClusterInfo` RPC is made. Others wait for it to finish.
+    pub async fn refresh_topology(&self) -> bool {
+        let generation_before_wait = self.refresh_generation.load(Ordering::Acquire);
+
+        // Acquire the refresh mutex. If another task is already refreshing,
+        // we wait for it to finish rather than issuing a duplicate RPC.
+        let _guard = self.refresh_mutex.lock().await;
+
+        let generation_after_wait = self.refresh_generation.load(Ordering::Acquire);
+        if generation_after_wait != generation_before_wait {
+            return self.last_refresh_succeeded.load(Ordering::Acquire);
+        }
+
+        let refreshed = self.refresh_topology_once().await;
+        self.last_refresh_succeeded
+            .store(refreshed, Ordering::Release);
+        self.refresh_generation.fetch_add(1, Ordering::AcqRel);
+        refreshed
+    }
+
+    /// Build the list of addresses to try when refreshing topology.
+    /// Combines the immutable seed addresses with the current topology's addresses
+    /// (which include any redirect overrides).
+    fn refresh_candidate_addresses(&self) -> Vec<String> {
+        let topo_addrs = self
+            .topology
+            .read()
+            .expect("topology lock poisoned")
+            .all_addresses();
+        let mut addrs: Vec<String> = self
+            .seed_addresses
+            .iter()
+            .cloned()
+            .chain(topo_addrs)
+            .collect();
+        addrs.sort();
+        addrs.dedup();
+        addrs
+    }
+
+    async fn refresh_topology_once(&self) -> bool {
+        let addresses = self.refresh_candidate_addresses();
+
+        for addr in &addresses {
+            match Self::fetch_topology(addr, &self.config).await {
+                Ok(new_topo) => {
+                    debug!(
+                        address = %addr,
+                        num_shards = new_topo.num_shards,
+                        "Topology refreshed"
+                    );
+
+                    let new_addrs = new_topo.all_addresses();
+
+                    // Replace topology (clears overrides since we have fresh data)
+                    {
+                        let mut topo = self.topology.write().expect("topology lock poisoned");
+                        *topo = new_topo;
+                    }
+
+                    // Pre-populate endpoints for any new servers
+                    for a in &new_addrs {
+                        let _ = self.get_or_connect(a);
+                    }
+
+                    return true;
+                }
+                Err(e) => {
+                    debug!(address = %addr, error = %e, "Failed to refresh topology from server");
+                }
+            }
+        }
+
+        warn!("Failed to refresh topology from any known server");
+        false
+    }
+
+    /// Get all unique addresses in the current topology.
+    pub fn all_addresses(&self) -> Vec<String> {
+        self.topology
+            .read()
+            .expect("topology lock poisoned")
+            .all_addresses()
+    }
+
+    /// Get a snapshot of the current topology.
+    pub fn topology(&self) -> ClusterTopology {
+        self.topology
+            .read()
+            .expect("topology lock poisoned")
+            .clone()
+    }
+
+    /// Get or create a lazy connection to the given address.
+    ///
+    /// Returns immediately without blocking on TCP. The actual connection is
+    /// established on the first RPC call. tonic handles reconnection automatically.
+    fn get_or_connect(&self, addr: &str) -> anyhow::Result<InterceptedSiloClient> {
+        let addr = ensure_http_scheme(addr);
+        if let Some(client) = self.connections.get(&addr) {
+            return Ok(client.clone());
+        }
+
+        let client = create_silo_client_lazy(&addr, &self.config)?;
+        self.connections.insert(addr, client.clone());
+        Ok(client)
+    }
+}

--- a/tests/bench_routing_tests.rs
+++ b/tests/bench_routing_tests.rs
@@ -1,73 +1,9 @@
 mod grpc_integration_helpers;
 
-use std::net::SocketAddr;
-use std::sync::Arc;
-
-use grpc_integration_helpers::shutdown_server;
-use silo::coordination::NoneCoordinator;
-use silo::factory::ShardFactory;
-use silo::gubernator::MockGubernatorClient;
+use grpc_integration_helpers::{setup_multi_shard_server, shutdown_server};
 use silo::pb::silo_client::SiloClient;
 use silo::pb::*;
-use silo::server::run_server;
-use silo::settings::{AppConfig, Backend, DatabaseTemplate};
-use tokio::net::TcpListener;
-
-/// Helper to set up a multi-shard test server using the production code path.
-async fn setup_multi_shard_server(
-    initial_shard_count: u32,
-    config: AppConfig,
-) -> anyhow::Result<(
-    SiloClient<tonic::transport::Channel>,
-    tokio::sync::broadcast::Sender<()>,
-    tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>,
-    SocketAddr,
-    Arc<ShardFactory>,
-    tempfile::TempDir,
-)> {
-    let tmp = tempfile::tempdir()?;
-    let template = DatabaseTemplate {
-        backend: Backend::Fs,
-        path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        concurrency_reconcile_interval_ms: 5000,
-        slatedb: None,
-    };
-    let rate_limiter = MockGubernatorClient::new_arc();
-    let factory = Arc::new(ShardFactory::new(template, rate_limiter, None));
-
-    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
-    let addr = listener.local_addr()?;
-    let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
-
-    let coordinator = Arc::new(
-        NoneCoordinator::new(
-            "test-node",
-            format!("http://{}", addr),
-            initial_shard_count,
-            factory.clone(),
-            Vec::new(),
-        )
-        .await
-        .unwrap(),
-    );
-
-    let server = tokio::spawn(run_server(
-        listener,
-        factory.clone(),
-        coordinator,
-        config,
-        None,
-        shutdown_rx,
-    ));
-
-    let endpoint = format!("http://{}", addr);
-    let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
-    let client = SiloClient::new(channel);
-
-    Ok((client, shutdown_tx, server, addr, factory, tmp))
-}
+use silo::settings::AppConfig;
 
 /// This test reproduces the silo-bench routing bug: when the bench tool discovers
 /// cluster topology, it ignores the shard range information and picks a random shard
@@ -87,8 +23,11 @@ async fn bench_tenant_routing_with_shard_ranges() -> anyhow::Result<()> {
         let mut cfg = AppConfig::load(None).unwrap();
         cfg.tenancy.enabled = true;
 
-        let (mut client, shutdown_tx, server, _addr, _factory, _tmp) =
+        let (shutdown_tx, server, addr, _factory, _tmp) =
             setup_multi_shard_server(8, cfg).await?;
+        let endpoint = format!("http://{}", addr);
+        let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
+        let mut client = SiloClient::new(channel);
 
         // Discover cluster topology (same as silo-bench does)
         let cluster_info = client

--- a/tests/grpc_integration_helpers.rs
+++ b/tests/grpc_integration_helpers.rs
@@ -72,6 +72,68 @@ pub async fn create_test_factory() -> anyhow::Result<(Arc<ShardFactory>, tempfil
     Ok((Arc::new(factory), tmp))
 }
 
+/// Helper to set up a multi-shard test server using NoneCoordinator.
+///
+/// Creates a temporary storage directory, a ShardFactory, and spawns a gRPC
+/// server with the given number of initial shards. Returns the components
+/// needed to interact with and shut down the server.
+///
+/// Callers that need a `SiloClient` can create one from the returned `SocketAddr`:
+/// ```ignore
+/// let endpoint = format!("http://{}", addr);
+/// let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
+/// let client = SiloClient::new(channel);
+/// ```
+pub async fn setup_multi_shard_server(
+    initial_shard_count: u32,
+    config: AppConfig,
+) -> anyhow::Result<(
+    tokio::sync::broadcast::Sender<()>,
+    tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>,
+    SocketAddr,
+    Arc<ShardFactory>,
+    tempfile::TempDir,
+)> {
+    let tmp = tempfile::tempdir()?;
+    let template = DatabaseTemplate {
+        backend: Backend::Fs,
+        path: tmp.path().join("%shard%").to_string_lossy().to_string(),
+        wal: None,
+        apply_wal_on_close: true,
+        concurrency_reconcile_interval_ms: 5000,
+        slatedb: None,
+    };
+    let rate_limiter = MockGubernatorClient::new_arc();
+    let factory = Arc::new(ShardFactory::new(template, rate_limiter, None));
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
+    let addr = listener.local_addr()?;
+    let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
+
+    let coordinator = Arc::new(
+        NoneCoordinator::new(
+            "test-node",
+            format!("http://{}", addr),
+            initial_shard_count,
+            factory.clone(),
+            Vec::new(),
+        )
+        .await
+        .unwrap(),
+    );
+
+    let server = tokio::spawn(run_server(
+        listener,
+        factory.clone(),
+        coordinator,
+        config,
+        None,
+        shutdown_rx,
+    ));
+
+    Ok((shutdown_tx, server, addr, factory, tmp))
+}
+
 /// Helper to gracefully shutdown the server
 pub async fn shutdown_server(
     shutdown_tx: tokio::sync::broadcast::Sender<()>,

--- a/tests/routing_client_tests.rs
+++ b/tests/routing_client_tests.rs
@@ -1,0 +1,776 @@
+mod grpc_integration_helpers;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use futures::future::join_all;
+use grpc_integration_helpers::{setup_multi_shard_server, shutdown_server};
+use silo::pb::silo_server::{Silo, SiloServer};
+use silo::pb::*;
+use silo::routing_client::{ErrorAction, RoutingClient};
+use silo::settings::AppConfig;
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+#[derive(Clone)]
+struct CountingClusterInfoService {
+    grpc_addr: String,
+    request_count: Arc<AtomicUsize>,
+    response_delay: Duration,
+}
+
+impl CountingClusterInfoService {
+    fn unimplemented<T>(method: &'static str) -> Result<Response<T>, Status> {
+        Err(Status::unimplemented(method))
+    }
+}
+
+#[tonic::async_trait]
+impl Silo for CountingClusterInfoService {
+    type QueryArrowStream = futures::stream::Empty<Result<ArrowIpcMessage, Status>>;
+
+    async fn get_cluster_info(
+        &self,
+        _request: Request<GetClusterInfoRequest>,
+    ) -> Result<Response<GetClusterInfoResponse>, Status> {
+        self.request_count.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(self.response_delay).await;
+
+        Ok(Response::new(GetClusterInfoResponse {
+            num_shards: 1,
+            shard_owners: vec![ShardOwner {
+                shard_id: "counting-shard".to_string(),
+                grpc_addr: self.grpc_addr.clone(),
+                node_id: "counting-node".to_string(),
+                range_start: String::new(),
+                range_end: String::new(),
+                placement_ring: None,
+            }],
+            this_node_id: "counting-node".to_string(),
+            this_grpc_addr: self.grpc_addr.clone(),
+            members: vec![],
+        }))
+    }
+
+    async fn get_node_info(
+        &self,
+        _request: Request<GetNodeInfoRequest>,
+    ) -> Result<Response<GetNodeInfoResponse>, Status> {
+        Self::unimplemented("get_node_info")
+    }
+
+    async fn enqueue(
+        &self,
+        _request: Request<EnqueueRequest>,
+    ) -> Result<Response<EnqueueResponse>, Status> {
+        Self::unimplemented("enqueue")
+    }
+
+    async fn get_job(
+        &self,
+        _request: Request<GetJobRequest>,
+    ) -> Result<Response<GetJobResponse>, Status> {
+        Self::unimplemented("get_job")
+    }
+
+    async fn get_job_result(
+        &self,
+        _request: Request<GetJobResultRequest>,
+    ) -> Result<Response<GetJobResultResponse>, Status> {
+        Self::unimplemented("get_job_result")
+    }
+
+    async fn delete_job(
+        &self,
+        _request: Request<DeleteJobRequest>,
+    ) -> Result<Response<DeleteJobResponse>, Status> {
+        Self::unimplemented("delete_job")
+    }
+
+    async fn cancel_job(
+        &self,
+        _request: Request<CancelJobRequest>,
+    ) -> Result<Response<CancelJobResponse>, Status> {
+        Self::unimplemented("cancel_job")
+    }
+
+    async fn restart_job(
+        &self,
+        _request: Request<RestartJobRequest>,
+    ) -> Result<Response<RestartJobResponse>, Status> {
+        Self::unimplemented("restart_job")
+    }
+
+    async fn expedite_job(
+        &self,
+        _request: Request<ExpediteJobRequest>,
+    ) -> Result<Response<ExpediteJobResponse>, Status> {
+        Self::unimplemented("expedite_job")
+    }
+
+    async fn lease_task(
+        &self,
+        _request: Request<LeaseTaskRequest>,
+    ) -> Result<Response<LeaseTaskResponse>, Status> {
+        Self::unimplemented("lease_task")
+    }
+
+    async fn lease_tasks(
+        &self,
+        _request: Request<LeaseTasksRequest>,
+    ) -> Result<Response<LeaseTasksResponse>, Status> {
+        Self::unimplemented("lease_tasks")
+    }
+
+    async fn report_outcome(
+        &self,
+        _request: Request<ReportOutcomeRequest>,
+    ) -> Result<Response<ReportOutcomeResponse>, Status> {
+        Self::unimplemented("report_outcome")
+    }
+
+    async fn report_refresh_outcome(
+        &self,
+        _request: Request<ReportRefreshOutcomeRequest>,
+    ) -> Result<Response<ReportRefreshOutcomeResponse>, Status> {
+        Self::unimplemented("report_refresh_outcome")
+    }
+
+    async fn heartbeat(
+        &self,
+        _request: Request<HeartbeatRequest>,
+    ) -> Result<Response<HeartbeatResponse>, Status> {
+        Self::unimplemented("heartbeat")
+    }
+
+    async fn query(
+        &self,
+        _request: Request<QueryRequest>,
+    ) -> Result<Response<QueryResponse>, Status> {
+        Self::unimplemented("query")
+    }
+
+    async fn query_arrow(
+        &self,
+        _request: Request<QueryArrowRequest>,
+    ) -> Result<Response<Self::QueryArrowStream>, Status> {
+        Err(Status::unimplemented("query_arrow"))
+    }
+
+    async fn cpu_profile(
+        &self,
+        _request: Request<CpuProfileRequest>,
+    ) -> Result<Response<CpuProfileResponse>, Status> {
+        Self::unimplemented("cpu_profile")
+    }
+
+    async fn request_split(
+        &self,
+        _request: Request<RequestSplitRequest>,
+    ) -> Result<Response<RequestSplitResponse>, Status> {
+        Self::unimplemented("request_split")
+    }
+
+    async fn get_split_status(
+        &self,
+        _request: Request<GetSplitStatusRequest>,
+    ) -> Result<Response<GetSplitStatusResponse>, Status> {
+        Self::unimplemented("get_split_status")
+    }
+
+    async fn configure_shard(
+        &self,
+        _request: Request<ConfigureShardRequest>,
+    ) -> Result<Response<ConfigureShardResponse>, Status> {
+        Self::unimplemented("configure_shard")
+    }
+
+    async fn import_jobs(
+        &self,
+        _request: Request<ImportJobsRequest>,
+    ) -> Result<Response<ImportJobsResponse>, Status> {
+        Self::unimplemented("import_jobs")
+    }
+
+    async fn reset_shards(
+        &self,
+        _request: Request<ResetShardsRequest>,
+    ) -> Result<Response<ResetShardsResponse>, Status> {
+        Self::unimplemented("reset_shards")
+    }
+
+    async fn force_release_shard(
+        &self,
+        _request: Request<ForceReleaseShardRequest>,
+    ) -> Result<Response<ForceReleaseShardResponse>, Status> {
+        Self::unimplemented("force_release_shard")
+    }
+}
+
+async fn setup_counting_cluster_info_server(
+    response_delay: Duration,
+) -> anyhow::Result<(
+    tokio::sync::broadcast::Sender<()>,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+    SocketAddr,
+    Arc<AtomicUsize>,
+)> {
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
+    let addr = listener.local_addr()?;
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let service = CountingClusterInfoService {
+        grpc_addr: format!("http://{}", addr),
+        request_count: request_count.clone(),
+        response_delay,
+    };
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
+
+    let server = tokio::spawn(async move {
+        let incoming = async_stream::stream! {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _)) => yield Ok::<_, std::io::Error>(stream),
+                    Err(err) => {
+                        yield Err(err);
+                        break;
+                    }
+                }
+            }
+        };
+
+        Server::builder()
+            .add_service(SiloServer::new(service))
+            .serve_with_incoming_shutdown(incoming, async move {
+                let _ = shutdown_rx.recv().await;
+            })
+            .await
+            .map_err(anyhow::Error::from)
+    });
+
+    Ok((shutdown_tx, server, addr, request_count))
+}
+
+async fn shutdown_counting_server(
+    shutdown_tx: tokio::sync::broadcast::Sender<()>,
+    server: tokio::task::JoinHandle<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    let _ = shutdown_tx.send(());
+    match server.await {
+        Ok(inner) => inner,
+        Err(err) => Err(anyhow::anyhow!(err)),
+    }
+}
+
+/// Test that classify_error correctly identifies NOT_FOUND with redirect metadata.
+#[silo::test(flavor = "multi_thread")]
+async fn classify_error_not_found_with_redirect() {
+    let mut status = tonic::Status::not_found("shard not found");
+    status.metadata_mut().insert(
+        "x-silo-shard-owner-addr",
+        "http://other-node:7450".parse().unwrap(),
+    );
+
+    let action = silo::routing_client::classify_error(&status, "shard-123");
+    match action {
+        ErrorAction::Redirect { shard_id, new_addr } => {
+            assert_eq!(shard_id, "shard-123");
+            assert_eq!(new_addr, "http://other-node:7450");
+        }
+        other => panic!("expected Redirect, got {:?}", other),
+    }
+}
+
+/// Test that classify_error correctly identifies NOT_FOUND without redirect as RefreshTopology.
+#[silo::test(flavor = "multi_thread")]
+async fn classify_error_not_found_without_redirect() {
+    let status = tonic::Status::not_found("shard not found");
+    let action = silo::routing_client::classify_error(&status, "shard-123");
+    assert!(
+        matches!(action, ErrorAction::RefreshTopology),
+        "expected RefreshTopology, got {:?}",
+        action
+    );
+}
+
+/// Test that classify_error correctly identifies FailedPrecondition as RefreshTopology.
+#[silo::test(flavor = "multi_thread")]
+async fn classify_error_failed_precondition() {
+    let status = tonic::Status::failed_precondition(
+        "tenant 'bench-0' is not within shard X range [4, 8); refresh topology and retry",
+    );
+    let action = silo::routing_client::classify_error(&status, "shard-456");
+    assert!(
+        matches!(action, ErrorAction::RefreshTopology),
+        "expected RefreshTopology, got {:?}",
+        action
+    );
+}
+
+/// Test that classify_error returns RetryWithBackoff for UNAVAILABLE errors.
+#[silo::test(flavor = "multi_thread")]
+async fn classify_error_unavailable() {
+    let status = tonic::Status::unavailable("shard temporarily unavailable");
+    let action = silo::routing_client::classify_error(&status, "shard-456");
+    assert!(
+        matches!(action, ErrorAction::RetryWithBackoff),
+        "expected RetryWithBackoff, got {:?}",
+        action
+    );
+}
+
+/// Test that classify_error returns NotRoutingError for other error types.
+#[silo::test(flavor = "multi_thread")]
+async fn classify_error_other_errors() {
+    let status = tonic::Status::internal("database error");
+    let action = silo::routing_client::classify_error(&status, "shard-789");
+    assert!(
+        matches!(action, ErrorAction::NotRoutingError),
+        "expected NotRoutingError, got {:?}",
+        action
+    );
+}
+
+/// Test that RoutingClient discovers topology and can route tenants to correct shards.
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_discovers_topology() -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_millis(15000), async {
+        let mut cfg = AppConfig::load(None).unwrap();
+        cfg.tenancy.enabled = true;
+
+        let (shutdown_tx, server, addr, _factory, _tmp) = setup_multi_shard_server(4, cfg).await?;
+
+        let client = RoutingClient::discover(&format!("http://{}", addr)).await?;
+        let topo = client.topology();
+
+        assert_eq!(topo.shard_owners.len(), 4, "should discover 4 shards");
+
+        // Every tenant should map to exactly one shard
+        for tenant in &["bench-0", "bench-1", "bench-2", "bench-3"] {
+            let owner = topo.shard_for_tenant(tenant);
+            assert!(
+                owner.is_some(),
+                "tenant '{}' should have an owning shard",
+                tenant
+            );
+        }
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test that RoutingClient can successfully enqueue to the correct shard via tenant routing.
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_enqueue_correct_shard() -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_millis(15000), async {
+        let mut cfg = AppConfig::load(None).unwrap();
+        cfg.tenancy.enabled = true;
+
+        let (shutdown_tx, server, addr, _factory, _tmp) = setup_multi_shard_server(4, cfg).await?;
+
+        let client = RoutingClient::discover(&format!("http://{}", addr)).await?;
+
+        // Enqueue to correct shard for each tenant - should all succeed
+        for tenant in &["bench-0", "bench-1", "bench-2", "bench-3"] {
+            let (mut silo_client, shard) = client.client_for_tenant(tenant)?;
+
+            let result = silo_client
+                .enqueue(EnqueueRequest {
+                    shard: shard.clone(),
+                    id: format!("test-{}", tenant),
+                    priority: 5,
+                    start_at_ms: 0,
+                    retry_policy: None,
+                    payload: Some(SerializedBytes {
+                        encoding: Some(serialized_bytes::Encoding::Msgpack(
+                            rmp_serde::to_vec(&serde_json::json!({"tenant": tenant})).unwrap(),
+                        )),
+                    }),
+                    limits: vec![],
+                    tenant: Some(tenant.to_string()),
+                    metadata: std::collections::HashMap::new(),
+                    task_group: "default".to_string(),
+                })
+                .await;
+
+            assert!(
+                result.is_ok(),
+                "enqueue should succeed for tenant '{}' on shard '{}': {:?}",
+                tenant,
+                shard,
+                result.err()
+            );
+        }
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test that sending to the wrong shard produces a FailedPrecondition error,
+/// and that handle_routing_error triggers a topology refresh that allows
+/// subsequent requests to succeed.
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_handles_failed_precondition_with_refresh() -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_millis(15000), async {
+        let mut cfg = AppConfig::load(None).unwrap();
+        cfg.tenancy.enabled = true;
+
+        let (shutdown_tx, server, addr, _factory, _tmp) = setup_multi_shard_server(8, cfg).await?;
+
+        let client = RoutingClient::discover(&format!("http://{}", addr)).await?;
+        let topo = client.topology();
+
+        // Find a tenant that is NOT in the first shard's range
+        let first_shard = &topo.shard_owners[0];
+        let tenants = ["bench-0", "bench-1", "bench-2", "bench-3"];
+        let wrong_tenant = tenants.iter().find(|tenant| {
+            topo.shard_for_tenant(tenant)
+                .map(|owner| owner.shard_id != first_shard.shard_id)
+                .unwrap_or(true)
+        });
+
+        let wrong_tenant = match wrong_tenant {
+            Some(t) => *t,
+            None => {
+                // All tenants map to the first shard (unlikely with 8 shards)
+                shutdown_server(shutdown_tx, server).await?;
+                return Ok(());
+            }
+        };
+
+        // Send to the wrong shard deliberately
+        let (mut silo_client, _correct_shard) = client.client_for_tenant(wrong_tenant)?;
+
+        let result = silo_client
+            .enqueue(EnqueueRequest {
+                shard: first_shard.shard_id.clone(), // WRONG shard for this tenant
+                id: "wrong-shard-test".to_string(),
+                priority: 5,
+                start_at_ms: 0,
+                retry_policy: None,
+                payload: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({"test": true})).unwrap(),
+                    )),
+                }),
+                limits: vec![],
+                tenant: Some(wrong_tenant.to_string()),
+                metadata: std::collections::HashMap::new(),
+                task_group: "default".to_string(),
+            })
+            .await;
+
+        // Should fail with FailedPrecondition
+        assert!(result.is_err(), "enqueue to wrong shard should fail");
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.code(),
+            tonic::Code::FailedPrecondition,
+            "should get FailedPrecondition, got: {}",
+            err
+        );
+
+        // handle_routing_error should trigger a topology refresh and return Some
+        let handled = client
+            .handle_routing_error(&err, &first_shard.shard_id)
+            .await;
+        assert!(
+            handled.is_some(),
+            "handle_routing_error should succeed for FailedPrecondition"
+        );
+
+        // After refresh, routing to the correct shard via client_for_tenant should work
+        let (mut silo_client, shard) = client.client_for_tenant(wrong_tenant)?;
+        let result = silo_client
+            .enqueue(EnqueueRequest {
+                shard: shard.clone(),
+                id: "after-refresh-test".to_string(),
+                priority: 5,
+                start_at_ms: 0,
+                retry_policy: None,
+                payload: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({"test": true})).unwrap(),
+                    )),
+                }),
+                limits: vec![],
+                tenant: Some(wrong_tenant.to_string()),
+                metadata: std::collections::HashMap::new(),
+                task_group: "default".to_string(),
+            })
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "enqueue should succeed after topology refresh: {:?}",
+            result.err()
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test that refresh_topology picks up the current cluster state.
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_refresh_topology() -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_millis(15000), async {
+        let mut cfg = AppConfig::load(None).unwrap();
+        cfg.tenancy.enabled = true;
+
+        let (shutdown_tx, server, addr, _factory, _tmp) = setup_multi_shard_server(4, cfg).await?;
+
+        let client = RoutingClient::discover(&format!("http://{}", addr)).await?;
+
+        // Initial topology should have 4 shards
+        let topo = client.topology();
+        assert_eq!(topo.shard_owners.len(), 4);
+
+        // Refresh topology - should still have 4 shards (unchanged cluster)
+        let refreshed = client.refresh_topology().await;
+        assert!(refreshed, "refresh_topology should succeed");
+
+        let topo = client.topology();
+        assert_eq!(
+            topo.shard_owners.len(),
+            4,
+            "should still have 4 shards after refresh"
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test that handle_routing_error correctly processes a redirect by updating the
+/// shard-to-address override. Even though the redirect target won't exist in this
+/// single-node test, the topology update should be visible.
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_handles_redirect_metadata() -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_millis(15000), async {
+        let mut cfg = AppConfig::load(None).unwrap();
+        cfg.tenancy.enabled = true;
+
+        let (shutdown_tx, server, addr, _factory, _tmp) = setup_multi_shard_server(4, cfg).await?;
+
+        let client = RoutingClient::discover(&format!("http://{}", addr)).await?;
+        let topo = client.topology();
+        let first_shard_id = topo.shard_owners[0].shard_id.clone();
+        let original_addr = topo.address_for_shard(&first_shard_id).unwrap().to_string();
+
+        // Simulate a NOT_FOUND with redirect metadata (as if the server told us the shard moved)
+        let mut status = tonic::Status::not_found("shard not found");
+        let redirect_addr = format!("http://127.0.0.1:{}", 19999);
+        status
+            .metadata_mut()
+            .insert("x-silo-shard-owner-addr", redirect_addr.parse().unwrap());
+
+        let handled = client.handle_routing_error(&status, &first_shard_id).await;
+        assert!(handled.is_some(), "redirect metadata should be handled");
+
+        let topo = client.topology();
+        let new_addr = topo.address_for_shard(&first_shard_id).unwrap().to_string();
+        assert_eq!(
+            new_addr, redirect_addr,
+            "shard address should be updated to redirect target"
+        );
+        assert_ne!(
+            new_addr, original_addr,
+            "address should differ from original"
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test that redirect metadata teaches the client a new discovery address so a
+/// later topology refresh can recover even after the original discovery node is gone.
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_refreshes_via_redirect_discovery_address() -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_millis(15000), async {
+        let mut cfg_a = AppConfig::load(None).unwrap();
+        cfg_a.tenancy.enabled = true;
+
+        let mut cfg_b = AppConfig::load(None).unwrap();
+        cfg_b.tenancy.enabled = true;
+
+        let (shutdown_tx_a, server_a, addr_a, _factory_a, _tmp_a) =
+            setup_multi_shard_server(1, cfg_a).await?;
+        let client = RoutingClient::discover(&format!("http://{}", addr_a)).await?;
+        let shard_id = client.topology().shard_owners[0].shard_id.clone();
+
+        let (shutdown_tx_b, server_b, addr_b, _factory_b, _tmp_b) =
+            setup_multi_shard_server(1, cfg_b).await?;
+
+        let redirect_addr = format!("http://{}", addr_b);
+        let mut status = tonic::Status::not_found("shard moved");
+        status
+            .metadata_mut()
+            .insert("x-silo-shard-owner-addr", redirect_addr.parse().unwrap());
+
+        let handled = client.handle_routing_error(&status, &shard_id).await;
+        assert!(handled.is_some(), "redirect metadata should be handled");
+
+        shutdown_server(shutdown_tx_a, server_a).await?;
+
+        let refreshed = client.refresh_topology().await;
+        assert!(
+            refreshed,
+            "refresh_topology should succeed via the redirect-learned address"
+        );
+
+        let topo = client.topology();
+        assert_eq!(
+            topo.this_grpc_addr, redirect_addr,
+            "refresh should use the redirect-learned discovery address"
+        );
+
+        shutdown_server(shutdown_tx_b, server_b).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test that concurrent refresh callers share one GetClusterInfo refresh RPC.
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_coalesces_concurrent_refreshes() -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_millis(15000), async {
+        let (shutdown_tx, server, addr, request_count) =
+            setup_counting_cluster_info_server(Duration::from_millis(150)).await?;
+
+        let client = RoutingClient::discover(&format!("http://{}", addr)).await?;
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            1,
+            "discovery should issue one GetClusterInfo RPC"
+        );
+
+        let caller_count = 8;
+        let barrier = Arc::new(tokio::sync::Barrier::new(caller_count + 1));
+        let refreshes = (0..caller_count)
+            .map(|_| {
+                let client = client.clone();
+                let barrier = barrier.clone();
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    client.refresh_topology().await
+                })
+            })
+            .collect::<Vec<_>>();
+
+        barrier.wait().await;
+
+        for result in join_all(refreshes).await {
+            assert!(
+                result.expect("refresh task should join"),
+                "refresh_topology should succeed"
+            );
+        }
+
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            2,
+            "concurrent refreshes should share a single GetClusterInfo RPC"
+        );
+
+        shutdown_counting_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test that the RoutingClient connection pool shares connections across
+/// multiple client_for_tenant calls to the same shard.
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_connection_pool_reuse() -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_millis(15000), async {
+        let mut cfg = AppConfig::load(None).unwrap();
+        cfg.tenancy.enabled = true;
+
+        let (shutdown_tx, server, addr, _factory, _tmp) = setup_multi_shard_server(4, cfg).await?;
+
+        let client = RoutingClient::discover(&format!("http://{}", addr)).await?;
+
+        // Call client_for_tenant many times - all should succeed and reuse connections
+        for _ in 0..20 {
+            let (_silo_client, _shard) = client.client_for_tenant("bench-0")?;
+        }
+
+        // The connection pool should have exactly the number of unique addresses
+        // (1 server in this test)
+        let all_addrs = client.all_addresses();
+        assert_eq!(all_addrs.len(), 1, "should have exactly 1 unique address");
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test that invalidate_connection removes a cached connection, forcing a fresh
+/// one to be created on the next request.
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_invalidate_connection() -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_millis(15000), async {
+        let mut cfg = AppConfig::load(None).unwrap();
+        cfg.tenancy.enabled = true;
+
+        let (shutdown_tx, server, addr, _factory, _tmp) = setup_multi_shard_server(4, cfg).await?;
+
+        let server_addr = format!("http://{}", addr);
+        let client = RoutingClient::discover(&server_addr).await?;
+
+        // Ensure a connection exists by making a request
+        let (mut silo_client, _shard) = client.client_for_tenant("bench-0")?;
+        let topo = silo_client
+            .get_cluster_info(silo::pb::GetClusterInfoRequest {})
+            .await;
+        assert!(topo.is_ok(), "initial request should succeed");
+
+        // Invalidate the connection
+        client.invalidate_connection(&server_addr);
+
+        // Next request should still work — a fresh lazy connection is created
+        let (mut silo_client, _shard) = client.client_for_tenant("bench-0")?;
+        let topo = silo_client
+            .get_cluster_info(silo::pb::GetClusterInfoRequest {})
+            .await;
+        assert!(
+            topo.is_ok(),
+            "request after invalidation should succeed: {:?}",
+            topo.err()
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -8,16 +8,13 @@ mod grpc_integration_helpers;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
-use grpc_integration_helpers::{create_test_factory, setup_test_server, shutdown_server};
-use silo::coordination::NoneCoordinator;
-use silo::factory::ShardFactory;
-use silo::gubernator::MockGubernatorClient;
+use grpc_integration_helpers::{
+    create_test_factory, setup_multi_shard_server, setup_test_server, shutdown_server,
+};
 use silo::pb::silo_client::SiloClient;
 use silo::pb::*;
-use silo::server::run_server;
-use silo::settings::{AppConfig, Backend, DatabaseTemplate};
+use silo::settings::AppConfig;
 use silo::siloctl::{self, GlobalOptions};
-use tokio::net::TcpListener;
 
 // Global mutex to serialize profile tests - only one CPU profiler can run at a time system-wide
 static PROFILE_TEST_MUTEX: Mutex<()> = Mutex::new(());
@@ -1119,61 +1116,6 @@ fn test_compute_midpoint_same_prefix() {
 // Multi-shard routing tests
 // ============================================================================
 
-async fn setup_multi_shard_server(
-    initial_shard_count: u32,
-    config: AppConfig,
-) -> anyhow::Result<(
-    SiloClient<tonic::transport::Channel>,
-    tokio::sync::broadcast::Sender<()>,
-    tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>,
-    SocketAddr,
-    Arc<ShardFactory>,
-    tempfile::TempDir,
-)> {
-    let tmp = tempfile::tempdir()?;
-    let template = DatabaseTemplate {
-        backend: Backend::Fs,
-        path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        concurrency_reconcile_interval_ms: 5000,
-        slatedb: None,
-    };
-    let rate_limiter = MockGubernatorClient::new_arc();
-    let factory = Arc::new(ShardFactory::new(template, rate_limiter, None));
-
-    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
-    let addr = listener.local_addr()?;
-    let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
-
-    let coordinator = Arc::new(
-        NoneCoordinator::new(
-            "test-node",
-            format!("http://{}", addr),
-            initial_shard_count,
-            factory.clone(),
-            Vec::new(),
-        )
-        .await
-        .unwrap(),
-    );
-
-    let server = tokio::spawn(run_server(
-        listener,
-        factory.clone(),
-        coordinator,
-        config,
-        None,
-        shutdown_rx,
-    ));
-
-    let endpoint = format!("http://{}", addr);
-    let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
-    let client = SiloClient::new(channel);
-
-    Ok((client, shutdown_tx, server, addr, factory, tmp))
-}
-
 /// Test that siloctl commands auto-route to the correct shard owner
 /// even when there are multiple shards in the cluster.
 #[silo::test(flavor = "multi_thread")]
@@ -1181,8 +1123,10 @@ async fn siloctl_auto_routes_job_commands_multi_shard() -> anyhow::Result<()> {
     tokio::time::timeout(std::time::Duration::from_millis(15000), async {
         let cfg = AppConfig::load(None).unwrap();
 
-        let (mut client, shutdown_tx, server, addr, _factory, _tmp) =
-            setup_multi_shard_server(8, cfg).await?;
+        let (shutdown_tx, server, addr, _factory, _tmp) = setup_multi_shard_server(8, cfg).await?;
+        let endpoint = format!("http://{}", addr);
+        let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
+        let mut client = SiloClient::new(channel);
 
         // Discover topology
         let cluster_info = client
@@ -1268,8 +1212,7 @@ async fn siloctl_cluster_info_shows_ranges() -> anyhow::Result<()> {
     tokio::time::timeout(std::time::Duration::from_millis(15000), async {
         let cfg = AppConfig::load(None).unwrap();
 
-        let (_client, shutdown_tx, server, addr, _factory, _tmp) =
-            setup_multi_shard_server(4, cfg).await?;
+        let (shutdown_tx, server, addr, _factory, _tmp) = setup_multi_shard_server(4, cfg).await?;
 
         // Test human-readable output includes ranges
         let opts = opts_for_addr(&addr);
@@ -1318,8 +1261,10 @@ async fn siloctl_shard_split_status_auto_routes() -> anyhow::Result<()> {
     tokio::time::timeout(std::time::Duration::from_millis(15000), async {
         let cfg = AppConfig::load(None).unwrap();
 
-        let (mut client, shutdown_tx, server, addr, _factory, _tmp) =
-            setup_multi_shard_server(4, cfg).await?;
+        let (shutdown_tx, server, addr, _factory, _tmp) = setup_multi_shard_server(4, cfg).await?;
+        let endpoint = format!("http://{}", addr);
+        let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
+        let mut client = SiloClient::new(channel);
 
         // Discover topology
         let cluster_info = client
@@ -1356,8 +1301,7 @@ async fn siloctl_unknown_shard_returns_clear_error() -> anyhow::Result<()> {
     tokio::time::timeout(std::time::Duration::from_millis(15000), async {
         let cfg = AppConfig::load(None).unwrap();
 
-        let (_client, shutdown_tx, server, addr, _factory, _tmp) =
-            setup_multi_shard_server(4, cfg).await?;
+        let (shutdown_tx, server, addr, _factory, _tmp) = setup_multi_shard_server(4, cfg).await?;
 
         let opts = opts_for_addr(&addr);
 


### PR DESCRIPTION
## Summary
- Extract cluster-aware gRPC client from silo-bench into a reusable `RoutingClient` in `src/routing_client.rs`
- Handles `NOT_FOUND` with redirect metadata (shard moved to another node) by updating shard→address mapping
- Handles `FailedPrecondition` (stale tenant routing after splits) by refreshing full topology
- Shared connection pool via `DashMap` replaces per-worker/enqueuer connection `HashMap`s in silo-bench
- Uses `std::sync::RwLock` for topology (tiny critical section, writes are rare) for minimal hot-path overhead
- 10 new tests covering error classification, topology discovery, refresh, redirect handling, and connection reuse