### PR TITLE
Fix siloctl to use xxhash-based routing for shard splitting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5377,7 +5377,7 @@ dependencies = [
 
 [[package]]
 name = "silo"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Harry Brundage <harry@gadget.dev>"]
 edition = "2024"
 name = "silo"
 description = "A background job server on top of object storage"
-version = "0.1.0"
+version = "0.2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/bin/siloctl.rs
+++ b/src/bin/siloctl.rs
@@ -69,6 +69,11 @@ enum Command {
         #[command(subcommand)]
         action: ShardAction,
     },
+    /// Tenant operations
+    Tenant {
+        #[command(subcommand)]
+        action: TenantAction,
+    },
     /// Execute SQL query against a shard
     Query {
         /// Shard ID (UUID) to query
@@ -135,6 +140,20 @@ enum ShardAction {
     ForceRelease {
         /// Shard ID (UUID) to force-release
         shard: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum TenantAction {
+    /// Show which shard a tenant belongs to
+    Locate {
+        /// Tenant ID to look up
+        tenant_id: String,
+    },
+    /// Compute the xxhash for a tenant ID
+    Hash {
+        /// Tenant ID to hash
+        tenant_id: String,
     },
 }
 
@@ -222,6 +241,14 @@ async fn run(args: Args) -> anyhow::Result<()> {
             }
             ShardAction::ForceRelease { shard } => {
                 siloctl::shard_force_release(&opts, &mut stdout, shard).await
+            }
+        },
+        Command::Tenant { action } => match action {
+            TenantAction::Locate { tenant_id } => {
+                siloctl::tenant_locate(&opts, &mut stdout, tenant_id).await
+            }
+            TenantAction::Hash { tenant_id } => {
+                siloctl::tenant_hash(&opts, &mut stdout, tenant_id)
             }
         },
         Command::Query { shard, sql } => siloctl::query(&opts, &mut stdout, shard, sql).await,

--- a/src/bin/siloctl.rs
+++ b/src/bin/siloctl.rs
@@ -247,9 +247,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
             TenantAction::Locate { tenant_id } => {
                 siloctl::tenant_locate(&opts, &mut stdout, tenant_id).await
             }
-            TenantAction::Hash { tenant_id } => {
-                siloctl::tenant_hash(&opts, &mut stdout, tenant_id)
-            }
+            TenantAction::Hash { tenant_id } => siloctl::tenant_hash(&opts, &mut stdout, tenant_id),
         },
         Command::Query { shard, sql } => siloctl::query(&opts, &mut stdout, shard, sql).await,
         Command::Profile {

--- a/src/siloctl.rs
+++ b/src/siloctl.rs
@@ -164,10 +164,10 @@ pub async fn cluster_info<W: Write>(opts: &GlobalOptions, out: &mut W) -> anyhow
         writeln!(out, "Shard Ownership:")?;
         writeln!(
             out,
-            "{:<38}  {:<14}  {:<20}  gRPC Address",
+            "{:<38}  {:<40}  {:<20}  gRPC Address",
             "Shard", "Range", "Node ID"
         )?;
-        writeln!(out, "{}", "-".repeat(100))?;
+        writeln!(out, "{}", "-".repeat(120))?;
         for owner in &response.shard_owners {
             let range = format!(
                 "[{}, {})",
@@ -184,7 +184,7 @@ pub async fn cluster_info<W: Write>(opts: &GlobalOptions, out: &mut W) -> anyhow
             );
             writeln!(
                 out,
-                "{:<38}  {:<14}  {:<20}  {}",
+                "{:<38}  {:<40}  {:<20}  {}",
                 owner.shard_id, range, owner.node_id, owner.grpc_addr
             )?;
         }
@@ -895,6 +895,77 @@ pub async fn validate_config<W: Write>(
             Err(anyhow::anyhow!("Config validation failed: {}", e))
         }
     }
+}
+
+/// Locate which shard a tenant belongs to by hashing the tenant ID
+/// and finding the shard whose range contains the hash.
+pub async fn tenant_locate<W: Write>(
+    opts: &GlobalOptions,
+    out: &mut W,
+    tenant_id: &str,
+) -> anyhow::Result<()> {
+    let mut client = connect(&opts.address, opts.auth_token.as_deref()).await?;
+    let response = client
+        .get_cluster_info(GetClusterInfoRequest {})
+        .await?
+        .into_inner();
+
+    let hashed = crate::shard_range::hash_tenant(tenant_id);
+
+    // Find the shard whose range contains the hashed tenant
+    let owner = response.shard_owners.iter().find(|s| {
+        let range =
+            crate::shard_range::ShardRange::new(s.range_start.clone(), s.range_end.clone());
+        range.contains(&hashed)
+    });
+
+    match owner {
+        Some(owner) => {
+            if opts.json {
+                let json_output = serde_json::json!({
+                    "tenant_id": tenant_id,
+                    "tenant_hash": hashed,
+                    "shard_id": owner.shard_id,
+                    "node_id": owner.node_id,
+                    "grpc_addr": owner.grpc_addr,
+                    "range_start": owner.range_start,
+                    "range_end": owner.range_end,
+                });
+                writeln!(out, "{}", serde_json::to_string_pretty(&json_output)?)?;
+            } else {
+                writeln!(out, "Tenant Location")?;
+                writeln!(out, "===============")?;
+                writeln!(out, "Tenant ID:   {}", tenant_id)?;
+                writeln!(out, "Tenant Hash: {}", hashed)?;
+                writeln!(out, "Shard ID:    {}", owner.shard_id)?;
+                writeln!(out, "Node ID:     {}", owner.node_id)?;
+                writeln!(out, "gRPC Addr:   {}", owner.grpc_addr)?;
+                let range = format!(
+                    "[{}, {})",
+                    if owner.range_start.is_empty() {
+                        "-\u{221e}"
+                    } else {
+                        &owner.range_start
+                    },
+                    if owner.range_end.is_empty() {
+                        "+\u{221e}"
+                    } else {
+                        &owner.range_end
+                    }
+                );
+                writeln!(out, "Shard Range: {}", range)?;
+            }
+        }
+        None => {
+            return Err(anyhow::anyhow!(
+                "no shard found for tenant '{}' (hash: {})",
+                tenant_id,
+                hashed
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Compute the midpoint of a hash-space range defined by hex-encoded u64 boundaries.

--- a/src/siloctl.rs
+++ b/src/siloctl.rs
@@ -897,6 +897,27 @@ pub async fn validate_config<W: Write>(
     }
 }
 
+/// Compute and display the xxhash for a tenant ID.
+pub fn tenant_hash<W: Write>(
+    opts: &GlobalOptions,
+    out: &mut W,
+    tenant_id: &str,
+) -> anyhow::Result<()> {
+    let hashed = crate::shard_range::hash_tenant(tenant_id);
+
+    if opts.json {
+        let json_output = serde_json::json!({
+            "tenant_id": tenant_id,
+            "hash": hashed,
+        });
+        writeln!(out, "{}", serde_json::to_string_pretty(&json_output)?)?;
+    } else {
+        writeln!(out, "{}", hashed)?;
+    }
+
+    Ok(())
+}
+
 /// Locate which shard a tenant belongs to by hashing the tenant ID
 /// and finding the shard whose range contains the hash.
 pub async fn tenant_locate<W: Write>(

--- a/src/siloctl.rs
+++ b/src/siloctl.rs
@@ -642,25 +642,19 @@ pub async fn shard_split<W: Write>(
     let split_point = if let Some(point) = split_point {
         point
     } else if auto {
-        // Compute midpoint of the shard's range
-        let start = if shard_owner.range_start.is_empty() {
-            "0".to_string()
-        } else {
-            shard_owner.range_start.clone()
-        };
-        let end = if shard_owner.range_end.is_empty() {
-            "zzzzzzzz".to_string()
-        } else {
-            shard_owner.range_end.clone()
-        };
-
-        compute_midpoint(&start, &end).ok_or_else(|| {
+        // Compute numeric midpoint of the shard's hash-space range
+        let range = crate::shard_range::ShardRange::new(
+            shard_owner.range_start.clone(),
+            shard_owner.range_end.clone(),
+        );
+        let mid = range.midpoint().ok_or_else(|| {
             anyhow::anyhow!(
                 "Cannot compute midpoint for range [{}, {})",
                 shard_owner.range_start,
                 shard_owner.range_end
             )
-        })?
+        })?;
+        crate::shard_range::format_hash_boundary(mid)
     } else {
         return Err(anyhow::anyhow!(
             "Either --at <split-point> or --auto must be specified"
@@ -903,56 +897,13 @@ pub async fn validate_config<W: Write>(
     }
 }
 
-/// Compute the lexicographic midpoint of two strings
+/// Compute the midpoint of a hash-space range defined by hex-encoded u64 boundaries.
+///
+/// Delegates to [`ShardRange::midpoint`](crate::shard_range::ShardRange::midpoint)
+/// and formats the result as a 16-character hex string.
 pub fn compute_midpoint(start: &str, end: &str) -> Option<String> {
-    if start >= end {
-        return None;
-    }
-
-    let start_bytes = start.as_bytes();
-    let end_bytes = end.as_bytes();
-
-    // Find the first differing position
-    let min_len = start_bytes.len().min(end_bytes.len());
-    let mut diff_pos = 0;
-    while diff_pos < min_len && start_bytes[diff_pos] == end_bytes[diff_pos] {
-        diff_pos += 1;
-    }
-
-    if diff_pos == min_len {
-        // One is a prefix of the other
-        if start_bytes.len() < end_bytes.len() {
-            // Start is shorter, add a middle character
-            let mut mid = start.to_string();
-            mid.push('M');
-            if mid.as_str() > start && mid.as_str() < end {
-                return Some(mid);
-            }
-        }
-        return None;
-    }
-
-    // Compute midpoint at the differing position
-    let start_char = start_bytes[diff_pos];
-    let end_char = end_bytes[diff_pos];
-
-    if end_char <= start_char + 1 {
-        // Too close, extend with a high character
-        let mut mid = String::from_utf8_lossy(&start_bytes[..=diff_pos]).to_string();
-        mid.push('~');
-        if mid.as_str() > start && mid.as_str() < end {
-            return Some(mid);
-        }
-        return None;
-    }
-
-    let mid_char = start_char + (end_char - start_char) / 2;
-    let mut result = String::from_utf8_lossy(&start_bytes[..diff_pos]).to_string();
-    result.push(mid_char as char);
-
-    if result.as_str() > start && result.as_str() < end {
-        Some(result)
-    } else {
-        None
-    }
+    let range = crate::shard_range::ShardRange::new(start, end);
+    range
+        .midpoint()
+        .map(crate::shard_range::format_hash_boundary)
 }

--- a/src/siloctl.rs
+++ b/src/siloctl.rs
@@ -935,8 +935,7 @@ pub async fn tenant_locate<W: Write>(
 
     // Find the shard whose range contains the hashed tenant
     let owner = response.shard_owners.iter().find(|s| {
-        let range =
-            crate::shard_range::ShardRange::new(s.range_start.clone(), s.range_end.clone());
+        let range = crate::shard_range::ShardRange::new(s.range_start.clone(), s.range_end.clone());
         range.contains(&hashed)
     });
 

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -1071,45 +1071,39 @@ async fn siloctl_validate_config() -> anyhow::Result<()> {
     Ok(())
 }
 
-// Unit tests for compute_midpoint
+// Unit tests for compute_midpoint (hash-space hex boundaries)
 
 #[silo::test]
-fn test_compute_midpoint_normal() {
-    let mid = siloctl::compute_midpoint("a", "z").unwrap();
-    assert!(mid.as_str() > "a", "midpoint should be > start");
-    assert!(mid.as_str() < "z", "midpoint should be < end");
+fn test_compute_midpoint_full_range() {
+    // Unbounded range: ["", "") → midpoint of [0, u64::MAX]
+    let mid = siloctl::compute_midpoint("", "").unwrap();
+    assert_eq!(mid, "7fffffffffffffff");
 }
 
 #[silo::test]
-fn test_compute_midpoint_equal_strings() {
-    assert!(siloctl::compute_midpoint("abc", "abc").is_none());
+fn test_compute_midpoint_normal_hex_range() {
+    let mid = siloctl::compute_midpoint("2000000000000000", "6000000000000000").unwrap();
+    assert_eq!(mid, "4000000000000000");
 }
 
 #[silo::test]
-fn test_compute_midpoint_start_greater_than_end() {
-    assert!(siloctl::compute_midpoint("z", "a").is_none());
+fn test_compute_midpoint_unbounded_start() {
+    // ["", "8000000000000000") → midpoint of [0, 0x8000000000000000]
+    let mid = siloctl::compute_midpoint("", "8000000000000000").unwrap();
+    assert_eq!(mid, "4000000000000000");
 }
 
 #[silo::test]
-fn test_compute_midpoint_prefix_case() {
-    let mid = siloctl::compute_midpoint("abc", "abcdef").unwrap();
-    assert!(mid.as_str() > "abc", "midpoint should be > start");
-    assert!(mid.as_str() < "abcdef", "midpoint should be < end");
+fn test_compute_midpoint_unbounded_end() {
+    // ["8000000000000000", "") → midpoint of [0x8000000000000000, u64::MAX]
+    let mid = siloctl::compute_midpoint("8000000000000000", "").unwrap();
+    assert_eq!(mid, "bfffffffffffffff");
 }
 
 #[silo::test]
-fn test_compute_midpoint_adjacent_chars() {
-    // 'a' and 'b' are adjacent, so midpoint extends with '~'
-    let mid = siloctl::compute_midpoint("a", "b").unwrap();
-    assert!(mid.as_str() > "a", "midpoint should be > start");
-    assert!(mid.as_str() < "b", "midpoint should be < end");
-}
-
-#[silo::test]
-fn test_compute_midpoint_same_prefix() {
-    let mid = siloctl::compute_midpoint("hello", "world").unwrap();
-    assert!(mid.as_str() > "hello", "midpoint should be > start");
-    assert!(mid.as_str() < "world", "midpoint should be < end");
+fn test_compute_midpoint_adjacent_values() {
+    // Range too small to split (end <= start + 1)
+    assert!(siloctl::compute_midpoint("0000000000000005", "0000000000000006").is_none());
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- `shard split --auto` was computing midpoints using a lexicographic string algorithm with incorrect bounds (`"zzzzzzzz"`), but shard ranges are now 16-char hex-encoded u64 hash values from xxhash. Replaced with delegation to `ShardRange::midpoint()` and `format_hash_boundary()`, matching the hash-space routing used by the rest of the system
- Fix `siloctl cluster info` column widths — the Range column was 14 chars wide but hash-based ranges like `[2000000000000000, 4000000000000000)` are 40 chars, causing misaligned output. Widened to 40
- Add `siloctl tenant hash <tenant_id>` command to compute the xxhash for a tenant ID without needing a server connection. Supports `--json` output

## Test plan
- [x] All 25 siloctl tests pass
- [x] `siloctl cluster info` output aligns correctly with hash-based ranges
- [x] `siloctl tenant hash` returns correct xxhash values matching the routing client
- [x] Verify `siloctl shard split --auto` produces correct hex midpoints against a running cluster