### PR TITLE
Add siloctl job result command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5385,6 +5385,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.7.9",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ flate2 = "1"
 urlencoding = "2"
 storekey = { version = "0.11", features = ["storekey-derive"] }
 hex = "0.4"
+base64 = "0.22"
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
 
 [features]

--- a/src/bin/siloctl.rs
+++ b/src/bin/siloctl.rs
@@ -7,8 +7,8 @@ use std::io;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use clap::{Parser, Subcommand};
-use silo::siloctl::{self, GlobalOptions};
+use clap::{Parser, Subcommand, ValueEnum};
+use silo::siloctl::{self, BytesOutputFormat, GlobalOptions};
 
 #[derive(Parser, Debug)]
 #[command(name = "siloctl")]
@@ -169,6 +169,16 @@ enum JobAction {
         #[arg(long)]
         attempts: bool,
     },
+    /// Get the result or error data of a completed job
+    Result {
+        /// Shard ID (UUID) where the job is stored
+        shard: String,
+        /// Job ID
+        id: String,
+        /// Output format for the result bytes
+        #[arg(long, short = 'f', default_value = "hex")]
+        format: OutputFormat,
+    },
     /// Cancel a job
     Cancel {
         /// Shard ID (UUID) where the job is stored
@@ -199,6 +209,26 @@ enum JobAction {
     },
 }
 
+#[derive(ValueEnum, Debug, Clone, Copy)]
+enum OutputFormat {
+    /// Hex-encoded bytes
+    Hex,
+    /// Base64-encoded bytes
+    Base64,
+    /// Decode msgpack and pretty-print as JSON
+    Msgpack,
+}
+
+impl OutputFormat {
+    fn to_bytes_output_format(self) -> BytesOutputFormat {
+        match self {
+            OutputFormat::Hex => BytesOutputFormat::Hex,
+            OutputFormat::Base64 => BytesOutputFormat::Base64,
+            OutputFormat::Msgpack => BytesOutputFormat::MsgpackJson,
+        }
+    }
+}
+
 async fn run(args: Args) -> anyhow::Result<()> {
     let opts = args.to_global_options();
     let mut stdout = io::stdout();
@@ -213,6 +243,10 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 id,
                 attempts,
             } => siloctl::job_get(&opts, &mut stdout, shard, id, *attempts).await,
+            JobAction::Result { shard, id, format } => {
+                siloctl::job_result(&opts, &mut stdout, shard, id, format.to_bytes_output_format())
+                    .await
+            }
             JobAction::Cancel { shard, id } => {
                 siloctl::job_cancel(&opts, &mut stdout, shard, id).await
             }

--- a/src/siloctl.rs
+++ b/src/siloctl.rs
@@ -12,7 +12,8 @@ use crate::pb::silo_client::SiloClient;
 use crate::pb::{
     CancelJobRequest, ConfigureShardRequest, CpuProfileRequest, DeleteJobRequest,
     ExpediteJobRequest, ForceReleaseShardRequest, GetClusterInfoRequest, GetJobRequest,
-    GetSplitStatusRequest, QueryRequest, RequestSplitRequest, RestartJobRequest,
+    GetJobResultRequest, GetSplitStatusRequest, QueryRequest, RequestSplitRequest,
+    RestartJobRequest,
 };
 use flate2::Compression;
 use flate2::write::GzEncoder;
@@ -313,6 +314,124 @@ pub async fn job_get<W: Write>(
     }
 
     Ok(())
+}
+
+/// Output format for raw bytes
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BytesOutputFormat {
+    /// Hex-encoded output
+    Hex,
+    /// Base64-encoded output
+    Base64,
+    /// Decode msgpack and pretty-print as JSON
+    MsgpackJson,
+}
+
+/// Get the result or error data of a completed job
+pub async fn job_result<W: Write>(
+    opts: &GlobalOptions,
+    out: &mut W,
+    shard: &str,
+    id: &str,
+    format: BytesOutputFormat,
+) -> anyhow::Result<()> {
+    let mut client =
+        connect_to_shard_owner(&opts.address, shard, opts.auth_token.as_deref()).await?;
+    let response = client
+        .get_job_result(GetJobResultRequest {
+            shard: shard.to_string(),
+            id: id.to_string(),
+            tenant: opts.tenant.clone(),
+        })
+        .await?
+        .into_inner();
+
+    let status = job_status_to_string(response.status);
+
+    match response.result {
+        Some(crate::pb::get_job_result_response::Result::SuccessData(data)) => {
+            let raw = extract_serialized_bytes(&data);
+            if opts.json {
+                let json_output = serde_json::json!({
+                    "id": response.id,
+                    "status": status,
+                    "finished_at_ms": response.finished_at_ms,
+                    "result": format_bytes(&raw, format)?,
+                });
+                writeln!(out, "{}", serde_json::to_string_pretty(&json_output)?)?;
+            } else {
+                writeln!(out, "Job:     {}", response.id)?;
+                writeln!(out, "Status:  {}", status)?;
+                writeln!(out, "Result:")?;
+                writeln!(out, "{}", format_bytes(&raw, format)?)?;
+            }
+        }
+        Some(crate::pb::get_job_result_response::Result::Failure(failure)) => {
+            let error_data = failure
+                .error_data
+                .map(|d| extract_serialized_bytes(&d))
+                .unwrap_or_default();
+            if opts.json {
+                let json_output = serde_json::json!({
+                    "id": response.id,
+                    "status": status,
+                    "finished_at_ms": response.finished_at_ms,
+                    "error_code": failure.error_code,
+                    "error_data": format_bytes(&error_data, format)?,
+                });
+                writeln!(out, "{}", serde_json::to_string_pretty(&json_output)?)?;
+            } else {
+                writeln!(out, "Job:        {}", response.id)?;
+                writeln!(out, "Status:     {}", status)?;
+                writeln!(out, "Error Code: {}", failure.error_code)?;
+                writeln!(out, "Error Data:")?;
+                writeln!(out, "{}", format_bytes(&error_data, format)?)?;
+            }
+        }
+        Some(crate::pb::get_job_result_response::Result::Cancelled(cancelled)) => {
+            if opts.json {
+                let json_output = serde_json::json!({
+                    "id": response.id,
+                    "status": status,
+                    "cancelled_at_ms": cancelled.cancelled_at_ms,
+                });
+                writeln!(out, "{}", serde_json::to_string_pretty(&json_output)?)?;
+            } else {
+                writeln!(out, "Job:    {}", response.id)?;
+                writeln!(out, "Status: {}", status)?;
+                writeln!(
+                    out,
+                    "Cancelled at: {}",
+                    format_timestamp_ms(cancelled.cancelled_at_ms)
+                )?;
+            }
+        }
+        None => {
+            return Err(anyhow::anyhow!("no result data returned for job {}", id));
+        }
+    }
+
+    Ok(())
+}
+
+fn extract_serialized_bytes(data: &crate::pb::SerializedBytes) -> Vec<u8> {
+    match &data.encoding {
+        Some(crate::pb::serialized_bytes::Encoding::Msgpack(bytes)) => bytes.clone(),
+        None => vec![],
+    }
+}
+
+fn format_bytes(raw: &[u8], format: BytesOutputFormat) -> anyhow::Result<String> {
+    use base64::Engine;
+    match format {
+        BytesOutputFormat::Hex => Ok(hex::encode(raw)),
+        BytesOutputFormat::Base64 => Ok(base64::engine::general_purpose::STANDARD.encode(raw)),
+        BytesOutputFormat::MsgpackJson => {
+            let value: serde_json::Value = rmp_serde::from_slice(raw)
+                .map_err(|e| anyhow::anyhow!("failed to decode msgpack: {}", e))?;
+            Ok(serde_json::to_string_pretty(&value)?)
+        }
+    }
 }
 
 /// Cancel a job

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -14,7 +14,7 @@ use grpc_integration_helpers::{
 use silo::pb::silo_client::SiloClient;
 use silo::pb::*;
 use silo::settings::AppConfig;
-use silo::siloctl::{self, GlobalOptions};
+use silo::siloctl::{self, BytesOutputFormat, GlobalOptions};
 
 // Global mutex to serialize profile tests - only one CPU profiler can run at a time system-wide
 static PROFILE_TEST_MUTEX: Mutex<()> = Mutex::new(());
@@ -1317,6 +1317,419 @@ async fn siloctl_unknown_shard_returns_clear_error() -> anyhow::Result<()> {
             "error should indicate shard not found in cluster: {}",
             err
         );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Helper: enqueue a job, lease it, and report a successful outcome with result data.
+async fn enqueue_and_complete_job(
+    client: &mut SiloClient<tonic::transport::Channel>,
+    job_id: &str,
+    result_data: &serde_json::Value,
+) -> anyhow::Result<()> {
+    client
+        .enqueue(EnqueueRequest {
+            shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+            id: job_id.to_string(),
+            priority: 50,
+            start_at_ms: 0,
+            retry_policy: None,
+            payload: Some(SerializedBytes {
+                encoding: Some(serialized_bytes::Encoding::Msgpack(
+                    rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
+                )),
+            }),
+            limits: vec![],
+            tenant: None,
+            metadata: std::collections::HashMap::new(),
+            task_group: "default".to_string(),
+        })
+        .await?;
+
+    let lease_resp = client
+        .lease_tasks(LeaseTasksRequest {
+            shard: Some(crate::grpc_integration_helpers::TEST_SHARD_ID.to_string()),
+            worker_id: "test-worker".to_string(),
+            max_tasks: 1,
+            task_group: "default".to_string(),
+        })
+        .await?
+        .into_inner();
+
+    let task = lease_resp
+        .tasks
+        .iter()
+        .find(|t| t.job_id == job_id)
+        .expect("should find leased task for job");
+
+    client
+        .report_outcome(ReportOutcomeRequest {
+            shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+            task_id: task.id.clone(),
+            outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
+                encoding: Some(serialized_bytes::Encoding::Msgpack(
+                    rmp_serde::to_vec(result_data).unwrap(),
+                )),
+            })),
+        })
+        .await?;
+
+    Ok(())
+}
+
+/// Helper: enqueue a job, lease it, and report a failed outcome with error data.
+async fn enqueue_and_fail_job(
+    client: &mut SiloClient<tonic::transport::Channel>,
+    job_id: &str,
+    error_code: &str,
+    error_data: &serde_json::Value,
+) -> anyhow::Result<()> {
+    client
+        .enqueue(EnqueueRequest {
+            shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+            id: job_id.to_string(),
+            priority: 50,
+            start_at_ms: 0,
+            retry_policy: None,
+            payload: Some(SerializedBytes {
+                encoding: Some(serialized_bytes::Encoding::Msgpack(
+                    rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
+                )),
+            }),
+            limits: vec![],
+            tenant: None,
+            metadata: std::collections::HashMap::new(),
+            task_group: "default".to_string(),
+        })
+        .await?;
+
+    let lease_resp = client
+        .lease_tasks(LeaseTasksRequest {
+            shard: Some(crate::grpc_integration_helpers::TEST_SHARD_ID.to_string()),
+            worker_id: "test-worker".to_string(),
+            max_tasks: 1,
+            task_group: "default".to_string(),
+        })
+        .await?
+        .into_inner();
+
+    let task = lease_resp
+        .tasks
+        .iter()
+        .find(|t| t.job_id == job_id)
+        .expect("should find leased task for job");
+
+    client
+        .report_outcome(ReportOutcomeRequest {
+            shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+            task_id: task.id.clone(),
+            outcome: Some(report_outcome_request::Outcome::Failure(Failure {
+                code: error_code.to_string(),
+                data: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(error_data).unwrap(),
+                    )),
+                }),
+            })),
+        })
+        .await?;
+
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn siloctl_job_result_success_hex() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(30000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let result_data = serde_json::json!({"answer": 42});
+        enqueue_and_complete_job(&mut client, "result-hex-job", &result_data).await?;
+
+        let opts = opts_for_addr(&addr);
+        let mut output = Vec::new();
+        siloctl::job_result(
+            &opts,
+            &mut output,
+            crate::grpc_integration_helpers::TEST_SHARD_ID,
+            "result-hex-job",
+            BytesOutputFormat::Hex,
+        )
+        .await?;
+        let stdout = String::from_utf8(output)?;
+
+        assert!(
+            stdout.contains("result-hex-job"),
+            "should contain job ID: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("succeeded"),
+            "should show succeeded status: {}",
+            stdout
+        );
+        // Verify it contains hex-encoded bytes
+        let expected_hex = hex::encode(rmp_serde::to_vec(&result_data).unwrap());
+        assert!(
+            stdout.contains(&expected_hex),
+            "should contain hex-encoded result bytes: {}",
+            stdout
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn siloctl_job_result_success_msgpack_decode() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(30000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let result_data = serde_json::json!({"message": "hello world", "count": 123});
+        enqueue_and_complete_job(&mut client, "result-msgpack-job", &result_data).await?;
+
+        // Test msgpack decode in human-readable mode
+        let opts = opts_for_addr(&addr);
+        let mut output = Vec::new();
+        siloctl::job_result(
+            &opts,
+            &mut output,
+            crate::grpc_integration_helpers::TEST_SHARD_ID,
+            "result-msgpack-job",
+            BytesOutputFormat::MsgpackJson,
+        )
+        .await?;
+        let stdout = String::from_utf8(output)?;
+
+        assert!(
+            stdout.contains("result-msgpack-job"),
+            "should contain job ID: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("hello world"),
+            "decoded msgpack should contain the original string value: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("123"),
+            "decoded msgpack should contain the original numeric value: {}",
+            stdout
+        );
+
+        // Test msgpack decode in JSON mode
+        let opts_json = opts_for_addr_json(&addr);
+        let mut json_output = Vec::new();
+        siloctl::job_result(
+            &opts_json,
+            &mut json_output,
+            crate::grpc_integration_helpers::TEST_SHARD_ID,
+            "result-msgpack-job",
+            BytesOutputFormat::MsgpackJson,
+        )
+        .await?;
+        let json_stdout = String::from_utf8(json_output)?;
+
+        let parsed: serde_json::Value = serde_json::from_str(&json_stdout)
+            .unwrap_or_else(|_| panic!("Failed to parse JSON output: {}", json_stdout));
+        assert_eq!(parsed["id"], "result-msgpack-job");
+        assert_eq!(parsed["status"], "succeeded");
+        // The result field should be a pretty-printed JSON string of the decoded msgpack
+        let result_str = parsed["result"]
+            .as_str()
+            .expect("result should be a string");
+        let decoded: serde_json::Value = serde_json::from_str(result_str)
+            .unwrap_or_else(|_| panic!("result should be valid JSON: {}", result_str));
+        assert_eq!(decoded["message"], "hello world");
+        assert_eq!(decoded["count"], 123);
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn siloctl_job_result_failure_msgpack_decode() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(30000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let error_data = serde_json::json!({"reason": "timeout", "retry_after_ms": 5000});
+        enqueue_and_fail_job(&mut client, "result-fail-job", "TIMEOUT", &error_data).await?;
+
+        // Test msgpack decode of error data
+        let opts = opts_for_addr(&addr);
+        let mut output = Vec::new();
+        siloctl::job_result(
+            &opts,
+            &mut output,
+            crate::grpc_integration_helpers::TEST_SHARD_ID,
+            "result-fail-job",
+            BytesOutputFormat::MsgpackJson,
+        )
+        .await?;
+        let stdout = String::from_utf8(output)?;
+
+        assert!(
+            stdout.contains("result-fail-job"),
+            "should contain job ID: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("failed"),
+            "should show failed status: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("TIMEOUT"),
+            "should show error code: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("timeout"),
+            "decoded error data should contain reason: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("5000"),
+            "decoded error data should contain retry_after_ms: {}",
+            stdout
+        );
+
+        // Test JSON mode
+        let opts_json = opts_for_addr_json(&addr);
+        let mut json_output = Vec::new();
+        siloctl::job_result(
+            &opts_json,
+            &mut json_output,
+            crate::grpc_integration_helpers::TEST_SHARD_ID,
+            "result-fail-job",
+            BytesOutputFormat::MsgpackJson,
+        )
+        .await?;
+        let json_stdout = String::from_utf8(json_output)?;
+
+        let parsed: serde_json::Value = serde_json::from_str(&json_stdout)
+            .unwrap_or_else(|_| panic!("Failed to parse JSON output: {}", json_stdout));
+        assert_eq!(parsed["id"], "result-fail-job");
+        assert_eq!(parsed["status"], "failed");
+        assert_eq!(parsed["error_code"], "TIMEOUT");
+        let error_str = parsed["error_data"]
+            .as_str()
+            .expect("error_data should be a string");
+        let decoded: serde_json::Value = serde_json::from_str(error_str)
+            .unwrap_or_else(|_| panic!("error_data should be valid JSON: {}", error_str));
+        assert_eq!(decoded["reason"], "timeout");
+        assert_eq!(decoded["retry_after_ms"], 5000);
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn siloctl_job_result_base64() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(30000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let result_data = serde_json::json!({"key": "value"});
+        enqueue_and_complete_job(&mut client, "result-b64-job", &result_data).await?;
+
+        let opts = opts_for_addr(&addr);
+        let mut output = Vec::new();
+        siloctl::job_result(
+            &opts,
+            &mut output,
+            crate::grpc_integration_helpers::TEST_SHARD_ID,
+            "result-b64-job",
+            BytesOutputFormat::Base64,
+        )
+        .await?;
+        let stdout = String::from_utf8(output)?;
+
+        use base64::Engine;
+        let expected_b64 = base64::engine::general_purpose::STANDARD
+            .encode(rmp_serde::to_vec(&result_data).unwrap());
+        assert!(
+            stdout.contains(&expected_b64),
+            "should contain base64-encoded result: {}",
+            stdout
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn siloctl_job_result_not_terminal() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(30000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        // Enqueue a job but don't complete it — schedule in the future so it stays scheduled
+        let future_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64
+            + 60000;
+
+        client
+            .enqueue(EnqueueRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: "result-nonterminal-job".to_string(),
+                priority: 50,
+                start_at_ms: future_ms,
+                retry_policy: None,
+                payload: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
+                    )),
+                }),
+                limits: vec![],
+                tenant: None,
+                metadata: std::collections::HashMap::new(),
+                task_group: "default".to_string(),
+            })
+            .await?;
+
+        let opts = opts_for_addr(&addr);
+        let mut output = Vec::new();
+        let result = siloctl::job_result(
+            &opts,
+            &mut output,
+            crate::grpc_integration_helpers::TEST_SHARD_ID,
+            "result-nonterminal-job",
+            BytesOutputFormat::Hex,
+        )
+        .await;
+
+        assert!(result.is_err(), "should fail for non-terminal job");
 
         shutdown_server(shutdown_tx, server).await?;
         Ok::<(), anyhow::Error>(())


### PR DESCRIPTION
## Summary
- Adds `siloctl job result <shard> <job-id>` command that calls the `GetJobResult` RPC to dump raw result/error bytes from completed jobs
- Supports `--format hex` (default), `--format base64`, and `--format msgpack` (decodes msgpack and pretty-prints as JSON)
- Handles success, failure (with error code + error data), and cancelled states
- Works with both human-readable and `--json` output modes

## Test plan
- [x] 5 integration tests covering hex, base64, msgpack decode (success + failure), and non-terminal job error case
- [ ] Manual tophat against live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)