### PR TITLE
Fix wrong-shard retry for worker RPCs and add tenant_id validation

### DIFF
--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -278,7 +278,7 @@ message RefreshFloatingLimitTask {
   int64 lease_ms = 6;                  // How long the lease lasts. Heartbeat before this expires.
   string shard = 7;                    // Shard ID (UUID) this task came from (needed for reporting outcome).
   string task_group = 8;               // Task group this refresh task belongs to.
-  optional string tenant_id = 9;       // Tenant ID if multi-tenancy is enabled.
+  optional string tenant_id = 9;       // Tenant ID for routing. Required if multi-tenancy is enabled.
 }
 
 // Response containing tasks leased to a worker.
@@ -288,7 +288,6 @@ message LeaseTasksResponse {
 }
 
 // Request to report the outcome of a completed task.
-// Note: tenant is determined from the task lease, not from the request.
 message ReportOutcomeRequest {
   string shard = 1;          // Shard ID (UUID) the task came from.
   string task_id = 2;        // The task's unique ID.
@@ -297,6 +296,7 @@ message ReportOutcomeRequest {
     Failure failure = 4;        // Job failed. Contains error details.
     Cancelled cancelled = 6;    // Worker acknowledges job was cancelled.
   }
+  optional string tenant_id = 7;  // Tenant ID for shard routing. Required if multi-tenancy is enabled. Should come from Task.tenant_id.
 }
 
 // Error details for a failed task.
@@ -312,7 +312,6 @@ message Cancelled {}
 message ReportOutcomeResponse {}
 
 // Request to report the outcome of a floating limit refresh task.
-// Note: tenant is determined from the task lease, not from the request.
 message ReportRefreshOutcomeRequest {
   string shard = 1;          // Shard ID (UUID) the task came from.
   string task_id = 2;        // The task's unique ID.
@@ -320,6 +319,7 @@ message ReportRefreshOutcomeRequest {
     RefreshSuccess success = 4; // Refresh succeeded with new max concurrency.
     RefreshFailure failure = 5; // Refresh failed.
   }
+  optional string tenant_id = 6;  // Tenant ID for shard routing. Required if multi-tenancy is enabled. Should come from RefreshTask.tenant_id.
 }
 
 // Successful floating limit refresh with the new computed value.
@@ -338,11 +338,11 @@ message ReportRefreshOutcomeResponse {}
 
 // Request to extend a task lease and check for cancellation.
 // Workers must heartbeat before lease_ms expires to keep the task.
-// Note: tenant is determined from the task lease, not from the request.
 message HeartbeatRequest {
   string shard = 1;          // Shard ID (UUID) the task came from.
   string worker_id = 2;      // Worker ID that holds the lease.
   string task_id = 3;        // The task's unique ID.
+  optional string tenant_id = 4;  // Tenant ID for shard routing. Required if multi-tenancy is enabled. Should come from Task.tenant_id.
 }
 
 // Response indicating if the lease was extended and if the job was cancelled.

--- a/src/bin/silo-bench.rs
+++ b/src/bin/silo-bench.rs
@@ -178,7 +178,11 @@ impl TenantSelector {
 const MAX_ROUTING_RETRIES: u32 = 3;
 
 /// Pre-serialized empty success payload, shared across all outcome reports.
-fn make_success_outcome_request(shard: String, task_id: String) -> ReportOutcomeRequest {
+fn make_success_outcome_request(
+    shard: String,
+    task_id: String,
+    tenant_id: Option<String>,
+) -> ReportOutcomeRequest {
     ReportOutcomeRequest {
         shard,
         task_id,
@@ -187,6 +191,7 @@ fn make_success_outcome_request(shard: String, task_id: String) -> ReportOutcome
                 rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
             )),
         })),
+        tenant_id,
     }
 }
 
@@ -234,14 +239,18 @@ async fn worker_loop(
 
                 for task in tasks {
                     let task_shard = task.shard.clone();
+                    let task_tenant = task.tenant_id.clone();
 
                     let mut report_client = match client.client_for_shard(&task_shard) {
                         Ok(c) => c,
                         Err(_) => silo_client.clone(),
                     };
 
-                    let outcome_request =
-                        make_success_outcome_request(task_shard.clone(), task.id.clone());
+                    let outcome_request = make_success_outcome_request(
+                        task_shard.clone(),
+                        task.id.clone(),
+                        task_tenant.clone(),
+                    );
 
                     match report_client.report_outcome(outcome_request).await {
                         Ok(_) => {
@@ -252,8 +261,11 @@ async fn worker_loop(
                             if client.handle_routing_error(&e, &task_shard).await.is_some() {
                                 // Retry once with updated routing
                                 if let Ok(mut retry_client) = client.client_for_shard(&task_shard) {
-                                    let retry_req =
-                                        make_success_outcome_request(task_shard, task.id.clone());
+                                    let retry_req = make_success_outcome_request(
+                                        task_shard,
+                                        task.id.clone(),
+                                        task_tenant,
+                                    );
                                     match retry_client.report_outcome(retry_req).await {
                                         Ok(_) => {
                                             completed_count.fetch_add(1, Ordering::Relaxed);

--- a/src/server.rs
+++ b/src/server.rs
@@ -243,6 +243,10 @@ fn leased_task_to_proto(lt: &crate::task::LeasedTask, shard_id: &str) -> Task {
 fn map_err(e: JobStoreShardError) -> Status {
     match e {
         JobStoreShardError::JobNotFound(_) => Status::not_found("job not found"),
+        JobStoreShardError::LeaseNotFound(_) => Status::not_found("lease not found"),
+        JobStoreShardError::LeaseOwnerMismatch { .. } => {
+            Status::failed_precondition("lease owner mismatch")
+        }
         JobStoreShardError::JobAlreadyCancelled(_) => {
             Status::failed_precondition("job is already cancelled")
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -727,6 +727,29 @@ impl SiloService {
 
         Ok(())
     }
+
+    /// Validate the tenant_id field on worker RPCs (reportOutcome, heartbeat, reportRefreshOutcome).
+    ///
+    /// When tenancy is enabled, the client MUST send tenant_id so the server can verify
+    /// the request is routed to the correct shard. When tenancy is disabled, tenant_id
+    /// is ignored (workers don't have meaningful tenant routing).
+    async fn validate_worker_tenant(
+        &self,
+        shard_id: &crate::shard_range::ShardId,
+        tenant_id: Option<&str>,
+    ) -> Result<(), Status> {
+        if !self.cfg.tenancy.enabled {
+            return Ok(());
+        }
+
+        let tenant = tenant_id.and_then(|t| if t.is_empty() { None } else { Some(t) });
+        match tenant {
+            Some(t) => self.validate_tenant_in_shard_range(shard_id, t).await,
+            None => Err(Status::invalid_argument(
+                "tenant_id is required for worker operations when tenancy is enabled",
+            )),
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -1226,6 +1249,8 @@ impl Silo for SiloService {
         let shard_str = r.shard.to_string();
         let shard_id = Self::parse_shard_id(&r.shard)?;
         let shard = self.shard_with_redirect(&shard_id).await?;
+        self.validate_worker_tenant(&shard_id, r.tenant_id.as_deref())
+            .await?;
         let (outcome, status_str) = match r
             .outcome
             .ok_or_else(|| Status::invalid_argument("missing outcome"))?
@@ -1277,7 +1302,8 @@ impl Silo for SiloService {
         let r = req.into_inner();
         let shard_id = Self::parse_shard_id(&r.shard)?;
         let shard = self.shard_with_redirect(&shard_id).await?;
-        // Tenant is extracted from the lease on the server side, not from the request
+        self.validate_worker_tenant(&shard_id, r.tenant_id.as_deref())
+            .await?;
         let outcome = r
             .outcome
             .ok_or_else(|| Status::invalid_argument("missing outcome"))?;
@@ -1306,7 +1332,8 @@ impl Silo for SiloService {
         let r = req.into_inner();
         let shard_id = Self::parse_shard_id(&r.shard)?;
         let shard = self.shard_with_redirect(&shard_id).await?;
-        // Tenant is extracted from the lease on the server side, not from the request
+        self.validate_worker_tenant(&shard_id, r.tenant_id.as_deref())
+            .await?;
         let result = shard
             .heartbeat_task(&r.worker_id, &r.task_id)
             .await

--- a/tests/grpc_enqueue_tests.rs
+++ b/tests/grpc_enqueue_tests.rs
@@ -64,6 +64,7 @@ async fn grpc_server_enqueue_and_workflow() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 

--- a/tests/grpc_expedite_tests.rs
+++ b/tests/grpc_expedite_tests.rs
@@ -100,6 +100,7 @@ async fn grpc_expedite_future_scheduled_job() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!("expedited success")).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -241,6 +242,7 @@ async fn grpc_expedite_running_job_fails() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!("done")).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 

--- a/tests/grpc_job_tests.rs
+++ b/tests/grpc_job_tests.rs
@@ -86,6 +86,7 @@ async fn grpc_get_job_includes_status() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!({"result": "done"})).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -261,6 +262,7 @@ async fn grpc_get_job_result_success() -> anyhow::Result<()> {
                 outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
                     encoding: Some(serialized_bytes::Encoding::Msgpack(result_data.clone())),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -355,6 +357,7 @@ async fn grpc_get_job_result_failure() -> anyhow::Result<()> {
                         encoding: Some(serialized_bytes::Encoding::Msgpack(error_data.clone())),
                     }),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -515,6 +518,7 @@ async fn grpc_get_job_result_cancelled_while_running() -> anyhow::Result<()> {
                 shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
                 task_id: task.id.clone(),
                 outcome: Some(report_outcome_request::Outcome::Cancelled(Cancelled {})),
+                tenant_id: None,
             })
             .await?;
 
@@ -734,6 +738,7 @@ async fn grpc_get_job_next_attempt_starts_after() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!({"result": "done"})).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -822,6 +827,7 @@ async fn grpc_get_job_next_attempt_after_retry() -> anyhow::Result<()> {
                         encoding: Some(serialized_bytes::Encoding::Msgpack(b"{}".to_vec())),
                     }),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -1246,6 +1252,7 @@ async fn grpc_get_job_result_field_without_attempts() -> anyhow::Result<()> {
                 outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
                     encoding: Some(serialized_bytes::Encoding::Msgpack(result_data.clone())),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -1324,6 +1331,7 @@ async fn grpc_get_job_result_field_with_attempts() -> anyhow::Result<()> {
                 outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
                     encoding: Some(serialized_bytes::Encoding::Msgpack(result_data.clone())),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -1420,6 +1428,7 @@ async fn grpc_get_job_result_field_none_for_failed() -> anyhow::Result<()> {
                         )),
                     }),
                 })),
+                tenant_id: None,
             })
             .await?;
 

--- a/tests/grpc_lease_task_tests.rs
+++ b/tests/grpc_lease_task_tests.rs
@@ -72,6 +72,7 @@ async fn lease_task_grpc_basic() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!("leased success")).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -202,6 +203,7 @@ async fn lease_task_grpc_already_running() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!("done")).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 

--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -468,6 +468,7 @@ async fn grpc_server_report_outcome_missing_outcome() -> anyhow::Result<()> {
                 shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
                 task_id: "fake-task".to_string(),
                 outcome: None, // Missing!
+                tenant_id: None,
             })
             .await;
 
@@ -504,6 +505,7 @@ async fn grpc_server_report_refresh_outcome_missing_outcome() -> anyhow::Result<
                 shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
                 task_id: "fake-refresh-task".to_string(),
                 outcome: None, // Missing!
+                tenant_id: None,
             })
             .await;
 
@@ -679,6 +681,7 @@ async fn grpc_server_get_node_info_tracks_lifecycle() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!({"result": "done"})).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -822,6 +825,7 @@ async fn grpc_server_reset_shards_clears_fs_backend_data() -> anyhow::Result<()>
                         rmp_serde::to_vec(&serde_json::json!({"result": "done"})).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -1546,6 +1550,272 @@ async fn grpc_force_release_shard_invalid_id_returns_error() -> anyhow::Result<(
             status.code(),
             tonic::Code::InvalidArgument,
             "invalid shard ID should return InvalidArgument"
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// When tenancy is enabled, report_outcome/heartbeat/report_refresh_outcome must include tenant_id.
+#[silo::test(flavor = "multi_thread")]
+async fn grpc_worker_rpcs_require_tenant_when_tenancy_enabled() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let mut cfg = AppConfig::load(None).unwrap();
+        cfg.tenancy.enabled = true;
+
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), cfg).await?;
+
+        // report_outcome without tenant_id should fail
+        let res = client
+            .report_outcome(ReportOutcomeRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                task_id: "fake-task".to_string(),
+                outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
+                    )),
+                })),
+                tenant_id: None,
+            })
+            .await;
+
+        match res {
+            Ok(_) => panic!("expected error for missing tenant_id on report_outcome"),
+            Err(status) => {
+                assert_eq!(status.code(), tonic::Code::InvalidArgument);
+                assert!(
+                    status.message().contains("tenant_id"),
+                    "error should mention tenant_id: {}",
+                    status.message()
+                );
+            }
+        }
+
+        // heartbeat without tenant_id should fail
+        let res = client
+            .heartbeat(HeartbeatRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                worker_id: "test-worker".to_string(),
+                task_id: "fake-task".to_string(),
+                tenant_id: None,
+            })
+            .await;
+
+        match res {
+            Ok(_) => panic!("expected error for missing tenant_id on heartbeat"),
+            Err(status) => {
+                assert_eq!(status.code(), tonic::Code::InvalidArgument);
+                assert!(
+                    status.message().contains("tenant_id"),
+                    "error should mention tenant_id: {}",
+                    status.message()
+                );
+            }
+        }
+
+        // report_refresh_outcome without tenant_id should fail
+        let res = client
+            .report_refresh_outcome(ReportRefreshOutcomeRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                task_id: "fake-task".to_string(),
+                outcome: Some(report_refresh_outcome_request::Outcome::Success(
+                    RefreshSuccess {
+                        new_max_concurrency: 10,
+                    },
+                )),
+                tenant_id: None,
+            })
+            .await;
+
+        match res {
+            Ok(_) => panic!("expected error for missing tenant_id on report_refresh_outcome"),
+            Err(status) => {
+                assert_eq!(status.code(), tonic::Code::InvalidArgument);
+                assert!(
+                    status.message().contains("tenant_id"),
+                    "error should mention tenant_id: {}",
+                    status.message()
+                );
+            }
+        }
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// When tenancy is disabled, worker RPCs should work without tenant_id.
+#[silo::test(flavor = "multi_thread")]
+async fn grpc_worker_rpcs_skip_tenant_validation_when_tenancy_disabled() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let mut cfg = AppConfig::load(None).unwrap();
+        cfg.tenancy.enabled = false;
+
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), cfg).await?;
+
+        // Enqueue a job and lease it so we have a real task
+        client
+            .enqueue(EnqueueRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: "job-no-tenant".to_string(),
+                priority: 5,
+                start_at_ms: 0,
+                retry_policy: None,
+                payload: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
+                    )),
+                }),
+                limits: vec![],
+                tenant: None,
+                metadata: std::collections::HashMap::new(),
+                task_group: "default".to_string(),
+            })
+            .await?;
+
+        let lease_resp = client
+            .lease_tasks(LeaseTasksRequest {
+                shard: Some(crate::grpc_integration_helpers::TEST_SHARD_ID.to_string()),
+                worker_id: "test-worker".to_string(),
+                max_tasks: 1,
+                task_group: "default".to_string(),
+            })
+            .await?
+            .into_inner();
+
+        assert_eq!(lease_resp.tasks.len(), 1);
+        let task = &lease_resp.tasks[0];
+
+        // heartbeat without tenant_id should succeed when tenancy is disabled
+        let hb = client
+            .heartbeat(HeartbeatRequest {
+                shard: task.shard.clone(),
+                worker_id: "test-worker".to_string(),
+                task_id: task.id.clone(),
+                tenant_id: None,
+            })
+            .await;
+        assert!(
+            hb.is_ok(),
+            "heartbeat should succeed without tenant_id when tenancy is disabled"
+        );
+
+        // report_outcome without tenant_id should succeed when tenancy is disabled
+        let res = client
+            .report_outcome(ReportOutcomeRequest {
+                shard: task.shard.clone(),
+                task_id: task.id.clone(),
+                outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
+                    )),
+                })),
+                tenant_id: None,
+            })
+            .await;
+        assert!(
+            res.is_ok(),
+            "report_outcome should succeed without tenant_id when tenancy is disabled"
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// When tenancy is enabled, worker RPCs should accept valid tenant_id and succeed.
+#[silo::test(flavor = "multi_thread")]
+async fn grpc_worker_rpcs_accept_valid_tenant_when_tenancy_enabled() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let mut cfg = AppConfig::load(None).unwrap();
+        cfg.tenancy.enabled = true;
+
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), cfg).await?;
+
+        let tenant = "test-tenant";
+
+        // Enqueue a job with tenant
+        client
+            .enqueue(EnqueueRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: "job-with-tenant".to_string(),
+                priority: 5,
+                start_at_ms: 0,
+                retry_policy: None,
+                payload: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
+                    )),
+                }),
+                limits: vec![],
+                tenant: Some(tenant.to_string()),
+                metadata: std::collections::HashMap::new(),
+                task_group: "default".to_string(),
+            })
+            .await?;
+
+        let lease_resp = client
+            .lease_tasks(LeaseTasksRequest {
+                shard: Some(crate::grpc_integration_helpers::TEST_SHARD_ID.to_string()),
+                worker_id: "test-worker".to_string(),
+                max_tasks: 1,
+                task_group: "default".to_string(),
+            })
+            .await?
+            .into_inner();
+
+        assert_eq!(lease_resp.tasks.len(), 1);
+        let task = &lease_resp.tasks[0];
+        assert_eq!(task.tenant_id.as_deref(), Some(tenant));
+
+        // heartbeat with valid tenant_id should succeed
+        let hb = client
+            .heartbeat(HeartbeatRequest {
+                shard: task.shard.clone(),
+                worker_id: "test-worker".to_string(),
+                task_id: task.id.clone(),
+                tenant_id: Some(tenant.to_string()),
+            })
+            .await;
+        assert!(
+            hb.is_ok(),
+            "heartbeat should succeed with valid tenant_id: {:?}",
+            hb.err()
+        );
+
+        // report_outcome with valid tenant_id should succeed
+        let res = client
+            .report_outcome(ReportOutcomeRequest {
+                shard: task.shard.clone(),
+                task_id: task.id.clone(),
+                outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
+                    )),
+                })),
+                tenant_id: Some(tenant.to_string()),
+            })
+            .await;
+        assert!(
+            res.is_ok(),
+            "report_outcome should succeed with valid tenant_id: {:?}",
+            res.err()
         );
 
         shutdown_server(shutdown_tx, server).await?;

--- a/tests/grpc_restart_tests.rs
+++ b/tests/grpc_restart_tests.rs
@@ -110,6 +110,7 @@ async fn grpc_restart_cancelled_job() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!("done")).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -188,6 +189,7 @@ async fn grpc_restart_failed_job() -> anyhow::Result<()> {
                         )),
                     }),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -246,6 +248,7 @@ async fn grpc_restart_failed_job() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!("success after restart")).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -387,6 +390,7 @@ async fn grpc_restart_running_job_fails() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 
@@ -449,6 +453,7 @@ async fn grpc_restart_succeeded_job_fails() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!({})).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -670,6 +670,7 @@ async fn siloctl_job_get_with_attempts() -> anyhow::Result<()> {
                         rmp_serde::to_vec(&serde_json::json!({"result": "done"})).unwrap(),
                     )),
                 })),
+                tenant_id: None,
             })
             .await?;
 

--- a/tests/turmoil_runner/scenarios/cancel_releases_ticket.rs
+++ b/tests/turmoil_runner/scenarios/cancel_releases_ticket.rs
@@ -247,6 +247,7 @@ pub fn run() {
                             shard: TEST_SHARD_ID.to_string(),
                             worker_id: "worker-1".into(),
                             task_id: task_id.clone(),
+                            tenant_id: None,
                         }))
                         .await;
 
@@ -273,6 +274,7 @@ pub fn run() {
                                         outcome: Some(report_outcome_request::Outcome::Cancelled(
                                             silo::pb::Cancelled {},
                                         )),
+                                        tenant_id: None,
                                     }))
                                     .await
                                 {
@@ -324,6 +326,7 @@ pub fn run() {
                                         )),
                                     },
                                 )),
+                                tenant_id: None,
                             }))
                             .await
                         {

--- a/tests/turmoil_runner/scenarios/chaos.rs
+++ b/tests/turmoil_runner/scenarios/chaos.rs
@@ -562,6 +562,7 @@ pub fn run() {
                                     shard: TEST_SHARD_ID.to_string(),
                                     task_id: task.id.clone(),
                                     outcome: Some(outcome),
+                                    tenant_id: None,
                                 }))
                                 .await
                             {
@@ -620,6 +621,7 @@ pub fn run() {
                             outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
                                 encoding: Some(serialized_bytes::Encoding::Msgpack(rmp_serde::to_vec(&serde_json::json!("chaos_done")).unwrap())),
                             })),
+                            tenant_id: None,
                         }))
                         .await
                     {

--- a/tests/turmoil_runner/scenarios/concurrency_limits.rs
+++ b/tests/turmoil_runner/scenarios/concurrency_limits.rs
@@ -390,6 +390,7 @@ pub fn run() {
                                     shard: TEST_SHARD_ID.to_string(),
                                     task_id: task.id.clone(),
                                     outcome: Some(outcome),
+                                    tenant_id: None,
                                 }))
                                 .await
                             {
@@ -460,6 +461,7 @@ pub fn run() {
                             outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
                                 encoding: Some(serialized_bytes::Encoding::Msgpack(rmp_serde::to_vec(&serde_json::json!("done")).unwrap())),
                             })),
+                            tenant_id: None,
                         }))
                         .await
                     {

--- a/tests/turmoil_runner/scenarios/concurrent_grant_race.rs
+++ b/tests/turmoil_runner/scenarios/concurrent_grant_race.rs
@@ -163,6 +163,7 @@ pub fn run() {
                                                 ),
                                             },
                                         )),
+                                        tenant_id: None,
                                     }))
                                     .await
                                 {

--- a/tests/turmoil_runner/scenarios/expedite_concurrency.rs
+++ b/tests/turmoil_runner/scenarios/expedite_concurrency.rs
@@ -351,6 +351,7 @@ pub fn run() {
                                     )),
                                 },
                             )),
+                            tenant_id: None,
                         }))
                         .await
                     {

--- a/tests/turmoil_runner/scenarios/fault_injection_partition.rs
+++ b/tests/turmoil_runner/scenarios/fault_injection_partition.rs
@@ -133,6 +133,7 @@ pub fn run() {
                                     .unwrap(),
                             )),
                         })),
+                        tenant_id: None,
                     }))
                     .await?;
                 tracing::trace!(job_id = %task.job_id, "complete");

--- a/tests/turmoil_runner/scenarios/floating_concurrency.rs
+++ b/tests/turmoil_runner/scenarios/floating_concurrency.rs
@@ -154,6 +154,7 @@ pub fn run() {
                                     )),
                                 },
                             )),
+                            tenant_id: None,
                         }))
                         .await
                     {
@@ -191,6 +192,7 @@ pub fn run() {
                                     },
                                 ),
                             ),
+                            tenant_id: None,
                         }))
                         .await
                     {

--- a/tests/turmoil_runner/scenarios/grpc_end_to_end.rs
+++ b/tests/turmoil_runner/scenarios/grpc_end_to_end.rs
@@ -113,6 +113,7 @@ pub fn run() {
                                 rmp_serde::to_vec(&serde_json::json!({"result": "ok"})).unwrap(),
                             )),
                         })),
+                        tenant_id: None,
                     }))
                     .await?;
                 tracing::trace!(job_id = %task.job_id, "complete");

--- a/tests/turmoil_runner/scenarios/high_latency.rs
+++ b/tests/turmoil_runner/scenarios/high_latency.rs
@@ -402,6 +402,7 @@ pub fn run() {
                                     shard: TEST_SHARD_ID.to_string(),
                                     task_id: task.id.clone(),
                                     outcome: Some(outcome),
+                                    tenant_id: None,
                                 }))
                                 .await
                             {
@@ -466,6 +467,7 @@ pub fn run() {
                                     )),
                                 },
                             )),
+                            tenant_id: None,
                         }))
                         .await
                     {

--- a/tests/turmoil_runner/scenarios/high_message_loss.rs
+++ b/tests/turmoil_runner/scenarios/high_message_loss.rs
@@ -148,6 +148,7 @@ pub fn run() {
                                             )),
                                         },
                                     )),
+                                    tenant_id: None,
                                 }))
                                 .await
                             {

--- a/tests/turmoil_runner/scenarios/k8s_coordination.rs
+++ b/tests/turmoil_runner/scenarios/k8s_coordination.rs
@@ -819,6 +819,7 @@ pub fn run() {
                                     shard: task_shard_id.to_string(),
                                     task_id: task.id.clone(),
                                     outcome: Some(outcome),
+                                    tenant_id: task.tenant_id.clone(),
                                 }))
                                 .await
                             {

--- a/tests/turmoil_runner/scenarios/k8s_permanent_leases.rs
+++ b/tests/turmoil_runner/scenarios/k8s_permanent_leases.rs
@@ -697,6 +697,7 @@ where
                                     shard: task_shard_id.to_string(),
                                     task_id: task.id.clone(),
                                     outcome: Some(outcome),
+                                    tenant_id: task.tenant_id.clone(),
                                 }))
                                 .await
                             {

--- a/tests/turmoil_runner/scenarios/k8s_shard_splits.rs
+++ b/tests/turmoil_runner/scenarios/k8s_shard_splits.rs
@@ -1238,6 +1238,7 @@ pub fn run() {
                                     shard: task_shard_id.to_string(),
                                     task_id: task.id.clone(),
                                     outcome: Some(outcome),
+                                    tenant_id: task.tenant_id.clone(),
                                 }))
                                 .await
                             {

--- a/tests/turmoil_runner/scenarios/lease_expiry.rs
+++ b/tests/turmoil_runner/scenarios/lease_expiry.rs
@@ -183,6 +183,7 @@ pub fn run() {
                                             )),
                                         },
                                     )),
+                                    tenant_id: None,
                                 }))
                                 .await?;
 

--- a/tests/turmoil_runner/scenarios/multiple_workers.rs
+++ b/tests/turmoil_runner/scenarios/multiple_workers.rs
@@ -107,6 +107,7 @@ pub fn run() {
                                     )),
                                 },
                             )),
+                            tenant_id: None,
                         }))
                         .await?;
 
@@ -172,6 +173,7 @@ pub fn run() {
                                     )),
                                 },
                             )),
+                            tenant_id: None,
                         }))
                         .await?;
 

--- a/tests/turmoil_runner/scenarios/rate_limits.rs
+++ b/tests/turmoil_runner/scenarios/rate_limits.rs
@@ -218,6 +218,7 @@ pub fn run() {
                                     )),
                                 },
                             )),
+                            tenant_id: None,
                         }))
                         .await
                     {

--- a/tests/turmoil_runner/scenarios/retry_releases_ticket.rs
+++ b/tests/turmoil_runner/scenarios/retry_releases_ticket.rs
@@ -213,6 +213,7 @@ pub fn run() {
                                             data: None,
                                         },
                                     )),
+                                    tenant_id: None,
                                 }))
                                 .await?;
 
@@ -256,6 +257,7 @@ pub fn run() {
                                             )),
                                         },
                                     )),
+                                    tenant_id: None,
                                 }))
                                 .await?;
 
@@ -292,6 +294,7 @@ pub fn run() {
                                         )),
                                     },
                                 )),
+                                tenant_id: None,
                             }))
                             .await?;
 

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -834,6 +834,8 @@ export interface ReportOutcomeOptions<Result = unknown> {
   shard: string;
   /** The outcome of the task */
   outcome: TaskOutcome<Result>;
+  /** Tenant ID for shard routing validation (from Task.tenantId) */
+  tenant?: string;
 }
 
 /**
@@ -860,6 +862,8 @@ export interface RefreshTask {
   shard: string;
   /** Task group this task belongs to */
   taskGroup: string;
+  /** Tenant ID if multi-tenancy is enabled */
+  tenant?: string;
 }
 
 /** Outcome for reporting refresh task success */
@@ -888,6 +892,8 @@ export interface ReportRefreshOutcomeOptions {
   shard: string;
   /** The outcome of the refresh */
   outcome: RefreshOutcome;
+  /** Tenant ID for shard routing validation (from RefreshTask.tenantId) */
+  tenant?: string;
 }
 
 /** Result from a heartbeat request */
@@ -1452,6 +1458,53 @@ export class SiloGRPCClient {
   }
 
   /**
+   * Execute an operation with retry logic for wrong shard errors, using a known shard ID.
+   * Used by shard-routed operations (reportOutcome, heartbeat, reportRefreshOutcome)
+   * where the shard ID is already known from the task, rather than resolved from a tenant.
+   * @internal
+   */
+  private async _withWrongShardRetryForShard<T>(
+    shardId: string,
+    operation: (client: SiloClient) => Promise<T>,
+  ): Promise<T> {
+    let lastError: unknown;
+    let delay = this._wrongShardRetryDelayMs;
+    let client = this._getClientForShard(shardId);
+
+    for (let attempt = 0; attempt <= this._maxWrongShardRetries; attempt++) {
+      try {
+        return await operation(client);
+      } catch (error) {
+        if (isWrongShardError(error) && attempt < this._maxWrongShardRetries) {
+          lastError = error;
+
+          // Check for redirect address in metadata
+          const redirectAddr = extractRedirectAddress(error);
+          if (redirectAddr) {
+            // Update routing and create connection to new server
+            const mappedAddr = this._mapAddress(redirectAddr);
+            this._shardToServer.set(shardId, mappedAddr);
+            const conn = this._getOrCreateConnection(mappedAddr);
+            client = conn.client;
+          } else {
+            // No redirect info, try refreshing topology
+            await this.refreshTopology();
+            client = this._getClientForShard(shardId);
+          }
+
+          // Wait with exponential backoff before retrying
+          await sleep(delay);
+          delay = Math.min(delay * 2, 5000); // Cap at 5 seconds
+          continue;
+        }
+        throw error;
+      }
+    }
+    // Should not reach here, but throw last error if we do
+    throw lastError;
+  }
+
+  /**
    * Refresh the cluster topology by calling GetClusterInfo.
    * This updates the shard → server mapping and range info.
    */
@@ -1914,6 +1967,7 @@ export class SiloGRPCClient {
         leaseMs: rt.leaseMs,
         shard: rt.shard,
         taskGroup: rt.taskGroup,
+        tenant: rt.tenantId,
       }));
 
       return {
@@ -1966,16 +2020,18 @@ export class SiloGRPCClient {
     }
 
     try {
-      // Route to the correct shard (from Task.shard)
-      const client = this._getClientForShard(options.shard);
-      await client.reportOutcome(
-        {
-          shard: options.shard,
-          taskId: options.taskId,
-          outcome,
-        },
-        this._rpcOptions(),
-      );
+      // Route to the correct shard (from Task.shard), with retry on stale routing
+      await this._withWrongShardRetryForShard(options.shard, async (client) => {
+        await client.reportOutcome(
+          {
+            shard: options.shard,
+            taskId: options.taskId,
+            tenantId: options.tenant,
+            outcome,
+          },
+          this._rpcOptions(),
+        );
+      });
     } catch (error) {
       throwMappedRpcError(error, {
         operation: "reportOutcome",
@@ -2013,15 +2069,17 @@ export class SiloGRPCClient {
           };
 
     try {
-      const client = this._getClientForShard(options.shard);
-      await client.reportRefreshOutcome(
-        {
-          shard: options.shard,
-          taskId: options.taskId,
-          outcome,
-        },
-        this._rpcOptions(),
-      );
+      await this._withWrongShardRetryForShard(options.shard, async (client) => {
+        await client.reportRefreshOutcome(
+          {
+            shard: options.shard,
+            taskId: options.taskId,
+            tenantId: options.tenant,
+            outcome,
+          },
+          this._rpcOptions(),
+        );
+      });
     } catch (error) {
       throwMappedRpcError(error, {
         operation: "reportRefreshOutcome",
@@ -2035,6 +2093,7 @@ export class SiloGRPCClient {
    * @param workerId The worker ID that owns the task.
    * @param taskId   The task ID.
    * @param shard    The shard the task came from (from Task.shard).
+   * @param tenant   Optional tenant ID for shard routing validation (from Task.tenantId).
    * @returns HeartbeatResult indicating if the job was cancelled.
    * @throws TaskNotFoundError if the task (lease) doesn't exist.
    */
@@ -2042,22 +2101,25 @@ export class SiloGRPCClient {
     workerId: string,
     taskId: string,
     shard: string,
+    tenant?: string,
   ): Promise<HeartbeatResult> {
     try {
-      const client = this._getClientForShard(shard);
-      const call = client.heartbeat(
-        {
-          shard,
-          workerId,
-          taskId,
-        },
-        this._rpcOptions(),
-      );
-      const response = await call.response;
-      return {
-        cancelled: response.cancelled,
-        cancelledAtMs: response.cancelledAtMs,
-      };
+      return await this._withWrongShardRetryForShard(shard, async (client) => {
+        const call = client.heartbeat(
+          {
+            shard,
+            workerId,
+            taskId,
+            tenantId: tenant,
+          },
+          this._rpcOptions(),
+        );
+        const response = await call.response;
+        return {
+          cancelled: response.cancelled,
+          cancelledAtMs: response.cancelledAtMs,
+        };
+      });
     } catch (error) {
       throwMappedRpcError(error, { operation: "heartbeat", taskId });
     }

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -747,7 +747,7 @@ export interface RefreshFloatingLimitTask {
     /**
      * @generated from protobuf field: optional string tenant_id = 9
      */
-    tenantId?: string; // Tenant ID if multi-tenancy is enabled.
+    tenantId?: string; // Tenant ID for routing. Required if multi-tenancy is enabled.
 }
 /**
  * Response containing tasks leased to a worker.
@@ -805,7 +805,7 @@ export interface ReportOutcomeRequest {
     /**
      * @generated from protobuf field: optional string tenant_id = 7
      */
-    tenantId?: string; // Tenant ID for shard routing validation. From Task.tenant_id.
+    tenantId?: string; // Tenant ID for shard routing. Required if multi-tenancy is enabled. Should come from Task.tenant_id.
 }
 /**
  * Error details for a failed task.
@@ -871,7 +871,7 @@ export interface ReportRefreshOutcomeRequest {
     /**
      * @generated from protobuf field: optional string tenant_id = 6
      */
-    tenantId?: string; // Tenant ID for shard routing validation. From RefreshTask.tenant_id.
+    tenantId?: string; // Tenant ID for shard routing. Required if multi-tenancy is enabled. Should come from RefreshTask.tenant_id.
 }
 /**
  * Successful floating limit refresh with the new computed value.
@@ -928,7 +928,7 @@ export interface HeartbeatRequest {
     /**
      * @generated from protobuf field: optional string tenant_id = 4
      */
-    tenantId?: string; // Tenant ID for shard routing validation. From Task.tenant_id.
+    tenantId?: string; // Tenant ID for shard routing. Required if multi-tenancy is enabled. Should come from Task.tenant_id.
 }
 /**
  * Response indicating if the lease was extended and if the job was cancelled.

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -766,7 +766,6 @@ export interface LeaseTasksResponse {
 }
 /**
  * Request to report the outcome of a completed task.
- * Note: tenant is determined from the task lease, not from the request.
  *
  * @generated from protobuf message silo.v1.ReportOutcomeRequest
  */
@@ -803,6 +802,10 @@ export interface ReportOutcomeRequest {
     } | {
         oneofKind: undefined;
     };
+    /**
+     * @generated from protobuf field: optional string tenant_id = 7
+     */
+    tenantId?: string; // Tenant ID for shard routing validation. From Task.tenant_id.
 }
 /**
  * Error details for a failed task.
@@ -835,7 +838,6 @@ export interface ReportOutcomeResponse {
 }
 /**
  * Request to report the outcome of a floating limit refresh task.
- * Note: tenant is determined from the task lease, not from the request.
  *
  * @generated from protobuf message silo.v1.ReportRefreshOutcomeRequest
  */
@@ -866,6 +868,10 @@ export interface ReportRefreshOutcomeRequest {
     } | {
         oneofKind: undefined;
     };
+    /**
+     * @generated from protobuf field: optional string tenant_id = 6
+     */
+    tenantId?: string; // Tenant ID for shard routing validation. From RefreshTask.tenant_id.
 }
 /**
  * Successful floating limit refresh with the new computed value.
@@ -903,7 +909,6 @@ export interface ReportRefreshOutcomeResponse {
 /**
  * Request to extend a task lease and check for cancellation.
  * Workers must heartbeat before lease_ms expires to keep the task.
- * Note: tenant is determined from the task lease, not from the request.
  *
  * @generated from protobuf message silo.v1.HeartbeatRequest
  */
@@ -920,6 +925,10 @@ export interface HeartbeatRequest {
      * @generated from protobuf field: string task_id = 3
      */
     taskId: string; // The task's unique ID.
+    /**
+     * @generated from protobuf field: optional string tenant_id = 4
+     */
+    tenantId?: string; // Tenant ID for shard routing validation. From Task.tenant_id.
 }
 /**
  * Response indicating if the lease was extended and if the job was cancelled.
@@ -3902,7 +3911,8 @@ class ReportOutcomeRequest$Type extends MessageType<ReportOutcomeRequest> {
             { no: 2, name: "task_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "success", kind: "message", oneof: "outcome", T: () => SerializedBytes },
             { no: 4, name: "failure", kind: "message", oneof: "outcome", T: () => Failure },
-            { no: 6, name: "cancelled", kind: "message", oneof: "outcome", T: () => Cancelled }
+            { no: 6, name: "cancelled", kind: "message", oneof: "outcome", T: () => Cancelled },
+            { no: 7, name: "tenant_id", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<ReportOutcomeRequest>): ReportOutcomeRequest {
@@ -3943,6 +3953,9 @@ class ReportOutcomeRequest$Type extends MessageType<ReportOutcomeRequest> {
                         cancelled: Cancelled.internalBinaryRead(reader, reader.uint32(), options, (message.outcome as any).cancelled)
                     };
                     break;
+                case /* optional string tenant_id */ 7:
+                    message.tenantId = reader.string();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -3970,6 +3983,9 @@ class ReportOutcomeRequest$Type extends MessageType<ReportOutcomeRequest> {
         /* silo.v1.Cancelled cancelled = 6; */
         if (message.outcome.oneofKind === "cancelled")
             Cancelled.internalBinaryWrite(message.outcome.cancelled, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        /* optional string tenant_id = 7; */
+        if (message.tenantId !== undefined)
+            writer.tag(7, WireType.LengthDelimited).string(message.tenantId);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -4117,7 +4133,8 @@ class ReportRefreshOutcomeRequest$Type extends MessageType<ReportRefreshOutcomeR
             { no: 1, name: "shard", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "task_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "success", kind: "message", oneof: "outcome", T: () => RefreshSuccess },
-            { no: 5, name: "failure", kind: "message", oneof: "outcome", T: () => RefreshFailure }
+            { no: 5, name: "failure", kind: "message", oneof: "outcome", T: () => RefreshFailure },
+            { no: 6, name: "tenant_id", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<ReportRefreshOutcomeRequest>): ReportRefreshOutcomeRequest {
@@ -4152,6 +4169,9 @@ class ReportRefreshOutcomeRequest$Type extends MessageType<ReportRefreshOutcomeR
                         failure: RefreshFailure.internalBinaryRead(reader, reader.uint32(), options, (message.outcome as any).failure)
                     };
                     break;
+                case /* optional string tenant_id */ 6:
+                    message.tenantId = reader.string();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -4176,6 +4196,9 @@ class ReportRefreshOutcomeRequest$Type extends MessageType<ReportRefreshOutcomeR
         /* silo.v1.RefreshFailure failure = 5; */
         if (message.outcome.oneofKind === "failure")
             RefreshFailure.internalBinaryWrite(message.outcome.failure, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
+        /* optional string tenant_id = 6; */
+        if (message.tenantId !== undefined)
+            writer.tag(6, WireType.LengthDelimited).string(message.tenantId);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -4332,7 +4355,8 @@ class HeartbeatRequest$Type extends MessageType<HeartbeatRequest> {
         super("silo.v1.HeartbeatRequest", [
             { no: 1, name: "shard", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "worker_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "task_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 3, name: "task_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "tenant_id", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<HeartbeatRequest>): HeartbeatRequest {
@@ -4358,6 +4382,9 @@ class HeartbeatRequest$Type extends MessageType<HeartbeatRequest> {
                 case /* string task_id */ 3:
                     message.taskId = reader.string();
                     break;
+                case /* optional string tenant_id */ 4:
+                    message.tenantId = reader.string();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -4379,6 +4406,9 @@ class HeartbeatRequest$Type extends MessageType<HeartbeatRequest> {
         /* string task_id = 3; */
         if (message.taskId !== "")
             writer.tag(3, WireType.LengthDelimited).string(message.taskId);
+        /* optional string tenant_id = 4; */
+        if (message.tenantId !== undefined)
+            writer.tag(4, WireType.LengthDelimited).string(message.tenantId);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/typescript_client/src/worker.ts
+++ b/typescript_client/src/worker.ts
@@ -524,7 +524,7 @@ export class SiloWorker<
 
     // Start heartbeat for this refresh task (no TaskExecution needed, refresh tasks can't be cancelled)
     const heartbeatInterval = setInterval(() => {
-      this._sendHeartbeat(task.id, shard).catch((error) => {
+      this._sendHeartbeat(task.id, shard, task.tenant).catch((error) => {
         this._onError(error instanceof Error ? error : new Error(String(error)), {
           taskId: task.id,
         });
@@ -581,6 +581,7 @@ export class SiloWorker<
       await this._client.reportOutcome({
         taskId: execution.task.id,
         shard: execution.task.shard,
+        tenant: execution.task.tenantId,
         outcome: { type: "cancelled" },
       });
       return;
@@ -590,6 +591,7 @@ export class SiloWorker<
     await this._client.reportOutcome({
       taskId: execution.task.id,
       shard: execution.task.shard,
+      tenant: execution.task.tenantId,
       outcome,
     });
   }
@@ -627,6 +629,7 @@ export class SiloWorker<
     await this._client.reportRefreshOutcome({
       taskId: task.id,
       shard,
+      tenant: task.tenant,
       outcome,
     });
   }
@@ -644,6 +647,7 @@ export class SiloWorker<
       this._workerId,
       execution.task.id,
       execution.task.shard,
+      execution.task.tenantId,
     );
 
     // If the server reports cancellation, mark the execution as cancelled
@@ -655,8 +659,8 @@ export class SiloWorker<
   /**
    * Send a heartbeat for a task (for refresh tasks that don't need TaskExecution).
    */
-  private async _sendHeartbeat(taskId: string, shard: string): Promise<void> {
-    await this._client.heartbeat(this._workerId, taskId, shard);
+  private async _sendHeartbeat(taskId: string, shard: string, tenant?: string): Promise<void> {
+    await this._client.heartbeat(this._workerId, taskId, shard, tenant);
   }
 
   /**

--- a/typescript_client/test/client-integration.test.ts
+++ b/typescript_client/test/client-integration.test.ts
@@ -328,6 +328,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: { type: "success", result: resultData },
       });
 
@@ -373,6 +374,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: { type: "failure", code: "TEST_ERR", data: { msg: "failed" } },
       });
 
@@ -426,6 +428,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: {
           type: "success",
           result: { processed: true, output: "done" },
@@ -467,6 +470,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: {
           type: "failure",
           code: "PROCESSING_ERROR",
@@ -500,11 +504,12 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       const task = result.tasks.find((t) => t.jobId === handle.id);
       expect(task).toBeDefined();
 
-      await client.heartbeat("test-worker-3", task!.id, task!.shard);
+      await client.heartbeat("test-worker-3", task!.id, task!.shard, task!.tenantId);
 
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: { type: "success", result: {} },
       });
     });
@@ -547,6 +552,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: { type: "success", result: {} },
       });
 
@@ -609,6 +615,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: { type: "success", result: { expedited: true } },
       });
 
@@ -663,6 +670,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: { type: "success", result: {} },
       });
     });
@@ -730,6 +738,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task.shard,
         taskId: task.id,
+        tenant: task.tenantId,
         outcome: { type: "success", result: { leased: true } },
       });
 
@@ -781,6 +790,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task.shard,
         taskId: task.id,
+        tenant: task.tenantId,
         outcome: { type: "success", result: {} },
       });
     });
@@ -1034,6 +1044,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: { type: "success", result: {} },
       });
 
@@ -1076,6 +1087,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: { type: "success", result: resultData },
       });
 
@@ -1120,6 +1132,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: {
           type: "failure",
           code: "TEST_ERROR",
@@ -1291,6 +1304,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportRefreshOutcome({
         taskId: refreshTask!.id,
         shard: refreshTask!.shard,
+        tenant: refreshTask!.tenant,
         outcome: {
           type: "success",
           newMaxConcurrency: 10,
@@ -1302,6 +1316,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
         await client.reportOutcome({
           taskId: task.id,
           shard: task.shard,
+          tenant: task.tenantId,
           outcome: { type: "success", result: {} },
         });
       }
@@ -1363,6 +1378,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       await client.reportRefreshOutcome({
         taskId: refreshTask!.id,
         shard: refreshTask!.shard,
+        tenant: refreshTask!.tenant,
         outcome: {
           type: "failure",
           code: "API_UNAVAILABLE",
@@ -1377,6 +1393,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
         await client.reportOutcome({
           taskId: task.id,
           shard: task.shard,
+          tenant: task.tenantId,
           outcome: { type: "success", result: {} },
         });
       }
@@ -1425,6 +1442,7 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
         await client.reportOutcome({
           taskId: task.id,
           shard: task.shard,
+          tenant: task.tenantId,
           outcome: { type: "success", result: {} },
         });
       }

--- a/typescript_client/test/job-handle.test.ts
+++ b/typescript_client/test/job-handle.test.ts
@@ -138,6 +138,7 @@ describe.skipIf(!RUN_INTEGRATION)("JobHandle integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: { type: "success", result: {} },
       });
     });
@@ -205,6 +206,7 @@ describe.skipIf(!RUN_INTEGRATION)("JobHandle integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: { type: "success", result: {} },
       });
 
@@ -253,6 +255,7 @@ describe.skipIf(!RUN_INTEGRATION)("JobHandle integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: { type: "success", result: resultData },
       });
 
@@ -294,6 +297,7 @@ describe.skipIf(!RUN_INTEGRATION)("JobHandle integration", () => {
       await client.reportOutcome({
         shard: task!.shard,
         taskId: task!.id,
+        tenant: task!.tenantId,
         outcome: {
           type: "failure",
           code: "TEST_ERROR",

--- a/typescript_client/test/shard-routing.test.ts
+++ b/typescript_client/test/shard-routing.test.ts
@@ -565,6 +565,228 @@ describe("Shard Routing", () => {
     });
   });
 
+  describe("Wrong Shard Retry for shard-routed operations", () => {
+    let client: SiloGRPCClient;
+
+    const setupMockTopology = (c: SiloGRPCClient) => {
+      (c as any)._shards = [
+        {
+          shardId: "00000000-0000-0000-0000-000000000001",
+          serverAddr: "localhost:7450",
+          rangeStart: "",
+          rangeEnd: "",
+        },
+      ];
+      (c as any)._shardToServer.set("00000000-0000-0000-0000-000000000001", "localhost:7450");
+      (c as any)._topologyReady = true;
+    };
+
+    const SHARD_ID = "00000000-0000-0000-0000-000000000001";
+
+    beforeEach(() => {
+      client = new SiloGRPCClient({
+        servers: "localhost:7450",
+        useTls: false,
+        shardRouting: {
+          maxWrongShardRetries: 3,
+          wrongShardRetryDelayMs: 1,
+          topologyRefreshIntervalMs: 0,
+        },
+      });
+      setupMockTopology(client);
+    });
+
+    afterEach(() => {
+      client.close();
+    });
+
+    describe("reportOutcome", () => {
+      it("retries on wrong shard error with redirect metadata", async () => {
+        let callCount = 0;
+        const mockReportOutcome = vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            throw new RpcError("shard not found", "NOT_FOUND", {
+              "x-silo-shard-owner-addr": "localhost:7450",
+            });
+          }
+          return { response: Promise.resolve({}) };
+        });
+
+        const connections = (client as any)._connections as Map<string, any>;
+        const conn = connections.values().next().value;
+        conn.client.reportOutcome = mockReportOutcome;
+        (client as any).refreshTopology = vi.fn().mockResolvedValue(undefined);
+
+        await client.reportOutcome({
+          taskId: "task-1",
+          shard: SHARD_ID,
+          outcome: { type: "success", result: { ok: true } },
+        });
+
+        expect(mockReportOutcome).toHaveBeenCalledTimes(2);
+      });
+
+      it("retries on wrong shard error without redirect metadata (triggers topology refresh)", async () => {
+        let callCount = 0;
+        const mockReportOutcome = vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            throw new RpcError("shard not found", "NOT_FOUND", {});
+          }
+          return { response: Promise.resolve({}) };
+        });
+
+        const connections = (client as any)._connections as Map<string, any>;
+        const conn = connections.values().next().value;
+        conn.client.reportOutcome = mockReportOutcome;
+
+        const refreshSpy = vi.fn().mockResolvedValue(undefined);
+        (client as any).refreshTopology = refreshSpy;
+
+        await client.reportOutcome({
+          taskId: "task-1",
+          shard: SHARD_ID,
+          outcome: { type: "success", result: { ok: true } },
+        });
+
+        expect(mockReportOutcome).toHaveBeenCalledTimes(2);
+        expect(refreshSpy).toHaveBeenCalled();
+      });
+
+      it("stops retrying after maxWrongShardRetries", async () => {
+        const mockReportOutcome = vi.fn().mockImplementation(() => {
+          throw new RpcError("shard not found", "NOT_FOUND", {});
+        });
+
+        const connections = (client as any)._connections as Map<string, any>;
+        const conn = connections.values().next().value;
+        conn.client.reportOutcome = mockReportOutcome;
+        (client as any).refreshTopology = vi.fn().mockResolvedValue(undefined);
+
+        await expect(
+          client.reportOutcome({
+            taskId: "task-1",
+            shard: SHARD_ID,
+            outcome: { type: "success", result: { ok: true } },
+          }),
+        ).rejects.toThrow();
+
+        // Initial call + 3 retries = 4 total
+        expect(mockReportOutcome).toHaveBeenCalledTimes(4);
+      });
+
+      it("does not retry on non-wrong-shard errors", async () => {
+        const mockReportOutcome = vi.fn().mockImplementation(() => {
+          throw new RpcError("internal error", "INTERNAL", {});
+        });
+
+        const connections = (client as any)._connections as Map<string, any>;
+        const conn = connections.values().next().value;
+        conn.client.reportOutcome = mockReportOutcome;
+
+        await expect(
+          client.reportOutcome({
+            taskId: "task-1",
+            shard: SHARD_ID,
+            outcome: { type: "success", result: { ok: true } },
+          }),
+        ).rejects.toThrow("internal error");
+
+        expect(mockReportOutcome).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("heartbeat", () => {
+      it("retries on wrong shard error with redirect metadata", async () => {
+        let callCount = 0;
+        const mockHeartbeat = vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            throw new RpcError("shard not found", "NOT_FOUND", {
+              "x-silo-shard-owner-addr": "localhost:7450",
+            });
+          }
+          return { response: Promise.resolve({ cancelled: false }) };
+        });
+
+        const connections = (client as any)._connections as Map<string, any>;
+        const conn = connections.values().next().value;
+        conn.client.heartbeat = mockHeartbeat;
+        (client as any).refreshTopology = vi.fn().mockResolvedValue(undefined);
+
+        const result = await client.heartbeat("worker-1", "task-1", SHARD_ID);
+
+        expect(result.cancelled).toBe(false);
+        expect(mockHeartbeat).toHaveBeenCalledTimes(2);
+      });
+
+      it("stops retrying after maxWrongShardRetries", async () => {
+        const mockHeartbeat = vi.fn().mockImplementation(() => {
+          throw new RpcError("shard not found", "NOT_FOUND", {});
+        });
+
+        const connections = (client as any)._connections as Map<string, any>;
+        const conn = connections.values().next().value;
+        conn.client.heartbeat = mockHeartbeat;
+        (client as any).refreshTopology = vi.fn().mockResolvedValue(undefined);
+
+        await expect(client.heartbeat("worker-1", "task-1", SHARD_ID)).rejects.toThrow();
+
+        expect(mockHeartbeat).toHaveBeenCalledTimes(4);
+      });
+    });
+
+    describe("reportRefreshOutcome", () => {
+      it("retries on wrong shard error with redirect metadata", async () => {
+        let callCount = 0;
+        const mockReportRefreshOutcome = vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            throw new RpcError("shard not found", "NOT_FOUND", {
+              "x-silo-shard-owner-addr": "localhost:7450",
+            });
+          }
+          return { response: Promise.resolve({}) };
+        });
+
+        const connections = (client as any)._connections as Map<string, any>;
+        const conn = connections.values().next().value;
+        conn.client.reportRefreshOutcome = mockReportRefreshOutcome;
+        (client as any).refreshTopology = vi.fn().mockResolvedValue(undefined);
+
+        await client.reportRefreshOutcome({
+          taskId: "task-1",
+          shard: SHARD_ID,
+          outcome: { type: "success", newMaxConcurrency: 10 },
+        });
+
+        expect(mockReportRefreshOutcome).toHaveBeenCalledTimes(2);
+      });
+
+      it("stops retrying after maxWrongShardRetries", async () => {
+        const mockReportRefreshOutcome = vi.fn().mockImplementation(() => {
+          throw new RpcError("shard not found", "NOT_FOUND", {});
+        });
+
+        const connections = (client as any)._connections as Map<string, any>;
+        const conn = connections.values().next().value;
+        conn.client.reportRefreshOutcome = mockReportRefreshOutcome;
+        (client as any).refreshTopology = vi.fn().mockResolvedValue(undefined);
+
+        await expect(
+          client.reportRefreshOutcome({
+            taskId: "task-1",
+            shard: SHARD_ID,
+            outcome: { type: "success", newMaxConcurrency: 10 },
+          }),
+        ).rejects.toThrow();
+
+        expect(mockReportRefreshOutcome).toHaveBeenCalledTimes(4);
+      });
+    });
+  });
+
   describe("Lazy topology auto-refresh", () => {
     let client: SiloGRPCClient;
 

--- a/typescript_client/test/worker.test.ts
+++ b/typescript_client/test/worker.test.ts
@@ -32,6 +32,7 @@ function createTask(
   id: string,
   jobId: string,
   shard: string = "00000000-0000-0000-0000-000000000001",
+  tenantId?: string,
 ): Task {
   return {
     id,
@@ -51,6 +52,7 @@ function createTask(
     isLastAttempt: false,
     metadata: {},
     limits: [],
+    tenantId,
   };
 }
 
@@ -259,7 +261,59 @@ describe("SiloWorker", () => {
         taskId: "task-1",
         outcome: { type: "success", result: { processed: true } },
         shard: "00000000-0000-0000-0000-000000000001",
+        tenant: undefined,
       });
+    });
+
+    it("passes tenant_id through to reportOutcome and heartbeat for multitenant tasks", async () => {
+      const task = createTask(
+        "task-mt",
+        "job-mt",
+        "00000000-0000-0000-0000-000000000001",
+        "tenant-abc",
+      );
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      const heartbeat = vi.fn().mockResolvedValue({ cancelled: false });
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValue(tasksResult([]));
+
+      // Handler that takes long enough for at least one heartbeat to fire
+      const handler: TaskHandler = vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        return { type: "success", result: { result: "ok" } };
+      });
+
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        heartbeatIntervalMs: 50,
+        pollIntervalMs: 10,
+      });
+
+      worker.start();
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      await worker.stop();
+
+      // reportOutcome should include the tenant from the task
+      expect(reportOutcome).toHaveBeenCalledWith({
+        taskId: "task-mt",
+        outcome: { type: "success", result: { result: "ok" } },
+        shard: "00000000-0000-0000-0000-000000000001",
+        tenant: "tenant-abc",
+      });
+
+      // heartbeat should include the tenant from the task
+      expect(heartbeat).toHaveBeenCalledWith(
+        "test-worker",
+        "task-mt",
+        "00000000-0000-0000-0000-000000000001",
+        "tenant-abc",
+      );
     });
 
     it("passes limits to handler in task context", async () => {
@@ -561,11 +615,12 @@ describe("SiloWorker", () => {
       await worker.stop();
 
       // Should have sent multiple heartbeats
-      // heartbeat(workerId, taskId, shard)
+      // heartbeat(workerId, taskId, shard, tenant)
       expect(heartbeat).toHaveBeenCalledWith(
         "test-worker",
         "task-hb",
         "00000000-0000-0000-0000-000000000001",
+        undefined,
       );
       expect(heartbeat.mock.calls.length).toBeGreaterThanOrEqual(2);
     });


### PR DESCRIPTION
## Summary

- **Fix stale shard routing bug**: `reportOutcome`, `reportRefreshOutcome`, and `heartbeat` in the TypeScript client now retry on wrong-shard errors instead of failing when shard ownership changes during task execution. A new `_withWrongShardRetryForShard` method handles shard-routed retries (following redirects or refreshing topology).
- **Add `tenant_id` to worker RPCs**: Added `tenant_id` field to `ReportOutcomeRequest`, `ReportRefreshOutcomeRequest`, and `HeartbeatRequest` proto messages. The TypeScript worker passes tenant through all three RPCs.
- **Server-side tenant validation**: When multitenancy is enabled, the server now enforces that worker RPCs include a valid `tenant_id` and rejects with `INVALID_ARGUMENT` if missing, or redirects if the tenant doesn't belong to the target shard.
- **Updated DST workers and benchmark**: DST scenarios and the benchmark worker now pass `task.tenant_id` in outcome requests for more realistic simulation.

## Test plan

- [x] 7 new TypeScript shard-routing retry tests (redirect, topology refresh, max retries, error passthrough)
- [x] 1 new TypeScript multitenant worker test (tenant_id flows through reportOutcome and heartbeat)
- [x] 3 new Rust integration tests (reject missing tenant, skip when disabled, accept valid tenant)
- [x] All ~25 existing Rust test files updated with `tenant_id: None` for modified proto messages
- [x] All TypeScript tests pass (119 tests)
- [x] All Rust tests pass (non-DST/k8s/etcd)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)