### PR TITLE
Add ready_to_start_latency_ms metric

### DIFF
--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -47,11 +47,13 @@ Leases represent tasks actively being processed by workers.
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `silo_task_leases_active` | Gauge | `shard`, `task_group` | Number of tasks currently leased to workers |
+| `silo_ready_to_start_latency_ms` | Histogram | `shard`, `task_group` | Time between when a task became ready and when it was first leased (in milliseconds) |
 
 **Key insights:**
 - This metric shows in-flight work at any given moment
 - Sudden drops may indicate worker crashes or network issues
 - Compare against worker count to understand utilization
+- `silo_ready_to_start_latency_ms` measures scheduling delay — high values indicate workers aren't polling fast enough or broker scan intervals are too long. Unlike `silo_job_wait_time_seconds` (which measures total time from enqueue), this metric isolates the time a task sat ready but unleased
 
 ### Broker Metrics
 

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -11,7 +11,7 @@ use crate::job::{JobStatus, JobView};
 use crate::job_attempt::{AttemptStatus, JobAttempt, JobAttemptView};
 use crate::job_store_shard::helpers::{DbWriteBatcher, now_epoch_ms};
 use crate::job_store_shard::{DequeueResult, JobStoreShard, JobStoreShardError, LimitTaskParams};
-use crate::keys::{attempt_key, job_info_key, leased_task_key};
+use crate::keys::{attempt_key, job_info_key, leased_task_key, parse_task_key};
 use crate::shard_range::ShardRange;
 use crate::task::{DEFAULT_LEASE_MS, LeaseRecord, LeasedRefreshTask, LeasedTask, Task};
 use crate::task_broker::BrokerTask;
@@ -427,9 +427,13 @@ impl JobStoreShard {
                     .leased_tasks_for_dst
                     .push((tenant, job_id.to_string(), request_id));
 
-                // Record concurrency ticket metric
+                // Record concurrency ticket metric and ready-to-start latency
                 if let Some(ref m) = self.metrics {
                     m.record_concurrency_ticket_granted();
+                    if let Some(parsed) = parse_task_key(task_key) {
+                        let latency_ms = (now_ms - parsed.start_time_ms as i64).max(0) as f64;
+                        m.record_ready_to_start_latency_ms(self.name(), req_task_group, latency_ms);
+                    }
                 }
             }
             RequestTicketTaskOutcome::Requested => {
@@ -697,6 +701,12 @@ impl JobStoreShard {
             job_id.to_string(),
             task_id.to_string(),
         ));
+
+        // Record ready-to-start latency metric
+        if let (Some(m), Some(parsed)) = (&self.metrics, parse_task_key(task_key)) {
+            let latency_ms = (now_ms - parsed.start_time_ms as i64).max(0) as f64;
+            m.record_ready_to_start_latency_ms(self.name(), decoded.task_group(), latency_ms);
+        }
 
         Ok(())
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -45,6 +45,12 @@ const WAIT_TIME_BUCKETS: &[f64] = &[
     0.001, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0, 1800.0, 3600.0,
 ];
 
+/// Histogram buckets for ready-to-start latency (in milliseconds)
+const READY_TO_START_LATENCY_MS_BUCKETS: &[f64] = &[
+    1.0, 10.0, 50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 30000.0, 60000.0, 300000.0, 600000.0,
+    1800000.0, 3600000.0,
+];
+
 /// Silo metrics handle containing all metric instruments.
 #[derive(Clone)]
 pub struct Metrics {
@@ -70,6 +76,7 @@ pub struct Metrics {
 
     // Lease metrics
     task_leases_active: GaugeVec,
+    ready_to_start_latency_ms: HistogramVec,
 
     // Concurrency metrics
     concurrency_tickets_granted: Counter,
@@ -196,6 +203,13 @@ impl Metrics {
         self.task_leases_active
             .with_label_values(&[shard, task_group])
             .dec();
+    }
+
+    /// Record the latency between when a task became ready and when it was first leased, in milliseconds.
+    pub fn record_ready_to_start_latency_ms(&self, shard: &str, task_group: &str, latency_ms: f64) {
+        self.ready_to_start_latency_ms
+            .with_label_values(&[shard, task_group])
+            .observe(latency_ms);
     }
 
     /// Record a concurrency ticket being granted.
@@ -437,6 +451,18 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let ready_to_start_latency_ms = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_ready_to_start_latency_ms",
+                "Latency between when a task became ready and when it was first leased (in milliseconds)",
+            )
+            .buckets(READY_TO_START_LATENCY_MS_BUCKETS.to_vec()),
+            &["shard", "task_group"],
+        )?,
+    );
+
     // Concurrency metrics
     let concurrency_tickets_granted = register(
         &registry,
@@ -617,6 +643,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         broker_inflight_size,
         broker_scan_duration,
         task_leases_active,
+        ready_to_start_latency_ms,
         concurrency_tickets_granted,
         slatedb_get_requests,
         slatedb_scan_requests,

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -209,6 +209,9 @@ async fn test_metrics_all_recording_methods() {
     // record_job_wait_time
     metrics.record_job_wait_time("0", "default", 1.5);
 
+    // record_ready_to_start_latency_ms
+    metrics.record_ready_to_start_latency_ms("0", "default", 42.0);
+
     // record_broker_scan_duration
     metrics.record_broker_scan_duration("0", 0.01);
 
@@ -297,6 +300,12 @@ async fn test_metrics_all_recording_methods() {
     assert!(
         body_str.contains("silo_job_wait_time_seconds"),
         "should contain job wait time metric"
+    );
+
+    // Verify ready-to-start latency histogram was recorded
+    assert!(
+        body_str.contains("silo_ready_to_start_latency_ms"),
+        "should contain ready-to-start latency metric"
     );
 
     // Verify broker scan duration
@@ -505,6 +514,84 @@ async fn test_metrics_slatedb_multiple_shards() {
 
     db1.close().await.unwrap();
     db2.close().await.unwrap();
+}
+
+#[silo::test]
+async fn test_metrics_ready_to_start_latency() {
+    let (metrics, _app) = create_metrics_router();
+
+    // Record latency observations for different shards and task groups
+    metrics.record_ready_to_start_latency_ms("0", "default", 5.0);
+    metrics.record_ready_to_start_latency_ms("0", "default", 150.0);
+    metrics.record_ready_to_start_latency_ms("0", "high-priority", 2.0);
+    metrics.record_ready_to_start_latency_ms("1", "default", 1000.0);
+
+    let body_str = gather_metrics_text(&metrics);
+
+    // Should contain TYPE and HELP metadata
+    assert!(
+        body_str.contains("# TYPE silo_ready_to_start_latency_ms histogram"),
+        "should be a histogram type"
+    );
+    assert!(
+        body_str.contains("# HELP silo_ready_to_start_latency_ms"),
+        "should have a HELP description"
+    );
+
+    let find_line = |substrings: &[&str]| -> Option<String> {
+        body_str
+            .lines()
+            .find(|l| substrings.iter().all(|s| l.contains(s)))
+            .map(|s| s.to_string())
+    };
+
+    // Verify count for shard 0, default task group (2 observations)
+    let count_line = find_line(&[
+        "silo_ready_to_start_latency_ms_count",
+        "shard=\"0\"",
+        "task_group=\"default\"",
+    ]);
+    assert!(
+        count_line.as_ref().map_or(false, |l| l.ends_with(" 2")),
+        "should have 2 observations for shard 0 default, found: {:?}",
+        count_line
+    );
+
+    // Verify sum for shard 0, default task group (5.0 + 150.0 = 155.0)
+    let sum_line = find_line(&[
+        "silo_ready_to_start_latency_ms_sum",
+        "shard=\"0\"",
+        "task_group=\"default\"",
+    ]);
+    assert!(
+        sum_line.as_ref().map_or(false, |l| l.ends_with(" 155")),
+        "sum should be 155 for shard 0 default, found: {:?}",
+        sum_line
+    );
+
+    // Verify count for shard 0, high-priority task group (1 observation)
+    let hp_count_line = find_line(&[
+        "silo_ready_to_start_latency_ms_count",
+        "shard=\"0\"",
+        "task_group=\"high-priority\"",
+    ]);
+    assert!(
+        hp_count_line.as_ref().map_or(false, |l| l.ends_with(" 1")),
+        "should have 1 observation for shard 0 high-priority, found: {:?}",
+        hp_count_line
+    );
+
+    // Verify shard 1 is tracked separately
+    let shard1_count = find_line(&[
+        "silo_ready_to_start_latency_ms_count",
+        "shard=\"1\"",
+        "task_group=\"default\"",
+    ]);
+    assert!(
+        shard1_count.as_ref().map_or(false, |l| l.ends_with(" 1")),
+        "should have 1 observation for shard 1 default, found: {:?}",
+        shard1_count
+    );
 }
 
 /// Gather metrics text from the Prometheus registry.


### PR DESCRIPTION
## Summary
- Adds `silo_ready_to_start_latency_ms` histogram metric that measures the time between when a task becomes ready (`start_time_ms` in the task key) and when it is first leased to a worker
- Recorded in both the direct `RunAttempt` dequeue path and the concurrency-gated `RequestTicket` → `Granted` path
- Labels: `shard`, `task_group` (consistent with existing metrics)
- Buckets span 1ms to 1hr for wide coverage of scheduling delays

## Test plan
- [x] Added `test_metrics_ready_to_start_latency` — verifies histogram TYPE/HELP metadata, count and sum values across multiple shards and task groups
- [x] Updated `test_metrics_all_recording_methods` to include the new metric
- [x] All existing metrics tests pass
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new Prometheus histogram and records it in dequeue paths; risk is mainly metric cardinality/overhead and correctness of timestamp parsing, with no changes to core task execution semantics.
> 
> **Overview**
> Adds a new Prometheus histogram metric, `silo_ready_to_start_latency_ms` (labels: `shard`, `task_group`), with millisecond buckets spanning ~1ms to 1hr.
> 
> Records this metric during dequeue when tasks are first leased in both the direct `RunAttempt` path and the concurrency-gated `RequestTicket`→`Granted` path by parsing `start_time_ms` from the task key and observing `now_ms - start_time_ms`.
> 
> Updates observability docs to describe the metric and expands metrics tests to cover registration/recording plus a dedicated histogram count/sum validation across shards/task groups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 389fbf97d9305a6a5d4f7e0c2b6f8e75739841ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->