### PR TITLE
Unref topology refresh interval so it doesn't keep the process alive

### DIFF
--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -1262,6 +1262,7 @@ export class SiloGRPCClient {
           console.error("[SiloGRPCClient] Failed to refresh topology:", err);
         });
       }, refreshInterval);
+      this._topologyRefreshInterval.unref();
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to Node.js timer behavior; it only affects whether the periodic topology refresh keeps the event loop alive, not the refresh logic itself.
> 
> **Overview**
> Prevents the TypeScript `SiloGRPCClient`'s periodic topology refresh from keeping the Node.js process alive by calling `unref()` on the `setInterval` handle when auto-refresh is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7218cdcaa349275cc0f15a5b569e84110b99396f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->