### PR TITLE
Fix k8s coordinator lost watcher notifications

### DIFF
--- a/src/coordination/k8s.rs
+++ b/src/coordination/k8s.rs
@@ -353,7 +353,10 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                                     if let Err(e) = self.refresh_members_cache().await {
                                         warn!(node_id = %self.base.node_id, error = %e, "failed to refresh members cache");
                                     }
-                                    self.membership_changed.notify_waiters();
+                                    // Use notify_one (not notify_waiters) so the permit is stored
+                                    // if the coordination loop is busy. notify_waiters drops the
+                                    // notification when no task is currently awaiting .notified().
+                                    self.membership_changed.notify_one();
                                 }
                                 LeaseWatchEvent::Deleted(lease) => {
                                     let lease_name = lease.metadata.name.as_deref().unwrap_or("unknown");
@@ -361,7 +364,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                                     if let Err(e) = self.refresh_members_cache().await {
                                         warn!(node_id = %self.base.node_id, error = %e, "failed to refresh members cache");
                                     }
-                                    self.membership_changed.notify_waiters();
+                                    self.membership_changed.notify_one();
                                 }
                                 LeaseWatchEvent::Init => {
                                     debug!(node_id = %self.base.node_id, "membership watcher initialized");
@@ -371,7 +374,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                                     if let Err(e) = self.refresh_members_cache().await {
                                         warn!(node_id = %self.base.node_id, error = %e, "failed to refresh members cache on init");
                                     }
-                                    self.membership_changed.notify_waiters();
+                                    self.membership_changed.notify_one();
                                 }
                             }
                         }
@@ -417,7 +420,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                                     if let Err(e) = self.reload_shard_map().await {
                                         warn!(node_id = %self.base.node_id, error = %e, "failed to reload shard map");
                                     }
-                                    self.shard_map_changed.notify_waiters();
+                                    self.shard_map_changed.notify_one();
                                 }
                                 ConfigMapWatchEvent::Deleted(cm) => {
                                     let cm_name = cm.metadata.name.as_deref().unwrap_or("unknown");
@@ -430,7 +433,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                                 ConfigMapWatchEvent::InitDone => {
                                     debug!(node_id = %self.base.node_id, "shard map watcher init done");
                                     // Notify on init done in case we missed events
-                                    self.shard_map_changed.notify_waiters();
+                                    self.shard_map_changed.notify_one();
                                 }
                             }
                         }
@@ -566,7 +569,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
         let mut renew_timer = tokio::time::interval(renew_interval);
 
         // Periodic reconciliation as a safety net to catch any missed watch events due to network issues
-        let safety_reconcile_interval = Duration::from_secs(30);
+        let safety_reconcile_interval = Duration::from_secs(5);
         let mut safety_reconcile_timer = tokio::time::interval(safety_reconcile_interval);
 
         // Reclaim shards from a previous run before initial reconciliation.

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -2606,6 +2606,9 @@ async fn k8s_graceful_shutdown_releases_shards_promptly() {
 /// coordination loop was busy (e.g., processing a previous reconcile), the membership
 /// change notification was lost and the node would not converge until the safety
 /// reconcile timer fired (previously 30s).
+///
+/// The timeout here (4s) is deliberately shorter than the safety reconcile interval (5s)
+/// so this test can only pass if the watcher notification actually drives convergence.
 #[silo::test(flavor = "multi_thread", worker_threads = 4)]
 async fn k8s_watcher_notification_drives_convergence_without_external_poke() {
     let prefix = unique_prefix();
@@ -2670,7 +2673,9 @@ async fn k8s_watcher_notification_drives_convergence_without_external_poke() {
     // DO NOT use wait_converged on c1 — it would poke the coordination loop via
     // notify_one(), masking any lost watcher notifications.
     // Instead, just poll owned_shards() and wait for c1 to acquire all shards.
-    let converged = wait_until(Duration::from_secs(15), || {
+    // Use a timeout shorter than the 5s safety reconcile interval so this test
+    // can only pass via watcher-driven notifications, not the safety timer.
+    let converged = wait_until(Duration::from_secs(4), || {
         let c1_ref = &c1;
         let all_ref = &all_shards;
         async move {

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -2593,6 +2593,106 @@ async fn k8s_graceful_shutdown_releases_shards_promptly() {
     h1.abort();
 }
 
+/// Regression test: verify that membership watcher notifications are not lost
+/// when the coordination loop is busy.
+///
+/// This test deliberately avoids using `wait_converged` on the remaining node
+/// after the peer shuts down. `wait_converged` calls `notify_one()` every 100ms
+/// which masks lost notifications from the watcher. By only polling `owned_shards()`,
+/// we verify the watcher's own notifications drive convergence.
+///
+/// Before the fix (notify_waiters → notify_one), the watcher used `notify_waiters()`
+/// which drops the notification when no task is awaiting `.notified()`. If the
+/// coordination loop was busy (e.g., processing a previous reconcile), the membership
+/// change notification was lost and the node would not converge until the safety
+/// reconcile timer fired (previously 30s).
+#[silo::test(flavor = "multi_thread", worker_threads = 4)]
+async fn k8s_watcher_notification_drives_convergence_without_external_poke() {
+    let prefix = unique_prefix();
+    let namespace = get_namespace();
+    let num_shards: u32 = 32;
+    let short_ttl: i64 = 5;
+
+    // Start two nodes
+    let (c1, h1) = match K8sCoordinator::start(
+        make_coordinator_config(
+            &namespace,
+            &prefix,
+            "notify-1",
+            "http://127.0.0.1:7450",
+            num_shards,
+            short_ttl,
+        ),
+        make_test_factory("notify-1"),
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Skipping test: {}", e);
+            return;
+        }
+    };
+    let (c2, h2) = K8sCoordinator::start(
+        make_coordinator_config(
+            &namespace,
+            &prefix,
+            "notify-2",
+            "http://127.0.0.1:7451",
+            num_shards,
+            short_ttl,
+        ),
+        make_test_factory("notify-2"),
+    )
+    .await
+    .expect("c2");
+
+    // Use wait_converged to reach initial 2-node convergence
+    assert!(c1.wait_converged(Duration::from_secs(20)).await);
+    assert!(c2.wait_converged(Duration::from_secs(20)).await);
+
+    let all_shards: HashSet<ShardId> = c1
+        .get_shard_map()
+        .await
+        .unwrap()
+        .shard_ids()
+        .into_iter()
+        .collect();
+    let c1_initial: HashSet<ShardId> = c1.owned_shards().await.into_iter().collect();
+    let c2_initial: HashSet<ShardId> = c2.owned_shards().await.into_iter().collect();
+    assert!(!c1_initial.is_empty(), "c1 should own some shards");
+    assert!(!c2_initial.is_empty(), "c2 should own some shards");
+
+    // Graceful shutdown of c2
+    c2.shutdown().await.unwrap();
+    h2.abort();
+
+    // DO NOT use wait_converged on c1 — it would poke the coordination loop via
+    // notify_one(), masking any lost watcher notifications.
+    // Instead, just poll owned_shards() and wait for c1 to acquire all shards.
+    let converged = wait_until(Duration::from_secs(15), || {
+        let c1_ref = &c1;
+        let all_ref = &all_shards;
+        async move {
+            let owned: HashSet<ShardId> = c1_ref.owned_shards().await.into_iter().collect();
+            owned == *all_ref
+        }
+    })
+    .await;
+
+    assert!(
+        converged,
+        "c1 should converge to all shards without wait_converged poking it. \
+         owned: {:?}, expected: {:?}",
+        c1.owned_shards().await,
+        all_shards
+    );
+
+    // Cleanup
+    c1.shutdown().await.unwrap();
+    h1.abort();
+}
+
 /// Test that request_split creates a split record in k8s.
 #[silo::test(flavor = "multi_thread", worker_threads = 2)]
 async fn k8s_request_split_creates_split_record() {


### PR DESCRIPTION
## Summary
- Change k8s membership and shard map watchers from `notify_waiters()` to `notify_one()` — `notify_waiters` silently drops notifications when the coordination loop isn't awaiting `.notified()`, while `notify_one` stores a permit for the next poll
- Reduce safety reconcile interval from 30s to 5s so any missed watch events are caught more promptly
- Add regression test that verifies convergence without `wait_converged` externally poking the coordination loop

## Test plan
- [x] All 74 k8s coordination tests pass (`cargo test --test k8s_coordination_tests -- --test-threads=1`)
- [x] Flaky test `k8s_graceful_shutdown_releases_shards_promptly` passes 6/6 runs
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the k8s coordinator’s reconciliation triggering and timing; mistakes could cause missed reconciles or increased reconcile churn/load, but the change is localized and covered by a targeted regression test.
> 
> **Overview**
> Fixes a k8s coordination race where watcher-driven membership/shard-map updates could be **silently dropped** by switching watcher signaling from `Notify::notify_waiters()` to `notify_one()` so a pending permit is retained when the coordination loop is busy.
> 
> Speeds up the coordination loop’s safety-net reconciliation interval from **30s to 5s**, and adds a regression test (`k8s_watcher_notification_drives_convergence_without_external_poke`) that ensures a surviving node converges after a peer shutdown *without* `wait_converged` externally poking the loop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daf9b5fb8da9a0fce8ad88086e96408ada2333e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->