### PR TITLE
Add topology refresh timeout and connectivity error retry to TS client

### DIFF
--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -1476,17 +1476,17 @@ export class SiloGRPCClient {
   }
 
   /**
-   * Execute an operation with retry on wrong-shard and connectivity errors.
+   * Core retry loop for wrong-shard and connectivity errors.
+   * Handles redirect metadata, topology refresh, and exponential backoff.
    * @internal
    */
-  private async _withShardRetry<T>(
-    tenant: string | undefined,
+  private async _retryLoop<T>(
+    resolveClient: () => { client: SiloClient; shard: string },
     operation: (client: SiloClient, shard: string) => Promise<T>,
   ): Promise<T> {
-    await this._ensureTopology();
     let lastError: unknown;
     let delay = this._retryDelayMs;
-    let { client, shard } = this._getClientForTenant(tenant);
+    let { client, shard } = resolveClient();
 
     for (let attempt = 0; attempt <= this._maxRetries; attempt++) {
       try {
@@ -1512,9 +1512,7 @@ export class SiloGRPCClient {
             // Connectivity error or wrong shard without redirect — refresh
             // topology so the retry can reach a different server
             await this.refreshTopology();
-            const result = this._getClientForTenant(tenant);
-            client = result.client;
-            shard = result.shard;
+            ({ client, shard } = resolveClient());
           }
 
           // Wait with exponential backoff before retrying
@@ -1530,6 +1528,18 @@ export class SiloGRPCClient {
   }
 
   /**
+   * Execute an operation with retry on wrong-shard and connectivity errors.
+   * @internal
+   */
+  private async _withShardRetry<T>(
+    tenant: string | undefined,
+    operation: (client: SiloClient, shard: string) => Promise<T>,
+  ): Promise<T> {
+    await this._ensureTopology();
+    return this._retryLoop(() => this._getClientForTenant(tenant), operation);
+  }
+
+  /**
    * Execute an operation with retry on wrong-shard and connectivity errors, using a known shard ID.
    * Used by shard-routed operations (reportOutcome, heartbeat, reportRefreshOutcome)
    * where the shard ID is already known from the task, rather than resolved from a tenant.
@@ -1539,47 +1549,10 @@ export class SiloGRPCClient {
     shardId: string,
     operation: (client: SiloClient) => Promise<T>,
   ): Promise<T> {
-    let lastError: unknown;
-    let delay = this._retryDelayMs;
-    let client = this._getClientForShard(shardId);
-
-    for (let attempt = 0; attempt <= this._maxRetries; attempt++) {
-      try {
-        return await operation(client);
-      } catch (error) {
-        if (
-          (isWrongShardError(error) || isConnectivityError(error)) &&
-          attempt < this._maxRetries
-        ) {
-          lastError = error;
-
-          // Check for redirect address in metadata (only on wrong shard errors)
-          const redirectAddr = isWrongShardError(error)
-            ? extractRedirectAddress(error)
-            : undefined;
-          if (redirectAddr) {
-            // Update routing and create connection to new server
-            const mappedAddr = this._mapAddress(redirectAddr);
-            this._shardToServer.set(shardId, mappedAddr);
-            const conn = this._getOrCreateConnection(mappedAddr);
-            client = conn.client;
-          } else {
-            // Connectivity error or wrong shard without redirect — refresh
-            // topology so the retry can reach a different server
-            await this.refreshTopology();
-            client = this._getClientForShard(shardId);
-          }
-
-          // Wait with exponential backoff before retrying
-          await sleep(delay);
-          delay = Math.min(delay * 2, 5000); // Cap at 5 seconds
-          continue;
-        }
-        throw error;
-      }
-    }
-    // Should not reach here, but throw last error if we do
-    throw lastError;
+    return this._retryLoop(
+      () => ({ client: this._getClientForShard(shardId), shard: shardId }),
+      (client) => operation(client),
+    );
   }
 
   /**
@@ -2074,17 +2047,9 @@ export class SiloGRPCClient {
     options: LeaseTasksOptions,
     serverIndex?: number,
   ): Promise<LeaseTasksResult> {
-    try {
-      // If shard is specified, route to that shard's server
-      // Otherwise, use round-robin server selection. If serverIndex is provided,
-      // use it for per-worker round-robin (avoids lock-step with shared counter).
-      const client =
-        options.shard !== undefined
-          ? this._getClientForShard(options.shard)
-          : serverIndex !== undefined
-            ? this._getClientAtIndex(serverIndex)
-            : this._getAnyClient();
-
+    const executeLeaseRpc = async (
+      client: SiloClient,
+    ): Promise<LeaseTasksResult> => {
       const call = client.leaseTasks(
         {
           shard: options.shard,
@@ -2110,10 +2075,31 @@ export class SiloGRPCClient {
         tenant: rt.tenantId,
       }));
 
-      return {
-        tasks: response.tasks,
-        refreshTasks,
-      };
+      return { tasks: response.tasks, refreshTasks };
+    };
+
+    try {
+      if (options.shard !== undefined) {
+        // Shard-routed: use standard shard retry for redirect + connectivity handling
+        return await this._withShardRetryForShard(
+          options.shard,
+          executeLeaseRpc,
+        );
+      }
+
+      // Round-robin: retry with topology refresh on connectivity errors.
+      // Each call to the resolver picks the next server via the round-robin
+      // counter (_getAnyClient) or the fixed worker index.
+      return await this._retryLoop(
+        () => {
+          const client =
+            serverIndex !== undefined
+              ? this._getClientAtIndex(serverIndex)
+              : this._getAnyClient();
+          return { client, shard: "" };
+        },
+        (client) => executeLeaseRpc(client),
+      );
     } catch (error) {
       throwMappedRpcError(error, { operation: "leaseTasks" });
     }

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -59,7 +59,9 @@ export class JobNotTerminalError extends Error {
   public readonly currentStatus?: JobStatus;
 
   constructor(jobId: string, tenant?: string, currentStatus?: JobStatus) {
-    const statusMsg = currentStatus ? ` (current status: ${currentStatus})` : "";
+    const statusMsg = currentStatus
+      ? ` (current status: ${currentStatus})`
+      : "";
     const tenantMsg = tenant ? ` in tenant "${tenant}"` : "";
     super(`Job "${jobId}"${tenantMsg} is not in a terminal state${statusMsg}`);
     this.name = "JobNotTerminalError";
@@ -274,7 +276,9 @@ export function initHasher(): Promise<void> {
  */
 export function hashTenant(tenantId: string): string {
   if (!_h64) {
-    throw new Error("XXH64 hasher not initialized. Call and await initHasher() first.");
+    throw new Error(
+      "XXH64 hasher not initialized. Call and await initHasher() first.",
+    );
   }
   return _h64(tenantId).toString(16).padStart(16, "0");
 }
@@ -349,7 +353,13 @@ export interface QueryResult<Row = Record<string, unknown>> {
 }
 
 /** Supported bind parameter value types for SQL query placeholders (`$1`, `$2`, ...). */
-export type QueryBindParameter = string | number | bigint | boolean | Uint8Array | null;
+export type QueryBindParameter =
+  | string
+  | number
+  | bigint
+  | boolean
+  | Uint8Array
+  | null;
 
 /** gRPC metadata key for shard owner address on redirect */
 const SHARD_OWNER_ADDR_METADATA_KEY = "x-silo-shard-owner-addr";
@@ -359,18 +369,18 @@ const SHARD_OWNER_ADDR_METADATA_KEY = "x-silo-shard-owner-addr";
  */
 export interface ShardRoutingConfig {
   /**
-   * Maximum number of retries when receiving a "wrong shard" error.
-   * This can happen during cluster rebalancing.
+   * Maximum number of retries when a request fails due to a wrong shard
+   * routing or a connectivity error (UNAVAILABLE / DEADLINE_EXCEEDED).
    * @default 5
    */
-  maxWrongShardRetries?: number;
+  maxRetries?: number;
 
   /**
-   * Initial delay in ms before retrying after a wrong shard error.
-   * Uses exponential backoff.
+   * Initial delay in ms before retrying a failed request.
+   * Uses exponential backoff capped at 5 seconds.
    * @default 100
    */
-  wrongShardRetryDelayMs?: number;
+  retryDelayMs?: number;
 
   /**
    * How often to refresh the cluster topology (in ms).
@@ -378,6 +388,14 @@ export interface ShardRoutingConfig {
    * @default 30000
    */
   topologyRefreshIntervalMs?: number;
+
+  /**
+   * Maximum time in ms to wait for a single topology refresh attempt
+   * (i.e. one GetClusterInfo RPC per server). If the attempt exceeds
+   * this timeout, the client moves on to the next server.
+   * @default 10000
+   */
+  topologyRefreshTimeoutMs?: number;
 }
 
 /**
@@ -510,7 +528,10 @@ export interface FloatingConcurrencyLimitConfig {
 }
 
 /** A limit that can be a concurrency limit, rate limit, or floating concurrency limit */
-export type JobLimit = ConcurrencyLimitConfig | RateLimitConfig | FloatingConcurrencyLimitConfig;
+export type JobLimit =
+  | ConcurrencyLimitConfig
+  | RateLimitConfig
+  | FloatingConcurrencyLimitConfig;
 
 /** Job details returned from getJob */
 export interface Job<Payload = unknown, Result = unknown> {
@@ -697,7 +718,9 @@ function toProtoQueryParameter(value: QueryBindParameter): QueryParameter {
   throw new Error(`unsupported query bind parameter type: ${typeof value}`);
 }
 
-function toProtoQueryParameters(parameters?: QueryBindParameter[]): QueryParameter[] {
+function toProtoQueryParameters(
+  parameters?: QueryBindParameter[],
+): QueryParameter[] {
   if (!parameters || parameters.length === 0) {
     return [];
   }
@@ -722,7 +745,8 @@ function fromProtoLimit(limit: Limit): JobLimit | undefined {
       key: fl.key,
       defaultMaxConcurrency: fl.defaultMaxConcurrency,
       refreshIntervalMs: fl.refreshIntervalMs,
-      metadata: Object.keys(fl.metadata).length > 0 ? { ...fl.metadata } : undefined,
+      metadata:
+        Object.keys(fl.metadata).length > 0 ? { ...fl.metadata } : undefined,
     };
   } else if (limit.limit.oneofKind === "rateLimit") {
     const rl = limit.limit.rateLimit;
@@ -824,7 +848,10 @@ export interface CancelledOutcome {
   type: "cancelled";
 }
 
-export type TaskOutcome<Result> = SuccessOutcome<Result> | FailureOutcome | CancelledOutcome;
+export type TaskOutcome<Result> =
+  | SuccessOutcome<Result>
+  | FailureOutcome
+  | CancelledOutcome;
 
 /** Options for reporting task outcome */
 export interface ReportOutcomeOptions<Result = unknown> {
@@ -919,7 +946,21 @@ export interface LeaseTasksResult {
 function isWrongShardError(error: unknown): boolean {
   if (error instanceof RpcError) {
     // gRPC NOT_FOUND status with "shard not found" message
-    return error.code === "NOT_FOUND" && error.message.includes("shard not found");
+    return (
+      error.code === "NOT_FOUND" && error.message.includes("shard not found")
+    );
+  }
+  return false;
+}
+
+/**
+ * Check if an error indicates a connectivity problem that may be resolved
+ * by refreshing topology and retrying on a different server.
+ * @internal
+ */
+function isConnectivityError(error: unknown): boolean {
+  if (error instanceof RpcError) {
+    return error.code === "UNAVAILABLE" || error.code === "DEADLINE_EXCEEDED";
   }
   return false;
 }
@@ -964,7 +1005,11 @@ function mapRpcError(error: unknown, context: RpcErrorContext): Error {
       return new SiloNotFoundError(error.message);
     case "ALREADY_EXISTS":
       if (context.jobId) {
-        return new JobAlreadyExistsError(context.jobId, context.tenant, error.message);
+        return new JobAlreadyExistsError(
+          context.jobId,
+          context.tenant,
+          error.message,
+        );
       }
       return new SiloAlreadyExistsError(error.message);
     case "INVALID_ARGUMENT":
@@ -1102,10 +1147,13 @@ export class SiloGRPCClient {
   private readonly _authInterceptor: RpcInterceptor | null;
 
   /** @internal */
-  private readonly _maxWrongShardRetries: number;
+  private readonly _maxRetries: number;
 
   /** @internal */
-  private readonly _wrongShardRetryDelayMs: number;
+  private readonly _retryDelayMs: number;
+
+  /** @internal */
+  private readonly _topologyRefreshTimeoutMs: number;
 
   /** @internal Shard ID (string UUID) → server address */
   private _shardToServer: Map<string, string> = new Map();
@@ -1120,7 +1168,8 @@ export class SiloGRPCClient {
   private _pendingTopologyRefresh: Promise<void> | null = null;
 
   /** @internal */
-  private _topologyRefreshInterval: ReturnType<typeof setInterval> | null = null;
+  private _topologyRefreshInterval: ReturnType<typeof setInterval> | null =
+    null;
   /** Counter for round-robin server selection */
   private _anyClientCounter: number = 0;
 
@@ -1205,7 +1254,12 @@ export class SiloGRPCClient {
       this._authInterceptor = null;
     }
 
-    // Default gRPC service config with retry policy for transient failures
+    // Default gRPC service config with retry policy for transient failures.
+    // Only RESOURCE_EXHAUSTED is retried at the gRPC level (server-side
+    // backpressure on a live connection). UNAVAILABLE is NOT retried here
+    // because our application-level retry (_withShardRetry) handles it with
+    // topology refresh, allowing re-routing to a different server instead of
+    // repeatedly hitting the same dead connection.
     const defaultServiceConfig = {
       methodConfig: [
         {
@@ -1215,7 +1269,7 @@ export class SiloGRPCClient {
             initialBackoff: "0.1s",
             maxBackoff: "5s",
             backoffMultiplier: 2,
-            retryableStatusCodes: ["UNAVAILABLE", "RESOURCE_EXHAUSTED"],
+            retryableStatusCodes: ["RESOURCE_EXHAUSTED"],
           },
         },
       ],
@@ -1240,8 +1294,10 @@ export class SiloGRPCClient {
 
     // Shard routing configuration
 
-    this._maxWrongShardRetries = options.shardRouting?.maxWrongShardRetries ?? 5;
-    this._wrongShardRetryDelayMs = options.shardRouting?.wrongShardRetryDelayMs ?? 100;
+    this._maxRetries = options.shardRouting?.maxRetries ?? 5;
+    this._retryDelayMs = options.shardRouting?.retryDelayMs ?? 100;
+    this._topologyRefreshTimeoutMs =
+      options.shardRouting?.topologyRefreshTimeoutMs ?? 10_000;
 
     // Parse initial servers
     this._initialServers = this._parseServers(options.servers);
@@ -1255,7 +1311,8 @@ export class SiloGRPCClient {
     }
 
     // Start topology refresh if configured
-    const refreshInterval = options.shardRouting?.topologyRefreshIntervalMs ?? 30000;
+    const refreshInterval =
+      options.shardRouting?.topologyRefreshIntervalMs ?? 30000;
     if (refreshInterval > 0) {
       this._topologyRefreshInterval = setInterval(() => {
         this.refreshTopology().catch((err) => {
@@ -1281,7 +1338,9 @@ export class SiloGRPCClient {
       return [servers];
     }
     if (Array.isArray(servers)) {
-      return servers.map((s) => (typeof s === "string" ? s : `${s.host}:${s.port}`));
+      return servers.map((s) =>
+        typeof s === "string" ? s : `${s.host}:${s.port}`,
+      );
     }
     return [`${servers.host}:${servers.port}`];
   }
@@ -1305,7 +1364,9 @@ export class SiloGRPCClient {
         host: address,
         channelCredentials: this._channelCredentials,
         clientOptions: this._grpcClientOptions,
-        ...(this._authInterceptor ? { interceptors: [this._authInterceptor] } : {}),
+        ...(this._authInterceptor
+          ? { interceptors: [this._authInterceptor] }
+          : {}),
       });
       const client = new SiloClient(transport);
       conn = { address, transport, client };
@@ -1321,12 +1382,16 @@ export class SiloGRPCClient {
   private _resolveShard(tenant: string | undefined): string {
     const tenantId = tenant ?? DEFAULT_TENANT;
     if (this._shards.length === 0) {
-      throw new Error("Cluster topology not discovered yet. Call refreshTopology() first.");
+      throw new Error(
+        "Cluster topology not discovered yet. Call refreshTopology() first.",
+      );
     }
     const hashed = hashTenant(tenantId);
     const shardInfo = shardForTenant(hashed, this._shards);
     if (!shardInfo) {
-      throw new Error(`No shard found for tenant "${tenantId}". This indicates a topology error.`);
+      throw new Error(
+        `No shard found for tenant "${tenantId}". This indicates a topology error.`,
+      );
     }
     return shardInfo.shardId;
   }
@@ -1411,27 +1476,32 @@ export class SiloGRPCClient {
   }
 
   /**
-   * Execute an operation with retry logic for wrong shard errors.
+   * Execute an operation with retry on wrong-shard and connectivity errors.
    * @internal
    */
-  private async _withWrongShardRetry<T>(
+  private async _withShardRetry<T>(
     tenant: string | undefined,
     operation: (client: SiloClient, shard: string) => Promise<T>,
   ): Promise<T> {
     await this._ensureTopology();
     let lastError: unknown;
-    let delay = this._wrongShardRetryDelayMs;
+    let delay = this._retryDelayMs;
     let { client, shard } = this._getClientForTenant(tenant);
 
-    for (let attempt = 0; attempt <= this._maxWrongShardRetries; attempt++) {
+    for (let attempt = 0; attempt <= this._maxRetries; attempt++) {
       try {
         return await operation(client, shard);
       } catch (error) {
-        if (isWrongShardError(error) && attempt < this._maxWrongShardRetries) {
+        if (
+          (isWrongShardError(error) || isConnectivityError(error)) &&
+          attempt < this._maxRetries
+        ) {
           lastError = error;
 
-          // Check for redirect address in metadata
-          const redirectAddr = extractRedirectAddress(error);
+          // Check for redirect address in metadata (only on wrong shard errors)
+          const redirectAddr = isWrongShardError(error)
+            ? extractRedirectAddress(error)
+            : undefined;
           if (redirectAddr) {
             // Update routing and create connection to new server
             const mappedAddr = this._mapAddress(redirectAddr);
@@ -1439,7 +1509,8 @@ export class SiloGRPCClient {
             const conn = this._getOrCreateConnection(mappedAddr);
             client = conn.client;
           } else {
-            // No redirect info, try refreshing topology
+            // Connectivity error or wrong shard without redirect — refresh
+            // topology so the retry can reach a different server
             await this.refreshTopology();
             const result = this._getClientForTenant(tenant);
             client = result.client;
@@ -1459,28 +1530,33 @@ export class SiloGRPCClient {
   }
 
   /**
-   * Execute an operation with retry logic for wrong shard errors, using a known shard ID.
+   * Execute an operation with retry on wrong-shard and connectivity errors, using a known shard ID.
    * Used by shard-routed operations (reportOutcome, heartbeat, reportRefreshOutcome)
    * where the shard ID is already known from the task, rather than resolved from a tenant.
    * @internal
    */
-  private async _withWrongShardRetryForShard<T>(
+  private async _withShardRetryForShard<T>(
     shardId: string,
     operation: (client: SiloClient) => Promise<T>,
   ): Promise<T> {
     let lastError: unknown;
-    let delay = this._wrongShardRetryDelayMs;
+    let delay = this._retryDelayMs;
     let client = this._getClientForShard(shardId);
 
-    for (let attempt = 0; attempt <= this._maxWrongShardRetries; attempt++) {
+    for (let attempt = 0; attempt <= this._maxRetries; attempt++) {
       try {
         return await operation(client);
       } catch (error) {
-        if (isWrongShardError(error) && attempt < this._maxWrongShardRetries) {
+        if (
+          (isWrongShardError(error) || isConnectivityError(error)) &&
+          attempt < this._maxRetries
+        ) {
           lastError = error;
 
-          // Check for redirect address in metadata
-          const redirectAddr = extractRedirectAddress(error);
+          // Check for redirect address in metadata (only on wrong shard errors)
+          const redirectAddr = isWrongShardError(error)
+            ? extractRedirectAddress(error)
+            : undefined;
           if (redirectAddr) {
             // Update routing and create connection to new server
             const mappedAddr = this._mapAddress(redirectAddr);
@@ -1488,7 +1564,8 @@ export class SiloGRPCClient {
             const conn = this._getOrCreateConnection(mappedAddr);
             client = conn.client;
           } else {
-            // No redirect info, try refreshing topology
+            // Connectivity error or wrong shard without redirect — refresh
+            // topology so the retry can reach a different server
             await this.refreshTopology();
             client = this._getClientForShard(shardId);
           }
@@ -1519,12 +1596,23 @@ export class SiloGRPCClient {
     for (const serverAddr of servers) {
       try {
         const conn = this._getOrCreateConnection(serverAddr);
-        const call = conn.client.getClusterInfo({}, this._rpcOptions());
+
+        // Apply a per-server deadline so a single hung connection doesn't
+        // block the entire refresh. The user-supplied rpcOptions are merged
+        // underneath so that the timeout always takes effect.
+        const baseOpts = this._rpcOptions() ?? {};
+        const refreshOpts: RpcOptions = {
+          ...baseOpts,
+          timeout: this._topologyRefreshTimeoutMs,
+        };
+
+        const call = conn.client.getClusterInfo({}, refreshOpts);
         const response = await call.response;
 
         // Update shard → server mapping and build shards array
         // Skip shards without a valid address (cluster may not have fully converged)
         this._shardToServer.clear();
+        const activeAddresses = new Set<string>();
         const shards: ShardInfoWithRange[] = [];
         for (const owner of response.shardOwners) {
           // Skip shards that don't have an owner yet (empty grpcAddr)
@@ -1533,6 +1621,7 @@ export class SiloGRPCClient {
             continue;
           }
           const addr = this._mapAddress(owner.grpcAddr);
+          activeAddresses.add(addr);
           this._shardToServer.set(owner.shardId, addr);
           shards.push({
             shardId: owner.shardId,
@@ -1542,6 +1631,20 @@ export class SiloGRPCClient {
           });
           // Ensure we have a connection to this server
           this._getOrCreateConnection(addr);
+        }
+
+        // Close and remove connections to servers that are no longer in the
+        // topology. This prevents stale connections (e.g. to old pod IPs
+        // after a StatefulSet restart) from accumulating and causing timeouts
+        // on subsequent refreshes.
+        for (const [addr, existingConn] of this._connections) {
+          if (
+            !activeAddresses.has(addr) &&
+            !this._initialServers.includes(addr)
+          ) {
+            existingConn.transport.close();
+            this._connections.delete(addr);
+          }
         }
 
         // Sort shards by rangeStart for efficient binary search lookup
@@ -1582,31 +1685,34 @@ export class SiloGRPCClient {
    */
   public async enqueue(options: EnqueueJobOptions): Promise<JobHandle> {
     try {
-      const id = await this._withWrongShardRetry(options.tenant, async (client, shard) => {
-        const call = client.enqueue(
-          {
-            shard,
-            id: options.id ?? "",
-            priority: options.priority ?? 50,
-            startAtMs: options.startAtMs ?? BigInt(Date.now()),
-            retryPolicy: options.retryPolicy,
-            payload: {
-              encoding: {
-                oneofKind: "msgpack",
-                msgpack: encodeBytes(options.payload),
+      const id = await this._withShardRetry(
+        options.tenant,
+        async (client, shard) => {
+          const call = client.enqueue(
+            {
+              shard,
+              id: options.id ?? "",
+              priority: options.priority ?? 50,
+              startAtMs: options.startAtMs ?? BigInt(Date.now()),
+              retryPolicy: options.retryPolicy,
+              payload: {
+                encoding: {
+                  oneofKind: "msgpack",
+                  msgpack: encodeBytes(options.payload),
+                },
               },
+              limits: options.limits?.map(toProtoLimit) ?? [],
+              tenant: options.tenant,
+              metadata: options.metadata ?? {},
+              taskGroup: options.taskGroup,
             },
-            limits: options.limits?.map(toProtoLimit) ?? [],
-            tenant: options.tenant,
-            metadata: options.metadata ?? {},
-            taskGroup: options.taskGroup,
-          },
-          this._rpcOptions(),
-        );
+            this._rpcOptions(),
+          );
 
-        const response = await call.response;
-        return response.id;
-      });
+          const response = await call.response;
+          return response.id;
+        },
+      );
       return new JobHandle(this, id, options.tenant);
     } catch (error) {
       throwMappedRpcError(error, {
@@ -1625,9 +1731,13 @@ export class SiloGRPCClient {
    * @returns The job details.
    * @throws JobNotFoundError if the job doesn't exist.
    */
-  public async getJob(id: string, tenant?: string, options?: GetJobOptions): Promise<Job> {
+  public async getJob(
+    id: string,
+    tenant?: string,
+    options?: GetJobOptions,
+  ): Promise<Job> {
     try {
-      return await this._withWrongShardRetry(tenant, async (client, shard) => {
+      return await this._withShardRetry(tenant, async (client, shard) => {
         const call = client.getJob(
           {
             shard,
@@ -1651,12 +1761,16 @@ export class SiloGRPCClient {
             "payload",
           ),
           retryPolicy: response.retryPolicy,
-          limits: response.limits.map(fromProtoLimit).filter((l): l is JobLimit => l !== undefined),
+          limits: response.limits
+            .map(fromProtoLimit)
+            .filter((l): l is JobLimit => l !== undefined),
           metadata: response.metadata,
           status: protoJobStatusToPublic(response.status),
           statusChangedAtMs: response.statusChangedAtMs,
           attempts:
-            response.attempts.length > 0 ? response.attempts.map(protoAttemptToPublic) : undefined,
+            response.attempts.length > 0
+              ? response.attempts.map(protoAttemptToPublic)
+              : undefined,
           nextAttemptStartsAfterMs: response.nextAttemptStartsAfterMs,
           taskGroup: response.taskGroup,
           result: response.result
@@ -1682,7 +1796,7 @@ export class SiloGRPCClient {
    */
   public async deleteJob(id: string, tenant?: string): Promise<void> {
     try {
-      await this._withWrongShardRetry(tenant, async (client, shard) => {
+      await this._withShardRetry(tenant, async (client, shard) => {
         await client.deleteJob(
           {
             shard,
@@ -1707,7 +1821,7 @@ export class SiloGRPCClient {
    */
   public async cancelJob(id: string, tenant?: string): Promise<void> {
     try {
-      await this._withWrongShardRetry(tenant, async (client, shard) => {
+      await this._withShardRetry(tenant, async (client, shard) => {
         await client.cancelJob(
           {
             shard,
@@ -1732,7 +1846,7 @@ export class SiloGRPCClient {
    */
   public async restartJob(id: string, tenant?: string): Promise<void> {
     try {
-      await this._withWrongShardRetry(tenant, async (client, shard) => {
+      await this._withShardRetry(tenant, async (client, shard) => {
         await client.restartJob(
           {
             shard,
@@ -1743,7 +1857,11 @@ export class SiloGRPCClient {
         );
       });
     } catch (error) {
-      throwMappedRpcError(error, { operation: "restartJob", jobId: id, tenant });
+      throwMappedRpcError(error, {
+        operation: "restartJob",
+        jobId: id,
+        tenant,
+      });
     }
   }
 
@@ -1759,7 +1877,7 @@ export class SiloGRPCClient {
    */
   public async expediteJob(id: string, tenant?: string): Promise<void> {
     try {
-      await this._withWrongShardRetry(tenant, async (client, shard) => {
+      await this._withShardRetry(tenant, async (client, shard) => {
         await client.expediteJob(
           {
             shard,
@@ -1770,7 +1888,11 @@ export class SiloGRPCClient {
         );
       });
     } catch (error) {
-      throwMappedRpcError(error, { operation: "expediteJob", jobId: id, tenant });
+      throwMappedRpcError(error, {
+        operation: "expediteJob",
+        jobId: id,
+        tenant,
+      });
     }
   }
 
@@ -1788,23 +1910,26 @@ export class SiloGRPCClient {
    */
   public async leaseTask(options: LeaseTaskOptions): Promise<Task> {
     try {
-      return await this._withWrongShardRetry(options.tenant, async (client, shard) => {
-        const call = client.leaseTask(
-          {
-            shard,
-            id: options.id,
-            tenant: options.tenant,
-            workerId: options.workerId,
-          },
-          this._rpcOptions(),
-        );
+      return await this._withShardRetry(
+        options.tenant,
+        async (client, shard) => {
+          const call = client.leaseTask(
+            {
+              shard,
+              id: options.id,
+              tenant: options.tenant,
+              workerId: options.workerId,
+            },
+            this._rpcOptions(),
+          );
 
-        const response = await call.response;
-        if (!response.task) {
-          throw new Error("leaseTask response missing task");
-        }
-        return response.task;
-      });
+          const response = await call.response;
+          if (!response.task) {
+            throw new Error("leaseTask response missing task");
+          }
+          return response.task;
+        },
+      );
     } catch (error) {
       throwMappedRpcError(error, {
         operation: "leaseTask",
@@ -1835,9 +1960,12 @@ export class SiloGRPCClient {
    * @throws JobNotTerminalError if the job is not yet in a terminal state.
    * @internal
    */
-  public async getJobResult<T = unknown>(id: string, tenant?: string): Promise<JobResult<T>> {
+  public async getJobResult<T = unknown>(
+    id: string,
+    tenant?: string,
+  ): Promise<JobResult<T>> {
     try {
-      return await this._withWrongShardRetry(tenant, async (client, shard) => {
+      return await this._withShardRetry(tenant, async (client, shard) => {
         const call = client.getJobResult(
           {
             shard,
@@ -1861,7 +1989,10 @@ export class SiloGRPCClient {
             response.result.successData.encoding.oneofKind === "msgpack" &&
             response.result.successData.encoding.msgpack.length > 0
           ) {
-            result = decodeBytes<T>(response.result.successData.encoding.msgpack, "successData");
+            result = decodeBytes<T>(
+              response.result.successData.encoding.msgpack,
+              "successData",
+            );
           }
           return { status: JobStatus.Succeeded, result };
         }
@@ -1870,10 +2001,14 @@ export class SiloGRPCClient {
           let errorData: unknown;
           if (
             response.result.oneofKind === "failure" &&
-            response.result.failure.errorData?.encoding.oneofKind === "msgpack" &&
+            response.result.failure.errorData?.encoding.oneofKind ===
+              "msgpack" &&
             response.result.failure.errorData.encoding.msgpack.length > 0
           ) {
-            errorData = decodeBytes(response.result.failure.errorData.encoding.msgpack, "failure");
+            errorData = decodeBytes(
+              response.result.failure.errorData.encoding.msgpack,
+              "failure",
+            );
           }
           return {
             status: JobStatus.Failed,
@@ -1900,7 +2035,11 @@ export class SiloGRPCClient {
           throw new JobNotTerminalError(id, tenant);
         }
       }
-      throwMappedRpcError(error, { operation: "getJobResult", jobId: id, tenant });
+      throwMappedRpcError(error, {
+        operation: "getJobResult",
+        jobId: id,
+        tenant,
+      });
     }
   }
 
@@ -1988,14 +2127,20 @@ export class SiloGRPCClient {
   public async reportOutcome(options: ReportOutcomeOptions): Promise<void> {
     let outcome:
       | { oneofKind: "success"; success: SerializedBytes }
-      | { oneofKind: "failure"; failure: { code: string; data?: SerializedBytes } }
+      | {
+          oneofKind: "failure";
+          failure: { code: string; data?: SerializedBytes };
+        }
       | { oneofKind: "cancelled"; cancelled: Record<string, never> };
 
     if (options.outcome.type === "success") {
       outcome = {
         oneofKind: "success" as const,
         success: {
-          encoding: { oneofKind: "msgpack", msgpack: encodeBytes(options.outcome.result) },
+          encoding: {
+            oneofKind: "msgpack",
+            msgpack: encodeBytes(options.outcome.result),
+          },
         },
       };
     } else if (options.outcome.type === "failure") {
@@ -2022,7 +2167,7 @@ export class SiloGRPCClient {
 
     try {
       // Route to the correct shard (from Task.shard), with retry on stale routing
-      await this._withWrongShardRetryForShard(options.shard, async (client) => {
+      await this._withShardRetryForShard(options.shard, async (client) => {
         await client.reportOutcome(
           {
             shard: options.shard,
@@ -2054,7 +2199,9 @@ export class SiloGRPCClient {
    * @param options The options for reporting the refresh outcome.
    * @throws TaskNotFoundError if the refresh task (lease) doesn't exist.
    */
-  public async reportRefreshOutcome(options: ReportRefreshOutcomeOptions): Promise<void> {
+  public async reportRefreshOutcome(
+    options: ReportRefreshOutcomeOptions,
+  ): Promise<void> {
     const outcome =
       options.outcome.type === "success"
         ? {
@@ -2070,7 +2217,7 @@ export class SiloGRPCClient {
           };
 
     try {
-      await this._withWrongShardRetryForShard(options.shard, async (client) => {
+      await this._withShardRetryForShard(options.shard, async (client) => {
         await client.reportRefreshOutcome(
           {
             shard: options.shard,
@@ -2105,7 +2252,7 @@ export class SiloGRPCClient {
     tenant?: string,
   ): Promise<HeartbeatResult> {
     try {
-      return await this._withWrongShardRetryForShard(shard, async (client) => {
+      return await this._withShardRetryForShard(shard, async (client) => {
         const call = client.heartbeat(
           {
             shard,
@@ -2139,7 +2286,7 @@ export class SiloGRPCClient {
     parameters?: QueryBindParameter[],
   ): Promise<QueryResult<Row>> {
     try {
-      return await this._withWrongShardRetry(tenant, async (client, shard) => {
+      return await this._withShardRetry(tenant, async (client, shard) => {
         const call = client.query(
           {
             shard,
@@ -2161,7 +2308,9 @@ export class SiloGRPCClient {
           if (row.encoding.oneofKind === "msgpack") {
             return decodeBytes<Row>(row.encoding.msgpack, `row[${index}]`);
           }
-          throw new Error(`Unsupported encoding for row[${index}]: ${row.encoding.oneofKind}`);
+          throw new Error(
+            `Unsupported encoding for row[${index}]: ${row.encoding.oneofKind}`,
+          );
         });
 
         return { columns, rows, rowCount: response.rowCount };
@@ -2251,7 +2400,10 @@ export function encodeBytes(value: unknown): Uint8Array {
  * @param bytes The MessagePack bytes to decode.
  * @returns The decoded value.
  */
-export function decodeBytes<T = unknown>(bytes: Uint8Array | undefined, field: string): T {
+export function decodeBytes<T = unknown>(
+  bytes: Uint8Array | undefined,
+  field: string,
+): T {
   if (!bytes || bytes.length === 0) {
     throw new Error(`No bytes to decode for field ${field}`);
   }

--- a/typescript_client/test/client-integration.test.ts
+++ b/typescript_client/test/client-integration.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { SiloGRPCClient, JobStatus, decodeBytes, GubernatorAlgorithm } from "../src/client";
+import {
+  SiloGRPCClient,
+  JobStatus,
+  decodeBytes,
+  GubernatorAlgorithm,
+} from "../src/client";
 
 // Support comma-separated list of servers for multi-node testing
 const SILO_SERVERS = (
@@ -7,7 +12,8 @@ const SILO_SERVERS = (
   process.env.SILO_SERVER ||
   "localhost:7450"
 ).split(",");
-const RUN_INTEGRATION = process.env.RUN_INTEGRATION === "true" || process.env.CI === "true";
+const RUN_INTEGRATION =
+  process.env.RUN_INTEGRATION === "true" || process.env.CI === "true";
 
 // Default task group for all integration tests
 const DEFAULT_TASK_GROUP = "integration-test-group";
@@ -85,6 +91,31 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
 
       const topology = client.getTopology();
       expect(topology.shards.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("skips non-existent server and discovers topology from a valid one", async () => {
+      // Use localhost on a port that nothing is listening on — the OS will
+      // immediately refuse the connection so the test doesn't block waiting
+      // for a TCP timeout.
+      const badServer = "localhost:1";
+      const testClient = new SiloGRPCClient({
+        servers: [badServer, ...SILO_SERVERS],
+        useTls: false,
+        shardRouting: {
+          topologyRefreshIntervalMs: 0,
+          topologyRefreshTimeoutMs: 500,
+        },
+      });
+
+      try {
+        await testClient.refreshTopology();
+
+        const topology = testClient.getTopology();
+        expect(topology.shards.length).toBeGreaterThanOrEqual(1);
+        expect(topology.shardToServer.size).toBeGreaterThanOrEqual(1);
+      } finally {
+        testClient.close();
+      }
     });
   });
 
@@ -338,7 +369,9 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       expect(succeededJob.result).toEqual(resultData);
 
       // getJob with includeAttempts should also have result
-      const jobWithAttempts = await client.getJob(handle.id, tenant, { includeAttempts: true });
+      const jobWithAttempts = await client.getJob(handle.id, tenant, {
+        includeAttempts: true,
+      });
       expect(jobWithAttempts.status).toBe(JobStatus.Succeeded);
       expect(jobWithAttempts.result).toEqual(resultData);
       expect(jobWithAttempts.attempts).toBeDefined();
@@ -420,7 +453,9 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       expect(task?.priority).toBe(1);
 
       const taskPayload = decodeBytes(
-        task?.payload?.encoding.oneofKind === "msgpack" ? task.payload.encoding.msgpack : undefined,
+        task?.payload?.encoding.oneofKind === "msgpack"
+          ? task.payload.encoding.msgpack
+          : undefined,
         "payload",
       );
       expect(taskPayload).toEqual(payload);
@@ -504,7 +539,12 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       const task = result.tasks.find((t) => t.jobId === handle.id);
       expect(task).toBeDefined();
 
-      await client.heartbeat("test-worker-3", task!.id, task!.shard, task!.tenantId);
+      await client.heartbeat(
+        "test-worker-3",
+        task!.id,
+        task!.shard,
+        task!.tenantId,
+      );
 
       await client.reportOutcome({
         shard: task!.shard,
@@ -591,7 +631,9 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
         maxTasks: 1,
         taskGroup: DEFAULT_TASK_GROUP,
       });
-      expect(resultBefore.tasks.find((t) => t.jobId === handle.id)).toBeUndefined();
+      expect(
+        resultBefore.tasks.find((t) => t.jobId === handle.id),
+      ).toBeUndefined();
 
       // Expedite the job
       await client.expediteJob(handle.id, tenant);
@@ -626,7 +668,9 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
 
     it("expedite throws error for non-existent job", async () => {
       const tenant = "expedite-tenant";
-      await expect(client.expediteJob("non-existent-job-id", tenant)).rejects.toThrow();
+      await expect(
+        client.expediteJob("non-existent-job-id", tenant),
+      ).rejects.toThrow();
     });
 
     it("expedite throws error for running job", async () => {
@@ -812,7 +856,10 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       }
 
       // SQL queries require tenant in WHERE clause for filtering
-      const result = await client.query(`SELECT * FROM jobs WHERE tenant = '${tenant}'`, tenant);
+      const result = await client.query(
+        `SELECT * FROM jobs WHERE tenant = '${tenant}'`,
+        tenant,
+      );
       expect(result.rowCount).toBeGreaterThanOrEqual(3);
       expect(result.columns.length).toBeGreaterThan(0);
       expect(result.columns.some((c) => c.name === "id")).toBe(true);
@@ -1162,44 +1209,48 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       });
 
       // Try to await with a short timeout - should fail
-      await expect(handle.awaitResult({ pollIntervalMs: 50, timeoutMs: 200 })).rejects.toThrow(
-        /Timeout/,
-      );
+      await expect(
+        handle.awaitResult({ pollIntervalMs: 50, timeoutMs: 200 }),
+      ).rejects.toThrow(/Timeout/);
     });
   });
 
   describe("large payloads", () => {
-    it("enqueues and retrieves a 10MB payload", { timeout: 30_000 }, async () => {
-      const tenant = "large-payload-tenant";
+    it(
+      "enqueues and retrieves a 10MB payload",
+      { timeout: 30_000 },
+      async () => {
+        const tenant = "large-payload-tenant";
 
-      // Build a ~10MB payload using a raw Buffer.
-      // msgpack encodes Buffers as binary data without base64 expansion,
-      // so the wire size stays close to 10MB. This validates we're above
-      // the default 4MB gRPC limit without overwhelming CI resources.
-      const sizeBytes = 10 * 1024 * 1024;
-      const largeBuffer = Buffer.alloc(sizeBytes, 0x42);
-      const payload = { data: largeBuffer };
+        // Build a ~10MB payload using a raw Buffer.
+        // msgpack encodes Buffers as binary data without base64 expansion,
+        // so the wire size stays close to 10MB. This validates we're above
+        // the default 4MB gRPC limit without overwhelming CI resources.
+        const sizeBytes = 10 * 1024 * 1024;
+        const largeBuffer = Buffer.alloc(sizeBytes, 0x42);
+        const payload = { data: largeBuffer };
 
-      const taskGroup = "large-payload-test-group";
+        const taskGroup = "large-payload-test-group";
 
-      const handle = await client.enqueue({
-        tenant,
-        taskGroup,
-        payload,
-        priority: 50,
-      });
+        const handle = await client.enqueue({
+          tenant,
+          taskGroup,
+          payload,
+          priority: 50,
+        });
 
-      expect(handle.id).toBeTruthy();
+        expect(handle.id).toBeTruthy();
 
-      // Retrieve the job and verify the payload round-trips correctly
-      const job = await client.getJob(handle.id, tenant);
-      expect(job).toBeDefined();
-      expect(job?.id).toBe(handle.id);
+        // Retrieve the job and verify the payload round-trips correctly
+        const job = await client.getJob(handle.id, tenant);
+        expect(job).toBeDefined();
+        expect(job?.id).toBe(handle.id);
 
-      const retrieved = job?.payload as { data: Uint8Array };
-      expect(retrieved.data.length).toBe(sizeBytes);
-      expect(Buffer.from(retrieved.data).equals(largeBuffer)).toBe(true);
-    });
+        const retrieved = job?.payload as { data: Uint8Array };
+        expect(retrieved.data.length).toBe(sizeBytes);
+        expect(Buffer.from(retrieved.data).equals(largeBuffer)).toBe(true);
+      },
+    );
   });
 
   describe("floating concurrency limits", () => {
@@ -1292,7 +1343,9 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       expect(result.tasks.length).toBeGreaterThanOrEqual(0);
 
       // Find our refresh task - it MUST exist
-      const refreshTask = result.refreshTasks.find((rt) => rt.queueKey === queueKey);
+      const refreshTask = result.refreshTasks.find(
+        (rt) => rt.queueKey === queueKey,
+      );
       expect(refreshTask).toBeDefined();
       expect(refreshTask!.id).toBeTruthy();
       expect(refreshTask!.queueKey).toBe(queueKey);
@@ -1371,7 +1424,9 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       });
 
       // Find our refresh task - it MUST exist
-      const refreshTask = result.refreshTasks.find((rt) => rt.queueKey === queueKey);
+      const refreshTask = result.refreshTasks.find(
+        (rt) => rt.queueKey === queueKey,
+      );
       expect(refreshTask).toBeDefined();
 
       // Report failure
@@ -1432,7 +1487,9 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       });
 
       // Filter to just our jobs
-      const ourTasks = result.tasks.filter((t) => handles.some((h) => h.id === t.jobId));
+      const ourTasks = result.tasks.filter((t) =>
+        handles.some((h) => h.id === t.jobId),
+      );
 
       // Should have at most 1 task due to concurrency limit
       expect(ourTasks.length).toBeLessThanOrEqual(1);
@@ -1478,7 +1535,9 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
       const job = await client.getJob(handle.id, tenant);
       expect(job.limits).toHaveLength(2);
 
-      const floatingLimit = job.limits.find((l) => l.type === "floatingConcurrency");
+      const floatingLimit = job.limits.find(
+        (l) => l.type === "floatingConcurrency",
+      );
       const regularLimit = job.limits.find((l) => l.type === "concurrency");
 
       expect(floatingLimit).toBeDefined();
@@ -1518,8 +1577,8 @@ describe.skipIf(!RUN_INTEGRATION)("Shard routing integration", () => {
         servers: SILO_SERVERS,
         useTls: false,
         shardRouting: {
-          maxWrongShardRetries: 2,
-          wrongShardRetryDelayMs: 50,
+          maxRetries: 2,
+          retryDelayMs: 50,
           topologyRefreshIntervalMs: 0,
         },
       });
@@ -1545,8 +1604,8 @@ describe.skipIf(!RUN_INTEGRATION)("Shard routing integration", () => {
         servers: SILO_SERVERS,
         useTls: false,
         shardRouting: {
-          maxWrongShardRetries: 5,
-          wrongShardRetryDelayMs: 10,
+          maxRetries: 5,
+          retryDelayMs: 10,
           topologyRefreshIntervalMs: 0,
         },
       });
@@ -1609,42 +1668,46 @@ describe.skipIf(!RUN_INTEGRATION)("Shard routing integration", () => {
       }
     });
 
-    it("handles high volume of different tenants", { timeout: 30000 }, async () => {
-      const client = new SiloGRPCClient({
-        servers: SILO_SERVERS,
-        useTls: false,
-        shardRouting: {
-          topologyRefreshIntervalMs: 0,
-        },
-      });
+    it(
+      "handles high volume of different tenants",
+      { timeout: 30000 },
+      async () => {
+        const client = new SiloGRPCClient({
+          servers: SILO_SERVERS,
+          useTls: false,
+          shardRouting: {
+            topologyRefreshIntervalMs: 0,
+          },
+        });
 
-      try {
-        await client.refreshTopology();
+        try {
+          await client.refreshTopology();
 
-        const numTenants = 50;
-        const results: Array<{ tenant: string; jobId: string }> = [];
+          const numTenants = 50;
+          const results: Array<{ tenant: string; jobId: string }> = [];
 
-        // Enqueue jobs for many tenants
-        for (let i = 0; i < numTenants; i++) {
-          const tenant = `bulk-tenant-${i}`;
-          const handle = await client.enqueue({
-            tenant,
-            taskGroup: DEFAULT_TASK_GROUP,
-            payload: { index: i },
-          });
-          results.push({ tenant, jobId: handle.id });
+          // Enqueue jobs for many tenants
+          for (let i = 0; i < numTenants; i++) {
+            const tenant = `bulk-tenant-${i}`;
+            const handle = await client.enqueue({
+              tenant,
+              taskGroup: DEFAULT_TASK_GROUP,
+              payload: { index: i },
+            });
+            results.push({ tenant, jobId: handle.id });
+          }
+
+          // Verify random sample can be retrieved
+          const samples = [0, 10, 25, 49].map((i) => results[i]);
+          for (const { tenant, jobId } of samples) {
+            const job = await client.getJob(jobId, tenant);
+            expect(job?.id).toBe(jobId);
+          }
+        } finally {
+          client.close();
         }
-
-        // Verify random sample can be retrieved
-        const samples = [0, 10, 25, 49].map((i) => results[i]);
-        for (const { tenant, jobId } of samples) {
-          const job = await client.getJob(jobId, tenant);
-          expect(job?.id).toBe(jobId);
-        }
-      } finally {
-        client.close();
-      }
-    });
+      },
+    );
   });
 
   describe("topology changes", () => {

--- a/typescript_client/test/client.test.ts
+++ b/typescript_client/test/client.test.ts
@@ -82,7 +82,9 @@ describe("decodeBytes", () => {
   });
 
   it("throws for undefined input", () => {
-    expect(() => decodeBytes(undefined, "test")).toThrow("No bytes to decode for field test");
+    expect(() => decodeBytes(undefined, "test")).toThrow(
+      "No bytes to decode for field test",
+    );
   });
 
   it("throws for empty byte array", () => {
@@ -326,12 +328,12 @@ describe("SiloGRPCClient", () => {
   });
 
   describe("error mapping", () => {
-    const mockWithWrongShardRetryError = (
+    const mockWithShardRetryError = (
       client: SiloGRPCClient,
       code: string,
       message: string,
     ) => {
-      (client as any)._withWrongShardRetry = vi
+      (client as any)._withShardRetry = vi
         .fn()
         .mockRejectedValue(new RpcError(message, code, {}));
     };
@@ -341,7 +343,7 @@ describe("SiloGRPCClient", () => {
         servers: "localhost:7450",
         ...defaultOptions,
       });
-      mockWithWrongShardRetryError(client, "ALREADY_EXISTS", "job already exists");
+      mockWithShardRetryError(client, "ALREADY_EXISTS", "job already exists");
 
       const error = await client
         .enqueue({
@@ -375,7 +377,7 @@ describe("SiloGRPCClient", () => {
           servers: "localhost:7450",
           ...defaultOptions,
         });
-        mockWithWrongShardRetryError(client, grpcCode, `rpc failed: ${grpcCode}`);
+        mockWithShardRetryError(client, grpcCode, `rpc failed: ${grpcCode}`);
 
         await expect(client.query("SELECT 1")).rejects.toThrow(ErrorClass);
       },
@@ -386,9 +388,11 @@ describe("SiloGRPCClient", () => {
         servers: "localhost:7450",
         ...defaultOptions,
       });
-      mockWithWrongShardRetryError(client, "NOT_FOUND", "job not found");
+      mockWithShardRetryError(client, "NOT_FOUND", "job not found");
 
-      await expect(client.getJob("job-404", "tenant-abc")).rejects.toThrow(JobNotFoundError);
+      await expect(client.getJob("job-404", "tenant-abc")).rejects.toThrow(
+        JobNotFoundError,
+      );
     });
 
     it("maps NOT_FOUND on heartbeat to TaskNotFoundError", async () => {
@@ -398,13 +402,15 @@ describe("SiloGRPCClient", () => {
       });
       (client as any)._getClientForShard = vi.fn().mockReturnValue({
         heartbeat: vi.fn().mockReturnValue({
-          response: Promise.reject(new RpcError("task not found", "NOT_FOUND", {})),
+          response: Promise.reject(
+            new RpcError("task not found", "NOT_FOUND", {}),
+          ),
         }),
       });
 
-      await expect(client.heartbeat("worker-a", "task-404", "shard-1")).rejects.toThrow(
-        TaskNotFoundError,
-      );
+      await expect(
+        client.heartbeat("worker-a", "task-404", "shard-1"),
+      ).rejects.toThrow(TaskNotFoundError);
     });
   });
 });
@@ -478,7 +484,9 @@ describe("AwaitJobOptions type", () => {
 describe("JobNotFoundError", () => {
   it("formats error message with job id and tenant", () => {
     const error = new JobNotFoundError("job-123", "tenant-abc");
-    expect(error.message).toBe('Job "job-123" not found in tenant "tenant-abc"');
+    expect(error.message).toBe(
+      'Job "job-123" not found in tenant "tenant-abc"',
+    );
     expect(error.name).toBe("JobNotFoundError");
     expect(error.code).toBe("SILO_JOB_NOT_FOUND");
     expect(error.jobId).toBe("job-123");
@@ -502,7 +510,11 @@ describe("JobNotFoundError", () => {
 
 describe("JobNotTerminalError", () => {
   it("formats error message with job id, tenant, and status", () => {
-    const error = new JobNotTerminalError("job-123", "tenant-abc", JobStatus.Running);
+    const error = new JobNotTerminalError(
+      "job-123",
+      "tenant-abc",
+      JobStatus.Running,
+    );
     expect(error.message).toBe(
       'Job "job-123" in tenant "tenant-abc" is not in a terminal state (current status: Running)',
     );
@@ -548,7 +560,9 @@ describe("TaskNotFoundError", () => {
 describe("JobAlreadyExistsError", () => {
   it("formats error message with job id and tenant", () => {
     const error = new JobAlreadyExistsError("job-123", "tenant-abc");
-    expect(error.message).toBe('Job "job-123" already exists in tenant "tenant-abc"');
+    expect(error.message).toBe(
+      'Job "job-123" already exists in tenant "tenant-abc"',
+    );
     expect(error.name).toBe("JobAlreadyExistsError");
     expect(error.code).toBe("SILO_JOB_ALREADY_EXISTS");
     expect(error.grpcCode).toBe("ALREADY_EXISTS");
@@ -677,10 +691,10 @@ describe("SiloGRPCClient.query deserialization", () => {
       rowCount: 2,
     };
 
-    (client as any)._withWrongShardRetry = vi
+    (client as any)._withShardRetry = vi
       .fn()
       .mockImplementation(async (_tenant: any, _operation: any) => {
-        // Simulate the internal deserialization that happens inside the real _withWrongShardRetry callback
+        // Simulate the internal deserialization that happens inside the real _withShardRetry callback
         const columns = mockResponse.columns.map((c: any) => ({
           name: c.name,
           dataType: c.dataType,
@@ -714,7 +728,7 @@ describe("SiloGRPCClient.query deserialization", () => {
       count: number;
     }
 
-    (client as any)._withWrongShardRetry = vi.fn().mockImplementation(async () => {
+    (client as any)._withShardRetry = vi.fn().mockImplementation(async () => {
       return {
         columns: [{ name: "count", dataType: "Int64" }],
         rows: [{ count: 42 }],
@@ -722,7 +736,9 @@ describe("SiloGRPCClient.query deserialization", () => {
       };
     });
 
-    const result = await client.query<CountRow>("SELECT COUNT(*) as count FROM jobs");
+    const result = await client.query<CountRow>(
+      "SELECT COUNT(*) as count FROM jobs",
+    );
     const row: CountRow = result.rows[0];
     expect(row.count).toBe(42);
   });

--- a/typescript_client/test/shard-routing.test.ts
+++ b/typescript_client/test/shard-routing.test.ts
@@ -765,6 +765,132 @@ describe("Shard Routing", () => {
       expect(staleConn.client.reportOutcome).toHaveBeenCalledTimes(1);
     });
 
+    it("retries shard-routed leaseTasks on a different server after UNAVAILABLE", async () => {
+      client = new SiloGRPCClient({
+        servers: "localhost:7450",
+        useTls: false,
+        shardRouting: {
+          maxRetries: 3,
+          retryDelayMs: 1,
+          topologyRefreshIntervalMs: 0,
+        },
+      });
+
+      const SHARD_ID = "00000000-0000-0000-0000-000000000001";
+
+      // Set up initial topology: shard → server-a
+      (client as any)._shards = [
+        {
+          shardId: SHARD_ID,
+          serverAddr: "10.0.0.1:7450",
+          rangeStart: "",
+          rangeEnd: "",
+        },
+      ];
+      (client as any)._shardToServer.set(SHARD_ID, "10.0.0.1:7450");
+      (client as any)._topologyReady = true;
+
+      // Create stale connection that returns UNAVAILABLE
+      const staleConn = (client as any)._getOrCreateConnection("10.0.0.1:7450");
+      staleConn.client.leaseTasks = vi.fn().mockImplementation(() => {
+        throw new RpcError(
+          "connect ETIMEDOUT 10.0.0.1:7450",
+          "UNAVAILABLE",
+          {},
+        );
+      });
+
+      // Mock refreshTopology to point shard to server-b
+      (client as any).refreshTopology = vi.fn().mockImplementation(async () => {
+        (client as any)._shardToServer.set(SHARD_ID, "10.0.0.2:7450");
+        const newConn = (client as any)._getOrCreateConnection("10.0.0.2:7450");
+        newConn.client.leaseTasks = vi.fn().mockReturnValue({
+          response: Promise.resolve({ tasks: [], refreshTasks: [] }),
+        });
+      });
+
+      const result = await client.leaseTasks({
+        shard: SHARD_ID,
+        workerId: "worker-1",
+        maxTasks: 1,
+        taskGroup: "default",
+      });
+
+      expect(result.tasks).toEqual([]);
+      expect((client as any).refreshTopology).toHaveBeenCalled();
+      expect(staleConn.client.leaseTasks).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries round-robin leaseTasks on a different server after UNAVAILABLE", async () => {
+      client = new SiloGRPCClient({
+        servers: "localhost:7450",
+        useTls: false,
+        shardRouting: {
+          maxRetries: 3,
+          retryDelayMs: 1,
+          topologyRefreshIntervalMs: 0,
+        },
+      });
+
+      // Set up topology with two servers
+      (client as any)._shards = [
+        {
+          shardId: "00000000-0000-0000-0000-000000000001",
+          serverAddr: "10.0.0.1:7450",
+          rangeStart: "",
+          rangeEnd: "8",
+        },
+        {
+          shardId: "00000000-0000-0000-0000-000000000002",
+          serverAddr: "10.0.0.2:7450",
+          rangeStart: "8",
+          rangeEnd: "",
+        },
+      ];
+      (client as any)._shardToServer.set(
+        "00000000-0000-0000-0000-000000000001",
+        "10.0.0.1:7450",
+      );
+      (client as any)._shardToServer.set(
+        "00000000-0000-0000-0000-000000000002",
+        "10.0.0.2:7450",
+      );
+      (client as any)._topologyReady = true;
+
+      // Clear the initial localhost connection so round-robin only sees our test servers
+      (client as any)._connections.clear();
+
+      // First server is dead
+      const deadConn = (client as any)._getOrCreateConnection("10.0.0.1:7450");
+      deadConn.client.leaseTasks = vi.fn().mockImplementation(() => {
+        throw new RpcError("connect ETIMEDOUT", "UNAVAILABLE", {});
+      });
+
+      // Second server is healthy
+      const healthyConn = (client as any)._getOrCreateConnection(
+        "10.0.0.2:7450",
+      );
+      healthyConn.client.leaseTasks = vi.fn().mockReturnValue({
+        response: Promise.resolve({ tasks: [], refreshTasks: [] }),
+      });
+
+      // Mock refreshTopology as no-op (topology is already correct, just need round-robin to advance)
+      (client as any).refreshTopology = vi.fn().mockResolvedValue(undefined);
+
+      // Force round-robin to start at the dead server
+      (client as any)._anyClientCounter = 0;
+
+      const result = await client.leaseTasks({
+        workerId: "worker-1",
+        maxTasks: 1,
+        taskGroup: "default",
+      });
+
+      expect(result.tasks).toEqual([]);
+      expect((client as any).refreshTopology).toHaveBeenCalled();
+      expect(deadConn.client.leaseTasks).toHaveBeenCalledTimes(1);
+    });
+
     it("gives up after maxRetries even with UNAVAILABLE errors", async () => {
       client = new SiloGRPCClient({
         servers: "localhost:7450",

--- a/typescript_client/test/shard-routing.test.ts
+++ b/typescript_client/test/shard-routing.test.ts
@@ -1,5 +1,19 @@
-import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
-import { SiloGRPCClient, shardForTenant, hashTenant, initHasher, type ShardInfoWithRange } from "../src/client";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  afterEach,
+  beforeAll,
+  beforeEach,
+} from "vitest";
+import {
+  SiloGRPCClient,
+  shardForTenant,
+  hashTenant,
+  initHasher,
+  type ShardInfoWithRange,
+} from "../src/client";
 import { RpcError } from "@protobuf-ts/runtime-rpc";
 
 describe("Shard Routing", () => {
@@ -28,18 +42,37 @@ describe("Shard Routing", () => {
   describe("shardForTenant lexicographic lookup (expects hash-space keys)", () => {
     it("finds correct shard for key in range", () => {
       const shards: ShardInfoWithRange[] = [
-        { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "8000000000000000" },
-        { shardId: "shard-2", serverAddr: "server-b:7450", rangeStart: "8000000000000000", rangeEnd: "" },
+        {
+          shardId: "shard-1",
+          serverAddr: "server-a:7450",
+          rangeStart: "",
+          rangeEnd: "8000000000000000",
+        },
+        {
+          shardId: "shard-2",
+          serverAddr: "server-b:7450",
+          rangeStart: "8000000000000000",
+          rangeEnd: "",
+        },
       ];
 
       // Keys in hash space — direct lexicographic comparison
-      expect(shardForTenant("3000000000000000", shards)?.shardId).toBe("shard-1");
-      expect(shardForTenant("a000000000000000", shards)?.shardId).toBe("shard-2");
+      expect(shardForTenant("3000000000000000", shards)?.shardId).toBe(
+        "shard-1",
+      );
+      expect(shardForTenant("a000000000000000", shards)?.shardId).toBe(
+        "shard-2",
+      );
     });
 
     it("handles single full-range shard", () => {
       const shards: ShardInfoWithRange[] = [
-        { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "" },
+        {
+          shardId: "shard-1",
+          serverAddr: "server-a:7450",
+          rangeStart: "",
+          rangeEnd: "",
+        },
       ];
 
       expect(shardForTenant("anything", shards)?.shardId).toBe("shard-1");
@@ -51,22 +84,60 @@ describe("Shard Routing", () => {
 
     it("handles multiple shard ranges", () => {
       const shards: ShardInfoWithRange[] = [
-        { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "4000000000000000" },
-        { shardId: "shard-2", serverAddr: "server-b:7450", rangeStart: "4000000000000000", rangeEnd: "8000000000000000" },
-        { shardId: "shard-3", serverAddr: "server-a:7450", rangeStart: "8000000000000000", rangeEnd: "c000000000000000" },
-        { shardId: "shard-4", serverAddr: "server-b:7450", rangeStart: "c000000000000000", rangeEnd: "" },
+        {
+          shardId: "shard-1",
+          serverAddr: "server-a:7450",
+          rangeStart: "",
+          rangeEnd: "4000000000000000",
+        },
+        {
+          shardId: "shard-2",
+          serverAddr: "server-b:7450",
+          rangeStart: "4000000000000000",
+          rangeEnd: "8000000000000000",
+        },
+        {
+          shardId: "shard-3",
+          serverAddr: "server-a:7450",
+          rangeStart: "8000000000000000",
+          rangeEnd: "c000000000000000",
+        },
+        {
+          shardId: "shard-4",
+          serverAddr: "server-b:7450",
+          rangeStart: "c000000000000000",
+          rangeEnd: "",
+        },
       ];
 
-      expect(shardForTenant("1000000000000000", shards)?.shardId).toBe("shard-1");
-      expect(shardForTenant("5000000000000000", shards)?.shardId).toBe("shard-2");
-      expect(shardForTenant("9000000000000000", shards)?.shardId).toBe("shard-3");
-      expect(shardForTenant("d000000000000000", shards)?.shardId).toBe("shard-4");
+      expect(shardForTenant("1000000000000000", shards)?.shardId).toBe(
+        "shard-1",
+      );
+      expect(shardForTenant("5000000000000000", shards)?.shardId).toBe(
+        "shard-2",
+      );
+      expect(shardForTenant("9000000000000000", shards)?.shardId).toBe(
+        "shard-3",
+      );
+      expect(shardForTenant("d000000000000000", shards)?.shardId).toBe(
+        "shard-4",
+      );
     });
 
     it("end-to-end: hashTenant + shardForTenant routes tenants correctly", () => {
       const shards: ShardInfoWithRange[] = [
-        { shardId: "shard-1", serverAddr: "server-a:7450", rangeStart: "", rangeEnd: "8000000000000000" },
-        { shardId: "shard-2", serverAddr: "server-b:7450", rangeStart: "8000000000000000", rangeEnd: "" },
+        {
+          shardId: "shard-1",
+          serverAddr: "server-a:7450",
+          rangeStart: "",
+          rangeEnd: "8000000000000000",
+        },
+        {
+          shardId: "shard-2",
+          serverAddr: "server-b:7450",
+          rangeStart: "8000000000000000",
+          rangeEnd: "",
+        },
       ];
 
       // Hash first, then look up — this is what _resolveShard does
@@ -147,18 +218,18 @@ describe("Shard Routing", () => {
 
       const topology = client.getTopology();
       expect(topology.shards.length).toBe(4);
-      expect(topology.shardToServer.get("00000000-0000-0000-0000-000000000001")).toBe(
-        "server-a:7450",
-      );
-      expect(topology.shardToServer.get("00000000-0000-0000-0000-000000000002")).toBe(
-        "server-b:7450",
-      );
-      expect(topology.shardToServer.get("00000000-0000-0000-0000-000000000003")).toBe(
-        "server-a:7450",
-      );
-      expect(topology.shardToServer.get("00000000-0000-0000-0000-000000000004")).toBe(
-        "server-b:7450",
-      );
+      expect(
+        topology.shardToServer.get("00000000-0000-0000-0000-000000000001"),
+      ).toBe("server-a:7450");
+      expect(
+        topology.shardToServer.get("00000000-0000-0000-0000-000000000002"),
+      ).toBe("server-b:7450");
+      expect(
+        topology.shardToServer.get("00000000-0000-0000-0000-000000000003"),
+      ).toBe("server-a:7450");
+      expect(
+        topology.shardToServer.get("00000000-0000-0000-0000-000000000004"),
+      ).toBe("server-b:7450");
     });
 
     it("creates connections to discovered servers", async () => {
@@ -237,9 +308,9 @@ describe("Shard Routing", () => {
 
       const topology = client.getTopology();
       expect(topology.shards.length).toBe(1);
-      expect(topology.shardToServer.get("00000000-0000-0000-0000-000000000001")).toBe(
-        "working-server:7450",
-      );
+      expect(
+        topology.shardToServer.get("00000000-0000-0000-0000-000000000001"),
+      ).toBe("working-server:7450");
     });
 
     it("throws if all servers fail during topology refresh after exhausting retries", async () => {
@@ -256,6 +327,532 @@ describe("Shard Routing", () => {
       await expect(client.refreshTopology()).rejects.toThrow(
         "Failed to refresh cluster topology from any server",
       );
+    });
+
+    it("applies per-server timeout to getClusterInfo calls during refresh", async () => {
+      client.close();
+      client = new SiloGRPCClient({
+        servers: "localhost:7450",
+        useTls: false,
+        shardRouting: {
+          topologyRefreshIntervalMs: 0,
+          topologyRefreshTimeoutMs: 5000,
+        },
+      });
+
+      const capturedOptions: any[] = [];
+      const mockGetClusterInfo = vi
+        .fn()
+        .mockImplementation((_req: any, opts: any) => {
+          capturedOptions.push(opts);
+          return {
+            response: Promise.resolve({
+              numShards: 1,
+              shardOwners: [
+                {
+                  shardId: "00000000-0000-0000-0000-000000000001",
+                  grpcAddr: "localhost:7450",
+                  nodeId: "node-1",
+                  rangeStart: "",
+                  rangeEnd: "",
+                },
+              ],
+              thisNodeId: "node-1",
+              thisGrpcAddr: "localhost:7450",
+            }),
+          };
+        });
+
+      const connections = (client as any)._connections as Map<string, any>;
+      const conn = connections.values().next().value;
+      conn.client.getClusterInfo = mockGetClusterInfo;
+
+      await client.refreshTopology();
+
+      expect(capturedOptions.length).toBe(1);
+      expect(capturedOptions[0].timeout).toBe(5000);
+    });
+
+    it("uses default 10s timeout when topologyRefreshTimeoutMs is not set", async () => {
+      const capturedOptions: any[] = [];
+      const mockGetClusterInfo = vi
+        .fn()
+        .mockImplementation((_req: any, opts: any) => {
+          capturedOptions.push(opts);
+          return {
+            response: Promise.resolve({
+              numShards: 1,
+              shardOwners: [
+                {
+                  shardId: "00000000-0000-0000-0000-000000000001",
+                  grpcAddr: "localhost:7450",
+                  nodeId: "node-1",
+                  rangeStart: "",
+                  rangeEnd: "",
+                },
+              ],
+              thisNodeId: "node-1",
+              thisGrpcAddr: "localhost:7450",
+            }),
+          };
+        });
+
+      const connections = (client as any)._connections as Map<string, any>;
+      const conn = connections.values().next().value;
+      conn.client.getClusterInfo = mockGetClusterInfo;
+
+      await client.refreshTopology();
+
+      expect(capturedOptions.length).toBe(1);
+      expect(capturedOptions[0].timeout).toBe(10_000);
+    });
+
+    it("moves to next server when getClusterInfo times out on first server", async () => {
+      client.close();
+      client = new SiloGRPCClient({
+        servers: ["slow-server:7450", "fast-server:7450"],
+        useTls: false,
+        shardRouting: {
+          topologyRefreshIntervalMs: 0,
+          topologyRefreshTimeoutMs: 100,
+        },
+      });
+
+      const connections = (client as any)._connections as Map<string, any>;
+
+      // First server hangs (never resolves, simulating a timeout that gRPC would enforce)
+      const slowConn = connections.get("slow-server:7450");
+      slowConn.client.getClusterInfo = vi.fn().mockReturnValue({
+        response: new Promise((_resolve, reject) => {
+          setTimeout(() => reject(new Error("DEADLINE_EXCEEDED")), 50);
+        }),
+      });
+
+      // Second server responds immediately
+      const fastConn = connections.get("fast-server:7450");
+      fastConn.client.getClusterInfo = vi.fn().mockReturnValue({
+        response: Promise.resolve({
+          numShards: 1,
+          shardOwners: [
+            {
+              shardId: "00000000-0000-0000-0000-000000000001",
+              grpcAddr: "fast-server:7450",
+              nodeId: "node-1",
+              rangeStart: "",
+              rangeEnd: "",
+            },
+          ],
+          thisNodeId: "node-1",
+          thisGrpcAddr: "fast-server:7450",
+        }),
+      });
+
+      await client.refreshTopology();
+
+      const topology = client.getTopology();
+      expect(topology.shards.length).toBe(1);
+      expect(
+        topology.shardToServer.get("00000000-0000-0000-0000-000000000001"),
+      ).toBe("fast-server:7450");
+    });
+
+    it("cleans up stale connections after topology refresh", async () => {
+      // Simulate first topology refresh that discovers two servers by pod IP
+      const mockGetClusterInfo = vi.fn().mockReturnValue({
+        response: Promise.resolve({
+          numShards: 2,
+          shardOwners: [
+            {
+              shardId: "00000000-0000-0000-0000-000000000001",
+              grpcAddr: "10.0.0.1:7450",
+              nodeId: "node-a",
+              rangeStart: "",
+              rangeEnd: "8000000000000000",
+            },
+            {
+              shardId: "00000000-0000-0000-0000-000000000002",
+              grpcAddr: "10.0.0.2:7450",
+              nodeId: "node-b",
+              rangeStart: "8000000000000000",
+              rangeEnd: "",
+            },
+          ],
+          thisNodeId: "node-a",
+          thisGrpcAddr: "10.0.0.1:7450",
+        }),
+      });
+
+      const connections = (client as any)._connections as Map<string, any>;
+      const conn = connections.values().next().value;
+      conn.client.getClusterInfo = mockGetClusterInfo;
+
+      await client.refreshTopology();
+
+      // Should have connections to initial server + two discovered pod IPs
+      expect(connections.has("localhost:7450")).toBe(true);
+      expect(connections.has("10.0.0.1:7450")).toBe(true);
+      expect(connections.has("10.0.0.2:7450")).toBe(true);
+
+      // Now simulate pod restart: node-b gets new IP 10.0.0.3
+      // The response comes from the initial server (localhost:7450)
+      const updatedMock = vi.fn().mockReturnValue({
+        response: Promise.resolve({
+          numShards: 2,
+          shardOwners: [
+            {
+              shardId: "00000000-0000-0000-0000-000000000001",
+              grpcAddr: "10.0.0.1:7450",
+              nodeId: "node-a",
+              rangeStart: "",
+              rangeEnd: "8000000000000000",
+            },
+            {
+              shardId: "00000000-0000-0000-0000-000000000002",
+              grpcAddr: "10.0.0.3:7450",
+              nodeId: "node-b",
+              rangeStart: "8000000000000000",
+              rangeEnd: "",
+            },
+          ],
+          thisNodeId: "node-a",
+          thisGrpcAddr: "10.0.0.1:7450",
+        }),
+      });
+
+      // The refresh will try connections in order. Mock all of them to use the updated response.
+      for (const [, c] of connections) {
+        c.client.getClusterInfo = updatedMock;
+      }
+
+      await client.refreshTopology();
+
+      // Old pod IP should be removed
+      expect(connections.has("10.0.0.2:7450")).toBe(false);
+      // New pod IP should be present
+      expect(connections.has("10.0.0.3:7450")).toBe(true);
+      // Initial server should be preserved (never cleaned up)
+      expect(connections.has("localhost:7450")).toBe(true);
+      // Still-active server should be preserved
+      expect(connections.has("10.0.0.1:7450")).toBe(true);
+    });
+
+    it("preserves initial server connections even when not in topology response", async () => {
+      // The initial DNS-based server might not appear in the topology
+      // (the topology response uses pod IPs), but we should keep it
+      const mockGetClusterInfo = vi.fn().mockReturnValue({
+        response: Promise.resolve({
+          numShards: 1,
+          shardOwners: [
+            {
+              shardId: "00000000-0000-0000-0000-000000000001",
+              grpcAddr: "10.0.0.1:7450",
+              nodeId: "node-a",
+              rangeStart: "",
+              rangeEnd: "",
+            },
+          ],
+          thisNodeId: "node-a",
+          thisGrpcAddr: "10.0.0.1:7450",
+        }),
+      });
+
+      const connections = (client as any)._connections as Map<string, any>;
+      const conn = connections.values().next().value;
+      conn.client.getClusterInfo = mockGetClusterInfo;
+
+      await client.refreshTopology();
+
+      // localhost:7450 is the initial server and should be kept even though
+      // the topology only references 10.0.0.1:7450
+      expect(connections.has("localhost:7450")).toBe(true);
+      expect(connections.has("10.0.0.1:7450")).toBe(true);
+    });
+
+    it("closes transport on stale connections during cleanup", async () => {
+      const mockGetClusterInfo = vi.fn().mockReturnValue({
+        response: Promise.resolve({
+          numShards: 1,
+          shardOwners: [
+            {
+              shardId: "00000000-0000-0000-0000-000000000001",
+              grpcAddr: "10.0.0.1:7450",
+              nodeId: "node-a",
+              rangeStart: "",
+              rangeEnd: "",
+            },
+          ],
+          thisNodeId: "node-a",
+          thisGrpcAddr: "10.0.0.1:7450",
+        }),
+      });
+
+      const connections = (client as any)._connections as Map<string, any>;
+      const conn = connections.values().next().value;
+      conn.client.getClusterInfo = mockGetClusterInfo;
+
+      // First refresh: discover 10.0.0.1
+      await client.refreshTopology();
+
+      // Grab a reference to the old connection and spy on its transport.close
+      const oldConn = connections.get("10.0.0.1:7450");
+      const closeSpy = vi.spyOn(oldConn.transport, "close");
+
+      // Second refresh: pod IP changed to 10.0.0.2
+      const updatedMock = vi.fn().mockReturnValue({
+        response: Promise.resolve({
+          numShards: 1,
+          shardOwners: [
+            {
+              shardId: "00000000-0000-0000-0000-000000000001",
+              grpcAddr: "10.0.0.2:7450",
+              nodeId: "node-a",
+              rangeStart: "",
+              rangeEnd: "",
+            },
+          ],
+          thisNodeId: "node-a",
+          thisGrpcAddr: "10.0.0.2:7450",
+        }),
+      });
+
+      // Mock the initial server's getClusterInfo since it will be tried first
+      const initialConn = connections.get("localhost:7450");
+      initialConn.client.getClusterInfo = updatedMock;
+
+      await client.refreshTopology();
+
+      // The old connection's transport should have been closed
+      expect(closeSpy).toHaveBeenCalled();
+      expect(connections.has("10.0.0.1:7450")).toBe(false);
+      expect(connections.has("10.0.0.2:7450")).toBe(true);
+    });
+  });
+
+  describe("Connectivity error retry with topology refresh", () => {
+    let client: SiloGRPCClient;
+
+    afterEach(() => {
+      client.close();
+    });
+
+    it("retries on a different server after UNAVAILABLE triggers topology refresh", async () => {
+      client = new SiloGRPCClient({
+        servers: "localhost:7450",
+        useTls: false,
+        shardRouting: {
+          maxRetries: 3,
+          retryDelayMs: 1,
+          topologyRefreshIntervalMs: 0,
+        },
+      });
+
+      // Set up initial topology: shard → server-a (stale pod IP)
+      (client as any)._shards = [
+        {
+          shardId: "00000000-0000-0000-0000-000000000001",
+          serverAddr: "10.0.0.1:7450",
+          rangeStart: "",
+          rangeEnd: "",
+        },
+      ];
+      (client as any)._shardToServer.set(
+        "00000000-0000-0000-0000-000000000001",
+        "10.0.0.1:7450",
+      );
+      (client as any)._topologyReady = true;
+
+      const connections = (client as any)._connections as Map<string, any>;
+
+      // Create connection to stale server-a that will return UNAVAILABLE
+      const staleConn = (client as any)._getOrCreateConnection("10.0.0.1:7450");
+      staleConn.client.enqueue = vi.fn().mockImplementation(() => {
+        throw new RpcError(
+          "connect ETIMEDOUT 10.0.0.1:7450",
+          "UNAVAILABLE",
+          {},
+        );
+      });
+
+      // Mock refreshTopology to simulate discovering the shard moved to server-b
+      let refreshCalled = false;
+      const originalRefresh = client.refreshTopology.bind(client);
+      (client as any).refreshTopology = vi.fn().mockImplementation(async () => {
+        refreshCalled = true;
+        // Update topology: shard now lives on server-b (new pod IP)
+        (client as any)._shards = [
+          {
+            shardId: "00000000-0000-0000-0000-000000000001",
+            serverAddr: "10.0.0.2:7450",
+            rangeStart: "",
+            rangeEnd: "",
+          },
+        ];
+        (client as any)._shardToServer.set(
+          "00000000-0000-0000-0000-000000000001",
+          "10.0.0.2:7450",
+        );
+
+        // Create connection to new server-b that succeeds
+        const newConn = (client as any)._getOrCreateConnection("10.0.0.2:7450");
+        newConn.client.enqueue = vi.fn().mockReturnValue({
+          response: Promise.resolve({ id: "job-success" }),
+        });
+      });
+
+      const handle = await client.enqueue({
+        tenant: "test-tenant",
+        payload: { test: true },
+        taskGroup: "default",
+      });
+
+      expect(handle.id).toBe("job-success");
+      expect(refreshCalled).toBe(true);
+      // The stale server should have been tried exactly once before refreshing
+      expect(staleConn.client.enqueue).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries reportOutcome on a different server after UNAVAILABLE triggers topology refresh", async () => {
+      client = new SiloGRPCClient({
+        servers: "localhost:7450",
+        useTls: false,
+        shardRouting: {
+          maxRetries: 3,
+          retryDelayMs: 1,
+          topologyRefreshIntervalMs: 0,
+        },
+      });
+
+      const SHARD_ID = "00000000-0000-0000-0000-000000000001";
+
+      // Set up initial topology: shard → server-a
+      (client as any)._shards = [
+        {
+          shardId: SHARD_ID,
+          serverAddr: "10.0.0.1:7450",
+          rangeStart: "",
+          rangeEnd: "",
+        },
+      ];
+      (client as any)._shardToServer.set(SHARD_ID, "10.0.0.1:7450");
+      (client as any)._topologyReady = true;
+
+      // Create stale connection that returns UNAVAILABLE
+      const staleConn = (client as any)._getOrCreateConnection("10.0.0.1:7450");
+      staleConn.client.reportOutcome = vi.fn().mockImplementation(() => {
+        throw new RpcError(
+          "connect ETIMEDOUT 10.0.0.1:7450",
+          "UNAVAILABLE",
+          {},
+        );
+      });
+
+      // Mock refreshTopology to point shard to server-b
+      (client as any).refreshTopology = vi.fn().mockImplementation(async () => {
+        (client as any)._shardToServer.set(SHARD_ID, "10.0.0.2:7450");
+        const newConn = (client as any)._getOrCreateConnection("10.0.0.2:7450");
+        newConn.client.reportOutcome = vi.fn().mockReturnValue({
+          response: Promise.resolve({}),
+        });
+      });
+
+      await client.reportOutcome({
+        taskId: "task-1",
+        shard: SHARD_ID,
+        outcome: { type: "success", result: { ok: true } },
+      });
+
+      expect((client as any).refreshTopology).toHaveBeenCalled();
+      expect(staleConn.client.reportOutcome).toHaveBeenCalledTimes(1);
+    });
+
+    it("gives up after maxRetries even with UNAVAILABLE errors", async () => {
+      client = new SiloGRPCClient({
+        servers: "localhost:7450",
+        useTls: false,
+        shardRouting: {
+          maxRetries: 2,
+          retryDelayMs: 1,
+          topologyRefreshIntervalMs: 0,
+        },
+      });
+
+      // Set up topology
+      (client as any)._shards = [
+        {
+          shardId: "00000000-0000-0000-0000-000000000001",
+          serverAddr: "10.0.0.1:7450",
+          rangeStart: "",
+          rangeEnd: "",
+        },
+      ];
+      (client as any)._shardToServer.set(
+        "00000000-0000-0000-0000-000000000001",
+        "10.0.0.1:7450",
+      );
+      (client as any)._topologyReady = true;
+
+      // Every server always returns UNAVAILABLE
+      const staleConn = (client as any)._getOrCreateConnection("10.0.0.1:7450");
+      staleConn.client.enqueue = vi.fn().mockImplementation(() => {
+        throw new RpcError("connect ETIMEDOUT", "UNAVAILABLE", {});
+      });
+
+      // Topology refresh doesn't help — same broken server
+      (client as any).refreshTopology = vi.fn().mockResolvedValue(undefined);
+
+      await expect(
+        client.enqueue({
+          tenant: "test-tenant",
+          payload: { test: true },
+          taskGroup: "default",
+        }),
+      ).rejects.toThrow("connect ETIMEDOUT");
+
+      // Initial call + 2 retries = 3 total attempts
+      expect(staleConn.client.enqueue).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not retry non-retryable errors like INVALID_ARGUMENT", async () => {
+      client = new SiloGRPCClient({
+        servers: "localhost:7450",
+        useTls: false,
+        shardRouting: {
+          maxRetries: 3,
+          retryDelayMs: 1,
+          topologyRefreshIntervalMs: 0,
+        },
+      });
+
+      (client as any)._shards = [
+        {
+          shardId: "00000000-0000-0000-0000-000000000001",
+          serverAddr: "localhost:7450",
+          rangeStart: "",
+          rangeEnd: "",
+        },
+      ];
+      (client as any)._shardToServer.set(
+        "00000000-0000-0000-0000-000000000001",
+        "localhost:7450",
+      );
+      (client as any)._topologyReady = true;
+
+      const connections = (client as any)._connections as Map<string, any>;
+      const conn = connections.values().next().value;
+      conn.client.enqueue = vi.fn().mockImplementation(() => {
+        throw new RpcError("invalid payload", "INVALID_ARGUMENT", {});
+      });
+
+      await expect(
+        client.enqueue({
+          tenant: "test-tenant",
+          payload: { test: true },
+          taskGroup: "default",
+        }),
+      ).rejects.toThrow("invalid payload");
+
+      // Should NOT retry — thrown immediately
+      expect(conn.client.enqueue).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -278,12 +875,14 @@ describe("Shard Routing", () => {
         const serviceConfig = JSON.parse(grpcOptions["grpc.service_config"]);
         expect(serviceConfig.methodConfig).toBeDefined();
         expect(serviceConfig.methodConfig[0].retryPolicy).toBeDefined();
-        expect(serviceConfig.methodConfig[0].retryPolicy.retryableStatusCodes).toContain(
-          "UNAVAILABLE",
-        );
-        expect(serviceConfig.methodConfig[0].retryPolicy.retryableStatusCodes).toContain(
-          "RESOURCE_EXHAUSTED",
-        );
+        // UNAVAILABLE is NOT retried at the gRPC level — our application-level
+        // retry handles it with topology refresh for smarter re-routing
+        expect(
+          serviceConfig.methodConfig[0].retryPolicy.retryableStatusCodes,
+        ).not.toContain("UNAVAILABLE");
+        expect(
+          serviceConfig.methodConfig[0].retryPolicy.retryableStatusCodes,
+        ).toContain("RESOURCE_EXHAUSTED");
       } finally {
         client.close();
       }
@@ -339,7 +938,10 @@ describe("Shard Routing", () => {
           rangeEnd: "",
         },
       ];
-      (c as any)._shardToServer.set("00000000-0000-0000-0000-000000000001", "localhost:7450");
+      (c as any)._shardToServer.set(
+        "00000000-0000-0000-0000-000000000001",
+        "localhost:7450",
+      );
       (c as any)._topologyReady = true;
     };
 
@@ -348,8 +950,8 @@ describe("Shard Routing", () => {
         servers: "localhost:7450",
         useTls: false,
         shardRouting: {
-          maxWrongShardRetries: 3,
-          wrongShardRetryDelayMs: 1, // Fast retries for tests
+          maxRetries: 3,
+          retryDelayMs: 1, // Fast retries for tests
           topologyRefreshIntervalMs: 0,
         },
       });
@@ -384,7 +986,9 @@ describe("Shard Routing", () => {
           "x-silo-shard-owner-node": "node-2",
         });
 
-        expect(error.meta?.["x-silo-shard-owner-addr"]).toBe("other-server:7450");
+        expect(error.meta?.["x-silo-shard-owner-addr"]).toBe(
+          "other-server:7450",
+        );
         expect(error.meta?.["x-silo-shard-owner-node"]).toBe("node-2");
       });
     });
@@ -420,7 +1024,7 @@ describe("Shard Routing", () => {
         expect(mockEnqueue).toHaveBeenCalledTimes(2);
       });
 
-      it("stops retrying after maxWrongShardRetries", async () => {
+      it("stops retrying after maxRetries", async () => {
         const mockEnqueue = vi.fn().mockImplementation(() => {
           throw new RpcError("shard not found", "NOT_FOUND", {});
         });
@@ -481,7 +1085,9 @@ describe("Shard Routing", () => {
         const conn = connections.values().next().value;
         conn.client.enqueue = mockEnqueue;
 
-        const originalGetOrCreate = (client as any)._getOrCreateConnection.bind(client);
+        const originalGetOrCreate = (client as any)._getOrCreateConnection.bind(
+          client,
+        );
         const getOrCreateSpy = vi.fn().mockImplementation((addr: string) => {
           const newConn = originalGetOrCreate(addr);
           newConn.client.enqueue = mockEnqueue;
@@ -577,7 +1183,10 @@ describe("Shard Routing", () => {
           rangeEnd: "",
         },
       ];
-      (c as any)._shardToServer.set("00000000-0000-0000-0000-000000000001", "localhost:7450");
+      (c as any)._shardToServer.set(
+        "00000000-0000-0000-0000-000000000001",
+        "localhost:7450",
+      );
       (c as any)._topologyReady = true;
     };
 
@@ -588,8 +1197,8 @@ describe("Shard Routing", () => {
         servers: "localhost:7450",
         useTls: false,
         shardRouting: {
-          maxWrongShardRetries: 3,
-          wrongShardRetryDelayMs: 1,
+          maxRetries: 3,
+          retryDelayMs: 1,
           topologyRefreshIntervalMs: 0,
         },
       });
@@ -654,7 +1263,7 @@ describe("Shard Routing", () => {
         expect(refreshSpy).toHaveBeenCalled();
       });
 
-      it("stops retrying after maxWrongShardRetries", async () => {
+      it("stops retrying after maxRetries", async () => {
         const mockReportOutcome = vi.fn().mockImplementation(() => {
           throw new RpcError("shard not found", "NOT_FOUND", {});
         });
@@ -721,7 +1330,7 @@ describe("Shard Routing", () => {
         expect(mockHeartbeat).toHaveBeenCalledTimes(2);
       });
 
-      it("stops retrying after maxWrongShardRetries", async () => {
+      it("stops retrying after maxRetries", async () => {
         const mockHeartbeat = vi.fn().mockImplementation(() => {
           throw new RpcError("shard not found", "NOT_FOUND", {});
         });
@@ -731,7 +1340,9 @@ describe("Shard Routing", () => {
         conn.client.heartbeat = mockHeartbeat;
         (client as any).refreshTopology = vi.fn().mockResolvedValue(undefined);
 
-        await expect(client.heartbeat("worker-1", "task-1", SHARD_ID)).rejects.toThrow();
+        await expect(
+          client.heartbeat("worker-1", "task-1", SHARD_ID),
+        ).rejects.toThrow();
 
         expect(mockHeartbeat).toHaveBeenCalledTimes(4);
       });
@@ -764,7 +1375,7 @@ describe("Shard Routing", () => {
         expect(mockReportRefreshOutcome).toHaveBeenCalledTimes(2);
       });
 
-      it("stops retrying after maxWrongShardRetries", async () => {
+      it("stops retrying after maxRetries", async () => {
         const mockReportRefreshOutcome = vi.fn().mockImplementation(() => {
           throw new RpcError("shard not found", "NOT_FOUND", {});
         });

--- a/typescript_client/test/toxiproxy-integration.test.ts
+++ b/typescript_client/test/toxiproxy-integration.test.ts
@@ -1,20 +1,40 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  afterEach,
+} from "vitest";
 import { SiloGRPCClient } from "../src/client";
-import { Toxiproxy, Proxy, type Latency, type Bandwidth, type Timeout, type Slicer, type Slowclose } from "toxiproxy-node-client";
+import {
+  Toxiproxy,
+  Proxy,
+  type Latency,
+  type Bandwidth,
+  type Timeout,
+  type Slicer,
+  type Slowclose,
+} from "toxiproxy-node-client";
 
 // Direct silo servers (for setup/verification)
-const SILO_SERVERS = (process.env.SILO_SERVERS || process.env.SILO_SERVER || "localhost:7450").split(
-  ",",
-);
+const SILO_SERVERS = (
+  process.env.SILO_SERVERS ||
+  process.env.SILO_SERVER ||
+  "localhost:7450"
+).split(",");
 
 // Toxiproxy-proxied silo servers
 const TOXIPROXY_SILO_SERVERS = (
   process.env.TOXIPROXY_SILO_SERVERS || "localhost:17450,localhost:17451"
 ).split(",");
 
-const TOXIPROXY_API_URL = process.env.TOXIPROXY_API_URL || "http://127.0.0.1:8474";
+const TOXIPROXY_API_URL =
+  process.env.TOXIPROXY_API_URL || "http://127.0.0.1:8474";
 
-const RUN_INTEGRATION = process.env.RUN_INTEGRATION === "true" || process.env.CI === "true";
+const RUN_INTEGRATION =
+  process.env.RUN_INTEGRATION === "true" || process.env.CI === "true";
 
 const DEFAULT_TASK_GROUP = "toxiproxy-test-group";
 
@@ -79,7 +99,9 @@ async function waitForClusterConvergence(
     }
 
     if (attempt === maxAttempts) {
-      throw new Error(`Cluster did not converge after ${maxAttempts} attempts.`);
+      throw new Error(
+        `Cluster did not converge after ${maxAttempts} attempts.`,
+      );
     }
 
     await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -105,7 +127,11 @@ function createProxyClient(): SiloGRPCClient {
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /** Retry an operation until it succeeds, instead of using a fixed sleep. */
-async function retryUntilSuccess<T>(fn: () => Promise<T>, maxAttempts = 30, delayMs = 100): Promise<T> {
+async function retryUntilSuccess<T>(
+  fn: () => Promise<T>,
+  maxAttempts = 30,
+  delayMs = 100,
+): Promise<T> {
   let lastError: unknown;
   for (let i = 0; i < maxAttempts; i++) {
     try {
@@ -138,7 +164,11 @@ function createFastFailProxyClient(): SiloGRPCClient {
   return new SiloGRPCClient({
     servers: TOXIPROXY_SILO_SERVERS,
     useTls: false,
-    shardRouting: { topologyRefreshIntervalMs: 0 },
+    shardRouting: {
+      topologyRefreshIntervalMs: 0,
+      maxRetries: 2,
+      retryDelayMs: 50,
+    },
     addressMap: ADDRESS_MAP,
     rpcOptions: { timeout: 1000 },
     grpcClientOptions: {
@@ -321,7 +351,9 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
       await toxic2.remove();
 
       // Retry until gRPC reconnects instead of a fixed sleep
-      const job = await retryUntilSuccess(() => proxyClient.getJob(handle.id, tenant));
+      const job = await retryUntilSuccess(() =>
+        proxyClient.getJob(handle.id, tenant),
+      );
       expect(job?.id).toBe(handle.id);
     });
   });
@@ -337,16 +369,34 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
       });
       expect(handle.id).toBeTruthy();
 
-      await silo1.update({ enabled: false, listen: silo1.listen, upstream: silo1.upstream });
-      await silo2.update({ enabled: false, listen: silo2.listen, upstream: silo2.upstream });
+      await silo1.update({
+        enabled: false,
+        listen: silo1.listen,
+        upstream: silo1.upstream,
+      });
+      await silo2.update({
+        enabled: false,
+        listen: silo2.listen,
+        upstream: silo2.upstream,
+      });
 
       await expect(proxyClient.getJob(handle.id, tenant)).rejects.toThrow();
 
-      await silo1.update({ enabled: true, listen: silo1.listen, upstream: silo1.upstream });
-      await silo2.update({ enabled: true, listen: silo2.listen, upstream: silo2.upstream });
+      await silo1.update({
+        enabled: true,
+        listen: silo1.listen,
+        upstream: silo1.upstream,
+      });
+      await silo2.update({
+        enabled: true,
+        listen: silo2.listen,
+        upstream: silo2.upstream,
+      });
 
       // Retry until gRPC reconnects instead of a fixed sleep
-      const job = await retryUntilSuccess(() => proxyClient.getJob(handle.id, tenant));
+      const job = await retryUntilSuccess(() =>
+        proxyClient.getJob(handle.id, tenant),
+      );
       expect(job?.id).toBe(handle.id);
     });
   });
@@ -414,7 +464,11 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
       const fastClient = createFastFailProxyClient();
       await fastClient.refreshTopology();
 
-      await silo1.update({ enabled: false, listen: silo1.listen, upstream: silo1.upstream });
+      await silo1.update({
+        enabled: false,
+        listen: silo1.listen,
+        upstream: silo1.upstream,
+      });
 
       const results: string[] = [];
       const errors: Error[] = [];
@@ -435,7 +489,11 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
 
       expect(results.length + errors.length).toBe(5);
 
-      await silo1.update({ enabled: true, listen: silo1.listen, upstream: silo1.upstream });
+      await silo1.update({
+        enabled: true,
+        listen: silo1.listen,
+        upstream: silo1.upstream,
+      });
       fastClient.close();
     });
   });
@@ -534,7 +592,10 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
       expect(handle.id).toBeTruthy();
 
       const job = await proxyClient.getJob(handle.id, tenant);
-      expect(job?.payload).toEqual({ test: "slicer-latency", items: [1, 2, 3, 4, 5] });
+      expect(job?.payload).toEqual({
+        test: "slicer-latency",
+        items: [1, 2, 3, 4, 5],
+      });
     });
   });
 
@@ -544,13 +605,29 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
       // instead of retrying each server with full backoff (~3s per server)
       const freshClient = createFastFailProxyClient();
 
-      await silo1.update({ enabled: false, listen: silo1.listen, upstream: silo1.upstream });
-      await silo2.update({ enabled: false, listen: silo2.listen, upstream: silo2.upstream });
+      await silo1.update({
+        enabled: false,
+        listen: silo1.listen,
+        upstream: silo1.upstream,
+      });
+      await silo2.update({
+        enabled: false,
+        listen: silo2.listen,
+        upstream: silo2.upstream,
+      });
 
       await expect(freshClient.refreshTopology()).rejects.toThrow();
 
-      await silo1.update({ enabled: true, listen: silo1.listen, upstream: silo1.upstream });
-      await silo2.update({ enabled: true, listen: silo2.listen, upstream: silo2.upstream });
+      await silo1.update({
+        enabled: true,
+        listen: silo1.listen,
+        upstream: silo1.upstream,
+      });
+      await silo2.update({
+        enabled: true,
+        listen: silo2.listen,
+        upstream: silo2.upstream,
+      });
 
       freshClient.close();
     });


### PR DESCRIPTION
## Summary
- Add configurable per-server timeout on topology refresh RPCs (default 10s) to prevent indefinite hangs when K8s pods restart with new IPs
- Clean up stale connections after successful topology refresh — connections to servers no longer in the topology are closed and removed
- Add app-level retry on UNAVAILABLE/DEADLINE_EXCEEDED errors with topology refresh, replacing wasteful gRPC-level retries against the same dead server
- Rename internal retry helpers and config fields for clarity (`_withWrongShardRetry` → `_withShardRetry`, `maxWrongShardRetries` → `maxRetries`, etc.)

## Test plan
- [x] Unit tests for topology refresh timeout application, server fallback, stale connection cleanup
- [x] Unit tests for connectivity error retry with topology refresh (UNAVAILABLE triggers retry + re-route)
- [x] Integration test with non-existent server as first server validates fallback to valid server
- [x] Toxiproxy integration tests updated for new retry behavior
- [x] Validated tests fail without implementation changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core client retry/routing behavior by adding application-level retries on connectivity failures and pruning/closing connections during topology refresh; mistakes could cause retry storms, missed routing updates, or dropped connections.
> 
> **Overview**
> Improves `SiloGRPCClient` resiliency by adding a configurable per-server `GetClusterInfo` timeout (`topologyRefreshTimeoutMs`, default 10s), skipping hung/bad servers, and **closing/removing stale connections** after a successful topology refresh.
> 
> Reworks shard-routing retries into a shared `_retryLoop` used by most operations (including `leaseTasks`), expanding retries from just *wrong-shard* errors to also include connectivity failures (`UNAVAILABLE`/`DEADLINE_EXCEEDED`) with topology refresh + exponential backoff; gRPC-level retries are narrowed to `RESOURCE_EXHAUSTED` only.
> 
> Renames routing config and helpers (`maxWrongShardRetries`→`maxRetries`, `wrongShardRetryDelayMs`→`retryDelayMs`, `_withWrongShardRetry*`→`_withShardRetry*`) and updates unit/integration/toxiproxy tests to cover the new timeout, cleanup, and connectivity-retry behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b5de3c774d0a733c1054c0cdc8acb15d1dc9212. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->