### PR TITLE
Fix broker scanner backoff for empty shards

### DIFF
--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -268,9 +268,10 @@ impl TaskBroker {
                 }
 
                 // Adjust backoff: stay aggressive when buffer needs filling
-                if broker.buffer.len() < broker.target_buffer / 2 {
-                    sleep_ms = min_sleep_ms;
-                } else if inserted == 0 {
+                // AND the scan actually found tasks to insert. If the scan
+                // found nothing, back off even if the buffer is low — the DB
+                // is empty and there's no point hammering it at 200 scans/s.
+                if inserted == 0 {
                     sleep_ms = (sleep_ms * 2).min(max_sleep_ms);
                 } else {
                     sleep_ms = min_sleep_ms;
@@ -288,6 +289,9 @@ impl TaskBroker {
                 tokio::select! {
                     biased;
                     _ = broker.notify.notified() => {
+                        // Reset backoff on explicit wakeup so the next scan
+                        // runs aggressively (e.g. after a dequeue claim).
+                        sleep_ms = min_sleep_ms;
                         debug!("broker woken by notification");
                     }
                     _ = &mut delay => {},


### PR DESCRIPTION
## Summary
- Fix broker scanner never backing off for empty shards — `buffer.len() < target_buffer / 2` was checked before `inserted == 0`, causing empty shards to scan at ~200/s indefinitely
- Reset backoff on explicit notify wakeup so scanner responds aggressively after dequeue claims

## Context
Under production load testing (10k jobs to one shard), `silo_broker_scan_duration_seconds` rose across **all** shards on a pod, not just the loaded one. The root cause was empty shards hammering SlateDB at 200 scans/s, consuming tokio runtime cycles and increasing scheduling delays at await points for all shards.

## Test plan
- [x] `cargo test --test job_store_shard_dequeue_tests` — all 12 pass
- [x] `cargo test --test job_store_shard_enqueue_tests` — all pass
- [x] `just fmt` — clean (no clippy warnings)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the broker scanner backoff behavior, which can affect task pickup latency and DB load if the new thresholds/backoff reset conditions are wrong. Scope is small and limited to the background scan loop.
> 
> **Overview**
> Fixes the `TaskBroker` scan loop to **exponentially back off whenever a scan inserts zero tasks**, even if the in-memory buffer is low, preventing empty shards from continuously hammering SlateDB.
> 
> Also resets the scan backoff to `min_sleep_ms` when the scanner is woken via `notify`, so post-claim wakeups trigger an aggressive follow-up scan.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb75211f4769c924009c63e6989cea60a5ca1eec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->