### PR TITLE
Fix inconsistent status_kind in tenants UI, add pagination

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -708,12 +708,24 @@ fn build_status_index_batch(
                     .map(|(_, id, _, _)| id.as_str())
                     .collect::<Vec<_>>(),
             )),
-            "status_kind" => Arc::new(StringArray::from(
-                chunk
-                    .iter()
-                    .map(|(_, _, sk, _)| Some(sk.as_str()))
-                    .collect::<Vec<_>>(),
-            )),
+            "status_kind" => {
+                // Apply the same Waiting/Scheduled logic as display_status_kind.
+                // For Scheduled jobs, the index timestamp is next_attempt_starts_after_ms
+                // (see status_index_timestamp). If that time has passed, the job is Waiting.
+                let now_ms = crate::job_store_shard::helpers::now_epoch_ms();
+                Arc::new(StringArray::from(
+                    chunk
+                        .iter()
+                        .map(|(_, _, sk, ts)| {
+                            if sk == "Scheduled" && *ts <= now_ms {
+                                Some("Waiting")
+                            } else {
+                                Some(sk.as_str())
+                            }
+                        })
+                        .collect::<Vec<_>>(),
+                ))
+            }
             "status_changed_at_ms" => Arc::new(Int64Array::from(
                 chunk
                     .iter()

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -273,6 +273,22 @@ struct ShardTemplate {
     split_error: Option<String>,
 }
 
+#[derive(serde::Deserialize)]
+pub struct TenantsParams {
+    #[serde(default = "default_page")]
+    page: usize,
+    #[serde(default = "default_per_page")]
+    per_page: usize,
+}
+
+fn default_page() -> usize {
+    1
+}
+
+fn default_per_page() -> usize {
+    50
+}
+
 #[derive(Template)]
 #[template(path = "tenants.html")]
 struct TenantsTemplate {
@@ -281,6 +297,9 @@ struct TenantsTemplate {
     tenants: Vec<TenantSummaryRow>,
     total_tenants: usize,
     total_jobs: usize,
+    page: usize,
+    per_page: usize,
+    total_pages: usize,
     error: Option<String>,
 }
 
@@ -1052,7 +1071,10 @@ async fn queue_handler(
     )
 }
 
-async fn tenants_handler(State(state): State<AppState>) -> impl IntoResponse {
+async fn tenants_handler(
+    State(state): State<AppState>,
+    Query(params): Query<TenantsParams>,
+) -> impl IntoResponse {
     if !state.config.tenancy.enabled {
         return Html(
             ErrorTemplate {
@@ -1109,7 +1131,7 @@ async fn tenants_handler(State(state): State<AppState>) -> impl IntoResponse {
                             let entry = status_by_tenant.entry(tenant).or_default();
                             entry.total += count;
                             match status {
-                                "Scheduled" => entry.scheduled += count,
+                                "Scheduled" | "Waiting" => entry.scheduled += count,
                                 "Running" => entry.running += count,
                                 "Succeeded" | "Failed" | "Cancelled" => entry.terminal += count,
                                 _ => {}
@@ -1215,8 +1237,9 @@ async fn tenants_handler(State(state): State<AppState>) -> impl IntoResponse {
     }
 
     tenants.sort_by(|a, b| {
-        b.job_count
-            .cmp(&a.job_count)
+        b.scheduled_count
+            .cmp(&a.scheduled_count)
+            .then_with(|| b.job_count.cmp(&a.job_count))
             .then_with(|| a.name.cmp(&b.name))
     });
 
@@ -1227,12 +1250,30 @@ async fn tenants_handler(State(state): State<AppState>) -> impl IntoResponse {
         Some(errors.join("\n"))
     };
 
+    // Pagination
+    let page = params.page.max(1);
+    let per_page = params.per_page.clamp(1, 500);
+    let total_pages = if total_tenants == 0 {
+        1
+    } else {
+        total_tenants.div_ceil(per_page)
+    };
+    let start = (page - 1) * per_page;
+    let paginated_tenants = if start < tenants.len() {
+        tenants[start..(start + per_page).min(tenants.len())].to_vec()
+    } else {
+        Vec::new()
+    };
+
     let template = TenantsTemplate {
         nav_active: "tenants",
         tenancy_enabled: true,
-        tenants,
+        tenants: paginated_tenants,
         total_tenants,
         total_jobs,
+        page,
+        per_page,
+        total_pages,
         error,
     };
 
@@ -1295,7 +1336,7 @@ async fn tenant_handler(
                             let count = counts_col.value(i).max(0) as usize;
                             counts.total += count;
                             match status {
-                                "Scheduled" => counts.scheduled += count,
+                                "Scheduled" | "Waiting" => counts.scheduled += count,
                                 "Running" => counts.running += count,
                                 "Succeeded" | "Failed" | "Cancelled" => counts.terminal += count,
                                 _ => {}
@@ -1383,7 +1424,7 @@ async fn tenant_handler(
     }
 
     let upcoming_sql = format!(
-        "SELECT shard_id, id, status_kind, priority, enqueue_time_ms FROM jobs WHERE tenant = '{}' AND status_kind = 'Scheduled' ORDER BY enqueue_time_ms ASC LIMIT 100",
+        "SELECT shard_id, id, status_kind, priority, enqueue_time_ms FROM jobs WHERE tenant = '{}' AND (status_kind = 'Scheduled' OR status_kind = 'Waiting') ORDER BY enqueue_time_ms ASC LIMIT 100",
         tenant_escaped
     );
     match state.query_engine.sql(&upcoming_sql).await {

--- a/templates/tenants.html
+++ b/templates/tenants.html
@@ -21,7 +21,7 @@
             <h2 class="text-sm font-semibold text-zinc-300">Tenant Overview</h2>
         </div>
         <div class="p-4">
-            {% if tenants.is_empty() %}
+            {% if tenants.is_empty() && page == 1 %}
             <div class="text-zinc-500 text-center py-8">No tenant activity found</div>
             {% else %}
             <div class="overflow-x-auto">
@@ -54,6 +54,27 @@
             </div>
             {% endif %}
         </div>
+
+        {% if total_pages > 1 %}
+        <div class="border-t border-zinc-700 px-4 py-3 flex items-center justify-between">
+            <div class="text-sm text-zinc-500">
+                Page {{ page }} of {{ total_pages }}
+            </div>
+            <div class="flex gap-2">
+                {% if page > 1 %}
+                <a href="/tenants?page={{ page - 1 }}&per_page={{ per_page }}" class="px-3 py-1 text-sm bg-zinc-700 text-zinc-300 hover:bg-zinc-600 border border-zinc-600">Previous</a>
+                {% else %}
+                <span class="px-3 py-1 text-sm bg-zinc-800 text-zinc-600 border border-zinc-700 cursor-not-allowed">Previous</span>
+                {% endif %}
+
+                {% if page < total_pages %}
+                <a href="/tenants?page={{ page + 1 }}&per_page={{ per_page }}" class="px-3 py-1 text-sm bg-zinc-700 text-zinc-300 hover:bg-zinc-600 border border-zinc-600">Next</a>
+                {% else %}
+                <span class="px-3 py-1 text-sm bg-zinc-800 text-zinc-600 border border-zinc-700 cursor-not-allowed">Next</span>
+                {% endif %}
+            </div>
+        </div>
+        {% endif %}
     </div>
 </div>
 {% endblock %}

--- a/tests/cluster_query_tests.rs
+++ b/tests/cluster_query_tests.rs
@@ -1540,3 +1540,251 @@ async fn cluster_query_webui_style_no_tenant_filter() {
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(total_rows, 2, "Should see jobs from all tenants");
 }
+
+/// Verifies that the status_kind aggregation query (used by the tenants page)
+/// returns consistent results regardless of which scan path is used.
+///
+/// The bug: the status index fast path returned raw "Scheduled" from the index,
+/// while the standard path (used for SELECT *) applied display_status_kind which
+/// converts "Scheduled" to "Waiting" for jobs whose start time has passed.
+/// This caused the tenants page to show 0 scheduled jobs when the shard was remote.
+#[silo::test]
+async fn cluster_query_status_kind_consistent_between_scan_paths() {
+    let (_temps, factory, shard_map) = create_multi_shard_factory(1).await;
+    let now = now_ms();
+
+    let shard = get_shard(&factory, &shard_map, 0);
+
+    // Enqueue waiting jobs (start time in the past → "Waiting")
+    for i in 0..3 {
+        shard
+            .enqueue(
+                "tenant-a",
+                Some(format!("waiting-{}", i)),
+                10,
+                now - 5000,
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue waiting");
+    }
+
+    // Enqueue future-scheduled jobs (start time in the future → "Scheduled")
+    for i in 0..2 {
+        shard
+            .enqueue(
+                "tenant-a",
+                Some(format!("future-{}", i)),
+                10,
+                now + 120_000,
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue future");
+    }
+
+    let engine = ClusterQueryEngine::new(factory.clone(), None)
+        .await
+        .expect("create engine");
+
+    // Query 1: Aggregation query (tenants page pattern) - uses status index fast path
+    // because DataFusion only projects tenant + status_kind for the GROUP BY
+    let agg_batches = query_collect(
+        &engine,
+        "SELECT tenant, status_kind, COUNT(*) as cnt FROM jobs GROUP BY tenant, status_kind ORDER BY status_kind",
+    )
+    .await;
+
+    let mut agg_counts: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    for batch in &agg_batches {
+        let statuses = batch
+            .column_by_name("status_kind")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let counts = batch
+            .column_by_name("cnt")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            let status = if statuses.is_null(i) {
+                "null".to_string()
+            } else {
+                statuses.value(i).to_string()
+            };
+            *agg_counts.entry(status).or_default() += counts.value(i);
+        }
+    }
+
+    // Query 2: Full SELECT (remote shard pattern) - uses standard/fullscan path
+    // which goes through display_status_kind
+    let full_batches = query_collect(
+        &engine,
+        "SELECT status_kind FROM jobs WHERE tenant = 'tenant-a'",
+    )
+    .await;
+
+    let mut full_counts: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    for batch in &full_batches {
+        let statuses = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            let status = if statuses.is_null(i) {
+                "null".to_string()
+            } else {
+                statuses.value(i).to_string()
+            };
+            *full_counts.entry(status).or_default() += 1;
+        }
+    }
+
+    // Both queries should produce the same status_kind distribution
+    assert_eq!(
+        agg_counts, full_counts,
+        "Status kind counts should be identical between aggregation (fast path) and full scan paths.\n\
+         Aggregation path: {:?}\n\
+         Full scan path: {:?}",
+        agg_counts, full_counts
+    );
+
+    // Specifically verify: 3 Waiting + 2 Scheduled = 5 total
+    assert_eq!(
+        agg_counts.get("Waiting").copied().unwrap_or(0),
+        3,
+        "Should have 3 Waiting jobs"
+    );
+    assert_eq!(
+        agg_counts.get("Scheduled").copied().unwrap_or(0),
+        2,
+        "Should have 2 Scheduled jobs"
+    );
+}
+
+/// Verifies the tenants page aggregation handles both Waiting and Scheduled statuses.
+/// This is the exact query pattern used by the tenants_handler.
+#[silo::test]
+async fn cluster_query_tenants_page_counts_all_scheduled_statuses() {
+    let (_temps, factory, shard_map) = create_multi_shard_factory(1).await;
+    let now = now_ms();
+
+    let shard = get_shard(&factory, &shard_map, 0);
+
+    // Tenant A: 3 waiting + 2 future-scheduled + 1 running
+    for i in 0..3 {
+        shard
+            .enqueue(
+                "tenant-a",
+                Some(format!("a-wait-{}", i)),
+                10,
+                now - 5000,
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+    }
+    for i in 0..2 {
+        shard
+            .enqueue(
+                "tenant-a",
+                Some(format!("a-future-{}", i)),
+                10,
+                now + 120_000,
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+    }
+    // Dequeue one to make it Running
+    shard
+        .dequeue("worker", "default", 1)
+        .await
+        .expect("dequeue");
+
+    let engine = ClusterQueryEngine::new(factory.clone(), None)
+        .await
+        .expect("create engine");
+
+    // This is the exact query the tenants_handler uses
+    let batches = query_collect(
+        &engine,
+        "SELECT tenant, status_kind, COUNT(*) as cnt FROM jobs GROUP BY tenant, status_kind",
+    )
+    .await;
+
+    // Simulate the tenants_handler aggregation logic
+    let mut scheduled_count: i64 = 0;
+    let mut running_count: i64 = 0;
+    let mut total_count: i64 = 0;
+
+    for batch in &batches {
+        let statuses = batch
+            .column_by_name("status_kind")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let counts = batch
+            .column_by_name("cnt")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            let count = counts.value(i);
+            total_count += count;
+            let status = if statuses.is_null(i) {
+                ""
+            } else {
+                statuses.value(i)
+            };
+            match status {
+                "Scheduled" | "Waiting" => scheduled_count += count,
+                "Running" => running_count += count,
+                _ => {}
+            }
+        }
+    }
+
+    assert_eq!(
+        total_count, 5,
+        "Should have 5 total jobs (3 waiting + 2 future)"
+    );
+    // 2 waiting (3 enqueued - 1 dequeued) + 2 future-scheduled = 4
+    assert_eq!(
+        scheduled_count, 4,
+        "Should count both Waiting and Scheduled as scheduled. Got {} scheduled out of {} total",
+        scheduled_count, total_count
+    );
+    assert_eq!(running_count, 1, "Should have 1 running job");
+
+    // Verify: total = scheduled + running (no terminal jobs, nothing missing)
+    assert_eq!(
+        total_count,
+        scheduled_count + running_count,
+        "All jobs should be accounted for: total={} but scheduled+running={}",
+        total_count,
+        scheduled_count + running_count
+    );
+}


### PR DESCRIPTION
## Summary
- **Bug fix**: The status index fast path returned raw `"Scheduled"` while the standard scan path returned `"Waiting"` for ready-to-run jobs. This caused the tenants page to show 0 scheduled jobs when the shard was served by a remote pod in the cluster.
- **Bug fix**: Tenant detail page upcoming jobs query only filtered `status_kind = 'Scheduled'`, missing all `'Waiting'` jobs.
- **Feature**: Added pagination to the tenants list page (default 50 per page) and changed sort order to scheduled count descending.

## Root cause
Two code paths in `query.rs` produced different `status_kind` values for the same jobs:
- `build_status_index_batch` (fast path for minimal projections like GROUP BY) returned raw `"Scheduled"` from the index
- `build_job_pairs_batch` (standard path via `display_status_kind`) returned `"Waiting"` for jobs whose `next_attempt_starts_after_ms <= now`

The webui handlers only matched `"Scheduled"`, so `"Waiting"` jobs were counted in total but not in the scheduled column.

## Test plan
- [x] Added `cluster_query_status_kind_consistent_between_scan_paths` test proving both scan paths produce identical status_kind distributions
- [x] Added `cluster_query_tenants_page_counts_all_scheduled_statuses` test verifying the exact tenants page aggregation pattern
- [x] All 32 cluster_query_tests pass
- [x] All 19 query_waiting_tests pass
- [x] All webui_tests pass
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `status_kind` is materialized in the status-index fast path and updates tenants counting queries/UI; this could subtly affect job status reporting and any downstream aggregations relying on the previous raw `Scheduled` values.
> 
> **Overview**
> Fixes an inconsistency where the status-index scan path returned raw `Scheduled` while the full scan could surface `Waiting` for ready-to-run jobs, by applying the same `Scheduled`→`Waiting` mapping when building `status_kind` batches.
> 
> Updates the web UI tenants views to treat `Waiting` as scheduled-equivalent (including the tenant detail “upcoming jobs” query), changes tenant sorting to prioritize scheduled volume, and adds pagination support (`page`/`per_page`, default 50) with template navigation.
> 
> Adds cluster query tests to ensure `status_kind` distributions match between scan paths and that tenants-page aggregation counts both `Scheduled` and `Waiting`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86737486774f25ff020bd463270e79a3bee69e41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->