### PR TITLE
Return failed_precondition when importing a running job

### DIFF
--- a/src/bin/siloctl.rs
+++ b/src/bin/siloctl.rs
@@ -244,8 +244,14 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 attempts,
             } => siloctl::job_get(&opts, &mut stdout, shard, id, *attempts).await,
             JobAction::Result { shard, id, format } => {
-                siloctl::job_result(&opts, &mut stdout, shard, id, format.to_bytes_output_format())
-                    .await
+                siloctl::job_result(
+                    &opts,
+                    &mut stdout,
+                    shard,
+                    id,
+                    format.to_bytes_output_format(),
+                )
+                .await
             }
             JobAction::Cancel { shard, id } => {
                 siloctl::job_cancel(&opts, &mut stdout, shard, id).await

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -87,11 +87,27 @@ pub struct ImportJobParams {
 impl JobStoreShard {
     /// Import a batch of jobs, returning per-job results.
     /// Each job is imported independently; failures don't affect other jobs in the batch.
+    /// Returns an error if any job in the batch already exists and is currently Running.
     pub async fn import_jobs(
         &self,
         tenant: &str,
         jobs: Vec<ImportJobParams>,
     ) -> Result<Vec<ImportJobResult>, JobStoreShardError> {
+        // Pre-check: reject the entire batch if any job is currently Running.
+        for params in &jobs {
+            if let Some(status) = self.get_job_status(tenant, &params.id).await? {
+                if status.kind == JobStatusKind::Running {
+                    return Err(JobStoreShardError::JobNotReimportable(
+                        JobNotReimportableError {
+                            job_id: params.id.clone(),
+                            status: JobStatusKind::Running,
+                            reason: "job is currently running".to_string(),
+                        },
+                    ));
+                }
+            }
+        }
+
         let mut results = Vec::with_capacity(jobs.len());
         for params in jobs {
             let job_id = params.id.clone();
@@ -102,14 +118,6 @@ impl JobStoreShard {
                     error: None,
                     status,
                 }),
-                Err(
-                    e @ JobStoreShardError::JobNotReimportable(JobNotReimportableError {
-                        status: JobStatusKind::Running,
-                        ..
-                    }),
-                ) => {
-                    return Err(e);
-                }
                 Err(e) => results.push(ImportJobResult {
                     job_id,
                     success: false,

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -102,6 +102,14 @@ impl JobStoreShard {
                     error: None,
                     status,
                 }),
+                Err(
+                    e @ JobStoreShardError::JobNotReimportable(JobNotReimportableError {
+                        status: JobStatusKind::Running,
+                        ..
+                    }),
+                ) => {
+                    return Err(e);
+                }
                 Err(e) => results.push(ImportJobResult {
                     job_id,
                     success: false,

--- a/src/server.rs
+++ b/src/server.rs
@@ -254,6 +254,9 @@ fn map_err(e: JobStoreShardError) -> Status {
             Status::failed_precondition("job is already in terminal state")
         }
         JobStoreShardError::JobNotRestartable(ref e) => Status::failed_precondition(e.to_string()),
+        JobStoreShardError::JobNotReimportable(ref e) => {
+            Status::failed_precondition(e.to_string())
+        }
         JobStoreShardError::JobNotExpediteable(ref e) => Status::failed_precondition(e.to_string()),
         JobStoreShardError::JobNotLeaseable(ref e) => Status::failed_precondition(e.to_string()),
         JobStoreShardError::InvalidArgument(ref msg) => Status::invalid_argument(msg.clone()),
@@ -1493,6 +1496,16 @@ impl Silo for SiloService {
                             status: job_status_kind_to_proto(result.status).into(),
                         });
                     }
+                }
+                Err(
+                    e @ JobStoreShardError::JobNotReimportable(
+                        crate::job_store_shard::import::JobNotReimportableError {
+                            status: crate::job::JobStatusKind::Running,
+                            ..
+                        },
+                    ),
+                ) => {
+                    return Err(map_err(e));
                 }
                 Err(e) => {
                     for idx in indices {

--- a/src/server.rs
+++ b/src/server.rs
@@ -254,9 +254,7 @@ fn map_err(e: JobStoreShardError) -> Status {
             Status::failed_precondition("job is already in terminal state")
         }
         JobStoreShardError::JobNotRestartable(ref e) => Status::failed_precondition(e.to_string()),
-        JobStoreShardError::JobNotReimportable(ref e) => {
-            Status::failed_precondition(e.to_string())
-        }
+        JobStoreShardError::JobNotReimportable(ref e) => Status::failed_precondition(e.to_string()),
         JobStoreShardError::JobNotExpediteable(ref e) => Status::failed_precondition(e.to_string()),
         JobStoreShardError::JobNotLeaseable(ref e) => Status::failed_precondition(e.to_string()),
         JobStoreShardError::InvalidArgument(ref msg) => Status::invalid_argument(msg.clone()),

--- a/tests/job_store_shard_import_tests.rs
+++ b/tests/job_store_shard_import_tests.rs
@@ -1356,10 +1356,7 @@ async fn reimport_running_job_in_batch_fails_entire_call() {
     // Import two jobs: one will be running, one will be idle
     let job_a = base_import_params("batch-run-a");
     let job_b = base_import_params("batch-run-b");
-    shard
-        .import_jobs("-", vec![job_a, job_b])
-        .await
-        .unwrap();
+    shard.import_jobs("-", vec![job_a, job_b]).await.unwrap();
 
     // Dequeue job_a to make it Running
     let dequeued = shard.dequeue("worker-1", "default", 1).await.unwrap();

--- a/tests/job_store_shard_import_tests.rs
+++ b/tests/job_store_shard_import_tests.rs
@@ -1334,18 +1334,53 @@ async fn reimport_running_job_fails() {
     let dequeued = shard.dequeue("worker-1", "default", 1).await.unwrap();
     assert_eq!(dequeued.tasks.len(), 1);
 
-    // Try reimport while Running
+    // Try reimport while Running — should return an error, not a per-job result
     let mut reimport = base_import_params("reimp-rej-run");
     reimport.attempts = vec![failed_attempt(1_700_000_001_000)];
 
-    let results = shard.import_jobs("-", vec![reimport]).await.unwrap();
-    assert!(!results[0].success);
+    let err = shard
+        .import_jobs("-", vec![reimport])
+        .await
+        .expect_err("import should fail when job is running");
+    let err_msg = err.to_string();
     assert!(
-        results[0]
-            .error
-            .as_ref()
-            .unwrap()
-            .contains("currently running")
+        err_msg.contains("currently running"),
+        "error should mention 'currently running', got: {err_msg}"
+    );
+}
+
+#[silo::test]
+async fn reimport_running_job_in_batch_fails_entire_call() {
+    let (_tmp, shard) = test_helpers::open_temp_shard().await;
+
+    // Import two jobs: one will be running, one will be idle
+    let job_a = base_import_params("batch-run-a");
+    let job_b = base_import_params("batch-run-b");
+    shard
+        .import_jobs("-", vec![job_a, job_b])
+        .await
+        .unwrap();
+
+    // Dequeue job_a to make it Running
+    let dequeued = shard.dequeue("worker-1", "default", 1).await.unwrap();
+    assert_eq!(dequeued.tasks.len(), 1);
+    assert_eq!(dequeued.tasks[0].job().id(), "batch-run-a");
+
+    // Try reimporting both — should error because job_a is Running
+    let mut reimport_a = base_import_params("batch-run-a");
+    reimport_a.attempts = vec![failed_attempt(1_700_000_001_000)];
+
+    let mut reimport_b = base_import_params("batch-run-b");
+    reimport_b.attempts = vec![failed_attempt(1_700_000_001_000)];
+
+    let err = shard
+        .import_jobs("-", vec![reimport_a, reimport_b])
+        .await
+        .expect_err("batch import should fail when any job is running");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("currently running"),
+        "error should mention 'currently running', got: {err_msg}"
     );
 }
 

--- a/tests/job_store_shard_import_tests.rs
+++ b/tests/job_store_shard_import_tests.rs
@@ -1363,21 +1363,35 @@ async fn reimport_running_job_in_batch_fails_entire_call() {
     assert_eq!(dequeued.tasks.len(), 1);
     assert_eq!(dequeued.tasks[0].job().id(), "batch-run-a");
 
-    // Try reimporting both — should error because job_a is Running
-    let mut reimport_a = base_import_params("batch-run-a");
-    reimport_a.attempts = vec![failed_attempt(1_700_000_001_000)];
-
+    // Try reimporting both — put the non-running job first so it gets committed
+    // in its own transaction before the running job causes the batch to error.
     let mut reimport_b = base_import_params("batch-run-b");
     reimport_b.attempts = vec![failed_attempt(1_700_000_001_000)];
 
+    let mut reimport_a = base_import_params("batch-run-a");
+    reimport_a.attempts = vec![failed_attempt(1_700_000_001_000)];
+
     let err = shard
-        .import_jobs("-", vec![reimport_a, reimport_b])
+        .import_jobs("-", vec![reimport_b, reimport_a])
         .await
         .expect_err("batch import should fail when any job is running");
     let err_msg = err.to_string();
     assert!(
         err_msg.contains("currently running"),
         "error should mention 'currently running', got: {err_msg}"
+    );
+
+    // job_b should have been successfully reimported before the error —
+    // each job is its own transaction, so committed work is not rolled back.
+    let status_b = shard
+        .get_job_status("-", "batch-run-b")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        status_b.kind,
+        JobStatusKind::Failed,
+        "batch-run-b should have been reimported to Failed before batch-run-a errored"
     );
 }
 

--- a/tests/job_store_shard_import_tests.rs
+++ b/tests/job_store_shard_import_tests.rs
@@ -1363,8 +1363,8 @@ async fn reimport_running_job_in_batch_fails_entire_call() {
     assert_eq!(dequeued.tasks.len(), 1);
     assert_eq!(dequeued.tasks[0].job().id(), "batch-run-a");
 
-    // Try reimporting both — put the non-running job first so it gets committed
-    // in its own transaction before the running job causes the batch to error.
+    // Try reimporting both — the pre-check detects batch-run-a is Running
+    // and rejects the entire batch before any imports happen.
     let mut reimport_b = base_import_params("batch-run-b");
     reimport_b.attempts = vec![failed_attempt(1_700_000_001_000)];
 
@@ -1381,8 +1381,8 @@ async fn reimport_running_job_in_batch_fails_entire_call() {
         "error should mention 'currently running', got: {err_msg}"
     );
 
-    // job_b should have been successfully reimported before the error —
-    // each job is its own transaction, so committed work is not rolled back.
+    // job_b should NOT have been reimported — the pre-check rejects the
+    // entire batch before any imports are attempted.
     let status_b = shard
         .get_job_status("-", "batch-run-b")
         .await
@@ -1390,8 +1390,8 @@ async fn reimport_running_job_in_batch_fails_entire_call() {
         .unwrap();
     assert_eq!(
         status_b.kind,
-        JobStatusKind::Failed,
-        "batch-run-b should have been reimported to Failed before batch-run-a errored"
+        JobStatusKind::Scheduled,
+        "batch-run-b should still be Scheduled (not reimported)"
     );
 }
 


### PR DESCRIPTION
## Summary

- ImportJobs RPC now returns a `failed_precondition` gRPC error when attempting to import a job that already exists and is currently in the Running state
- Previously this was returned as a per-job `success=false` result; now it surfaces as a proper RPC-level error
- Added `JobNotReimportable` handling to the `map_err` function in the server

## Context

For importing jobs we are doing a drain-style cutover: jobs must complete their running attempts before being imported to Silo. If they have extra attempts that's fine, as long as they are not currently running. This change makes the constraint explicit at the RPC level so callers get a clear error if they try to import a job that hasn't finished draining yet.

## Test plan

- [x] Updated `reimport_running_job_fails` to verify `import_jobs` returns `Err` (not a per-job result) when the target job is Running
- [x] Added `reimport_running_job_in_batch_fails_entire_call` to verify a batch import fails entirely when any job in the batch is Running
- [x] All 80 import tests pass