### PR TITLE
Add tenant status counters for query UI

### DIFF
--- a/benches/query_performance.rs
+++ b/benches/query_performance.rs
@@ -92,6 +92,14 @@ async fn main() {
     .await;
     r.print();
 
+    let r = bench_query(
+        &engine,
+        "tenant_status_counts",
+        "SELECT tenant, status_kind, cnt FROM tenant_counts",
+    )
+    .await;
+    r.print();
+
     println!();
 
     // --- Per-Tenant Queries (Large Tenant) ---

--- a/benches/query_profile.rs
+++ b/benches/query_profile.rs
@@ -75,6 +75,10 @@ async fn main() {
             "SELECT tenant, COUNT(*) as cnt FROM jobs WHERE status_kind NOT IN ('Succeeded','Failed','Cancelled') GROUP BY tenant ORDER BY cnt DESC LIMIT 20",
         ),
         (
+            "tenant_status_counts",
+            "SELECT tenant, status_kind, cnt FROM tenant_counts",
+        ),
+        (
             "large_tenant_count",
             "SELECT COUNT(*) FROM jobs WHERE tenant = 'tenant_001'",
         ),

--- a/docs/src/content/docs/guides/internals.mdx
+++ b/docs/src/content/docs/guides/internals.mdx
@@ -45,7 +45,7 @@ Silo uses the [storekey](https://crates.io/crates/storekey) crate for binary key
 | 0x09 | Concurrency holder | Tasks holding concurrency slots: `(tenant, queue, task_id)` |
 | 0x0A | Job cancelled | Cancellation flags: `(tenant, job_id)` |
 | 0x0B | Floating limit | Dynamic concurrency limit state: `(tenant, queue_key)` |
-| 0xF0-0xFF | System | Internal counters, cleanup state, and metadata |
+| 0xF0-0xFF | System | Internal counters, cleanup state, and metadata. Includes per-shard total/completed job counters (`0xF0`, `0xF1`), cleanup progress (`0xF2`-`0xF6`), per-queue concurrency requester counters (`0xF7`), and per-tenant status counters (`0xF8`) maintained via merge operator on every status transition. |
 
 ## Clustering approach
 

--- a/docs/src/content/docs/guides/querying.mdx
+++ b/docs/src/content/docs/guides/querying.mdx
@@ -127,6 +127,10 @@ Pre-computed per-tenant, per-status job counts. Backed by merge-operator counter
 | `status_kind` | String | Job status kind (Scheduled, Running, Succeeded, etc.) |
 | `cnt` | Int64 | Number of jobs with this tenant and status |
 
+`tenant_counts` is a sparse aggregation. It returns one row per `(tenant, status_kind)` pair with a positive count. Statuses with zero jobs are omitted rather than returned as `cnt = 0`, so a missing row should be interpreted as zero.
+
+For example, if a tenant has 12 `Scheduled` jobs and no `Running` jobs, `tenant_counts` returns a `Scheduled` row and no `Running` row.
+
 ## Status Values
 
 The `status_kind` column has the following values:
@@ -222,6 +226,14 @@ SELECT task_group, AVG(CAST(priority AS DOUBLE)) as avg_priority
 FROM jobs
 WHERE tenant = 'customer-123'
 GROUP BY task_group
+```
+
+```sql
+-- Fast per-tenant status counts using the pre-computed sparse counter table
+SELECT status_kind, cnt
+FROM tenant_counts
+WHERE tenant = 'customer-123'
+ORDER BY status_kind
 ```
 
 ### Querying Metadata

--- a/docs/src/content/docs/guides/querying.mdx
+++ b/docs/src/content/docs/guides/querying.mdx
@@ -80,7 +80,7 @@ Use `siloctl cluster info` to see all shards and their owners. If you know the t
 
 ## Tables
 
-Silo exposes two tables: `jobs` and `queues`.
+Silo exposes three tables: `jobs`, `queues`, and `tenant_counts`.
 
 ### `jobs` Table
 
@@ -115,6 +115,17 @@ Shows the current state of concurrency queues — which jobs hold concurrency ti
 | `job_id` | String (nullable) | Job ID (present for requesters) |
 | `priority` | UInt8 (nullable) | Job priority (present for requesters) |
 | `timestamp_ms` | Int64 | When the ticket was granted or the request was made |
+
+### `tenant_counts` Table
+
+Pre-computed per-tenant, per-status job counts. Backed by merge-operator counters maintained on every status transition, making this table very fast for tenant-level status aggregation (sub-millisecond vs full scan).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `shard_id` | String | UUID of the shard |
+| `tenant` | String | Tenant identifier |
+| `status_kind` | String | Job status kind (Scheduled, Running, Succeeded, etc.) |
+| `cnt` | Int64 | Number of jobs with this tenant and status |
 
 ## Status Values
 

--- a/src/bin/siloctl.rs
+++ b/src/bin/siloctl.rs
@@ -244,8 +244,14 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 attempts,
             } => siloctl::job_get(&opts, &mut stdout, shard, id, *attempts).await,
             JobAction::Result { shard, id, format } => {
-                siloctl::job_result(&opts, &mut stdout, shard, id, format.to_bytes_output_format())
-                    .await
+                siloctl::job_result(
+                    &opts,
+                    &mut stdout,
+                    shard,
+                    id,
+                    format.to_bytes_output_format(),
+                )
+                .await
             }
             JobAction::Cancel { shard, id } => {
                 siloctl::job_cancel(&opts, &mut stdout, shard, id).await

--- a/src/cluster_query.rs
+++ b/src/cluster_query.rs
@@ -38,7 +38,9 @@ use crate::factory::ShardFactory;
 use crate::job_store_shard::JobStoreShard;
 use crate::pb::QueryArrowRequest;
 use crate::pb::silo_client::SiloClient;
-use crate::query::{JobsScanner, QueuesScanner, ScannerRef, explain_dataframe};
+use crate::query::{
+    JobsScanner, QueuesScanner, ScannerRef, TenantCountsScanner, explain_dataframe,
+};
 use crate::shard_range::ShardId;
 
 /// Cluster-wide SQL query engine using DataFusion.
@@ -99,12 +101,23 @@ impl ClusterQueryEngine {
         let queues_schema = QueuesScanner::base_schema();
         let queues_provider = Arc::new(ClusterTableProvider::new(
             queues_schema,
-            factory,
-            coordinator,
+            factory.clone(),
+            coordinator.clone(),
             TableKind::Queues,
-            auth_token,
+            auth_token.clone(),
         ));
         ctx.register_table("queues", queues_provider)?;
+
+        // Register cluster-wide tenant_counts table
+        let tenant_counts_schema = TenantCountsScanner::base_schema();
+        let tenant_counts_provider = Arc::new(ClusterTableProvider::new(
+            tenant_counts_schema,
+            factory,
+            coordinator,
+            TableKind::TenantCounts,
+            auth_token,
+        ));
+        ctx.register_table("tenant_counts", tenant_counts_provider)?;
 
         Ok(Self { ctx })
     }
@@ -188,6 +201,7 @@ impl ClusterQueryEngine {
 enum TableKind {
     Jobs,
     Queues,
+    TenantCounts,
 }
 
 /// A TableProvider that spans multiple shards in the cluster.
@@ -444,6 +458,9 @@ impl ExecutionPlan for ClusterExecutionPlan {
                     let scanner: ScannerRef = match table_kind {
                         TableKind::Jobs => Arc::new(JobsScanner::new(Arc::clone(&shard))),
                         TableKind::Queues => Arc::new(QueuesScanner::new(Arc::clone(&shard))),
+                        TableKind::TenantCounts => {
+                            Arc::new(TenantCountsScanner::new(Arc::clone(&shard)))
+                        }
                     };
 
                     // Execute the scan - scanner handles projection via schema
@@ -552,6 +569,7 @@ async fn query_remote_shard_batches(
     let table_name = match table_kind {
         TableKind::Jobs => "jobs",
         TableKind::Queues => "queues",
+        TableKind::TenantCounts => "tenant_counts",
     };
 
     let sql = build_sql_query(table_name, filters, limit);

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -7,6 +7,7 @@
 //! - Track cleanup progress and status for crash recovery
 
 use crate::coordination::SplitCleanupStatus;
+use crate::job_store_shard::helpers::{DbWriteBatcher, decode_job_status_owned};
 use crate::keys::{
     self, end_bound, parse_attempt_key, parse_concurrency_holder_key,
     parse_concurrency_request_key, parse_concurrency_requester_counter_key,
@@ -248,6 +249,8 @@ impl JobStoreShard {
         F: Fn(&[u8], &[u8]) -> Option<String>,
     {
         let end = end_bound(&start);
+        let decrements_total_jobs = start.as_slice() == [prefix::JOB_INFO];
+        let decrements_completed_jobs = start.as_slice() == [prefix::JOB_STATUS];
 
         let mut batch = WriteBatch::new();
         let mut batch_count = 0;
@@ -261,6 +264,32 @@ impl JobStoreShard {
                 && !range.contains_tenant(&tenant)
             {
                 batch.delete(&kv.key);
+
+                if decrements_total_jobs || decrements_completed_jobs {
+                    let mut writer = DbWriteBatcher::new(&self.db, &mut batch);
+
+                    if decrements_total_jobs {
+                        self.decrement_total_jobs_counter(&mut writer)?;
+                    }
+
+                    if decrements_completed_jobs {
+                        match decode_job_status_owned(&kv.value) {
+                            Ok(status) if status.is_terminal() => {
+                                self.decrement_completed_jobs_counter(&mut writer)?;
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                tracing::warn!(
+                                    shard = %self.name,
+                                    key = %hex::encode(&kv.key),
+                                    error = %e,
+                                    "cleanup: failed to decode job status for counter adjustment"
+                                );
+                            }
+                        }
+                    }
+                }
+
                 batch_count += 1;
                 progress.keys_deleted += 1;
             }

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -11,7 +11,8 @@ use crate::keys::{
     self, end_bound, parse_attempt_key, parse_concurrency_holder_key,
     parse_concurrency_request_key, parse_concurrency_requester_counter_key,
     parse_floating_limit_key, parse_job_cancelled_key, parse_job_info_key, parse_job_status_key,
-    parse_metadata_index_key, parse_status_time_index_key, tasks_prefix,
+    parse_metadata_index_key, parse_status_time_index_key, parse_tenant_status_counter_key,
+    tasks_prefix,
 };
 use crate::shard_range::ShardRange;
 use slatedb::WriteBatch;
@@ -170,6 +171,11 @@ impl JobStoreShard {
             (
                 vec![prefix::COUNTER_CONCURRENCY_REQUESTERS],
                 Box::new(|key, _| parse_concurrency_requester_counter_key(key).map(|p| p.tenant)),
+            ),
+            // Tenant status counter keys (0xF8)
+            (
+                vec![prefix::COUNTER_TENANT_STATUS],
+                Box::new(|key, _| parse_tenant_status_counter_key(key).map(|p| p.tenant)),
             ),
             // Task keys - tenant is in the value, not the key
             (

--- a/src/job_store_shard/counters.rs
+++ b/src/job_store_shard/counters.rs
@@ -162,6 +162,41 @@ impl JobStoreShard {
         Ok(())
     }
 
+    /// Scan all tenant status counters for this shard.
+    ///
+    /// Returns a vec of (tenant, status_kind, count) tuples, filtered to only
+    /// include tenants that belong to this shard's range. Entries with count <= 0
+    /// are excluded.
+    pub async fn scan_tenant_status_counters(
+        &self,
+    ) -> Result<Vec<(String, String, i64)>, JobStoreShardError> {
+        use crate::keys::{
+            end_bound, parse_tenant_status_counter_key, tenant_status_counter_prefix,
+        };
+        use slatedb::DbIterator;
+
+        let prefix = tenant_status_counter_prefix();
+        let end = end_bound(&prefix);
+        let range = self.get_range();
+
+        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(prefix..end).await?;
+        let mut results = Vec::new();
+
+        while let Some(kv) = iter.next().await? {
+            if let Some(parsed) = parse_tenant_status_counter_key(&kv.key) {
+                if !range.contains_tenant(&parsed.tenant) {
+                    continue;
+                }
+                let count = decode_counter(&kv.value);
+                if count > 0 {
+                    results.push((parsed.tenant, parsed.status_kind, count));
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Get the current concurrency requester count for a specific tenant/queue.
     pub async fn get_concurrency_requester_count(
         &self,

--- a/src/job_store_shard/counters.rs
+++ b/src/job_store_shard/counters.rs
@@ -35,6 +35,54 @@ pub struct ShardCounters {
     pub completed_jobs: i64,
 }
 
+/// Optional lexicographic tenant bounds for scanning tenant status counters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TenantStatusCounterScanRange {
+    pub start_tenant: Option<String>,
+    pub start_inclusive: bool,
+    pub end_tenant: Option<String>,
+    pub end_inclusive: bool,
+}
+
+impl TenantStatusCounterScanRange {
+    pub fn exact(tenant: impl Into<String>) -> Self {
+        let tenant = tenant.into();
+        Self {
+            start_tenant: Some(tenant.clone()),
+            start_inclusive: true,
+            end_tenant: Some(tenant),
+            end_inclusive: true,
+        }
+    }
+
+    fn scan_bounds(&self) -> (Vec<u8>, Vec<u8>) {
+        let start = match &self.start_tenant {
+            Some(tenant) if self.start_inclusive => {
+                crate::keys::tenant_status_counter_tenant_prefix(tenant)
+            }
+            Some(tenant) => {
+                let prefix = crate::keys::tenant_status_counter_tenant_prefix(tenant);
+                crate::keys::end_bound(&prefix)
+            }
+            None => crate::keys::tenant_status_counter_prefix(),
+        };
+
+        let end = match &self.end_tenant {
+            Some(tenant) if self.end_inclusive => {
+                let prefix = crate::keys::tenant_status_counter_tenant_prefix(tenant);
+                crate::keys::end_bound(&prefix)
+            }
+            Some(tenant) => crate::keys::tenant_status_counter_tenant_prefix(tenant),
+            None => {
+                let prefix = crate::keys::tenant_status_counter_prefix();
+                crate::keys::end_bound(&prefix)
+            }
+        };
+
+        (start, end)
+    }
+}
+
 impl ShardCounters {
     /// Calculate the number of open (non-terminal) jobs.
     pub fn open_jobs(&self) -> i64 {
@@ -164,22 +212,34 @@ impl JobStoreShard {
 
     /// Scan all tenant status counters for this shard.
     ///
-    /// Returns a vec of (tenant, status_kind, count) tuples, filtered to only
-    /// include tenants that belong to this shard's range. Entries with count <= 0
-    /// are excluded.
+    /// Returns a vec of (tenant, status_kind, count) tuples, optionally limited
+    /// to a lexicographic tenant range, filtered to only include tenants that
+    /// belong to this shard's range. Entries with count <= 0 are excluded.
     pub async fn scan_tenant_status_counters(
         &self,
+        tenant_range: Option<TenantStatusCounterScanRange>,
     ) -> Result<Vec<(String, String, i64)>, JobStoreShardError> {
         use crate::keys::{
             end_bound, parse_tenant_status_counter_key, tenant_status_counter_prefix,
         };
         use slatedb::DbIterator;
 
-        let prefix = tenant_status_counter_prefix();
-        let end = end_bound(&prefix);
+        let (start, end) = tenant_range
+            .as_ref()
+            .map(TenantStatusCounterScanRange::scan_bounds)
+            .unwrap_or_else(|| {
+                let prefix = tenant_status_counter_prefix();
+                let end = end_bound(&prefix);
+                (prefix, end)
+            });
+
+        if start >= end {
+            return Ok(Vec::new());
+        }
+
         let range = self.get_range();
 
-        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(prefix..end).await?;
+        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(start..end).await?;
         let mut results = Vec::new();
 
         while let Some(kv) = iter.next().await? {

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -11,12 +11,14 @@ use crate::dst_events::{self, DstEvent};
 use crate::job::{JobInfo, JobStatus, Limit};
 use crate::job_store_shard::JobStoreShard;
 use crate::job_store_shard::JobStoreShardError;
+use crate::job_store_shard::counters::encode_counter;
 use crate::job_store_shard::helpers::{
     DbWriteBatcher, TxnWriter, WriteBatcher, decode_job_status_owned, now_epoch_ms, put_task,
     retry_on_txn_conflict,
 };
 use crate::keys::{
     idx_metadata_key, idx_status_time_key, job_info_key, job_status_key, status_index_timestamp,
+    tenant_status_counter_key,
 };
 use crate::retry::RetryPolicy;
 use crate::task::{GubernatorRateLimitData, Task};
@@ -604,6 +606,11 @@ impl JobStoreShard {
             let old_ts = status_index_timestamp(&old);
             let old_time = idx_status_time_key(tenant, old.kind.as_str(), old_ts, job_id);
             writer.delete(&old_time)?;
+            // Decrement old status counter
+            writer.merge(
+                tenant_status_counter_key(tenant, old.kind.as_str()),
+                encode_counter(-1),
+            )?;
         }
 
         Self::write_job_status_with_index(writer, tenant, job_id, new_status)
@@ -627,6 +634,13 @@ impl JobStoreShard {
         let ts = status_index_timestamp(&new_status);
         let timek = idx_status_time_key(tenant, new_kind.as_str(), ts, job_id);
         writer.put(&timek, [])?;
+
+        // Increment tenant status counter for the new status
+        writer.merge(
+            tenant_status_counter_key(tenant, new_kind.as_str()),
+            encode_counter(1),
+        )?;
+
         Ok(())
     }
 }

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -24,6 +24,7 @@ pub use restart::JobNotRestartableError;
 
 pub(crate) use enqueue::LimitTaskParams;
 use helpers::DbWriteBatcher;
+use helpers::WriteBatcher;
 pub use helpers::now_epoch_ms;
 
 use slatedb::Db;
@@ -664,9 +665,15 @@ impl JobStoreShard {
         // Update counters in the same batch
         let mut writer = DbWriteBatcher::new(&self.db, &mut batch);
         self.decrement_total_jobs_counter(&mut writer)?;
-        if status.is_some() {
+        if let Some(ref status) = status {
             // Job was in terminal state (we already checked it's terminal above)
             self.decrement_completed_jobs_counter(&mut writer)?;
+            // Decrement tenant status counter
+            let counter_key = crate::keys::tenant_status_counter_key(tenant, status.kind.as_str());
+            writer.merge(
+                &counter_key,
+                crate::job_store_shard::counters::encode_counter(-1),
+            )?;
         }
 
         self.db.write(batch).await?;

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -16,7 +16,7 @@ mod scan;
 
 pub use cleanup::{CleanupProgress, CleanupResult};
 
-pub use counters::{ShardCounters, counter_merge_operator};
+pub use counters::{ShardCounters, TenantStatusCounterScanRange, counter_merge_operator};
 pub use expedite::JobNotExpediteableError;
 pub use import::JobNotReimportableError;
 pub use lease_task::JobNotLeaseableError;

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -610,6 +610,11 @@ pub fn tenant_status_counter_prefix() -> Vec<u8> {
     vec![prefix::COUNTER_TENANT_STATUS]
 }
 
+/// Prefix for scanning all tenant status counters for a specific tenant.
+pub fn tenant_status_counter_tenant_prefix(tenant: &str) -> Vec<u8> {
+    encode_with_prefix(prefix::COUNTER_TENANT_STATUS, &(tenant,))
+}
+
 /// Parsed tenant status counter key components.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedTenantStatusCounterKey {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -32,6 +32,7 @@ pub(crate) mod prefix {
     pub const SHARD_CREATED_AT: u8 = 0xF5;
     pub const CLEANUP_COMPLETED_AT: u8 = 0xF6;
     pub const COUNTER_CONCURRENCY_REQUESTERS: u8 = 0xF7;
+    pub const COUNTER_TENANT_STATUS: u8 = 0xF8;
 }
 
 /// Encode a key with its namespace prefix.
@@ -596,6 +597,36 @@ pub fn parse_concurrency_requester_counter_key(
 /// Uses storekey encoding for collision-safe (tenant, queue) pairing.
 pub fn concurrency_counts_key(tenant: &str, queue: &str) -> Vec<u8> {
     encode_vec(&(tenant, queue)).expect("storekey encoding should not fail")
+}
+
+/// Key for a per-tenant, per-status counter.
+/// Tracks the number of jobs for each (tenant, status_kind) combination.
+pub fn tenant_status_counter_key(tenant: &str, status_kind: &str) -> Vec<u8> {
+    encode_with_prefix(prefix::COUNTER_TENANT_STATUS, &(tenant, status_kind))
+}
+
+/// Prefix for scanning all tenant status counters.
+pub fn tenant_status_counter_prefix() -> Vec<u8> {
+    vec![prefix::COUNTER_TENANT_STATUS]
+}
+
+/// Parsed tenant status counter key components.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedTenantStatusCounterKey {
+    pub tenant: String,
+    pub status_kind: String,
+}
+
+/// Parse a tenant status counter key back to its components.
+pub fn parse_tenant_status_counter_key(key: &[u8]) -> Option<ParsedTenantStatusCounterKey> {
+    if key.first() != Some(&prefix::COUNTER_TENANT_STATUS) {
+        return None;
+    }
+    let (tenant, status_kind): (String, String) = decode(&key[1..]).ok()?;
+    Some(ParsedTenantStatusCounterKey {
+        tenant,
+        status_kind,
+    })
 }
 
 /// Create an exclusive end bound for range scanning.

--- a/src/query.rs
+++ b/src/query.rs
@@ -92,6 +92,17 @@ impl ShardQueryEngine {
         let queues_provider = Arc::new(SiloTableProvider::new(queues_schema, queues_scanner));
         ctx.register_table("queues", queues_provider)?;
 
+        // Register tenant_counts table for pre-computed per-tenant status counters
+        let tenant_counts_schema = TenantCountsScanner::base_schema();
+        let tenant_counts_scanner: ScannerRef = Arc::new(TenantCountsScanner {
+            shard: Arc::clone(&shard),
+        });
+        let tenant_counts_provider = Arc::new(SiloTableProvider::new(
+            tenant_counts_schema,
+            tenant_counts_scanner,
+        ));
+        ctx.register_table("tenant_counts", tenant_counts_provider)?;
+
         Ok(Self { ctx })
     }
 
@@ -1644,6 +1655,127 @@ impl Scan for QueuesScanner {
                     .collect();
                 if let Ok(batch) = RecordBatch::try_new(Arc::clone(&proj_for_stream), empty_cols) {
                     let _ = tx.send(Ok(batch)).await;
+                }
+            }
+        });
+
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&projection),
+            ReceiverStream::new(rx).map(|r| r),
+        ))
+    }
+}
+
+/// Scanner for the tenant_counts table - reads pre-computed per-tenant, per-status counters.
+pub struct TenantCountsScanner {
+    pub(crate) shard: Arc<JobStoreShard>,
+}
+
+impl TenantCountsScanner {
+    /// Create a new TenantCountsScanner for the given shard
+    pub fn new(shard: Arc<JobStoreShard>) -> Self {
+        Self { shard }
+    }
+
+    /// Get the base schema for the tenant_counts table
+    pub fn base_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("shard_id", DataType::Utf8, false),
+            Field::new("tenant", DataType::Utf8, false),
+            Field::new("status_kind", DataType::Utf8, false),
+            Field::new("cnt", DataType::Int64, false),
+        ]))
+    }
+}
+
+impl std::fmt::Debug for TenantCountsScanner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TenantCountsScanner")
+    }
+}
+
+impl Scan for TenantCountsScanner {
+    fn describe(&self, _filters: &[Expr], _limit: Option<usize>) -> String {
+        "tenant_counts[]".to_string()
+    }
+
+    fn scan(
+        &self,
+        projection: SchemaRef,
+        _filters: &[Expr],
+        _batch_size: usize,
+        _limit: Option<usize>,
+    ) -> SendableRecordBatchStream {
+        let shard = Arc::clone(&self.shard);
+        let proj = Arc::clone(&projection);
+        let (tx, rx) = mpsc::channel::<DfResult<RecordBatch>>(2);
+
+        tokio::spawn(async move {
+            let entries = match shard.scan_tenant_status_counters().await {
+                Ok(e) => e,
+                Err(e) => {
+                    let _ = tx
+                        .send(Err(DataFusionError::Execution(e.to_string())))
+                        .await;
+                    return;
+                }
+            };
+
+            let shard_id = shard.name().to_string();
+            let n = entries.len();
+
+            if proj.fields().is_empty() {
+                match make_empty_projection_batch(&proj, n) {
+                    Ok(batch) => {
+                        let _ = tx.send(Ok(batch)).await;
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Err(e)).await;
+                    }
+                }
+                return;
+            }
+
+            let mut cols: Vec<ArrayRef> = Vec::with_capacity(proj.fields().len());
+            for f in proj.fields() {
+                let col: ArrayRef = match f.name().as_str() {
+                    "shard_id" => Arc::new(StringArray::from(vec![shard_id.as_str(); n])),
+                    "tenant" => Arc::new(StringArray::from(
+                        entries
+                            .iter()
+                            .map(|(t, _, _)| t.as_str())
+                            .collect::<Vec<_>>(),
+                    )),
+                    "status_kind" => Arc::new(StringArray::from(
+                        entries
+                            .iter()
+                            .map(|(_, s, _)| s.as_str())
+                            .collect::<Vec<_>>(),
+                    )),
+                    "cnt" => Arc::new(Int64Array::from(
+                        entries.iter().map(|(_, _, c)| *c).collect::<Vec<_>>(),
+                    )),
+                    other => {
+                        let _ = tx
+                            .send(Err(DataFusionError::Execution(format!(
+                                "unknown column {}",
+                                other
+                            ))))
+                            .await;
+                        return;
+                    }
+                };
+                cols.push(col);
+            }
+
+            match RecordBatch::try_new(proj, cols) {
+                Ok(batch) => {
+                    let _ = tx.send(Ok(batch)).await;
+                }
+                Err(e) => {
+                    let _ = tx
+                        .send(Err(DataFusionError::Execution(e.to_string())))
+                        .await;
                 }
             }
         });

--- a/src/query.rs
+++ b/src/query.rs
@@ -27,7 +27,7 @@ use tokio_stream::StreamExt;
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::job::{JobStatus, JobView};
-use crate::job_store_shard::JobStoreShard;
+use crate::job_store_shard::{JobStoreShard, TenantStatusCounterScanRange};
 
 /// Shared utility to get the EXPLAIN plan for a query.
 /// Used by both ShardQueryEngine and ClusterQueryEngine.
@@ -1695,23 +1695,27 @@ impl std::fmt::Debug for TenantCountsScanner {
 }
 
 impl Scan for TenantCountsScanner {
-    fn describe(&self, _filters: &[Expr], _limit: Option<usize>) -> String {
-        "tenant_counts[]".to_string()
+    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+        let tenant_range = parse_tenant_counts_scan_range(filters)
+            .map(|range| describe_tenant_status_counter_scan_range(&range))
+            .unwrap_or_else(|| "all".to_string());
+        format!("tenant_counts[{}], limit={:?}", tenant_range, limit)
     }
 
     fn scan(
         &self,
         projection: SchemaRef,
-        _filters: &[Expr],
+        filters: &[Expr],
         _batch_size: usize,
         _limit: Option<usize>,
     ) -> SendableRecordBatchStream {
         let shard = Arc::clone(&self.shard);
         let proj = Arc::clone(&projection);
+        let tenant_range = parse_tenant_counts_scan_range(filters);
         let (tx, rx) = mpsc::channel::<DfResult<RecordBatch>>(2);
 
         tokio::spawn(async move {
-            let entries = match shard.scan_tenant_status_counters().await {
+            let entries = match shard.scan_tenant_status_counters(tenant_range).await {
                 Ok(e) => e,
                 Err(e) => {
                     let _ = tx
@@ -1787,6 +1791,15 @@ impl Scan for TenantCountsScanner {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StringComparisonOp {
+    Eq,
+    Lt,
+    LtEq,
+    Gt,
+    GtEq,
+}
+
 fn parse_eq_filter(expr: &Expr) -> Option<(String, String)> {
     // Match forms: col("x") = lit("v") or lit = col
     match expr {
@@ -1802,6 +1815,148 @@ fn parse_eq_filter(expr: &Expr) -> Option<(String, String)> {
             }
         }
         _ => None,
+    }
+}
+
+fn parse_string_comparison_filter(expr: &Expr) -> Option<(String, StringComparisonOp, String)> {
+    match expr {
+        Expr::BinaryExpr(BinaryExpr { left, op, right }) => match (&**left, &**right) {
+            (Expr::Column(c), Expr::Literal(s, _)) => string_comparison_op(op)
+                .zip(literal_to_string(s))
+                .map(|(cmp, value)| (c.flat_name().to_string(), cmp, value)),
+            (Expr::Literal(s, _), Expr::Column(c)) => inverted_string_comparison_op(op)
+                .zip(literal_to_string(s))
+                .map(|(cmp, value)| (c.flat_name().to_string(), cmp, value)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn string_comparison_op(op: &Operator) -> Option<StringComparisonOp> {
+    match op {
+        Operator::Eq => Some(StringComparisonOp::Eq),
+        Operator::Lt => Some(StringComparisonOp::Lt),
+        Operator::LtEq => Some(StringComparisonOp::LtEq),
+        Operator::Gt => Some(StringComparisonOp::Gt),
+        Operator::GtEq => Some(StringComparisonOp::GtEq),
+        _ => None,
+    }
+}
+
+fn inverted_string_comparison_op(op: &Operator) -> Option<StringComparisonOp> {
+    match op {
+        Operator::Eq => Some(StringComparisonOp::Eq),
+        Operator::Lt => Some(StringComparisonOp::Gt),
+        Operator::LtEq => Some(StringComparisonOp::GtEq),
+        Operator::Gt => Some(StringComparisonOp::Lt),
+        Operator::GtEq => Some(StringComparisonOp::LtEq),
+        _ => None,
+    }
+}
+
+fn parse_tenant_counts_scan_range(filters: &[Expr]) -> Option<TenantStatusCounterScanRange> {
+    let mut lower: Option<(String, bool)> = None;
+    let mut upper: Option<(String, bool)> = None;
+    let mut saw_tenant_filter = false;
+
+    for filter in filters {
+        let Some((col, op, value)) = parse_string_comparison_filter(filter) else {
+            continue;
+        };
+        if col != "tenant" {
+            continue;
+        }
+
+        saw_tenant_filter = true;
+        match op {
+            StringComparisonOp::Eq => {
+                update_lower_string_bound(&mut lower, value.clone(), true);
+                update_upper_string_bound(&mut upper, value, true);
+            }
+            StringComparisonOp::Gt => update_lower_string_bound(&mut lower, value, false),
+            StringComparisonOp::GtEq => update_lower_string_bound(&mut lower, value, true),
+            StringComparisonOp::Lt => update_upper_string_bound(&mut upper, value, false),
+            StringComparisonOp::LtEq => update_upper_string_bound(&mut upper, value, true),
+        }
+    }
+
+    saw_tenant_filter.then(|| TenantStatusCounterScanRange {
+        start_tenant: lower.as_ref().map(|(value, _)| value.clone()),
+        start_inclusive: lower
+            .as_ref()
+            .map(|(_, inclusive)| *inclusive)
+            .unwrap_or(true),
+        end_tenant: upper.as_ref().map(|(value, _)| value.clone()),
+        end_inclusive: upper
+            .as_ref()
+            .map(|(_, inclusive)| *inclusive)
+            .unwrap_or(true),
+    })
+}
+
+fn update_lower_string_bound(bound: &mut Option<(String, bool)>, value: String, inclusive: bool) {
+    match bound {
+        Some((current_value, current_inclusive)) => match value.cmp(current_value) {
+            std::cmp::Ordering::Greater => {
+                *bound = Some((value, inclusive));
+            }
+            std::cmp::Ordering::Equal => {
+                *current_inclusive &= inclusive;
+            }
+            std::cmp::Ordering::Less => {}
+        },
+        None => *bound = Some((value, inclusive)),
+    }
+}
+
+fn update_upper_string_bound(bound: &mut Option<(String, bool)>, value: String, inclusive: bool) {
+    match bound {
+        Some((current_value, current_inclusive)) => match value.cmp(current_value) {
+            std::cmp::Ordering::Less => {
+                *bound = Some((value, inclusive));
+            }
+            std::cmp::Ordering::Equal => {
+                *current_inclusive &= inclusive;
+            }
+            std::cmp::Ordering::Greater => {}
+        },
+        None => *bound = Some((value, inclusive)),
+    }
+}
+
+fn describe_tenant_status_counter_scan_range(range: &TenantStatusCounterScanRange) -> String {
+    if range.start_inclusive
+        && range.end_inclusive
+        && range.start_tenant.is_some()
+        && range.start_tenant == range.end_tenant
+        && let Some(tenant) = range.start_tenant.as_ref()
+    {
+        return format!("tenant={:?}", tenant);
+    }
+
+    let mut parts = Vec::new();
+
+    if let Some(tenant) = &range.start_tenant {
+        parts.push(if range.start_inclusive {
+            format!("tenant>={:?}", tenant)
+        } else {
+            format!("tenant>{:?}", tenant)
+        });
+    }
+
+    if let Some(tenant) = &range.end_tenant {
+        parts.push(if range.end_inclusive {
+            format!("tenant<={:?}", tenant)
+        } else {
+            format!("tenant<{:?}", tenant)
+        });
+    }
+
+    if parts.is_empty() {
+        "all".to_string()
+    } else {
+        parts.join(", ")
     }
 }
 

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -1309,7 +1309,7 @@ async fn tenant_handler(
     let mut errors: Vec<String> = Vec::new();
 
     let count_sql = format!(
-        "SELECT status_kind, COUNT(*) as cnt FROM jobs WHERE tenant = '{}' GROUP BY status_kind",
+        "SELECT status_kind, cnt FROM tenant_counts WHERE tenant = '{}'",
         tenant_escaped
     );
     match state.query_engine.sql(&count_sql).await {

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -1094,8 +1094,7 @@ async fn tenants_handler(
     let mut queue_counts: HashMap<String, Vec<(String, usize)>> = HashMap::new();
     let mut errors: Vec<String> = Vec::new();
 
-    let jobs_sql =
-        "SELECT tenant, status_kind, COUNT(*) as cnt FROM jobs GROUP BY tenant, status_kind";
+    let jobs_sql = "SELECT tenant, status_kind, cnt FROM tenant_counts";
     match state.query_engine.sql(jobs_sql).await {
         Ok(df) => match df.collect().await {
             Ok(batches) => {

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -3351,3 +3351,217 @@ async fn fullscan_range_correctly_pairs_info_and_status() {
     assert_eq!(statuses[1], "Scheduled", "j2 should still be Scheduled");
     assert_eq!(statuses[2], "Scheduled", "j3 should still be Scheduled");
 }
+
+#[silo::test]
+async fn explain_tenant_counts() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let plan = sql
+        .explain("SELECT tenant, status_kind, cnt FROM tenant_counts")
+        .await
+        .expect("explain");
+
+    assert!(
+        plan.contains("TenantCountsScanner") || plan.contains("tenant_counts"),
+        "EXPLAIN should reference TenantCountsScanner, got: {}",
+        plan
+    );
+    // Should NOT contain FullScan
+    assert!(
+        !plan.contains("FullScan"),
+        "tenant_counts query should not use FullScan, got: {}",
+        plan
+    );
+}
+
+#[silo::test]
+async fn sql_tenant_counts_returns_correct_data() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+        let now = now_ms();
+
+        // Enqueue jobs for two tenants
+        for id in ["tc-a1", "tc-a2", "tc-a3"] {
+            shard
+                .enqueue(
+                    "tenant-a",
+                    Some(id.to_string()),
+                    10u8,
+                    now,
+                    None,
+                    test_helpers::msgpack_payload(&serde_json::json!({})),
+                    vec![],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue");
+        }
+        for id in ["tc-b1", "tc-b2"] {
+            shard
+                .enqueue(
+                    "tenant-b",
+                    Some(id.to_string()),
+                    10u8,
+                    now,
+                    None,
+                    test_helpers::msgpack_payload(&serde_json::json!({})),
+                    vec![],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue");
+        }
+
+        // Dequeue and succeed one job from tenant-a
+        let tasks = shard
+            .dequeue("w", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        assert_eq!(tasks.len(), 1);
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(
+                &task_id,
+                silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+            )
+            .await
+            .expect("report success");
+
+        let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+        let df = sql
+            .sql("SELECT tenant, status_kind, cnt FROM tenant_counts ORDER BY tenant, status_kind")
+            .await
+            .expect("sql");
+        let batches = df.collect().await.expect("collect");
+
+        // Collect results
+        let mut results: Vec<(String, String, i64)> = Vec::new();
+        for batch in &batches {
+            let tenants = batch
+                .column_by_name("tenant")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .unwrap();
+            let statuses = batch
+                .column_by_name("status_kind")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .unwrap();
+            let counts = batch
+                .column_by_name("cnt")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::Int64Array>()
+                .unwrap();
+            for i in 0..batch.num_rows() {
+                results.push((
+                    tenants.value(i).to_string(),
+                    statuses.value(i).to_string(),
+                    counts.value(i),
+                ));
+            }
+        }
+
+        // Should have: tenant-a/Scheduled=2, tenant-a/Succeeded=1, tenant-b/Scheduled=2
+        results.sort();
+        assert!(
+            results.contains(&("tenant-a".to_string(), "Scheduled".to_string(), 2)),
+            "expected tenant-a/Scheduled=2, got: {:?}",
+            results
+        );
+        assert!(
+            results.contains(&("tenant-a".to_string(), "Succeeded".to_string(), 1)),
+            "expected tenant-a/Succeeded=1, got: {:?}",
+            results
+        );
+        assert!(
+            results.contains(&("tenant-b".to_string(), "Scheduled".to_string(), 2)),
+            "expected tenant-b/Scheduled=2, got: {:?}",
+            results
+        );
+    });
+}
+
+#[silo::test]
+async fn sql_tenant_counts_count_star_preserves_row_count() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+        let now = now_ms();
+
+        for id in ["tc-a1", "tc-a2", "tc-a3"] {
+            shard
+                .enqueue(
+                    "tenant-a",
+                    Some(id.to_string()),
+                    10u8,
+                    now,
+                    None,
+                    test_helpers::msgpack_payload(&serde_json::json!({})),
+                    vec![],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue");
+        }
+        for id in ["tc-b1", "tc-b2"] {
+            shard
+                .enqueue(
+                    "tenant-b",
+                    Some(id.to_string()),
+                    10u8,
+                    now,
+                    None,
+                    test_helpers::msgpack_payload(&serde_json::json!({})),
+                    vec![],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue");
+        }
+
+        let tasks = shard
+            .dequeue("w", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        assert_eq!(tasks.len(), 1);
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(
+                &task_id,
+                silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+            )
+            .await
+            .expect("report success");
+
+        let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+        let batches = sql
+            .sql("SELECT COUNT(*) as cnt FROM tenant_counts")
+            .await
+            .expect("sql")
+            .collect()
+            .await
+            .expect("collect");
+
+        let counts = batches[0]
+            .column_by_name("cnt")
+            .expect("cnt column")
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("Int64 cnt");
+
+        assert_eq!(
+            counts.value(0),
+            3,
+            "tenant_counts should expose one row per tenant/status pair"
+        );
+    });
+}

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -3376,6 +3376,23 @@ async fn explain_tenant_counts() {
 }
 
 #[silo::test]
+async fn explain_tenant_counts_with_tenant_filter_uses_bounded_scan() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let plan = sql
+        .explain("SELECT status_kind, cnt FROM tenant_counts WHERE tenant = 'tenant-a'")
+        .await
+        .expect("explain");
+
+    assert!(
+        plan.contains("tenant=\"tenant-a\""),
+        "EXPLAIN should show the tenant-bounded tenant_counts scan, got: {}",
+        plan
+    );
+}
+
+#[silo::test]
 async fn sql_tenant_counts_returns_correct_data() {
     with_timeout!(20000, {
         let (_tmp, shard) = open_temp_shard().await;
@@ -3484,6 +3501,97 @@ async fn sql_tenant_counts_returns_correct_data() {
             results.contains(&("tenant-b".to_string(), "Scheduled".to_string(), 2)),
             "expected tenant-b/Scheduled=2, got: {:?}",
             results
+        );
+    });
+}
+
+#[silo::test]
+async fn sql_tenant_counts_filters_by_exact_tenant() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+        let now = now_ms();
+
+        for id in ["tc-a1", "tc-a2", "tc-a3"] {
+            shard
+                .enqueue(
+                    "tenant-a",
+                    Some(id.to_string()),
+                    10u8,
+                    now,
+                    None,
+                    test_helpers::msgpack_payload(&serde_json::json!({})),
+                    vec![],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue");
+        }
+        for id in ["tc-b1", "tc-b2"] {
+            shard
+                .enqueue(
+                    "tenant-b",
+                    Some(id.to_string()),
+                    10u8,
+                    now,
+                    None,
+                    test_helpers::msgpack_payload(&serde_json::json!({})),
+                    vec![],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue");
+        }
+
+        let tasks = shard
+            .dequeue("w", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        assert_eq!(tasks.len(), 1);
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(
+                &task_id,
+                silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+            )
+            .await
+            .expect("report success");
+
+        let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+        let batches = sql
+            .sql("SELECT status_kind, cnt FROM tenant_counts WHERE tenant = 'tenant-a' ORDER BY status_kind")
+            .await
+            .expect("sql")
+            .collect()
+            .await
+            .expect("collect");
+
+        let mut results: Vec<(String, i64)> = Vec::new();
+        for batch in batches {
+            let statuses = batch
+                .column_by_name("status_kind")
+                .expect("status_kind column")
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .expect("StringArray status_kind");
+            let counts = batch
+                .column_by_name("cnt")
+                .expect("cnt column")
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::Int64Array>()
+                .expect("Int64Array cnt");
+
+            for i in 0..batch.num_rows() {
+                results.push((statuses.value(i).to_string(), counts.value(i)));
+            }
+        }
+
+        assert_eq!(
+            results,
+            vec![("Scheduled".to_string(), 2), ("Succeeded".to_string(), 1)],
+            "exact tenant query should only return tenant-a counters"
         );
     });
 }

--- a/tests/shard_cleanup_tests.rs
+++ b/tests/shard_cleanup_tests.rs
@@ -129,6 +129,69 @@ async fn cleanup_removes_status_and_index_keys() {
 }
 
 #[silo::test]
+async fn cleanup_updates_shard_counters_for_deleted_tenants() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    // zzz(6d85) is IN range [, 8000), aaa(ae01) is OUT
+    enqueue_jobs_for_tenants(&shard, &["aaa", "zzz"], 2).await;
+
+    let leased_aaa = shard
+        .lease_task("aaa", "aaa-job-0", "worker")
+        .await
+        .expect("lease aaa job");
+    shard
+        .report_attempt_outcome(
+            leased_aaa.attempt().task_id(),
+            silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("complete aaa job");
+
+    let leased_zzz = shard
+        .lease_task("zzz", "zzz-job-0", "worker")
+        .await
+        .expect("lease zzz job");
+    shard
+        .report_attempt_outcome(
+            leased_zzz.attempt().task_id(),
+            silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("complete zzz job");
+
+    shard.db().flush().await.unwrap();
+
+    let counters_before = shard
+        .get_counters()
+        .await
+        .expect("get counters before cleanup");
+    assert_eq!(counters_before.total_jobs, 4);
+    assert_eq!(counters_before.completed_jobs, 2);
+
+    let left_range = ShardRange::new("", RANGE_BOUNDARY);
+    let result = shard
+        .after_split_cleanup_defunct_data(&left_range, 10)
+        .await
+        .expect("cleanup should succeed");
+
+    assert!(result.complete);
+    shard.db().flush().await.unwrap();
+
+    let counters_after = shard
+        .get_counters()
+        .await
+        .expect("get counters after cleanup");
+    assert_eq!(
+        counters_after.total_jobs, 2,
+        "total_jobs should only count in-range jobs after cleanup"
+    );
+    assert_eq!(
+        counters_after.completed_jobs, 1,
+        "completed_jobs should only count in-range terminal jobs after cleanup"
+    );
+}
+
+#[silo::test]
 async fn cleanup_handles_right_child_range() {
     let (_tmp, shard) = open_temp_shard().await;
 

--- a/tests/tenant_status_counter_tests.rs
+++ b/tests/tenant_status_counter_tests.rs
@@ -1,0 +1,546 @@
+mod test_helpers;
+
+use silo::job::JobStatusKind;
+use silo::job_attempt::AttemptOutcome;
+use silo::job_store_shard::import::{ImportJobParams, ImportedAttempt, ImportedAttemptStatus};
+use silo::retry::RetryPolicy;
+use silo::shard_range::ShardRange;
+
+use test_helpers::*;
+
+/// Helper to get tenant status counters as a map of status_kind -> count
+async fn get_status_counts(
+    shard: &std::sync::Arc<silo::job_store_shard::JobStoreShard>,
+    tenant: &str,
+) -> std::collections::HashMap<String, i64> {
+    let entries = shard
+        .scan_tenant_status_counters()
+        .await
+        .expect("scan_tenant_status_counters");
+    entries
+        .into_iter()
+        .filter(|(t, _, _)| t == tenant)
+        .map(|(_, status, count)| (status, count))
+        .collect()
+}
+
+#[silo::test]
+async fn counter_increments_on_enqueue() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    // Enqueue 3 jobs
+    for i in 0..3 {
+        shard
+            .enqueue(
+                "t1",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                msgpack_payload(&serde_json::json!({"i": i})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+    }
+
+    let counts = get_status_counts(&shard, "t1").await;
+    assert_eq!(counts.get("Scheduled").copied().unwrap_or(0), 3);
+}
+
+#[silo::test]
+async fn counter_transitions_through_lifecycle() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        // Enqueue
+        let job_id = shard
+            .enqueue(
+                "t1",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                msgpack_payload(&serde_json::json!({"test": "lifecycle"})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(counts.get("Scheduled").copied().unwrap_or(0), 1);
+
+        // Dequeue → Running
+        let tasks = shard
+            .dequeue("w", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        assert_eq!(tasks.len(), 1);
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(
+            counts.get("Scheduled").copied().unwrap_or(0),
+            0,
+            "Scheduled should be 0 after dequeue"
+        );
+        assert_eq!(
+            counts.get("Running").copied().unwrap_or(0),
+            1,
+            "Running should be 1 after dequeue"
+        );
+
+        // Report success → Succeeded
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .expect("report success");
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(counts.get("Running").copied().unwrap_or(0), 0);
+        assert_eq!(counts.get("Succeeded").copied().unwrap_or(0), 1);
+
+        // Verify job status
+        let status = shard
+            .get_job_status("t1", &job_id)
+            .await
+            .expect("get status")
+            .expect("exists");
+        assert_eq!(status.kind, JobStatusKind::Succeeded);
+    });
+}
+
+#[silo::test]
+async fn counter_handles_cancel() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let job_id = shard
+            .enqueue(
+                "t1",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                msgpack_payload(&serde_json::json!({"test": "cancel"})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(counts.get("Scheduled").copied().unwrap_or(0), 1);
+
+        // Cancel
+        shard.cancel_job("t1", &job_id).await.expect("cancel");
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(
+            counts.get("Scheduled").copied().unwrap_or(0),
+            0,
+            "Scheduled should be 0 after cancel"
+        );
+        assert_eq!(
+            counts.get("Cancelled").copied().unwrap_or(0),
+            1,
+            "Cancelled should be 1 after cancel"
+        );
+    });
+}
+
+#[silo::test]
+async fn counter_handles_restart() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let job_id = shard
+            .enqueue(
+                "t1",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                msgpack_payload(&serde_json::json!({"test": "restart"})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Cancel the job
+        shard.cancel_job("t1", &job_id).await.expect("cancel");
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(counts.get("Cancelled").copied().unwrap_or(0), 1);
+
+        // Restart
+        shard.restart_job("t1", &job_id).await.expect("restart");
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(
+            counts.get("Cancelled").copied().unwrap_or(0),
+            0,
+            "Cancelled should be 0 after restart"
+        );
+        assert_eq!(
+            counts.get("Scheduled").copied().unwrap_or(0),
+            1,
+            "Scheduled should be 1 after restart"
+        );
+    });
+}
+
+#[silo::test]
+async fn counter_handles_retry() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        // Enqueue with retry policy
+        shard
+            .enqueue(
+                "t1",
+                None,
+                10u8,
+                now_ms(),
+                Some(RetryPolicy {
+                    retry_count: 2,
+                    initial_interval_ms: 0,
+                    max_interval_ms: 0,
+                    randomize_interval: false,
+                    backoff_factor: 1.0,
+                }),
+                msgpack_payload(&serde_json::json!({"test": "retry"})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Dequeue
+        let tasks = shard
+            .dequeue("w", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        assert_eq!(tasks.len(), 1);
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(counts.get("Running").copied().unwrap_or(0), 1);
+
+        // Report error (will retry)
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(
+                &task_id,
+                AttemptOutcome::Error {
+                    error_code: "TEST".to_string(),
+                    error: vec![],
+                },
+            )
+            .await
+            .expect("report error");
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(
+            counts.get("Running").copied().unwrap_or(0),
+            0,
+            "Running should be 0 after retry"
+        );
+        assert_eq!(
+            counts.get("Scheduled").copied().unwrap_or(0),
+            1,
+            "Scheduled should be 1 after retry"
+        );
+    });
+}
+
+#[silo::test]
+async fn counter_handles_delete() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let job_id = shard
+            .enqueue(
+                "t1",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                msgpack_payload(&serde_json::json!({"test": "delete"})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Dequeue + succeed to make it terminal
+        let tasks = shard
+            .dequeue("w", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .expect("report success");
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(counts.get("Succeeded").copied().unwrap_or(0), 1);
+
+        // Delete
+        shard.delete_job("t1", &job_id).await.expect("delete");
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(
+            counts.get("Succeeded").copied().unwrap_or(0),
+            0,
+            "Succeeded should be 0 after delete"
+        );
+    });
+}
+
+#[silo::test]
+async fn counter_handles_import() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+        let now = now_ms();
+
+        let results = shard
+            .import_jobs(
+                "t1",
+                vec![
+                    ImportJobParams {
+                        id: "imp-1".to_string(),
+                        priority: 10,
+                        enqueue_time_ms: now,
+                        start_at_ms: now,
+                        retry_policy: None,
+                        payload: msgpack_payload(&serde_json::json!({"test": "import1"})),
+                        limits: vec![],
+                        metadata: None,
+                        task_group: "default".to_string(),
+                        attempts: vec![ImportedAttempt {
+                            status: ImportedAttemptStatus::Succeeded { result: vec![] },
+                            started_at_ms: now - 100,
+                            finished_at_ms: now,
+                        }],
+                    },
+                    ImportJobParams {
+                        id: "imp-2".to_string(),
+                        priority: 10,
+                        enqueue_time_ms: now,
+                        start_at_ms: now,
+                        retry_policy: None,
+                        payload: msgpack_payload(&serde_json::json!({"test": "import2"})),
+                        limits: vec![],
+                        metadata: None,
+                        task_group: "default".to_string(),
+                        attempts: vec![ImportedAttempt {
+                            status: ImportedAttemptStatus::Failed {
+                                error_code: "ERR".to_string(),
+                                error: vec![],
+                            },
+                            started_at_ms: now - 100,
+                            finished_at_ms: now,
+                        }],
+                    },
+                ],
+            )
+            .await
+            .expect("import");
+
+        assert!(results.iter().all(|r| r.success));
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(counts.get("Succeeded").copied().unwrap_or(0), 1);
+        assert_eq!(counts.get("Failed").copied().unwrap_or(0), 1);
+    });
+}
+
+#[silo::test]
+async fn counter_handles_reimport() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+        let now = now_ms();
+
+        // Import as Failed first (Succeeded cannot be reimported)
+        let results = shard
+            .import_jobs(
+                "t1",
+                vec![ImportJobParams {
+                    id: "reimp-1".to_string(),
+                    priority: 10,
+                    enqueue_time_ms: now,
+                    start_at_ms: now,
+                    retry_policy: None,
+                    payload: msgpack_payload(&serde_json::json!({"test": "reimport"})),
+                    limits: vec![],
+                    metadata: None,
+                    task_group: "default".to_string(),
+                    attempts: vec![ImportedAttempt {
+                        status: ImportedAttemptStatus::Failed {
+                            error_code: "ERR".to_string(),
+                            error: vec![],
+                        },
+                        started_at_ms: now - 100,
+                        finished_at_ms: now,
+                    }],
+                }],
+            )
+            .await
+            .expect("import");
+        assert!(results[0].success);
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(counts.get("Failed").copied().unwrap_or(0), 1);
+
+        // Reimport as Succeeded (should transition from Failed to Succeeded)
+        // The first attempt must exactly match the existing one
+        let results = shard
+            .import_jobs(
+                "t1",
+                vec![ImportJobParams {
+                    id: "reimp-1".to_string(),
+                    priority: 10,
+                    enqueue_time_ms: now,
+                    start_at_ms: now,
+                    retry_policy: None,
+                    payload: msgpack_payload(&serde_json::json!({"test": "reimport"})),
+                    limits: vec![],
+                    metadata: None,
+                    task_group: "default".to_string(),
+                    attempts: vec![
+                        // Must match existing attempt exactly
+                        ImportedAttempt {
+                            status: ImportedAttemptStatus::Failed {
+                                error_code: "ERR".to_string(),
+                                error: vec![],
+                            },
+                            started_at_ms: now - 100,
+                            finished_at_ms: now,
+                        },
+                        // New attempt
+                        ImportedAttempt {
+                            status: ImportedAttemptStatus::Succeeded { result: vec![] },
+                            started_at_ms: now + 1,
+                            finished_at_ms: now + 2,
+                        },
+                    ],
+                }],
+            )
+            .await
+            .expect("reimport");
+        assert!(results[0].success);
+
+        let counts = get_status_counts(&shard, "t1").await;
+        assert_eq!(
+            counts.get("Failed").copied().unwrap_or(0),
+            0,
+            "Failed should be 0 after reimport to Succeeded"
+        );
+        assert_eq!(
+            counts.get("Succeeded").copied().unwrap_or(0),
+            1,
+            "Succeeded should be 1 after reimport"
+        );
+    });
+}
+
+#[silo::test]
+async fn counter_scan_filters_by_shard_range() {
+    with_timeout!(20000, {
+        // Open shard with full range
+        let (_tmp, shard) = open_temp_shard().await;
+
+        // Enqueue jobs for different tenants
+        for tenant in &["alpha", "bravo"] {
+            shard
+                .enqueue(
+                    tenant,
+                    None,
+                    10u8,
+                    now_ms(),
+                    None,
+                    msgpack_payload(&serde_json::json!({"tenant": tenant})),
+                    vec![],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue");
+        }
+
+        // With full range, both tenants should be visible
+        let entries = shard.scan_tenant_status_counters().await.expect("scan");
+        assert_eq!(entries.len(), 2, "full range should see both tenants");
+
+        // Create a range that includes "alpha" but not "bravo" by hashing
+        let alpha_hash = silo::shard_range::hash_tenant("alpha");
+        let bravo_hash = silo::shard_range::hash_tenant("bravo");
+
+        // Pick the smaller hash as the one we want in range, exclude the other
+        let (included_tenant, _excluded_tenant, range) = if alpha_hash < bravo_hash {
+            // alpha < bravo: use range [alpha_hash, bravo_hash) which includes alpha
+            (
+                "alpha",
+                "bravo",
+                ShardRange::new(alpha_hash.clone(), bravo_hash.clone()),
+            )
+        } else {
+            // bravo < alpha: use range [bravo_hash, alpha_hash) which includes bravo
+            (
+                "bravo",
+                "alpha",
+                ShardRange::new(bravo_hash.clone(), alpha_hash.clone()),
+            )
+        };
+
+        let (_tmp2, restricted_shard) = open_temp_shard_with_range(range).await;
+
+        // Enqueue into restricted shard
+        for tenant in &["alpha", "bravo"] {
+            restricted_shard
+                .enqueue(
+                    tenant,
+                    None,
+                    10u8,
+                    now_ms(),
+                    None,
+                    msgpack_payload(&serde_json::json!({"tenant": tenant})),
+                    vec![],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue");
+        }
+
+        // Only the in-range tenant should appear in the scan
+        let entries = restricted_shard
+            .scan_tenant_status_counters()
+            .await
+            .expect("scan restricted");
+        assert!(
+            entries.iter().all(|(t, _, _)| t == included_tenant),
+            "only {} should be in range, got: {:?}",
+            included_tenant,
+            entries
+        );
+        assert_eq!(
+            entries.len(),
+            1,
+            "restricted range should only see one tenant"
+        );
+    });
+}

--- a/tests/tenant_status_counter_tests.rs
+++ b/tests/tenant_status_counter_tests.rs
@@ -2,6 +2,7 @@ mod test_helpers;
 
 use silo::job::JobStatusKind;
 use silo::job_attempt::AttemptOutcome;
+use silo::job_store_shard::TenantStatusCounterScanRange;
 use silo::job_store_shard::import::{ImportJobParams, ImportedAttempt, ImportedAttemptStatus};
 use silo::retry::RetryPolicy;
 use silo::shard_range::ShardRange;
@@ -14,7 +15,7 @@ async fn get_status_counts(
     tenant: &str,
 ) -> std::collections::HashMap<String, i64> {
     let entries = shard
-        .scan_tenant_status_counters()
+        .scan_tenant_status_counters(None)
         .await
         .expect("scan_tenant_status_counters");
     entries
@@ -482,7 +483,7 @@ async fn counter_scan_filters_by_shard_range() {
         }
 
         // With full range, both tenants should be visible
-        let entries = shard.scan_tenant_status_counters().await.expect("scan");
+        let entries = shard.scan_tenant_status_counters(None).await.expect("scan");
         assert_eq!(entries.len(), 2, "full range should see both tenants");
 
         // Create a range that includes "alpha" but not "bravo" by hashing
@@ -528,7 +529,7 @@ async fn counter_scan_filters_by_shard_range() {
 
         // Only the in-range tenant should appear in the scan
         let entries = restricted_shard
-            .scan_tenant_status_counters()
+            .scan_tenant_status_counters(None)
             .await
             .expect("scan restricted");
         assert!(
@@ -542,5 +543,45 @@ async fn counter_scan_filters_by_shard_range() {
             1,
             "restricted range should only see one tenant"
         );
+    });
+}
+
+#[silo::test]
+async fn counter_scan_can_limit_to_exact_tenant() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        for tenant in ["alpha", "bravo"] {
+            for i in 0..2 {
+                shard
+                    .enqueue(
+                        tenant,
+                        Some(format!("{tenant}-job-{i}")),
+                        10u8,
+                        now_ms(),
+                        None,
+                        msgpack_payload(&serde_json::json!({"tenant": tenant})),
+                        vec![],
+                        None,
+                        "default",
+                    )
+                    .await
+                    .expect("enqueue");
+            }
+        }
+
+        let entries = shard
+            .scan_tenant_status_counters(Some(TenantStatusCounterScanRange::exact("alpha")))
+            .await
+            .expect("scan exact tenant");
+
+        assert_eq!(
+            entries.len(),
+            1,
+            "exact tenant scan should only emit one status row"
+        );
+        assert_eq!(entries[0].0, "alpha");
+        assert_eq!(entries[0].1, "Scheduled");
+        assert_eq!(entries[0].2, 2);
     });
 }

--- a/tests/webui_tests.rs
+++ b/tests/webui_tests.rs
@@ -1270,4 +1270,8 @@ async fn test_tenant_detail_shows_upcoming_jobs_and_queues() {
         body.contains("detail-queue"),
         "tenant detail should show queue activity"
     );
+    assert!(
+        !body.contains("Tenant counts query failed"),
+        "tenant detail should render tenant status counts via tenant_counts"
+    );
 }


### PR DESCRIPTION
## Summary
- add per-tenant status counters in shard storage and expose them through the query engine
- switch the tenants web UI to read from tenant counter data
- add regression coverage for tenant count queries, including COUNT(*) empty-projection handling

## Validation
- direnv exec . just fmt
- direnv exec . cargo test --test query_tests tenant_counts
- direnv exec . cargo test --test tenant_status_counter_tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persistent counter keys updated on every job status transition and uses them for UI/query aggregation; correctness depends on counter maintenance during transitions, deletes, imports, and post-split cleanup.
> 
> **Overview**
> Adds merge-operator backed per-tenant/per-status counters (new `0xF8` keyspace) and keeps them in sync on status transitions, job deletion, and shard split cleanup, including new APIs to scan these counters with optional tenant bounds.
> 
> Exposes the counters as a new `tenant_counts` SQL table in both `ShardQueryEngine` and `ClusterQueryEngine` via a `TenantCountsScanner` that supports tenant-filter bounded scans and `COUNT(*)`/empty-projection handling, and switches the web UI tenant pages to query `tenant_counts` instead of aggregating via `jobs` scans.
> 
> Updates docs and benchmarks to describe/measure `tenant_counts`, and adds regression tests covering counter lifecycle behavior, query plans, bounded scans, and cleanup counter adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2498321f16e405bcbc19e580f68418759c64ff96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->