### PR TITLE
Add task_group label to TypeScript worker metrics

### DIFF
--- a/typescript_client/src/metrics.ts
+++ b/typescript_client/src/metrics.ts
@@ -14,8 +14,12 @@ export class WorkerMetrics {
   readonly emptyPollCounter: Counter<Attributes>;
   /** Gauge reporting the number of available task slots (maxConcurrentTasks - active - queued). */
   readonly availableTaskSlots: ObservableGauge<Attributes>;
+  /** Default attributes applied to all metric recordings. */
+  readonly defaultAttributes: Attributes;
 
-  constructor(meter: Meter, availableSlotsFn: () => number) {
+  constructor(meter: Meter, taskGroup: string, availableSlotsFn: () => number) {
+    this.defaultAttributes = { task_group: taskGroup };
+
     this.pollCounter = meter.createCounter("silo.worker.polls", {
       description: "Total number of poll calls to leaseTasks",
     });
@@ -28,7 +32,7 @@ export class WorkerMetrics {
       description: "Number of available task slots",
     });
     this.availableTaskSlots.addCallback((result) => {
-      result.observe(availableSlotsFn());
+      result.observe(availableSlotsFn(), this.defaultAttributes);
     });
   }
 }

--- a/typescript_client/src/worker.ts
+++ b/typescript_client/src/worker.ts
@@ -283,7 +283,7 @@ export class SiloWorker<
 
     // Initialize metrics
     const meter = getWorkerMeter(options.meter);
-    this._metrics = new WorkerMetrics(meter, () => this.availableTaskSlots);
+    this._metrics = new WorkerMetrics(meter, this._taskGroup, () => this.availableTaskSlots);
   }
 
   /**
@@ -483,9 +483,9 @@ export class SiloWorker<
     );
 
     // Record poll metrics
-    this._metrics.pollCounter.add(1);
+    this._metrics.pollCounter.add(1, this._metrics.defaultAttributes);
     if (result.tasks.length === 0 && result.refreshTasks.length === 0) {
-      this._metrics.emptyPollCounter.add(1);
+      this._metrics.emptyPollCounter.add(1, this._metrics.defaultAttributes);
     }
 
     // Add regular job tasks to the queue

--- a/typescript_client/test/worker-metrics.test.ts
+++ b/typescript_client/test/worker-metrics.test.ts
@@ -88,6 +88,15 @@ function getMetricValue(allMetrics: Record<string, DataPoint<number>[]>, name: s
   return points[0].value;
 }
 
+function getMetricAttributes(
+  allMetrics: Record<string, DataPoint<number>[]>,
+  name: string,
+): Record<string, unknown> {
+  const points = allMetrics[name];
+  if (!points || points.length === 0) return {};
+  return points[0].attributes as Record<string, unknown>;
+}
+
 describe("SiloWorker metrics", () => {
   let meterProvider: MeterProvider;
   let metricReader: TestReader;
@@ -289,6 +298,43 @@ describe("SiloWorker metrics", () => {
 
     finishTask!();
     await worker.stop();
+  });
+
+  it("includes task_group label on all metrics", async () => {
+    let pollCount = 0;
+    const leaseTasks = vi.fn().mockImplementation(async () => {
+      pollCount++;
+      return tasksResult([]);
+    });
+    const client = createMockClient({ leaseTasks });
+    const handler: TaskHandler = async () => ({ type: "success", result: {} });
+    const meter = meterProvider.getMeter("test");
+
+    const worker = new SiloWorker({
+      client,
+      workerId: "test-worker",
+      taskGroup: "my-task-group",
+      handler,
+      pollIntervalMs: 10,
+      meter,
+    });
+
+    worker.start();
+    while (pollCount < 2) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    await worker.stop();
+
+    const allMetrics = await collectMetrics(metricReader);
+    expect(getMetricAttributes(allMetrics, "silo.worker.polls")).toEqual({
+      task_group: "my-task-group",
+    });
+    expect(getMetricAttributes(allMetrics, "silo.worker.polls.empty")).toEqual({
+      task_group: "my-task-group",
+    });
+    expect(getMetricAttributes(allMetrics, "silo.worker.available_task_slots")).toEqual({
+      task_group: "my-task-group",
+    });
   });
 
   it("uses global meter provider when no meter is specified", () => {


### PR DESCRIPTION
## Summary
- All TypeScript worker metrics (`silo.worker.polls`, `silo.worker.polls.empty`, `silo.worker.available_task_slots`) now include a `task_group` attribute
- Enables distinguishing metrics when multiple workers with different task groups share a collector

## Test plan
- [x] Added test verifying `task_group` label is present on all three metrics
- [x] All existing worker-metrics tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metrics-only change that adds consistent OpenTelemetry attributes and updates tests; no task execution or server interaction logic is altered.
> 
> **Overview**
> All TypeScript worker metrics now emit a `task_group` attribute, applied consistently to `silo.worker.polls`, `silo.worker.polls.empty`, and `silo.worker.available_task_slots` via a shared `defaultAttributes` on `WorkerMetrics`.
> 
> `SiloWorker` passes its configured task group into `WorkerMetrics` and records counters/gauges with these attributes; tests were updated to assert the label is present on all three metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f28a9be287d4d5fd3255b4c61fa6d7466fb3ad9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->