### PR TITLE
Fix profiler?

### DIFF
--- a/nix/modules/docker.nix
+++ b/nix/modules/docker.nix
@@ -11,6 +11,12 @@
         pkgs.cacert
       ];
 
+      # pprof CPU profiler needs /tmp for temporary files during profile collection
+      fakeRootCommands = ''
+        mkdir -p ./tmp
+        chmod 1777 ./tmp
+      '';
+
       config = {
         Entrypoint = [ "${self'.packages.silo}/bin/silo" ];
         ExposedPorts = {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1637,7 +1637,10 @@ impl Silo for SiloService {
             .frequency(frequency as i32)
             .blocklist(&["libc", "libgcc", "pthread", "vdso"])
             .build()
-            .map_err(|e| Status::internal(format!("failed to start profiler: {}", e)))?;
+            .map_err(|e| {
+                tracing::error!(error = %e, error_debug = ?e, "failed to start CPU profiler");
+                Status::internal(format!("failed to start profiler: {:?}", e))
+            })?;
 
         // Profile for the requested duration
         tokio::time::sleep(std::time::Duration::from_secs(duration as u64)).await;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Docker image filesystem setup and improved error reporting for the CPU profiler path, with no impact on core request handling or data flow.
> 
> **Overview**
> Fixes CPU profiling in the production Docker image by creating a writable `/tmp` (mode `1777`) during image build so `pprof` can write temporary files.
> 
> Improves `cpu_profile` error handling by logging detailed profiler start failures via `tracing` and returning a debug-formatted internal error to aid diagnosis.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5beaadaa81c33892191ef3ed6585dbe37e2c1fc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->