### PR TITLE
Increase default retry budget for shard routing errors

### DIFF
--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -362,14 +362,14 @@ export interface ShardRoutingConfig {
   /**
    * Maximum number of retries when a request fails due to a wrong shard
    * routing or a connectivity error (UNAVAILABLE / DEADLINE_EXCEEDED).
-   * @default 5
+   * @default 8
    */
   maxRetries?: number;
 
   /**
    * Initial delay in ms before retrying a failed request.
    * Uses exponential backoff capped at 5 seconds.
-   * @default 100
+   * @default 250
    */
   retryDelayMs?: number;
 
@@ -1278,8 +1278,8 @@ export class SiloGRPCClient {
 
     // Shard routing configuration
 
-    this._maxRetries = options.shardRouting?.maxRetries ?? 5;
-    this._retryDelayMs = options.shardRouting?.retryDelayMs ?? 100;
+    this._maxRetries = options.shardRouting?.maxRetries ?? 8;
+    this._retryDelayMs = options.shardRouting?.retryDelayMs ?? 250;
     this._topologyRefreshTimeoutMs = options.shardRouting?.topologyRefreshTimeoutMs ?? 10_000;
 
     // Parse initial servers


### PR DESCRIPTION
## Summary
- Increases default `maxRetries` from 5 to 8 and `retryDelayMs` from 100ms to 250ms for shard routing retries
- Extends the total retry window from ~3s to ~22s, giving shard acquisition (e.g. during node eviction/rebalancing) enough time to complete before surfacing "shard not ready: acquisition in progress" errors to callers

## Test plan
- [ ] Existing shard-routing tests pass (they specify their own retry config so are unaffected by default changes)
- [ ] Worker and integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default retry/backoff parameters for shard-routing and connectivity errors, which can increase request latency and load during failures while reducing transient shard-acquisition errors.
> 
> **Overview**
> In the TypeScript gRPC client, increases the **default** shard-routing retry budget by bumping `ShardRoutingConfig` defaults and constructor fallbacks: `maxRetries` from 5→8 and initial `retryDelayMs` from 100ms→250ms.
> 
> This extends the application-level retry/backoff window for wrong-shard and connectivity (`UNAVAILABLE`/`DEADLINE_EXCEEDED`) failures without changing behavior when callers override `shardRouting` options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2fc6582c416d4d750196a493faa7bbe6b79a4c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->