### PR TITLE
Add CompactShard RPC to trigger full SlateDB compaction

### DIFF
--- a/nix/modules/docker.nix
+++ b/nix/modules/docker.nix
@@ -62,6 +62,9 @@
             pkgs.jq
             # grpcurl for testing gRPC endpoints
             pkgs.grpcurl
+            # Archive tools
+            pkgs.gnutar
+            pkgs.gzip
           ];
           pathsToLink = [ "/bin" "/etc" "/share" ];
         };

--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -574,6 +574,18 @@ message ForceReleaseShardRequest {
 message ForceReleaseShardResponse {
   bool released = 1; // True if the lease was released.
 }
+
+// Request to trigger a full compaction on a shard's SlateDB instance.
+// Merges all L0 SSTs and sorted runs into a single sorted run, removing tombstones.
+message CompactShardRequest {
+  string shard = 1; // The shard ID (UUID) to compact.
+}
+
+// Response after submitting a full compaction.
+message CompactShardResponse {
+  string status = 1; // Status message describing the compaction result.
+}
+
 // The Silo job queue service.
 service Silo {
   // Get cluster topology for client-side routing.
@@ -686,4 +698,9 @@ service Silo {
   // Operator escape hatch for recovering from permanently lost nodes.
   // After force-release, any live node that desires the shard can acquire it.
   rpc ForceReleaseShard(ForceReleaseShardRequest) returns (ForceReleaseShardResponse);
+
+  // Trigger a full compaction on a shard's SlateDB instance.
+  // Merges all L0 SSTs and sorted runs into a single sorted run, removing tombstones.
+  // This is useful for reclaiming space after bulk deletes or high job throughput.
+  rpc CompactShard(CompactShardRequest) returns (CompactShardResponse);
 }

--- a/src/bin/siloctl.rs
+++ b/src/bin/siloctl.rs
@@ -141,6 +141,11 @@ enum ShardAction {
         /// Shard ID (UUID) to force-release
         shard: String,
     },
+    /// Trigger a full compaction on a shard to remove tombstones and reclaim space
+    Compact {
+        /// Shard ID (UUID) to compact
+        shard: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -281,6 +286,9 @@ async fn run(args: Args) -> anyhow::Result<()> {
             }
             ShardAction::ForceRelease { shard } => {
                 siloctl::shard_force_release(&opts, &mut stdout, shard).await
+            }
+            ShardAction::Compact { shard } => {
+                siloctl::shard_compact(&opts, &mut stdout, shard).await
             }
         },
         Command::Tenant { action } => match action {

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -319,24 +319,21 @@ impl JobStoreShard {
     /// After cleanup deletes defunct keys, this method triggers a full
     /// compaction to reclaim storage space from the deleted data.
     ///
-    /// This uses SlateDB's Admin API to request a full compaction.
+    /// This uses SlateDB's Admin API to request a full compaction that merges
+    /// all L0 SSTs and sorted runs into a single sorted run, removing tombstones.
     pub async fn run_full_compaction(&self) -> Result<(), JobStoreShardError> {
         info!(shard = %self.name, "starting full compaction");
 
-        // SlateDB doesn't expose direct compaction API on the Db handle.
-        // Instead, we flush to ensure all data is in SSTs, then SlateDB's
-        // background compaction will handle the rest.
-        //
-        // For explicit compaction, we'd need to use the Admin API which requires
-        // the object store path. For now, we flush and let background compaction
-        // handle the cleanup over time.
+        // Flush memtable to SSTs first so all data is on disk
         self.db
             .flush_with_options(slatedb::config::FlushOptions {
                 flush_type: slatedb::config::FlushType::MemTable,
             })
             .await?;
 
-        info!(shard = %self.name, "flush complete, background compaction will reclaim space");
+        self.submit_full_compaction().await?;
+
+        info!(shard = %self.name, "full compaction submitted");
 
         // Clear cleanup progress markers since we're done
         self.clear_cleanup_progress().await?;
@@ -344,6 +341,54 @@ impl JobStoreShard {
         // Set status to CompactionDone - cleanup is fully complete
         self.set_cleanup_status(SplitCleanupStatus::CompactionDone)
             .await?;
+
+        Ok(())
+    }
+
+    /// Submit a full compaction via the SlateDB Admin API.
+    ///
+    /// Reads the current manifest to discover all L0 SSTs and sorted runs,
+    /// then submits a compaction spec that merges everything into a single
+    /// sorted run. The background compactor will execute this asynchronously.
+    pub async fn submit_full_compaction(&self) -> Result<(), JobStoreShardError> {
+        use slatedb::admin::AdminBuilder;
+        use slatedb::compactor::{CompactionSpec, SourceId};
+
+        let admin = AdminBuilder::new(self.db_path.as_str(), self.store.clone()).build();
+
+        let state = admin.read_compactor_state_view().await.map_err(|e| {
+            JobStoreShardError::Codec(format!("failed to read compactor state: {e}"))
+        })?;
+
+        // Build a full compaction spec: merge all L0 SSTs and sorted runs into
+        // the lowest sorted run, which allows tombstones to be dropped.
+        let manifest = state.manifest();
+        let sources: Vec<SourceId> = manifest
+            .l0
+            .iter()
+            .map(|sst| SourceId::Sst(sst.id.unwrap_compacted_id()))
+            .chain(
+                manifest
+                    .compacted
+                    .iter()
+                    .map(|sr| SourceId::SortedRun(sr.id)),
+            )
+            .collect();
+
+        if sources.is_empty() {
+            info!(shard = %self.name, "no SSTs or sorted runs to compact");
+            return Ok(());
+        }
+
+        let destination = manifest.compacted.iter().map(|sr| sr.id).min().unwrap_or(0);
+        let spec = CompactionSpec::new(sources, destination);
+
+        admin
+            .submit_compaction(spec)
+            .await
+            .map_err(|e| JobStoreShardError::Codec(format!("failed to submit compaction: {e}")))?;
+
+        info!(shard = %self.name, "full compaction submitted to SlateDB");
 
         Ok(())
     }

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -95,16 +95,16 @@ impl JobStoreShard {
     ) -> Result<Vec<ImportJobResult>, JobStoreShardError> {
         // Pre-check: reject the entire batch if any job is currently Running.
         for params in &jobs {
-            if let Some(status) = self.get_job_status(tenant, &params.id).await? {
-                if status.kind == JobStatusKind::Running {
-                    return Err(JobStoreShardError::JobNotReimportable(
-                        JobNotReimportableError {
-                            job_id: params.id.clone(),
-                            status: JobStatusKind::Running,
-                            reason: "job is currently running".to_string(),
-                        },
-                    ));
-                }
+            if let Some(status) = self.get_job_status(tenant, &params.id).await?
+                && status.kind == JobStatusKind::Running
+            {
+                return Err(JobStoreShardError::JobNotReimportable(
+                    JobNotReimportableError {
+                        job_id: params.id.clone(),
+                        status: JobStatusKind::Running,
+                        reason: "job is currently running".to_string(),
+                    },
+                ));
             }
         }
 

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -98,6 +98,10 @@ pub struct JobStoreShard {
     /// Cancellation token for background tasks like cleanup.
     /// Signaled when the shard is closing.
     cancellation: CancellationToken,
+    /// Object store for the shard's SlateDB instance (needed for Admin API).
+    store: Arc<dyn slatedb::object_store::ObjectStore>,
+    /// Database path relative to the object store root (needed for Admin API).
+    db_path: String,
 }
 
 #[derive(Debug, Error)]
@@ -242,7 +246,7 @@ impl JobStoreShard {
             concurrency_reconcile_interval,
         } = options;
 
-        let mut db_builder = slatedb::DbBuilder::new(db_path, store)
+        let mut db_builder = slatedb::DbBuilder::new(db_path, store.clone())
             .with_merge_operator(counters::counter_merge_operator());
 
         // Configure separate WAL object store if provided
@@ -286,6 +290,8 @@ impl JobStoreShard {
             metrics,
             concurrency_reconcile_interval,
             cancellation: CancellationToken::new(),
+            store,
+            db_path: db_path.to_string(),
         });
 
         // Periodically reconcile pending concurrency requests to self-heal from

--- a/src/server.rs
+++ b/src/server.rs
@@ -1868,6 +1868,27 @@ impl Silo for SiloService {
             current_ring: current.unwrap_or_default(),
         }))
     }
+
+    async fn compact_shard(
+        &self,
+        req: Request<CompactShardRequest>,
+    ) -> Result<Response<CompactShardResponse>, Status> {
+        let r = req.into_inner();
+        let shard_id = Self::parse_shard_id(&r.shard)?;
+
+        let shard = self.factory.get(&shard_id).ok_or_else(|| {
+            Status::not_found(format!("shard {} not found on this node", r.shard))
+        })?;
+
+        shard
+            .submit_full_compaction()
+            .await
+            .map_err(|e| Status::internal(format!("compaction failed: {}", e)))?;
+
+        Ok(Response::new(CompactShardResponse {
+            status: format!("full compaction submitted for shard {}", r.shard),
+        }))
+    }
 }
 
 /// Create an auth interceptor that validates Bearer tokens on incoming gRPC requests.

--- a/src/siloctl.rs
+++ b/src/siloctl.rs
@@ -10,9 +10,9 @@ use std::path::Path;
 use crate::cluster_client::AuthInterceptor;
 use crate::pb::silo_client::SiloClient;
 use crate::pb::{
-    CancelJobRequest, ConfigureShardRequest, CpuProfileRequest, DeleteJobRequest,
-    ExpediteJobRequest, ForceReleaseShardRequest, GetClusterInfoRequest, GetJobRequest,
-    GetJobResultRequest, GetSplitStatusRequest, QueryRequest, RequestSplitRequest,
+    CancelJobRequest, CompactShardRequest, ConfigureShardRequest, CpuProfileRequest,
+    DeleteJobRequest, ExpediteJobRequest, ForceReleaseShardRequest, GetClusterInfoRequest,
+    GetJobRequest, GetJobResultRequest, GetSplitStatusRequest, QueryRequest, RequestSplitRequest,
     RestartJobRequest,
 };
 use flate2::Compression;
@@ -976,6 +976,43 @@ pub async fn shard_force_release<W: Write>(
         writeln!(out, "{}", serde_json::to_string_pretty(&json_output)?)?;
     } else {
         writeln!(out, "Force-released shard lease for {}", shard)?;
+    }
+
+    Ok(())
+}
+
+/// Trigger a full compaction on a shard to remove tombstones and reclaim space.
+///
+/// This merges all L0 SSTs and sorted runs into a single sorted run,
+/// physically removing tombstones from completed/deleted jobs.
+pub async fn shard_compact<W: Write>(
+    opts: &GlobalOptions,
+    out: &mut W,
+    shard: &str,
+) -> anyhow::Result<()> {
+    let mut client =
+        connect_to_shard_owner(&opts.address, shard, opts.auth_token.as_deref()).await?;
+
+    if !opts.json {
+        writeln!(out, "Submitting full compaction for shard {}...", shard)?;
+        out.flush()?;
+    }
+
+    let response = client
+        .compact_shard(CompactShardRequest {
+            shard: shard.to_string(),
+        })
+        .await?
+        .into_inner();
+
+    if opts.json {
+        let json_output = serde_json::json!({
+            "shard_id": shard,
+            "status": response.status,
+        });
+        writeln!(out, "{}", serde_json::to_string_pretty(&json_output)?)?;
+    } else {
+        writeln!(out, "{}", response.status)?;
     }
 
     Ok(())

--- a/tests/compact_shard_tests.rs
+++ b/tests/compact_shard_tests.rs
@@ -1,0 +1,232 @@
+mod grpc_integration_helpers;
+mod test_helpers;
+
+use grpc_integration_helpers::{create_test_factory, setup_test_server, shutdown_server};
+use silo::pb::*;
+use silo::settings::AppConfig;
+use test_helpers::{msgpack_payload, open_temp_shard};
+
+/// Test that submit_full_compaction succeeds on a shard with data.
+/// Enqueues jobs, flushes, then triggers compaction. Verifies data is still readable after.
+#[silo::test]
+async fn submit_full_compaction_with_data() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    // Enqueue some jobs to create data in the LSM tree
+    for i in 0..10 {
+        let payload = msgpack_payload(&serde_json::json!({"value": i}));
+        shard
+            .enqueue(
+                "tenant-a",
+                Some(format!("job-{}", i)),
+                0,
+                0,
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue should succeed");
+    }
+
+    // Flush to ensure data is in SSTs
+    shard.db().flush().await.unwrap();
+
+    // Submit full compaction - should succeed
+    shard
+        .submit_full_compaction()
+        .await
+        .expect("submit_full_compaction should succeed");
+
+    // Verify data is still accessible after compaction submission
+    let job = shard
+        .get_job("tenant-a", "job-0")
+        .await
+        .expect("get_job should succeed");
+    assert!(job.is_some(), "job should still exist after compaction");
+}
+
+/// Test that submit_full_compaction succeeds on an empty shard (no-op).
+#[silo::test]
+async fn submit_full_compaction_empty_shard() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    // Flush to ensure memtable is empty
+    shard.db().flush().await.unwrap();
+
+    // Submit full compaction on empty shard - should succeed (no-op)
+    shard
+        .submit_full_compaction()
+        .await
+        .expect("submit_full_compaction on empty shard should succeed");
+}
+
+/// Test the CompactShard gRPC endpoint succeeds for a valid shard.
+#[silo::test(flavor = "multi_thread")]
+async fn grpc_compact_shard_succeeds() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let resp = client
+            .compact_shard(CompactShardRequest {
+                shard: grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+            })
+            .await?
+            .into_inner();
+
+        assert!(
+            resp.status.contains("full compaction submitted"),
+            "status should indicate compaction was submitted, got: {}",
+            resp.status
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test that CompactShard returns an error for an invalid shard ID.
+#[silo::test(flavor = "multi_thread")]
+async fn grpc_compact_shard_invalid_id() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let result = client
+            .compact_shard(CompactShardRequest {
+                shard: "not-a-valid-uuid".to_string(),
+            })
+            .await;
+
+        assert!(result.is_err(), "invalid shard ID should return an error");
+        let status = result.unwrap_err();
+        assert_eq!(
+            status.code(),
+            tonic::Code::InvalidArgument,
+            "invalid shard ID should return InvalidArgument"
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test that CompactShard returns NotFound for a shard not owned by this node.
+#[silo::test(flavor = "multi_thread")]
+async fn grpc_compact_shard_not_found() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        // Use a valid UUID that doesn't correspond to any shard on this node
+        let result = client
+            .compact_shard(CompactShardRequest {
+                shard: "11111111-1111-1111-1111-111111111111".to_string(),
+            })
+            .await;
+
+        assert!(result.is_err(), "unknown shard should return an error");
+        let status = result.unwrap_err();
+        assert_eq!(
+            status.code(),
+            tonic::Code::NotFound,
+            "unknown shard should return NotFound"
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Test CompactShard on a shard with data and tombstones from cancelled+deleted jobs.
+/// This simulates the production scenario where completed jobs leave tombstones.
+#[silo::test(flavor = "multi_thread")]
+async fn grpc_compact_shard_with_tombstones() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let shard_id =
+            silo::shard_range::ShardId::parse(grpc_integration_helpers::TEST_SHARD_ID).unwrap();
+        let shard = factory.get(&shard_id).expect("shard should exist");
+
+        // Enqueue, cancel, then delete jobs to create tombstones
+        for i in 0..5 {
+            let payload = msgpack_payload(&serde_json::json!({"data": i}));
+            shard
+                .enqueue(
+                    "tenant-a",
+                    Some(format!("tombstone-job-{}", i)),
+                    0,
+                    0,
+                    None,
+                    payload,
+                    vec![],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue should succeed");
+        }
+
+        // Cancel then delete jobs to create tombstones
+        for i in 0..5 {
+            shard
+                .cancel_job("tenant-a", &format!("tombstone-job-{}", i))
+                .await
+                .expect("cancel should succeed");
+            shard
+                .delete_job("tenant-a", &format!("tombstone-job-{}", i))
+                .await
+                .expect("delete should succeed");
+        }
+
+        // Flush to ensure tombstones are in SSTs
+        shard.db().flush().await.unwrap();
+
+        // Now compact via gRPC
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let resp = client
+            .compact_shard(CompactShardRequest {
+                shard: grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+            })
+            .await?
+            .into_inner();
+
+        assert!(
+            resp.status.contains("full compaction submitted"),
+            "status should indicate compaction was submitted, got: {}",
+            resp.status
+        );
+
+        // Verify deleted jobs are gone
+        for i in 0..5 {
+            let job = shard
+                .get_job("tenant-a", &format!("tombstone-job-{}", i))
+                .await
+                .expect("get_job should succeed");
+            assert!(job.is_none(), "deleted job should not exist");
+        }
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}

--- a/tests/routing_client_tests.rs
+++ b/tests/routing_client_tests.rs
@@ -208,6 +208,13 @@ impl Silo for CountingClusterInfoService {
     ) -> Result<Response<ForceReleaseShardResponse>, Status> {
         Self::unimplemented("force_release_shard")
     }
+
+    async fn compact_shard(
+        &self,
+        _request: Request<CompactShardRequest>,
+    ) -> Result<Response<CompactShardResponse>, Status> {
+        Self::unimplemented("compact_shard")
+    }
 }
 
 async fn setup_counting_cluster_info_server(

--- a/typescript_client/src/pb/silo.client.ts
+++ b/typescript_client/src/pb/silo.client.ts
@@ -4,6 +4,8 @@
 import type { RpcTransport } from "@protobuf-ts/runtime-rpc";
 import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import { Silo } from "./silo";
+import type { CompactShardResponse } from "./silo";
+import type { CompactShardRequest } from "./silo";
 import type { ForceReleaseShardResponse } from "./silo";
 import type { ForceReleaseShardRequest } from "./silo";
 import type { ResetShardsResponse } from "./silo";
@@ -240,6 +242,14 @@ export interface ISiloClient {
      * @generated from protobuf rpc: ForceReleaseShard
      */
     forceReleaseShard(input: ForceReleaseShardRequest, options?: RpcOptions): UnaryCall<ForceReleaseShardRequest, ForceReleaseShardResponse>;
+    /**
+     * Trigger a full compaction on a shard's SlateDB instance.
+     * Merges all L0 SSTs and sorted runs into a single sorted run, removing tombstones.
+     * This is useful for reclaiming space after bulk deletes or high job throughput.
+     *
+     * @generated from protobuf rpc: CompactShard
+     */
+    compactShard(input: CompactShardRequest, options?: RpcOptions): UnaryCall<CompactShardRequest, CompactShardResponse>;
 }
 /**
  * The Silo job queue service.
@@ -500,5 +510,16 @@ export class SiloClient implements ISiloClient, ServiceInfo {
     forceReleaseShard(input: ForceReleaseShardRequest, options?: RpcOptions): UnaryCall<ForceReleaseShardRequest, ForceReleaseShardResponse> {
         const method = this.methods[22], opt = this._transport.mergeOptions(options);
         return stackIntercept<ForceReleaseShardRequest, ForceReleaseShardResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * Trigger a full compaction on a shard's SlateDB instance.
+     * Merges all L0 SSTs and sorted runs into a single sorted run, removing tombstones.
+     * This is useful for reclaiming space after bulk deletes or high job throughput.
+     *
+     * @generated from protobuf rpc: CompactShard
+     */
+    compactShard(input: CompactShardRequest, options?: RpcOptions): UnaryCall<CompactShardRequest, CompactShardResponse> {
+        const method = this.methods[23], opt = this._transport.mergeOptions(options);
+        return stackIntercept<CompactShardRequest, CompactShardResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -1568,6 +1568,29 @@ export interface ForceReleaseShardResponse {
     released: boolean; // True if the lease was released.
 }
 /**
+ * Request to trigger a full compaction on a shard's SlateDB instance.
+ * Merges all L0 SSTs and sorted runs into a single sorted run, removing tombstones.
+ *
+ * @generated from protobuf message silo.v1.CompactShardRequest
+ */
+export interface CompactShardRequest {
+    /**
+     * @generated from protobuf field: string shard = 1
+     */
+    shard: string; // The shard ID (UUID) to compact.
+}
+/**
+ * Response after submitting a full compaction.
+ *
+ * @generated from protobuf message silo.v1.CompactShardResponse
+ */
+export interface CompactShardResponse {
+    /**
+     * @generated from protobuf field: string status = 1
+     */
+    status: string; // Status message describing the compaction result.
+}
+/**
  * Rate limiting algorithm for Gubernator-based limits.
  *
  * @generated from protobuf enum silo.v1.GubernatorAlgorithm
@@ -6449,6 +6472,100 @@ class ForceReleaseShardResponse$Type extends MessageType<ForceReleaseShardRespon
  * @generated MessageType for protobuf message silo.v1.ForceReleaseShardResponse
  */
 export const ForceReleaseShardResponse = new ForceReleaseShardResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class CompactShardRequest$Type extends MessageType<CompactShardRequest> {
+    constructor() {
+        super("silo.v1.CompactShardRequest", [
+            { no: 1, name: "shard", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<CompactShardRequest>): CompactShardRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.shard = "";
+        if (value !== undefined)
+            reflectionMergePartial<CompactShardRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: CompactShardRequest): CompactShardRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string shard */ 1:
+                    message.shard = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: CompactShardRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string shard = 1; */
+        if (message.shard !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.shard);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.CompactShardRequest
+ */
+export const CompactShardRequest = new CompactShardRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class CompactShardResponse$Type extends MessageType<CompactShardResponse> {
+    constructor() {
+        super("silo.v1.CompactShardResponse", [
+            { no: 1, name: "status", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<CompactShardResponse>): CompactShardResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.status = "";
+        if (value !== undefined)
+            reflectionMergePartial<CompactShardResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: CompactShardResponse): CompactShardResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string status */ 1:
+                    message.status = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: CompactShardResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string status = 1; */
+        if (message.status !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.status);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.CompactShardResponse
+ */
+export const CompactShardResponse = new CompactShardResponse$Type();
 /**
  * @generated ServiceType for protobuf service silo.v1.Silo
  */
@@ -6475,5 +6592,6 @@ export const Silo = new ServiceType("silo.v1.Silo", [
     { name: "ConfigureShard", options: {}, I: ConfigureShardRequest, O: ConfigureShardResponse },
     { name: "ImportJobs", options: {}, I: ImportJobsRequest, O: ImportJobsResponse },
     { name: "ResetShards", options: {}, I: ResetShardsRequest, O: ResetShardsResponse },
-    { name: "ForceReleaseShard", options: {}, I: ForceReleaseShardRequest, O: ForceReleaseShardResponse }
+    { name: "ForceReleaseShard", options: {}, I: ForceReleaseShardRequest, O: ForceReleaseShardResponse },
+    { name: "CompactShard", options: {}, I: CompactShardRequest, O: CompactShardResponse }
 ]);


### PR DESCRIPTION
## Summary
- Adds `CompactShard` gRPC endpoint and `siloctl shard compact` CLI command to trigger full SlateDB compaction on a shard
- Uses the SlateDB Admin API to merge all L0 SSTs and sorted runs into a single sorted run, physically removing tombstones from completed/deleted jobs
- Updates `run_full_compaction` (post-split cleanup) to use the same Admin API path instead of just flushing the memtable

## Context
Production pod `silo-production-2` was showing ~96% CPU usage. Profiling revealed the CPU was spent iterating through massive numbers of tombstones left by completed jobs during task broker scans, lease reaping, and concurrency reconciliation. SlateDB's default size-tiered compaction (`min_compaction_sources=4`) wasn't cleaning up tombstones fast enough.

This provides an operator escape hatch to force a full compaction when tombstone accumulation causes performance degradation.

## Test plan
- [x] Unit tests for `submit_full_compaction` with data and on empty shards
- [x] gRPC tests for `CompactShard` (success, invalid shard ID, unknown shard, with tombstones)
- [x] Existing cleanup tests still pass
- [ ] Manual test: `siloctl shard compact <shard-id>` against production silo pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new operator-triggered gRPC endpoint that can initiate potentially expensive full-compaction work on shard storage, which could impact performance if misused. Changes also alter post-split cleanup to use the new SlateDB Admin compaction path, affecting storage maintenance behavior.
> 
> **Overview**
> Adds an operator escape hatch to **trigger full SlateDB compaction per shard** via a new `CompactShard` gRPC RPC and `siloctl shard compact` command, returning a status message once the compaction is submitted.
> 
> Updates post-split cleanup compaction to submit an explicit full-compaction spec through SlateDB’s Admin API (after flushing), which requires persisting the shard `store` and `db_path` on `JobStoreShard`.
> 
> Includes new integration tests covering compaction submission (with data, empty shards, tombstones, and gRPC error cases), updates the generated TypeScript client bindings, and adds `gnutar`/`gzip` to the dev Docker image.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa62898339e70ebf057c987cdc09b30eab846ffa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->