### PR TITLE
Add LSM tree state and compact button to shard page

### DIFF
--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -146,6 +146,39 @@ pub enum JobStoreShardError {
     TransactionConflict(String),
 }
 
+/// Information about the LSM tree state of a shard's SlateDB instance.
+#[derive(Debug, Clone)]
+pub struct LsmState {
+    /// L0 SSTs (unflushed/uncompacted).
+    pub l0_ssts: Vec<LsmSstInfo>,
+    /// Sorted runs (compacted).
+    pub sorted_runs: Vec<LsmSortedRunInfo>,
+    /// Total estimated size of all L0 SSTs in bytes.
+    pub total_l0_size: u64,
+    /// Total estimated size of all sorted runs in bytes.
+    pub total_sorted_run_size: u64,
+}
+
+/// Information about a single SST file.
+#[derive(Debug, Clone)]
+pub struct LsmSstInfo {
+    /// SST identifier (debug format of SsTableId).
+    pub id: String,
+    /// Estimated size in bytes.
+    pub estimated_size: u64,
+}
+
+/// Information about a sorted run.
+#[derive(Debug, Clone)]
+pub struct LsmSortedRunInfo {
+    /// Sorted run identifier.
+    pub id: u32,
+    /// Number of SSTs in this sorted run.
+    pub sst_count: usize,
+    /// Estimated total size in bytes.
+    pub estimated_size: u64,
+}
+
 impl From<CodecError> for JobStoreShardError {
     fn from(e: CodecError) -> Self {
         JobStoreShardError::Codec(e.to_string())
@@ -440,6 +473,51 @@ impl JobStoreShard {
     /// Use this to collect storage-level statistics for observability.
     pub fn slatedb_stats(&self) -> std::sync::Arc<slatedb::stats::StatRegistry> {
         self.db.metrics()
+    }
+
+    /// Read LSM tree state from the SlateDB manifest.
+    ///
+    /// Returns information about L0 SSTs and sorted runs that helps operators
+    /// understand whether compaction is needed.
+    pub async fn read_lsm_state(&self) -> Result<LsmState, JobStoreShardError> {
+        use slatedb::admin::AdminBuilder;
+
+        let admin = AdminBuilder::new(self.db_path.as_str(), self.store.clone()).build();
+
+        let state = admin.read_compactor_state_view().await.map_err(|e| {
+            JobStoreShardError::Codec(format!("failed to read compactor state: {e}"))
+        })?;
+
+        let manifest = state.manifest();
+
+        let l0_ssts: Vec<LsmSstInfo> = manifest
+            .l0
+            .iter()
+            .map(|sst| LsmSstInfo {
+                id: format!("{:?}", sst.id),
+                estimated_size: sst.info.index_offset + sst.info.index_len,
+            })
+            .collect();
+
+        let sorted_runs: Vec<LsmSortedRunInfo> = manifest
+            .compacted
+            .iter()
+            .map(|sr| LsmSortedRunInfo {
+                id: sr.id,
+                sst_count: sr.ssts.len(),
+                estimated_size: sr.estimate_size(),
+            })
+            .collect();
+
+        let total_l0_size: u64 = l0_ssts.iter().map(|s| s.estimated_size).sum();
+        let total_sorted_run_size: u64 = sorted_runs.iter().map(|s| s.estimated_size).sum();
+
+        Ok(LsmState {
+            l0_ssts,
+            sorted_runs,
+            total_l0_size,
+            total_sorted_run_size,
+        })
     }
 
     /// Get the shard's tenant range.

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -271,6 +271,27 @@ struct ShardTemplate {
     split_phase: Option<String>,
     split_message: Option<String>,
     split_error: Option<String>,
+    /// LSM tree state (only available for locally-owned shards).
+    lsm_state: Option<LsmStateView>,
+    /// Success/error messages for compact operations.
+    compact_message: Option<String>,
+    compact_error: Option<String>,
+}
+
+/// View model for LSM tree state displayed in the shard detail page.
+struct LsmStateView {
+    l0_sst_count: usize,
+    total_l0_size: String,
+    sorted_run_count: usize,
+    total_sorted_run_size: String,
+    total_size: String,
+    sorted_runs: Vec<SortedRunView>,
+}
+
+struct SortedRunView {
+    id: u32,
+    sst_count: usize,
+    estimated_size: String,
 }
 
 #[derive(serde::Deserialize)]
@@ -357,6 +378,12 @@ pub struct ShardParams {
     /// Optional error message to display
     #[serde(default)]
     error: Option<String>,
+    /// Optional compact success message
+    #[serde(default)]
+    compact_message: Option<String>,
+    /// Optional compact error message
+    #[serde(default)]
+    compact_error: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
@@ -367,6 +394,22 @@ pub struct SplitFormParams {
     /// Auto-compute midpoint
     #[serde(default)]
     auto: bool,
+}
+
+fn format_byte_size(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = 1024 * KIB;
+    const GIB: u64 = 1024 * MIB;
+
+    if bytes >= GIB {
+        format!("{:.2} GiB", bytes as f64 / GIB as f64)
+    } else if bytes >= MIB {
+        format!("{:.2} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.2} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
 }
 
 fn format_uptime(startup_time_ms: Option<i64>) -> String {
@@ -1997,6 +2040,34 @@ async fn shard_handler(
         }
     });
 
+    // Read LSM tree state for locally-owned shards
+    let lsm_state = if let Some(shard) = state.factory.get(&shard_id) {
+        match shard.read_lsm_state().await {
+            Ok(lsm) => Some(LsmStateView {
+                l0_sst_count: lsm.l0_ssts.len(),
+                total_l0_size: format_byte_size(lsm.total_l0_size),
+                sorted_run_count: lsm.sorted_runs.len(),
+                total_sorted_run_size: format_byte_size(lsm.total_sorted_run_size),
+                total_size: format_byte_size(lsm.total_l0_size + lsm.total_sorted_run_size),
+                sorted_runs: lsm
+                    .sorted_runs
+                    .iter()
+                    .map(|sr| SortedRunView {
+                        id: sr.id,
+                        sst_count: sr.sst_count,
+                        estimated_size: format_byte_size(sr.estimated_size),
+                    })
+                    .collect(),
+            }),
+            Err(e) => {
+                warn!(shard_id = %params.id, error = %e, "failed to read LSM state");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let template = ShardTemplate {
         nav_active: "cluster",
         tenancy_enabled: state.config.tenancy.enabled,
@@ -2018,6 +2089,9 @@ async fn shard_handler(
         split_phase,
         split_message: params.message,
         split_error: params.error,
+        lsm_state,
+        compact_message: params.compact_message,
+        compact_error: params.compact_error,
     };
 
     Html(
@@ -2092,6 +2166,45 @@ async fn shard_split_handler(
     }
 }
 
+async fn shard_compact_handler(
+    State(state): State<AppState>,
+    Path(shard_id): Path<String>,
+) -> impl IntoResponse {
+    let parsed_shard_id = match crate::shard_range::ShardId::parse(&shard_id) {
+        Ok(id) => id,
+        Err(_) => {
+            return Redirect::to(&format!(
+                "/shard?id={}&compact_error={}",
+                shard_id,
+                urlencoding::encode("Invalid shard ID")
+            ));
+        }
+    };
+
+    let Some(shard) = state.factory.get(&parsed_shard_id) else {
+        return Redirect::to(&format!(
+            "/shard?id={}&compact_error={}",
+            shard_id,
+            urlencoding::encode("Shard not found on this node")
+        ));
+    };
+
+    match shard.submit_full_compaction().await {
+        Ok(()) => Redirect::to(&format!(
+            "/shard?id={}&compact_message={}",
+            shard_id,
+            urlencoding::encode(
+                "Full compaction submitted successfully. The compactor will process it in the background."
+            )
+        )),
+        Err(e) => Redirect::to(&format!(
+            "/shard?id={}&compact_error={}",
+            shard_id,
+            urlencoding::encode(&format!("Compaction failed: {}", e))
+        )),
+    }
+}
+
 async fn not_found_handler(State(state): State<AppState>) -> impl IntoResponse {
     Html(
         ErrorTemplate {
@@ -2118,6 +2231,7 @@ pub fn create_router(state: AppState) -> Router {
         .route("/cluster", get(cluster_handler))
         .route("/shard", get(shard_handler))
         .route("/shard/:id/split", post(shard_split_handler))
+        .route("/shard/:id/compact", post(shard_compact_handler))
         .route("/sql", get(sql_handler))
         .route("/sql/execute", get(sql_execute_handler))
         .route("/config", get(config_handler))

--- a/templates/shard.html
+++ b/templates/shard.html
@@ -10,21 +10,35 @@
             <h1 class="text-xl font-bold text-zinc-100">Shard Details</h1>
         </div>
     </div>
-    
+
     {% if let Some(msg) = split_message %}
     <div class="bg-emerald-900/30 border border-emerald-700 p-4">
         <div class="text-emerald-400 text-sm font-medium">Success</div>
         <pre class="text-emerald-300 text-xs mt-2 whitespace-pre-wrap">{{ msg }}</pre>
     </div>
     {% endif %}
-    
+
     {% if let Some(err) = split_error %}
     <div class="bg-red-900/30 border border-red-700 p-4">
         <div class="text-red-400 text-sm font-medium">Error</div>
         <pre class="text-red-300 text-xs mt-2 whitespace-pre-wrap">{{ err }}</pre>
     </div>
     {% endif %}
-    
+
+    {% if let Some(msg) = compact_message %}
+    <div class="bg-emerald-900/30 border border-emerald-700 p-4">
+        <div class="text-emerald-400 text-sm font-medium">Compaction</div>
+        <pre class="text-emerald-300 text-xs mt-2 whitespace-pre-wrap">{{ msg }}</pre>
+    </div>
+    {% endif %}
+
+    {% if let Some(err) = compact_error %}
+    <div class="bg-red-900/30 border border-red-700 p-4">
+        <div class="text-red-400 text-sm font-medium">Compaction Error</div>
+        <pre class="text-red-300 text-xs mt-2 whitespace-pre-wrap">{{ err }}</pre>
+    </div>
+    {% endif %}
+
     <!-- Shard Info -->
     <div class="bg-zinc-800 border border-zinc-700 overflow-hidden">
         <div class="bg-zinc-850 border-b border-zinc-700 px-4 py-2">
@@ -75,7 +89,88 @@
             </dl>
         </div>
     </div>
-    
+
+    <!-- LSM Tree State -->
+    {% if let Some(lsm) = lsm_state %}
+    <div class="bg-zinc-800 border border-zinc-700 overflow-hidden">
+        <div class="bg-zinc-850 border-b border-zinc-700 px-4 py-2 flex items-center justify-between">
+            <h2 class="text-sm font-semibold text-zinc-300">Storage (LSM Tree)</h2>
+            <span class="text-xs text-zinc-500">Total: {{ lsm.total_size }}</span>
+        </div>
+        <div class="p-4 space-y-4">
+            <!-- Summary -->
+            <dl class="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div>
+                    <dt class="text-xs text-zinc-500 uppercase tracking-wider">L0 SSTs</dt>
+                    <dd class="text-sm text-zinc-200 mt-1">{{ lsm.l0_sst_count }}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs text-zinc-500 uppercase tracking-wider">L0 Size</dt>
+                    <dd class="text-sm text-zinc-200 mt-1">{{ lsm.total_l0_size }}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs text-zinc-500 uppercase tracking-wider">Sorted Runs</dt>
+                    <dd class="text-sm text-zinc-200 mt-1">{{ lsm.sorted_run_count }}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs text-zinc-500 uppercase tracking-wider">Sorted Run Size</dt>
+                    <dd class="text-sm text-zinc-200 mt-1">{{ lsm.total_sorted_run_size }}</dd>
+                </div>
+            </dl>
+
+            {% if !lsm.sorted_runs.is_empty() %}
+            <!-- Sorted Runs Table -->
+            <div>
+                <h3 class="text-xs text-zinc-500 uppercase tracking-wider mb-2">Sorted Runs</h3>
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="text-left text-xs text-zinc-500 uppercase tracking-wider border-b border-zinc-700">
+                            <th class="pb-2 pr-4">Run ID</th>
+                            <th class="pb-2 pr-4">SSTs</th>
+                            <th class="pb-2">Size</th>
+                        </tr>
+                    </thead>
+                    <tbody class="text-zinc-300">
+                        {% for sr in lsm.sorted_runs %}
+                        <tr class="border-b border-zinc-700/50">
+                            <td class="py-1.5 pr-4 font-mono">{{ sr.id }}</td>
+                            <td class="py-1.5 pr-4">{{ sr.sst_count }}</td>
+                            <td class="py-1.5">{{ sr.estimated_size }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% endif %}
+
+            <!-- Compaction hints -->
+            {% if lsm.l0_sst_count > 4 || lsm.sorted_run_count > 1 %}
+            <div class="bg-amber-900/20 border border-amber-700/50 px-3 py-2 text-xs text-amber-300">
+                {% if lsm.l0_sst_count > 4 %}
+                High L0 SST count ({{ lsm.l0_sst_count }}) may indicate compaction lag.
+                {% endif %}
+                {% if lsm.sorted_run_count > 1 %}
+                Multiple sorted runs ({{ lsm.sorted_run_count }}) means read amplification; compaction will merge them.
+                {% endif %}
+            </div>
+            {% endif %}
+
+            <!-- Compact Button -->
+            <form action="/shard/{{ shard_id }}/compact" method="POST">
+                <button
+                    type="submit"
+                    class="px-4 py-2 bg-indigo-700 hover:bg-indigo-600 text-indigo-100 text-sm font-medium"
+                >
+                    Trigger Full Compaction
+                </button>
+                <p class="text-zinc-500 text-xs mt-1">
+                    Merges all L0 SSTs and sorted runs into a single sorted run. Runs in the background.
+                </p>
+            </form>
+        </div>
+    </div>
+    {% endif %}
+
     <!-- Split Shard Form -->
     {% if split_phase.is_none() %}
     <div class="bg-zinc-800 border border-zinc-700 overflow-hidden">
@@ -94,9 +189,9 @@
                         Split Point (Tenant ID)
                     </label>
                     <div class="flex gap-2">
-                        <input 
-                            type="text" 
-                            name="split_point" 
+                        <input
+                            type="text"
+                            name="split_point"
                             id="split_point"
                             placeholder="Enter tenant ID or leave empty for auto"
                             class="flex-1 bg-zinc-900 border border-zinc-700 text-zinc-200 text-sm px-3 py-2 font-mono focus:outline-none focus:border-emerald-500"
@@ -111,7 +206,7 @@
                     </p>
                 </div>
                 <div class="flex gap-2">
-                    <button 
+                    <button
                         type="submit"
                         class="px-4 py-2 bg-amber-700 hover:bg-amber-600 text-amber-100 text-sm font-medium"
                     >


### PR DESCRIPTION
## Summary
- Display LSM tree state (L0 SSTs, sorted runs, sizes) on the shard detail page for locally-owned shards
- Add a "Trigger Full Compaction" button that submits a full compaction (same as `siloctl shard compact`)
- Show compaction hints when L0 count is high or multiple sorted runs exist

## Test plan
- [x] `cargo test --test compact_shard_tests` — all 6 tests pass
- [x] `cargo clippy` — no warnings
- [ ] Manual: visit shard detail page, verify LSM state section appears for local shards
- [ ] Manual: click compact button, verify success message and compaction runs in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new operator-triggered path to submit full SlateDB compactions and surfaces internal manifest/LSM details; mistakes or overuse could impact storage performance and operational stability.
> 
> **Overview**
> Adds a shard-level storage observability section that reads SlateDB’s manifest via a new `JobStoreShard::read_lsm_state()` Admin API call and displays L0/sorted-run counts and estimated sizes (with hints when compaction may be needed).
> 
> Extends the shard detail page with a POST `/shard/:id/compact` action that triggers `submit_full_compaction()` for locally-owned shards and reports success/failure via query-param messages in the UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de43a20c3436fde232ed9ccbdcf587b0d03aaa4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->