### PR TITLE
Use bounded-load rendezvous hashing for even shard distribution

### DIFF
--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -421,8 +421,9 @@ impl CoordinatorBase {
 
     /// Compute shard owner map from members (shared by both backends).
     ///
-    /// Uses ring-aware selection to determine shard ownership based on
-    /// each shard's placement ring and member ring participation.
+    /// Uses bounded-load, ring-aware rendezvous hashing to determine shard
+    /// ownership based on each shard's placement ring and member ring
+    /// participation.
     pub async fn compute_shard_owner_map(&self, members: &[MemberInfo]) -> ShardOwnerMap {
         let addr_map: HashMap<String, String> = members
             .iter()
@@ -433,14 +434,13 @@ impl CoordinatorBase {
         let mut shard_to_addr = HashMap::new();
         let mut shard_to_node = HashMap::new();
 
-        for shard_info in shard_map.shards() {
-            // Use ring-aware selection
-            if let Some(owner_node) =
-                select_owner_for_shard(&shard_info.id, shard_info.placement_ring(), members)
-                && let Some(addr) = addr_map.get(&owner_node)
-            {
-                shard_to_addr.insert(shard_info.id, addr.clone());
-                shard_to_node.insert(shard_info.id, owner_node);
+        let shards: Vec<&crate::shard_range::ShardInfo> = shard_map.shards().iter().collect();
+        let assignments = compute_all_shard_assignments(&shards, members);
+
+        for (shard_id, owner_node) in assignments {
+            if let Some(addr) = addr_map.get(&owner_node) {
+                shard_to_addr.insert(shard_id, addr.clone());
+                shard_to_node.insert(shard_id, owner_node);
             }
         }
 
@@ -734,64 +734,101 @@ pub fn member_in_ring(member: &MemberInfo, shard_ring: Option<&str>) -> bool {
     }
 }
 
-/// Deterministically select the owner node for a shard using rendezvous hashing, filtering by placement ring.
-///
-/// Uses the shard's UUID as input to the hash function, ensuring consistent distribution regardless of when shards were created.
-///
-/// Only members that participate in the shard's placement ring are considered.
-/// If no members participate in the ring, returns None.
-pub fn select_owner_for_shard(
-    shard_id: &ShardId,
-    shard_ring: Option<&str>,
-    members: &[MemberInfo],
-) -> Option<String> {
-    // Filter to members that participate in this ring
-    let eligible: Vec<&String> = members
-        .iter()
-        .filter(|m| member_in_ring(m, shard_ring))
-        .map(|m| &m.node_id)
-        .collect();
+/// Compute the rendezvous hash score for a (member, shard) pair.
+fn rendezvous_score(member_id: &str, shard_id: &ShardId) -> u64 {
+    let member_hash = fnv1a64(member_id.as_bytes());
+    let shard_hash = fnv1a64(shard_id.as_uuid().as_bytes());
+    mix64(member_hash ^ shard_hash)
+}
 
-    if eligible.is_empty() {
-        return None;
+/// Compute shard-to-node assignments for all shards using bounded-load rendezvous hashing.
+///
+/// Standard rendezvous hashing assigns each shard independently to its highest-scoring node,
+/// which can produce significant imbalance when the shard count is low relative to the node count.
+/// Bounded-load rendezvous hashing adds a capacity constraint: each node in a given placement ring
+/// can own at most `ceil(ring_shards / ring_nodes)` shards.
+///
+/// Algorithm:
+/// 1. Group shards by placement ring
+/// 2. For each ring, compute rendezvous scores for all (shard, eligible_node) pairs
+/// 3. Sort by score descending (highest-preference assignments first)
+/// 4. Greedily assign each shard to its preferred node, skipping nodes that are at capacity
+///
+/// This preserves the key properties of rendezvous hashing (deterministic, stable on resize)
+/// while guaranteeing that shard counts differ by at most 1 across nodes within each ring.
+pub fn compute_all_shard_assignments(
+    shards: &[&crate::shard_range::ShardInfo],
+    members: &[MemberInfo],
+) -> HashMap<ShardId, String> {
+    // Group shards by placement ring (None = default ring)
+    let mut ring_groups: HashMap<Option<&str>, Vec<&crate::shard_range::ShardInfo>> =
+        HashMap::new();
+    for shard in shards {
+        ring_groups
+            .entry(shard.placement_ring())
+            .or_default()
+            .push(shard);
     }
 
-    let mut best: Option<(u64, &String)> = None;
-    for m in &eligible {
-        let member_hash = fnv1a64(m.as_bytes());
-        // Use the UUID bytes for consistent hashing
-        let shard_hash = fnv1a64(shard_id.as_uuid().as_bytes());
-        let score = mix64(member_hash ^ shard_hash);
-        if let Some((cur, _)) = best {
-            if score > cur {
-                best = Some((score, m));
+    let mut assignments: HashMap<ShardId, String> = HashMap::new();
+
+    for (ring, ring_shards) in &ring_groups {
+        let eligible_nodes: Vec<&String> = members
+            .iter()
+            .filter(|m| member_in_ring(m, *ring))
+            .map(|m| &m.node_id)
+            .collect();
+
+        if eligible_nodes.is_empty() {
+            continue;
+        }
+
+        let max_per_node = ring_shards.len().div_ceil(eligible_nodes.len());
+
+        // Build all (score, shard_id, node_id) tuples and sort by score descending
+        let mut scored: Vec<(u64, ShardId, &String)> = Vec::new();
+        for shard in ring_shards {
+            for node in &eligible_nodes {
+                let score = rendezvous_score(node, &shard.id);
+                scored.push((score, shard.id, node));
             }
-        } else {
-            best = Some((score, m));
+        }
+        scored.sort_unstable_by(|a, b| b.0.cmp(&a.0));
+
+        // Greedily assign: take highest-score pairs, respecting capacity
+        let mut node_counts: HashMap<&String, usize> = HashMap::new();
+        let mut assigned: HashSet<ShardId> = HashSet::new();
+
+        for (_, shard_id, node_id) in &scored {
+            if assigned.contains(shard_id) {
+                continue;
+            }
+            let count = node_counts.entry(node_id).or_insert(0);
+            if *count < max_per_node {
+                *count += 1;
+                assigned.insert(*shard_id);
+                assignments.insert(*shard_id, (*node_id).clone());
+            }
         }
     }
-    best.map(|(_, m)| (*m).clone())
+
+    assignments
 }
 
 /// Compute the desired set of shard ids for a node given current membership and considering placement rings.
 ///
-/// A shard is desired by a node if:
-/// 1. The node participates in the shard's placement ring
-/// 2. The node is selected as owner by rendezvous hashing among eligible members
+/// Uses bounded-load rendezvous hashing to ensure even distribution: within each placement ring,
+/// no node will own more than `ceil(ring_shards / ring_nodes)` shards.
 pub fn compute_desired_shards_for_node(
     shards: &[&crate::shard_range::ShardInfo],
     node_id: &str,
     members: &[MemberInfo],
 ) -> HashSet<ShardId> {
-    let mut desired: HashSet<ShardId> = HashSet::new();
-    for shard in shards {
-        if let Some(owner) = select_owner_for_shard(&shard.id, shard.placement_ring(), members)
-            && owner == node_id
-        {
-            desired.insert(shard.id);
-        }
-    }
-    desired
+    compute_all_shard_assignments(shards, members)
+        .into_iter()
+        .filter(|(_, owner)| owner == node_id)
+        .map(|(shard_id, _)| shard_id)
+        .collect()
 }
 
 fn fnv1a64(data: &[u8]) -> u64 {

--- a/tests/shard_range_tests.rs
+++ b/tests/shard_range_tests.rs
@@ -257,8 +257,8 @@ fn test_member_in_ring_default() {
 }
 
 #[silo::test]
-fn test_select_owner_for_shard_default() {
-    use silo::coordination::select_owner_for_shard;
+fn test_single_shard_assignment_default_ring() {
+    use silo::coordination::compute_all_shard_assignments;
 
     // Create members: one default-only, one with gpu ring
     let members = vec![
@@ -278,15 +278,20 @@ fn test_select_owner_for_shard_default() {
         },
     ];
 
-    // Default shard (no ring) should be owned by default-node
-    let shard_id = ShardId::new();
-    let owner = select_owner_for_shard(&shard_id, None, &members);
-    assert_eq!(owner, Some("default-node".to_string()));
+    let shard = ShardInfo::new(ShardId::new(), ShardRange::new("", ""));
+    let shard_refs = vec![&shard];
+    let assignments = compute_all_shard_assignments(&shard_refs, &members);
+
+    // Default shard (no ring) should be owned by default-node.
+    assert_eq!(
+        assignments.get(&shard.id),
+        Some(&"default-node".to_string())
+    );
 }
 
 #[silo::test]
-fn test_select_owner_for_shard_specific() {
-    use silo::coordination::select_owner_for_shard;
+fn test_single_shard_assignment_specific_ring() {
+    use silo::coordination::compute_all_shard_assignments;
 
     // Create members: one default-only, one with gpu ring
     let members = vec![
@@ -306,15 +311,18 @@ fn test_select_owner_for_shard_specific() {
         },
     ];
 
-    // GPU shard should be owned by gpu-node
-    let shard_id = ShardId::new();
-    let owner = select_owner_for_shard(&shard_id, Some("gpu"), &members);
-    assert_eq!(owner, Some("gpu-node".to_string()));
+    let mut shard = ShardInfo::new(ShardId::new(), ShardRange::new("", ""));
+    shard.placement_ring = Some("gpu".to_string());
+    let shard_refs = vec![&shard];
+    let assignments = compute_all_shard_assignments(&shard_refs, &members);
+
+    // GPU shard should be owned by gpu-node.
+    assert_eq!(assignments.get(&shard.id), Some(&"gpu-node".to_string()));
 }
 
 #[silo::test]
 fn test_member_with_multiple_rings_can_own_multiple_shard_types() {
-    use silo::coordination::select_owner_for_shard;
+    use silo::coordination::compute_all_shard_assignments;
 
     // Create member with multiple rings
     let members = vec![MemberInfo {
@@ -325,24 +333,31 @@ fn test_member_with_multiple_rings_can_own_multiple_shard_types() {
         placement_rings: vec!["gpu".to_string(), "high-memory".to_string()],
     }];
 
-    let shard_id = ShardId::new();
+    let mut gpu_shard = ShardInfo::new(ShardId::new(), ShardRange::new("", ""));
+    gpu_shard.placement_ring = Some("gpu".to_string());
+    let mut high_memory_shard = ShardInfo::new(ShardId::new(), ShardRange::new("m", ""));
+    high_memory_shard.placement_ring = Some("high-memory".to_string());
+    let default_shard = ShardInfo::new(ShardId::new(), ShardRange::new("z", ""));
+    let shard_refs = vec![&gpu_shard, &high_memory_shard, &default_shard];
+    let assignments = compute_all_shard_assignments(&shard_refs, &members);
 
-    // GPU shard - should work
-    let owner = select_owner_for_shard(&shard_id, Some("gpu"), &members);
-    assert_eq!(owner, Some("multi-ring-node".to_string()));
+    // Named-ring shards should be assigned to the multi-ring node.
+    assert_eq!(
+        assignments.get(&gpu_shard.id),
+        Some(&"multi-ring-node".to_string())
+    );
+    assert_eq!(
+        assignments.get(&high_memory_shard.id),
+        Some(&"multi-ring-node".to_string())
+    );
 
-    // High-memory shard - should work
-    let owner = select_owner_for_shard(&shard_id, Some("high-memory"), &members);
-    assert_eq!(owner, Some("multi-ring-node".to_string()));
-
-    // Default shard - should NOT work (node doesn't participate in default)
-    let owner = select_owner_for_shard(&shard_id, None, &members);
-    assert_eq!(owner, None);
+    // Default shard should not be assigned because there is no default-ring member.
+    assert_eq!(assignments.get(&default_shard.id), None);
 }
 
 #[silo::test]
 fn test_no_eligible_owner_returns_none() {
-    use silo::coordination::select_owner_for_shard;
+    use silo::coordination::compute_all_shard_assignments;
 
     // Create only default members
     let members = vec![MemberInfo {
@@ -353,15 +368,18 @@ fn test_no_eligible_owner_returns_none() {
         placement_rings: vec![],
     }];
 
-    // GPU shard has no eligible owner
-    let shard_id = ShardId::new();
-    let owner = select_owner_for_shard(&shard_id, Some("gpu"), &members);
-    assert_eq!(owner, None);
+    let mut shard = ShardInfo::new(ShardId::new(), ShardRange::new("", ""));
+    shard.placement_ring = Some("gpu".to_string());
+    let shard_refs = vec![&shard];
+    let assignments = compute_all_shard_assignments(&shard_refs, &members);
+
+    // GPU shard has no eligible owner.
+    assert_eq!(assignments.get(&shard.id), None);
 }
 
 #[silo::test]
-fn test_rendezvous_hash_consistent_with_ring_filtering() {
-    use silo::coordination::select_owner_for_shard;
+fn test_single_shard_assignment_is_deterministic_within_ring() {
+    use silo::coordination::compute_all_shard_assignments;
 
     // Create multiple members in the same ring
     let members = vec![
@@ -388,16 +406,22 @@ fn test_rendezvous_hash_consistent_with_ring_filtering() {
         },
     ];
 
-    let shard_id = ShardId::new();
+    let mut shard = ShardInfo::new(ShardId::new(), ShardRange::new("", ""));
+    shard.placement_ring = Some("gpu".to_string());
+    let shard_refs = vec![&shard];
 
-    // Same shard always maps to same owner (consistent hashing)
-    let owner1 = select_owner_for_shard(&shard_id, Some("gpu"), &members);
-    let owner2 = select_owner_for_shard(&shard_id, Some("gpu"), &members);
+    // Same shard always maps to same owner.
+    let owner1 = compute_all_shard_assignments(&shard_refs, &members)
+        .get(&shard.id)
+        .cloned();
+    let owner2 = compute_all_shard_assignments(&shard_refs, &members)
+        .get(&shard.id)
+        .cloned();
     assert_eq!(owner1, owner2);
     assert!(owner1.is_some());
 
     // Owner must be one of the gpu nodes
-    let owner = owner1.unwrap();
+    let owner = owner1.expect("single eligible ring should produce an owner");
     assert!(owner.starts_with("gpu-"));
 }
 
@@ -439,4 +463,256 @@ fn test_compute_desired_shards_for_node() {
     let desired_gpu = compute_desired_shards_for_node(&shards, "gpu-node", &members);
     assert!(!desired_gpu.contains(&default_shard.id));
     assert!(desired_gpu.contains(&gpu_shard.id));
+}
+
+#[silo::test]
+fn test_bounded_load_balancing_even_distribution() {
+    use silo::coordination::compute_all_shard_assignments;
+
+    // Create 8 shards in the default ring, 3 nodes — should get 3/3/2 distribution
+    let shards: Vec<ShardInfo> = (0..8)
+        .map(|i| {
+            ShardInfo::new(
+                ShardId::new(),
+                ShardRange::new(&format!("{}", i), &format!("{}", i + 1)),
+            )
+        })
+        .collect();
+    let shard_refs: Vec<&ShardInfo> = shards.iter().collect();
+
+    let members = vec![
+        MemberInfo {
+            node_id: "node-0".to_string(),
+            grpc_addr: "http://node0:7450".to_string(),
+            startup_time_ms: Some(1000),
+            hostname: None,
+            placement_rings: vec![],
+        },
+        MemberInfo {
+            node_id: "node-1".to_string(),
+            grpc_addr: "http://node1:7450".to_string(),
+            startup_time_ms: Some(1000),
+            hostname: None,
+            placement_rings: vec![],
+        },
+        MemberInfo {
+            node_id: "node-2".to_string(),
+            grpc_addr: "http://node2:7450".to_string(),
+            startup_time_ms: Some(1000),
+            hostname: None,
+            placement_rings: vec![],
+        },
+    ];
+
+    let assignments = compute_all_shard_assignments(&shard_refs, &members);
+
+    // All shards should be assigned
+    assert_eq!(assignments.len(), 8);
+
+    // Count per node
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for owner in assignments.values() {
+        *counts.entry(owner.as_str()).or_insert(0) += 1;
+    }
+
+    // With 8 shards and 3 nodes, max per node = ceil(8/3) = 3
+    // So distribution must be some permutation of [3, 3, 2]
+    let mut count_values: Vec<usize> = counts.values().copied().collect();
+    count_values.sort();
+    assert_eq!(
+        count_values,
+        vec![2, 3, 3],
+        "Expected 3/3/2 distribution, got {:?}",
+        counts
+    );
+}
+
+#[silo::test]
+fn test_bounded_load_balancing_deterministic() {
+    use silo::coordination::compute_all_shard_assignments;
+
+    let shards: Vec<ShardInfo> = (0..6)
+        .map(|i| {
+            ShardInfo::new(
+                ShardId::new(),
+                ShardRange::new(&format!("{}", i), &format!("{}", i + 1)),
+            )
+        })
+        .collect();
+    let shard_refs: Vec<&ShardInfo> = shards.iter().collect();
+
+    let members = vec![
+        MemberInfo {
+            node_id: "a".to_string(),
+            grpc_addr: "http://a:7450".to_string(),
+            startup_time_ms: Some(1000),
+            hostname: None,
+            placement_rings: vec![],
+        },
+        MemberInfo {
+            node_id: "b".to_string(),
+            grpc_addr: "http://b:7450".to_string(),
+            startup_time_ms: Some(1000),
+            hostname: None,
+            placement_rings: vec![],
+        },
+    ];
+
+    // Same inputs must always produce same outputs
+    let a1 = compute_all_shard_assignments(&shard_refs, &members);
+    let a2 = compute_all_shard_assignments(&shard_refs, &members);
+    assert_eq!(a1, a2);
+
+    // 6 shards / 2 nodes = exactly 3 each
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for owner in a1.values() {
+        *counts.entry(owner.as_str()).or_insert(0) += 1;
+    }
+    assert_eq!(counts.get("a"), Some(&3));
+    assert_eq!(counts.get("b"), Some(&3));
+}
+
+#[silo::test]
+fn test_bounded_load_stability_on_node_add() {
+    use silo::coordination::compute_all_shard_assignments;
+
+    let shards: Vec<ShardInfo> = (0..12)
+        .map(|i| {
+            ShardInfo::new(
+                ShardId::new(),
+                ShardRange::new(&format!("{}", i), &format!("{}", i + 1)),
+            )
+        })
+        .collect();
+    let shard_refs: Vec<&ShardInfo> = shards.iter().collect();
+
+    let members_2 = vec![
+        MemberInfo {
+            node_id: "node-a".to_string(),
+            grpc_addr: "http://a:7450".to_string(),
+            startup_time_ms: Some(1000),
+            hostname: None,
+            placement_rings: vec![],
+        },
+        MemberInfo {
+            node_id: "node-b".to_string(),
+            grpc_addr: "http://b:7450".to_string(),
+            startup_time_ms: Some(1000),
+            hostname: None,
+            placement_rings: vec![],
+        },
+    ];
+
+    let mut members_3 = members_2.clone();
+    members_3.push(MemberInfo {
+        node_id: "node-c".to_string(),
+        grpc_addr: "http://c:7450".to_string(),
+        startup_time_ms: Some(1000),
+        hostname: None,
+        placement_rings: vec![],
+    });
+
+    let before = compute_all_shard_assignments(&shard_refs, &members_2);
+    let after = compute_all_shard_assignments(&shard_refs, &members_3);
+
+    // Count how many shards changed owner
+    let mut moved = 0;
+    for shard in &shards {
+        if before.get(&shard.id) != after.get(&shard.id) {
+            moved += 1;
+        }
+    }
+
+    // With 12 shards going from 2 to 3 nodes, ideally ~4 move (1/3 of total).
+    // Allow up to 6 (half) as a reasonable bound — the key property is that
+    // the majority of shards stay put.
+    assert!(
+        moved <= 6,
+        "Too many shards moved: {moved}/12. Before: {before:?}, After: {after:?}"
+    );
+    // At least some should move to the new node
+    let new_node_count = after.values().filter(|v| v.as_str() == "node-c").count();
+    assert!(
+        new_node_count >= 2,
+        "New node should get some shards, got {new_node_count}"
+    );
+}
+
+#[silo::test]
+fn test_bounded_load_per_ring() {
+    use silo::coordination::compute_all_shard_assignments;
+
+    // 4 default shards, 4 gpu shards, with different eligible nodes per ring
+    let mut shards: Vec<ShardInfo> = Vec::new();
+    for i in 0..4 {
+        shards.push(ShardInfo::new(
+            ShardId::new(),
+            ShardRange::new(&format!("d{}", i), &format!("d{}", i + 1)),
+        ));
+    }
+    for i in 0..4 {
+        let mut s = ShardInfo::new(
+            ShardId::new(),
+            ShardRange::new(&format!("g{}", i), &format!("g{}", i + 1)),
+        );
+        s.placement_ring = Some("gpu".to_string());
+        shards.push(s);
+    }
+    let shard_refs: Vec<&ShardInfo> = shards.iter().collect();
+
+    let members = vec![
+        MemberInfo {
+            node_id: "default-1".to_string(),
+            grpc_addr: "http://d1:7450".to_string(),
+            startup_time_ms: Some(1000),
+            hostname: None,
+            placement_rings: vec![],
+        },
+        MemberInfo {
+            node_id: "default-2".to_string(),
+            grpc_addr: "http://d2:7450".to_string(),
+            startup_time_ms: Some(1000),
+            hostname: None,
+            placement_rings: vec![],
+        },
+        MemberInfo {
+            node_id: "gpu-1".to_string(),
+            grpc_addr: "http://g1:7450".to_string(),
+            startup_time_ms: Some(1000),
+            hostname: None,
+            placement_rings: vec!["gpu".to_string()],
+        },
+        MemberInfo {
+            node_id: "gpu-2".to_string(),
+            grpc_addr: "http://g2:7450".to_string(),
+            startup_time_ms: Some(1000),
+            hostname: None,
+            placement_rings: vec!["gpu".to_string()],
+        },
+    ];
+
+    let assignments = compute_all_shard_assignments(&shard_refs, &members);
+    assert_eq!(assignments.len(), 8);
+
+    // Default shards: 2 each across default-1 and default-2
+    let default_counts: std::collections::HashMap<&str, usize> = shards[0..4]
+        .iter()
+        .filter_map(|s| assignments.get(&s.id).map(|o| o.as_str()))
+        .fold(std::collections::HashMap::new(), |mut m, o| {
+            *m.entry(o).or_insert(0) += 1;
+            m
+        });
+    assert_eq!(default_counts.get("default-1"), Some(&2));
+    assert_eq!(default_counts.get("default-2"), Some(&2));
+
+    // GPU shards: 2 each across gpu-1 and gpu-2
+    let gpu_counts: std::collections::HashMap<&str, usize> = shards[4..8]
+        .iter()
+        .filter_map(|s| assignments.get(&s.id).map(|o| o.as_str()))
+        .fold(std::collections::HashMap::new(), |mut m, o| {
+            *m.entry(o).or_insert(0) += 1;
+            m
+        });
+    assert_eq!(gpu_counts.get("gpu-1"), Some(&2));
+    assert_eq!(gpu_counts.get("gpu-2"), Some(&2));
 }


### PR DESCRIPTION
## Summary
- Standard rendezvous hashing assigns each shard independently, producing significant imbalance at low shard counts (e.g. 5/1/2 across 3 nodes with 8 shards in production)
- Implements bounded-load rendezvous hashing: sorts all (shard, node) pairs by rendezvous score, greedily assigns respecting a `ceil(shards/nodes)` capacity cap per ring
- Guarantees shard counts differ by at most 1 across nodes while preserving stability (majority of shards stay put on resize) and determinism

## Test plan
- [x] New tests verify even distribution (8 shards / 3 nodes → 3/3/2)
- [x] New tests verify determinism (same inputs → same outputs)
- [x] New tests verify stability on node add (≤50% of shards move)
- [x] New tests verify per-ring balancing independently
- [x] Existing shard_range, coordination, routing tests all pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shard ownership selection algorithm, which can reshuffle shard-to-node assignments and affect load/traffic distribution during membership changes. New balancing logic is deterministic and ring-scoped but should be monitored for unexpected shard movement or unassigned shards when ring membership is misconfigured.
> 
> **Overview**
> Switches shard ownership computation from per-shard rendezvous selection to **bounded-load, ring-aware rendezvous hashing**, assigning shards across eligible nodes in each placement ring with a per-node cap of `ceil(shards/nodes)`.
> 
> Replaces `select_owner_for_shard` with `compute_all_shard_assignments` and updates `compute_shard_owner_map` and `compute_desired_shards_for_node` to use the new global assignment pass.
> 
> Expands tests to validate ring filtering plus **even distribution**, determinism, stability when adding nodes, and independent balancing per ring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fea29d598cb33295bc424bdf11cf9f64433c7815. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->