### PR TITLE
Harden K8s shard owner map convergence test

### DIFF
--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -732,7 +732,7 @@ async fn grpc_server_get_node_info_tracks_lifecycle() -> anyhow::Result<()> {
 /// queries but not be available for leaseTasks.
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_reset_shards_clears_fs_backend_data() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_secs(10), async {
         let test_shard_id = crate::grpc_integration_helpers::TEST_SHARD_ID;
         let tmp = tempfile::tempdir()?;
 
@@ -906,7 +906,7 @@ async fn grpc_server_reset_shards_clears_fs_backend_data() -> anyhow::Result<()>
         Ok::<(), anyhow::Error>(())
     })
     .await
-    .expect("test timed out")?;
+    .expect("reset_shards fs backend test timed out")?;
     Ok(())
 }
 
@@ -914,7 +914,7 @@ async fn grpc_server_reset_shards_clears_fs_backend_data() -> anyhow::Result<()>
 /// This reproduces the bug where relative paths might not resolve correctly.
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_reset_shards_with_relative_path() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_secs(10), async {
         let test_shard_id = crate::grpc_integration_helpers::TEST_SHARD_ID;
 
         // Create a temporary directory and use a RELATIVE path to it
@@ -1039,7 +1039,7 @@ async fn grpc_server_reset_shards_with_relative_path() -> anyhow::Result<()> {
         Ok::<(), anyhow::Error>(())
     })
     .await
-    .expect("test timed out")?;
+    .expect("reset_shards relative path test timed out")?;
     Ok(())
 }
 
@@ -1047,7 +1047,7 @@ async fn grpc_server_reset_shards_with_relative_path() -> anyhow::Result<()> {
 /// This ensures the object store deletion logic works correctly for non-filesystem backends.
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_reset_shards_clears_memory_backend_data() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_secs(10), async {
         let test_shard_id = crate::grpc_integration_helpers::TEST_SHARD_ID;
 
         // Use Memory backend to exercise the object store deletion path
@@ -1156,7 +1156,7 @@ async fn grpc_server_reset_shards_clears_memory_backend_data() -> anyhow::Result
         Ok::<(), anyhow::Error>(())
     })
     .await
-    .expect("test timed out")?;
+    .expect("reset_shards memory backend test timed out")?;
     Ok(())
 }
 

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -718,8 +718,15 @@ async fn k8s_get_shard_owner_map_accurate() {
     .await
     .expect("start c2");
 
-    assert!(c1.wait_converged(Duration::from_secs(30)).await);
-    assert!(c2.wait_converged(Duration::from_secs(30)).await);
+    // Allow more headroom in kind/CI while 16 shard leases rebalance across both nodes.
+    assert!(
+        c1.wait_converged(Duration::from_secs(45)).await,
+        "c1 should converge after two-node rebalance"
+    );
+    assert!(
+        c2.wait_converged(Duration::from_secs(45)).await,
+        "c2 should converge after two-node rebalance"
+    );
 
     // Get shard owner map
     let map = c1.get_shard_owner_map().await.expect("get_shard_owner_map");


### PR DESCRIPTION
## Summary
- increase the convergence timeout in `k8s_get_shard_owner_map_accurate`
- add explicit failure messages for both coordinators
- harden this known kind/CI timing-sensitive test without changing coordinator logic

## Verification
- `cargo test --test k8s_coordination_tests k8s_get_shard_owner_map_accurate -- --test-threads=1` (repeated locally)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust test timeouts and assertion messages to reduce CI flakiness, with no production logic modifications.
> 
> **Overview**
> Hardens timing-sensitive coordination and gRPC integration tests by increasing convergence/timeout budgets and improving failure diagnostics.
> 
> In `k8s_get_shard_owner_map_accurate`, increases `wait_converged` timeouts (30s → 45s) and adds explicit assertion messages for each coordinator. In `grpc_misc_tests.rs`, extends `reset_shards` regression-test timeouts (5s → 10s) and replaces generic timeout errors with test-specific messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 791635d7d4bc505199fb7932216008a58287a70b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->