### PR TITLE
Use sccache to share compilation artifacts among worktrees locally

### DIFF
--- a/nix/modules/devshell.nix
+++ b/nix/modules/devshell.nix
@@ -80,6 +80,7 @@
           watchexec # Auto-reload for development
           grpcurl # For health checking gRPC servers
           toxiproxy # Network fault injection proxy for testing
+          sccache # Shared compilation cache across worktrees
         ]);
 
         # Set the project root for the dev script
@@ -88,6 +89,11 @@
           export SILO_PROJECT_ROOT="$(pwd)"
           export RUSTFLAGS="-C force-frame-pointers=yes"
           export TOXIPROXY_CONFIG="${toxiproxyConfig}"
+          # Only use sccache locally -- in CI it has no warm cache and adds overhead
+          if [ -z "''${CI:-}" ]; then
+            export RUSTC_WRAPPER="${pkgs.sccache}/bin/sccache"
+            export SCCACHE_DIR="$HOME/.cache/sccache-silo"
+          fi
         '';
       };
     };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Nix devshell tooling by adding `sccache` and setting local-only environment variables; no production code or CI behavior should change.
> 
> **Overview**
> Improves local developer build performance by adding `sccache` to the Nix `devShell` and configuring `RUSTC_WRAPPER`/`SCCACHE_DIR` in `shellHook`.
> 
> ` sccache` is enabled only when `CI` is unset, avoiding extra overhead in CI environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66e8066680f9261679afb203e195d1e01a2dc149. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->