### PR TITLE
Fix RST_STREAM errors not retried under high-concurrency enqueue

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -2003,6 +2003,18 @@ where
         .expect("failed to build reflection service");
 
     let serve = tonic::transport::Server::builder()
+        // Increase HTTP/2 flow-control windows to improve throughput under
+        // high concurrency. The defaults (64 KiB stream, 1 MiB connection)
+        // can bottleneck when many streams are active simultaneously.
+        .initial_connection_window_size(Some(4 * 1024 * 1024)) // 4 MiB
+        .initial_stream_window_size(Some(2 * 1024 * 1024)) // 2 MiB
+        // Increase the number of reset streams the h2 layer remembers.
+        // When a stream is reset (e.g. due to "shard not ready" errors),
+        // h2 tracks it to correctly handle late-arriving frames. The
+        // default (20) is too low for burst traffic — when exceeded,
+        // evicted streams cause RST_STREAM with code 5 (STREAM_CLOSED)
+        // on late frames, which surfaces as gRPC INTERNAL errors.
+        .http2_max_pending_accept_reset_streams(Some(1000))
         .add_service(health_service)
         .add_service(reflection_service)
         .add_service(server)

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -942,11 +942,24 @@ function isWrongShardError(error: unknown): boolean {
 /**
  * Check if an error indicates a connectivity problem that may be resolved
  * by refreshing topology and retrying on a different server.
- * @internal
+ *
+ * Matches UNAVAILABLE, DEADLINE_EXCEEDED, and INTERNAL errors caused by
+ * HTTP/2 stream failures (e.g. RST_STREAM with code 5 when the h2 layer
+ * evicts a reset stream from memory and late-arriving frames trigger
+ * STREAM_CLOSED). These transport-level INTERNAL errors are transient
+ * and safe to retry with topology refresh.
  */
-function isConnectivityError(error: unknown): boolean {
+export function isConnectivityError(error: unknown): boolean {
   if (error instanceof RpcError) {
-    return error.code === "UNAVAILABLE" || error.code === "DEADLINE_EXCEEDED";
+    if (error.code === "UNAVAILABLE" || error.code === "DEADLINE_EXCEEDED") {
+      return true;
+    }
+    // RST_STREAM errors surface as INTERNAL with a message like
+    // "Received RST_STREAM with code <N>". These are transport-level
+    // failures (e.g. stream exhaustion) and should be retried.
+    if (error.code === "INTERNAL" && error.message.includes("RST_STREAM")) {
+      return true;
+    }
   }
   return false;
 }
@@ -1240,10 +1253,18 @@ export class SiloGRPCClient {
 
     // Default gRPC service config with retry policy for transient failures.
     // Only RESOURCE_EXHAUSTED is retried at the gRPC level (server-side
-    // backpressure on a live connection). UNAVAILABLE is NOT retried here
-    // because our application-level retry (_withShardRetry) handles it with
-    // topology refresh, allowing re-routing to a different server instead of
-    // repeatedly hitting the same dead connection.
+    // backpressure on a live connection).
+    // INTERNAL is NOT retried here because the silo server uses
+    // Status::internal() for deterministic errors (query failures, storage
+    // errors, codec errors) that would fail on every retry. Transport-level
+    // INTERNAL errors like RST_STREAM are instead handled by our
+    // application-level retry (isConnectivityError + _withShardRetry),
+    // which can match on the error message to distinguish transient
+    // RST_STREAM failures from permanent server errors.
+    // UNAVAILABLE is NOT retried here because our application-level retry
+    // (_withShardRetry) handles it with topology refresh, allowing
+    // re-routing to a different server instead of repeatedly hitting the
+    // same dead connection.
     const defaultServiceConfig = {
       methodConfig: [
         {

--- a/typescript_client/src/index.ts
+++ b/typescript_client/src/index.ts
@@ -16,6 +16,7 @@ export {
   SiloResourceExhaustedError,
   SiloUnavailableError,
   SiloDeadlineExceededError,
+  isConnectivityError,
   initHasher,
   hashTenant,
   shardForTenant,

--- a/typescript_client/test/client.test.ts
+++ b/typescript_client/test/client.test.ts
@@ -17,6 +17,7 @@ import {
   SiloResourceExhaustedError,
   SiloUnavailableError,
   SiloDeadlineExceededError,
+  isConnectivityError,
   encodeBytes,
   decodeBytes,
   type EnqueueJobOptions,
@@ -82,9 +83,7 @@ describe("decodeBytes", () => {
   });
 
   it("throws for undefined input", () => {
-    expect(() => decodeBytes(undefined, "test")).toThrow(
-      "No bytes to decode for field test",
-    );
+    expect(() => decodeBytes(undefined, "test")).toThrow("No bytes to decode for field test");
   });
 
   it("throws for empty byte array", () => {
@@ -328,14 +327,8 @@ describe("SiloGRPCClient", () => {
   });
 
   describe("error mapping", () => {
-    const mockWithShardRetryError = (
-      client: SiloGRPCClient,
-      code: string,
-      message: string,
-    ) => {
-      (client as any)._withShardRetry = vi
-        .fn()
-        .mockRejectedValue(new RpcError(message, code, {}));
+    const mockWithShardRetryError = (client: SiloGRPCClient, code: string, message: string) => {
+      (client as any)._withShardRetry = vi.fn().mockRejectedValue(new RpcError(message, code, {}));
     };
 
     it("maps ALREADY_EXISTS on enqueue to JobAlreadyExistsError", async () => {
@@ -390,9 +383,7 @@ describe("SiloGRPCClient", () => {
       });
       mockWithShardRetryError(client, "NOT_FOUND", "job not found");
 
-      await expect(client.getJob("job-404", "tenant-abc")).rejects.toThrow(
-        JobNotFoundError,
-      );
+      await expect(client.getJob("job-404", "tenant-abc")).rejects.toThrow(JobNotFoundError);
     });
 
     it("maps NOT_FOUND on heartbeat to TaskNotFoundError", async () => {
@@ -402,15 +393,13 @@ describe("SiloGRPCClient", () => {
       });
       (client as any)._getClientForShard = vi.fn().mockReturnValue({
         heartbeat: vi.fn().mockReturnValue({
-          response: Promise.reject(
-            new RpcError("task not found", "NOT_FOUND", {}),
-          ),
+          response: Promise.reject(new RpcError("task not found", "NOT_FOUND", {})),
         }),
       });
 
-      await expect(
-        client.heartbeat("worker-a", "task-404", "shard-1"),
-      ).rejects.toThrow(TaskNotFoundError);
+      await expect(client.heartbeat("worker-a", "task-404", "shard-1")).rejects.toThrow(
+        TaskNotFoundError,
+      );
     });
   });
 });
@@ -484,9 +473,7 @@ describe("AwaitJobOptions type", () => {
 describe("JobNotFoundError", () => {
   it("formats error message with job id and tenant", () => {
     const error = new JobNotFoundError("job-123", "tenant-abc");
-    expect(error.message).toBe(
-      'Job "job-123" not found in tenant "tenant-abc"',
-    );
+    expect(error.message).toBe('Job "job-123" not found in tenant "tenant-abc"');
     expect(error.name).toBe("JobNotFoundError");
     expect(error.code).toBe("SILO_JOB_NOT_FOUND");
     expect(error.jobId).toBe("job-123");
@@ -510,11 +497,7 @@ describe("JobNotFoundError", () => {
 
 describe("JobNotTerminalError", () => {
   it("formats error message with job id, tenant, and status", () => {
-    const error = new JobNotTerminalError(
-      "job-123",
-      "tenant-abc",
-      JobStatus.Running,
-    );
+    const error = new JobNotTerminalError("job-123", "tenant-abc", JobStatus.Running);
     expect(error.message).toBe(
       'Job "job-123" in tenant "tenant-abc" is not in a terminal state (current status: Running)',
     );
@@ -560,9 +543,7 @@ describe("TaskNotFoundError", () => {
 describe("JobAlreadyExistsError", () => {
   it("formats error message with job id and tenant", () => {
     const error = new JobAlreadyExistsError("job-123", "tenant-abc");
-    expect(error.message).toBe(
-      'Job "job-123" already exists in tenant "tenant-abc"',
-    );
+    expect(error.message).toBe('Job "job-123" already exists in tenant "tenant-abc"');
     expect(error.name).toBe("JobAlreadyExistsError");
     expect(error.code).toBe("SILO_JOB_ALREADY_EXISTS");
     expect(error.grpcCode).toBe("ALREADY_EXISTS");
@@ -736,10 +717,57 @@ describe("SiloGRPCClient.query deserialization", () => {
       };
     });
 
-    const result = await client.query<CountRow>(
-      "SELECT COUNT(*) as count FROM jobs",
-    );
+    const result = await client.query<CountRow>("SELECT COUNT(*) as count FROM jobs");
     const row: CountRow = result.rows[0];
     expect(row.count).toBe(42);
+  });
+});
+
+describe("isConnectivityError", () => {
+  it("returns true for UNAVAILABLE", () => {
+    const error = new RpcError("server unavailable", "UNAVAILABLE", {});
+    expect(isConnectivityError(error)).toBe(true);
+  });
+
+  it("returns true for DEADLINE_EXCEEDED", () => {
+    const error = new RpcError("deadline exceeded", "DEADLINE_EXCEEDED", {});
+    expect(isConnectivityError(error)).toBe(true);
+  });
+
+  it("returns true for INTERNAL with RST_STREAM message", () => {
+    const error = new RpcError("Received RST_STREAM with code 5", "INTERNAL", {});
+    expect(isConnectivityError(error)).toBe(true);
+  });
+
+  it("returns true for INTERNAL with RST_STREAM code 2", () => {
+    const error = new RpcError("Received RST_STREAM with code 2", "INTERNAL", {});
+    expect(isConnectivityError(error)).toBe(true);
+  });
+
+  it("returns false for INTERNAL without RST_STREAM", () => {
+    const error = new RpcError("internal server error", "INTERNAL", {});
+    expect(isConnectivityError(error)).toBe(false);
+  });
+
+  it("returns false for NOT_FOUND", () => {
+    const error = new RpcError("not found", "NOT_FOUND", {});
+    expect(isConnectivityError(error)).toBe(false);
+  });
+
+  it("returns false for ALREADY_EXISTS", () => {
+    const error = new RpcError("already exists", "ALREADY_EXISTS", {});
+    expect(isConnectivityError(error)).toBe(false);
+  });
+
+  it("returns false for RESOURCE_EXHAUSTED", () => {
+    const error = new RpcError("exhausted", "RESOURCE_EXHAUSTED", {});
+    expect(isConnectivityError(error)).toBe(false);
+  });
+
+  it("returns false for non-RpcError", () => {
+    expect(isConnectivityError(new Error("generic"))).toBe(false);
+    expect(isConnectivityError("string error")).toBe(false);
+    expect(isConnectivityError(null)).toBe(false);
+    expect(isConnectivityError(undefined)).toBe(false);
   });
 });

--- a/typescript_client/test/toxiproxy-integration.test.ts
+++ b/typescript_client/test/toxiproxy-integration.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeAll,
-  beforeEach,
-  afterAll,
-  afterEach,
-} from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from "vitest";
 import { SiloGRPCClient } from "../src/client";
 import {
   Toxiproxy,
@@ -17,6 +9,7 @@ import {
   type Slicer,
   type Slowclose,
 } from "toxiproxy-node-client";
+import type { ResetPeer } from "toxiproxy-node-client/dist/Toxic";
 
 // Direct silo servers (for setup/verification)
 const SILO_SERVERS = (
@@ -30,11 +23,9 @@ const TOXIPROXY_SILO_SERVERS = (
   process.env.TOXIPROXY_SILO_SERVERS || "localhost:17450,localhost:17451"
 ).split(",");
 
-const TOXIPROXY_API_URL =
-  process.env.TOXIPROXY_API_URL || "http://127.0.0.1:8474";
+const TOXIPROXY_API_URL = process.env.TOXIPROXY_API_URL || "http://127.0.0.1:8474";
 
-const RUN_INTEGRATION =
-  process.env.RUN_INTEGRATION === "true" || process.env.CI === "true";
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION === "true" || process.env.CI === "true";
 
 const DEFAULT_TASK_GROUP = "toxiproxy-test-group";
 
@@ -99,9 +90,7 @@ async function waitForClusterConvergence(
     }
 
     if (attempt === maxAttempts) {
-      throw new Error(
-        `Cluster did not converge after ${maxAttempts} attempts.`,
-      );
+      throw new Error(`Cluster did not converge after ${maxAttempts} attempts.`);
     }
 
     await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -351,9 +340,7 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
       await toxic2.remove();
 
       // Retry until gRPC reconnects instead of a fixed sleep
-      const job = await retryUntilSuccess(() =>
-        proxyClient.getJob(handle.id, tenant),
-      );
+      const job = await retryUntilSuccess(() => proxyClient.getJob(handle.id, tenant));
       expect(job?.id).toBe(handle.id);
     });
   });
@@ -394,9 +381,7 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
       });
 
       // Retry until gRPC reconnects instead of a fixed sleep
-      const job = await retryUntilSuccess(() =>
-        proxyClient.getJob(handle.id, tenant),
-      );
+      const job = await retryUntilSuccess(() => proxyClient.getJob(handle.id, tenant));
       expect(job?.id).toBe(handle.id);
     });
   });
@@ -597,6 +582,133 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
         items: [1, 2, 3, 4, 5],
       });
     });
+  });
+
+  describe("high concurrency enqueue", () => {
+    it("handles many concurrent enqueues without losing requests", async () => {
+      // Simulate a burst of concurrent enqueues similar to the production
+      // incident where 99K+ enqueues overwhelmed a single connection.
+      // @grpc/grpc-js handles HTTP/2 stream multiplexing natively; this
+      // test verifies that all requests complete under concurrent load.
+      const concurrency = 200;
+      const tenant = `high-concurrency-${Date.now()}`;
+
+      const promises = Array.from({ length: concurrency }, (_, i) =>
+        proxyClient.enqueue({
+          tenant: `${tenant}-${i}`,
+          taskGroup: DEFAULT_TASK_GROUP,
+          payload: { index: i, test: "high-concurrency" },
+        }),
+      );
+
+      const results = await Promise.allSettled(promises);
+      const succeeded = results.filter((r) => r.status === "fulfilled");
+      const failed = results.filter((r) => r.status === "rejected");
+
+      // All requests should succeed under concurrent load.
+      expect(succeeded.length).toBe(concurrency);
+      expect(failed.length).toBe(0);
+    }, 30_000);
+  });
+
+  describe("connection reset recovery", () => {
+    it("recovers from connection reset during enqueue", async () => {
+      const tenant = `reset-recovery-${Date.now()}`;
+
+      // First enqueue should succeed
+      const handle1 = await proxyClient.enqueue({
+        tenant,
+        taskGroup: DEFAULT_TASK_GROUP,
+        payload: { phase: "before-reset" },
+      });
+      expect(handle1.id).toBeTruthy();
+
+      // Add a reset_peer toxic to simulate RST_STREAM-like behavior.
+      // This causes the proxy to reset connections, producing errors
+      // similar to what happens during HTTP/2 stream exhaustion.
+      const toxic1 = await silo1.addToxic<ResetPeer>({
+        name: "reset-peer",
+        type: "reset_peer",
+        stream: "downstream",
+        toxicity: 1.0,
+        attributes: { timeout: 100 },
+      });
+      const toxic2 = await silo2.addToxic<ResetPeer>({
+        name: "reset-peer",
+        type: "reset_peer",
+        stream: "downstream",
+        toxicity: 1.0,
+        attributes: { timeout: 100 },
+      });
+
+      // Operations during the toxic should fail
+      await expect(
+        proxyClient.enqueue({
+          tenant: `${tenant}-during`,
+          taskGroup: DEFAULT_TASK_GROUP,
+          payload: { phase: "during-reset" },
+        }),
+      ).rejects.toThrow();
+
+      // Remove the toxic
+      await toxic1.remove();
+      await toxic2.remove();
+
+      // After recovery, operations should succeed
+      const handle3 = await retryUntilSuccess(() =>
+        proxyClient.enqueue({
+          tenant: `${tenant}-after`,
+          taskGroup: DEFAULT_TASK_GROUP,
+          payload: { phase: "after-reset" },
+        }),
+      );
+      expect(handle3.id).toBeTruthy();
+    });
+
+    it("retries and recovers from intermittent connection resets", async () => {
+      // Use a low toxicity to simulate intermittent RST_STREAM errors
+      // (only a fraction of requests are affected). The client's retry
+      // logic should recover transparently.
+      await silo1.addToxic<ResetPeer>({
+        name: "intermittent-reset",
+        type: "reset_peer",
+        stream: "downstream",
+        toxicity: 0.3, // 30% of connections get reset
+        attributes: { timeout: 200 },
+      });
+      await silo2.addToxic<ResetPeer>({
+        name: "intermittent-reset",
+        type: "reset_peer",
+        stream: "downstream",
+        toxicity: 0.3,
+        attributes: { timeout: 200 },
+      });
+
+      // With retry logic, most operations should eventually succeed
+      const results: string[] = [];
+      const errors: Error[] = [];
+
+      for (let i = 0; i < 10; i++) {
+        try {
+          const handle = await retryUntilSuccess(
+            () =>
+              proxyClient.enqueue({
+                tenant: `intermittent-${Date.now()}-${i}`,
+                taskGroup: DEFAULT_TASK_GROUP,
+                payload: { index: i },
+              }),
+            10,
+            200,
+          );
+          results.push(handle.id);
+        } catch (e) {
+          errors.push(e as Error);
+        }
+      }
+
+      // Most should succeed thanks to retries
+      expect(results.length).toBeGreaterThanOrEqual(8);
+    }, 30_000);
   });
 
   describe("topology refresh under network issues", () => {


### PR DESCRIPTION
## Summary

- Fixes a production issue where 99K+ concurrent enqueues caused RST_STREAM code 5 (STREAM_CLOSED) errors that escaped all retry layers
- Root cause: the h2 crate's reset-stream memory limit (default 20) gets overwhelmed during burst traffic, causing late-arriving frames to trigger STREAM_CLOSED errors that map to gRPC INTERNAL — which wasn't retried
- Client now retries INTERNAL errors containing "RST_STREAM" with topology refresh + backoff
- Server now remembers 1000 reset streams (up from 20) and has larger HTTP/2 flow-control windows

## Test plan

- [x] Unit tests for `isConnectivityError` covering RST_STREAM, standard retryable codes, and non-retryable codes
- [x] Toxiproxy integration tests for high-concurrency enqueue, connection reset recovery, and intermittent reset recovery
- [x] TypeScript typecheck passes
- [x] Rust compilation passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gRPC transport tuning and client retry classification, which can affect throughput and error-handling behavior under load. While scoped to transient transport failures, misclassification could cause extra retries or mask real INTERNAL errors.
> 
> **Overview**
> Improves resilience to HTTP/2 `RST_STREAM` failures under bursty/high-concurrency traffic by tuning server-side HTTP/2 settings and expanding the client’s notion of retryable connectivity errors.
> 
> On the Rust server, increases HTTP/2 flow-control window sizes and raises `h2`’s remembered reset-stream limit to reduce `STREAM_CLOSED`/`INTERNAL` errors from late frames. On the TypeScript client, exports and extends `isConnectivityError` to treat `INTERNAL` errors containing `RST_STREAM` as transient (handled via topology refresh + app-level retry), and adds unit + toxiproxy integration tests covering high-concurrency enqueues and connection reset recovery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb89139e1aa1fed2fcac3e4d59e66beaa8562713. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->