### PR TITLE
Add poll counter and latency server side metrics

### DIFF
--- a/nix/modules/devshell.nix
+++ b/nix/modules/devshell.nix
@@ -80,6 +80,7 @@
           watchexec # Auto-reload for development
           grpcurl # For health checking gRPC servers
           toxiproxy # Network fault injection proxy for testing
+          sccache # Shared compilation cache across worktrees
         ]);
 
         # Set the project root for the dev script
@@ -88,6 +89,11 @@
           export SILO_PROJECT_ROOT="$(pwd)"
           export RUSTFLAGS="-C force-frame-pointers=yes"
           export TOXIPROXY_CONFIG="${toxiproxyConfig}"
+          # Only use sccache locally -- in CI it has no warm cache and adds overhead
+          if [ -z "''${CI:-}" ]; then
+            export RUSTC_WRAPPER="${pkgs.sccache}/bin/sccache"
+            export SCCACHE_DIR="$HOME/.cache/sccache-silo"
+          fi
         '';
       };
     };

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -74,6 +74,10 @@ pub struct Metrics {
     broker_inflight_size: GaugeVec,
     broker_scan_duration: HistogramVec,
 
+    // Poll metrics
+    polls_total: CounterVec,
+    poll_duration: HistogramVec,
+
     // Lease metrics
     task_leases_active: GaugeVec,
     ready_to_start_latency_ms: HistogramVec,
@@ -187,6 +191,18 @@ impl Metrics {
     /// Record broker scan duration in seconds.
     pub fn record_broker_scan_duration(&self, shard: &str, duration_secs: f64) {
         self.broker_scan_duration
+            .with_label_values(&[shard])
+            .observe(duration_secs);
+    }
+
+    /// Record a poll (lease_tasks call) for a shard.
+    pub fn record_poll(&self, shard: &str) {
+        self.polls_total.with_label_values(&[shard]).inc();
+    }
+
+    /// Record poll duration (time to service a lease_tasks call for a shard) in seconds.
+    pub fn record_poll_duration(&self, shard: &str, duration_secs: f64) {
+        self.poll_duration
             .with_label_values(&[shard])
             .observe(duration_secs);
     }
@@ -439,6 +455,30 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    // Poll metrics
+    let polls_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_polls_total",
+                "Total number of lease_tasks polls received per shard",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let poll_duration = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_poll_duration_seconds",
+                "Duration of lease_tasks poll per shard in seconds",
+            )
+            .buckets(LATENCY_BUCKETS.to_vec()),
+            &["shard"],
+        )?,
+    );
+
     // Lease metrics
     let task_leases_active = register(
         &registry,
@@ -642,6 +682,8 @@ pub fn init() -> anyhow::Result<Metrics> {
         broker_buffer_size,
         broker_inflight_size,
         broker_scan_duration,
+        polls_total,
+        poll_duration,
         task_leases_active,
         ready_to_start_latency_ms,
         concurrency_tickets_granted,

--- a/src/server.rs
+++ b/src/server.rs
@@ -2009,6 +2009,18 @@ where
         .expect("failed to build reflection service");
 
     let serve = tonic::transport::Server::builder()
+        // Increase HTTP/2 flow-control windows to improve throughput under
+        // high concurrency. The defaults (64 KiB stream, 1 MiB connection)
+        // can bottleneck when many streams are active simultaneously.
+        .initial_connection_window_size(Some(4 * 1024 * 1024)) // 4 MiB
+        .initial_stream_window_size(Some(2 * 1024 * 1024)) // 2 MiB
+        // Increase the number of reset streams the h2 layer remembers.
+        // When a stream is reset (e.g. due to "shard not ready" errors),
+        // h2 tracks it to correctly handle late-arriving frames. The
+        // default (20) is too low for burst traffic — when exceeded,
+        // evicted streams cause RST_STREAM with code 5 (STREAM_CLOSED)
+        // on late frames, which surfaces as gRPC INTERNAL errors.
+        .http2_max_pending_accept_reset_streams(Some(1000))
         .add_service(health_service)
         .add_service(reflection_service)
         .add_service(server)

--- a/src/server.rs
+++ b/src/server.rs
@@ -1184,6 +1184,7 @@ impl Silo for SiloService {
                 break;
             }
 
+            let poll_start = std::time::Instant::now();
             let result = shard
                 .dequeue(&r.worker_id, &r.task_group, remaining)
                 .await
@@ -1192,6 +1193,11 @@ impl Silo for SiloService {
             let tasks_added = result.tasks.len();
             let shard_str = shard_id.to_string();
             let now_ms = crate::job_store_shard::now_epoch_ms();
+
+            if let Some(ref m) = self.metrics {
+                m.record_poll(&shard_str);
+                m.record_poll_duration(&shard_str, poll_start.elapsed().as_secs_f64());
+            }
 
             for lt in result.tasks {
                 // Record attempt and wait time metrics

--- a/tests/job_store_shard_enqueue_tests.rs
+++ b/tests/job_store_shard_enqueue_tests.rs
@@ -476,7 +476,10 @@ async fn cannot_delete_scheduled_job() {
 async fn priority_ordering_when_start_times_equal() {
     with_timeout!(20000, {
         let (_tmp, shard) = open_temp_shard().await;
-        let now = now_ms();
+        // Use a timestamp in the past so that both tasks are immediately eligible
+        // regardless of when the broker scanner runs (avoids a race where the first
+        // enqueue triggers a scan that completes before the second enqueue).
+        let past = now_ms() - 1000;
 
         // Enqueue two jobs with identical start_at_ms but different priorities
         let job_hi = shard
@@ -484,7 +487,7 @@ async fn priority_ordering_when_start_times_equal() {
                 "-",
                 None,
                 1u8, // higher priority
-                now,
+                past,
                 None,
                 test_helpers::msgpack_payload(&serde_json::json!({"j": "hi"})),
                 vec![],
@@ -498,7 +501,7 @@ async fn priority_ordering_when_start_times_equal() {
                 "-",
                 None,
                 50u8, // lower priority
-                now,
+                past,
                 None,
                 test_helpers::msgpack_payload(&serde_json::json!({"j": "lo"})),
                 vec![],
@@ -507,6 +510,11 @@ async fn priority_ordering_when_start_times_equal() {
             )
             .await
             .expect("enqueue lo");
+
+        // Allow the broker scanner to pick up both tasks before dequeuing.
+        // The first enqueue wakes the scanner which may complete before the second
+        // enqueue; this sleep ensures a subsequent scan sees both tasks in the DB.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // Dequeue two tasks; with equal times, lower priority number should come first
         let tasks = shard

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -942,11 +942,24 @@ function isWrongShardError(error: unknown): boolean {
 /**
  * Check if an error indicates a connectivity problem that may be resolved
  * by refreshing topology and retrying on a different server.
- * @internal
+ *
+ * Matches UNAVAILABLE, DEADLINE_EXCEEDED, and INTERNAL errors caused by
+ * HTTP/2 stream failures (e.g. RST_STREAM with code 5 when the h2 layer
+ * evicts a reset stream from memory and late-arriving frames trigger
+ * STREAM_CLOSED). These transport-level INTERNAL errors are transient
+ * and safe to retry with topology refresh.
  */
-function isConnectivityError(error: unknown): boolean {
+export function isConnectivityError(error: unknown): boolean {
   if (error instanceof RpcError) {
-    return error.code === "UNAVAILABLE" || error.code === "DEADLINE_EXCEEDED";
+    if (error.code === "UNAVAILABLE" || error.code === "DEADLINE_EXCEEDED") {
+      return true;
+    }
+    // RST_STREAM errors surface as INTERNAL with a message like
+    // "Received RST_STREAM with code <N>". These are transport-level
+    // failures (e.g. stream exhaustion) and should be retried.
+    if (error.code === "INTERNAL" && error.message.includes("RST_STREAM")) {
+      return true;
+    }
   }
   return false;
 }
@@ -1240,10 +1253,18 @@ export class SiloGRPCClient {
 
     // Default gRPC service config with retry policy for transient failures.
     // Only RESOURCE_EXHAUSTED is retried at the gRPC level (server-side
-    // backpressure on a live connection). UNAVAILABLE is NOT retried here
-    // because our application-level retry (_withShardRetry) handles it with
-    // topology refresh, allowing re-routing to a different server instead of
-    // repeatedly hitting the same dead connection.
+    // backpressure on a live connection).
+    // INTERNAL is NOT retried here because the silo server uses
+    // Status::internal() for deterministic errors (query failures, storage
+    // errors, codec errors) that would fail on every retry. Transport-level
+    // INTERNAL errors like RST_STREAM are instead handled by our
+    // application-level retry (isConnectivityError + _withShardRetry),
+    // which can match on the error message to distinguish transient
+    // RST_STREAM failures from permanent server errors.
+    // UNAVAILABLE is NOT retried here because our application-level retry
+    // (_withShardRetry) handles it with topology refresh, allowing
+    // re-routing to a different server instead of repeatedly hitting the
+    // same dead connection.
     const defaultServiceConfig = {
       methodConfig: [
         {

--- a/typescript_client/src/index.ts
+++ b/typescript_client/src/index.ts
@@ -16,6 +16,7 @@ export {
   SiloResourceExhaustedError,
   SiloUnavailableError,
   SiloDeadlineExceededError,
+  isConnectivityError,
   initHasher,
   hashTenant,
   shardForTenant,

--- a/typescript_client/test/client.test.ts
+++ b/typescript_client/test/client.test.ts
@@ -17,6 +17,7 @@ import {
   SiloResourceExhaustedError,
   SiloUnavailableError,
   SiloDeadlineExceededError,
+  isConnectivityError,
   encodeBytes,
   decodeBytes,
   type EnqueueJobOptions,
@@ -82,9 +83,7 @@ describe("decodeBytes", () => {
   });
 
   it("throws for undefined input", () => {
-    expect(() => decodeBytes(undefined, "test")).toThrow(
-      "No bytes to decode for field test",
-    );
+    expect(() => decodeBytes(undefined, "test")).toThrow("No bytes to decode for field test");
   });
 
   it("throws for empty byte array", () => {
@@ -328,14 +327,8 @@ describe("SiloGRPCClient", () => {
   });
 
   describe("error mapping", () => {
-    const mockWithShardRetryError = (
-      client: SiloGRPCClient,
-      code: string,
-      message: string,
-    ) => {
-      (client as any)._withShardRetry = vi
-        .fn()
-        .mockRejectedValue(new RpcError(message, code, {}));
+    const mockWithShardRetryError = (client: SiloGRPCClient, code: string, message: string) => {
+      (client as any)._withShardRetry = vi.fn().mockRejectedValue(new RpcError(message, code, {}));
     };
 
     it("maps ALREADY_EXISTS on enqueue to JobAlreadyExistsError", async () => {
@@ -390,9 +383,7 @@ describe("SiloGRPCClient", () => {
       });
       mockWithShardRetryError(client, "NOT_FOUND", "job not found");
 
-      await expect(client.getJob("job-404", "tenant-abc")).rejects.toThrow(
-        JobNotFoundError,
-      );
+      await expect(client.getJob("job-404", "tenant-abc")).rejects.toThrow(JobNotFoundError);
     });
 
     it("maps NOT_FOUND on heartbeat to TaskNotFoundError", async () => {
@@ -402,15 +393,13 @@ describe("SiloGRPCClient", () => {
       });
       (client as any)._getClientForShard = vi.fn().mockReturnValue({
         heartbeat: vi.fn().mockReturnValue({
-          response: Promise.reject(
-            new RpcError("task not found", "NOT_FOUND", {}),
-          ),
+          response: Promise.reject(new RpcError("task not found", "NOT_FOUND", {})),
         }),
       });
 
-      await expect(
-        client.heartbeat("worker-a", "task-404", "shard-1"),
-      ).rejects.toThrow(TaskNotFoundError);
+      await expect(client.heartbeat("worker-a", "task-404", "shard-1")).rejects.toThrow(
+        TaskNotFoundError,
+      );
     });
   });
 });
@@ -484,9 +473,7 @@ describe("AwaitJobOptions type", () => {
 describe("JobNotFoundError", () => {
   it("formats error message with job id and tenant", () => {
     const error = new JobNotFoundError("job-123", "tenant-abc");
-    expect(error.message).toBe(
-      'Job "job-123" not found in tenant "tenant-abc"',
-    );
+    expect(error.message).toBe('Job "job-123" not found in tenant "tenant-abc"');
     expect(error.name).toBe("JobNotFoundError");
     expect(error.code).toBe("SILO_JOB_NOT_FOUND");
     expect(error.jobId).toBe("job-123");
@@ -510,11 +497,7 @@ describe("JobNotFoundError", () => {
 
 describe("JobNotTerminalError", () => {
   it("formats error message with job id, tenant, and status", () => {
-    const error = new JobNotTerminalError(
-      "job-123",
-      "tenant-abc",
-      JobStatus.Running,
-    );
+    const error = new JobNotTerminalError("job-123", "tenant-abc", JobStatus.Running);
     expect(error.message).toBe(
       'Job "job-123" in tenant "tenant-abc" is not in a terminal state (current status: Running)',
     );
@@ -560,9 +543,7 @@ describe("TaskNotFoundError", () => {
 describe("JobAlreadyExistsError", () => {
   it("formats error message with job id and tenant", () => {
     const error = new JobAlreadyExistsError("job-123", "tenant-abc");
-    expect(error.message).toBe(
-      'Job "job-123" already exists in tenant "tenant-abc"',
-    );
+    expect(error.message).toBe('Job "job-123" already exists in tenant "tenant-abc"');
     expect(error.name).toBe("JobAlreadyExistsError");
     expect(error.code).toBe("SILO_JOB_ALREADY_EXISTS");
     expect(error.grpcCode).toBe("ALREADY_EXISTS");
@@ -736,10 +717,57 @@ describe("SiloGRPCClient.query deserialization", () => {
       };
     });
 
-    const result = await client.query<CountRow>(
-      "SELECT COUNT(*) as count FROM jobs",
-    );
+    const result = await client.query<CountRow>("SELECT COUNT(*) as count FROM jobs");
     const row: CountRow = result.rows[0];
     expect(row.count).toBe(42);
+  });
+});
+
+describe("isConnectivityError", () => {
+  it("returns true for UNAVAILABLE", () => {
+    const error = new RpcError("server unavailable", "UNAVAILABLE", {});
+    expect(isConnectivityError(error)).toBe(true);
+  });
+
+  it("returns true for DEADLINE_EXCEEDED", () => {
+    const error = new RpcError("deadline exceeded", "DEADLINE_EXCEEDED", {});
+    expect(isConnectivityError(error)).toBe(true);
+  });
+
+  it("returns true for INTERNAL with RST_STREAM message", () => {
+    const error = new RpcError("Received RST_STREAM with code 5", "INTERNAL", {});
+    expect(isConnectivityError(error)).toBe(true);
+  });
+
+  it("returns true for INTERNAL with RST_STREAM code 2", () => {
+    const error = new RpcError("Received RST_STREAM with code 2", "INTERNAL", {});
+    expect(isConnectivityError(error)).toBe(true);
+  });
+
+  it("returns false for INTERNAL without RST_STREAM", () => {
+    const error = new RpcError("internal server error", "INTERNAL", {});
+    expect(isConnectivityError(error)).toBe(false);
+  });
+
+  it("returns false for NOT_FOUND", () => {
+    const error = new RpcError("not found", "NOT_FOUND", {});
+    expect(isConnectivityError(error)).toBe(false);
+  });
+
+  it("returns false for ALREADY_EXISTS", () => {
+    const error = new RpcError("already exists", "ALREADY_EXISTS", {});
+    expect(isConnectivityError(error)).toBe(false);
+  });
+
+  it("returns false for RESOURCE_EXHAUSTED", () => {
+    const error = new RpcError("exhausted", "RESOURCE_EXHAUSTED", {});
+    expect(isConnectivityError(error)).toBe(false);
+  });
+
+  it("returns false for non-RpcError", () => {
+    expect(isConnectivityError(new Error("generic"))).toBe(false);
+    expect(isConnectivityError("string error")).toBe(false);
+    expect(isConnectivityError(null)).toBe(false);
+    expect(isConnectivityError(undefined)).toBe(false);
   });
 });

--- a/typescript_client/test/toxiproxy-integration.test.ts
+++ b/typescript_client/test/toxiproxy-integration.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeAll,
-  beforeEach,
-  afterAll,
-  afterEach,
-} from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from "vitest";
 import { SiloGRPCClient } from "../src/client";
 import {
   Toxiproxy,
@@ -17,6 +9,7 @@ import {
   type Slicer,
   type Slowclose,
 } from "toxiproxy-node-client";
+import type { ResetPeer } from "toxiproxy-node-client/dist/Toxic";
 
 // Direct silo servers (for setup/verification)
 const SILO_SERVERS = (
@@ -30,11 +23,9 @@ const TOXIPROXY_SILO_SERVERS = (
   process.env.TOXIPROXY_SILO_SERVERS || "localhost:17450,localhost:17451"
 ).split(",");
 
-const TOXIPROXY_API_URL =
-  process.env.TOXIPROXY_API_URL || "http://127.0.0.1:8474";
+const TOXIPROXY_API_URL = process.env.TOXIPROXY_API_URL || "http://127.0.0.1:8474";
 
-const RUN_INTEGRATION =
-  process.env.RUN_INTEGRATION === "true" || process.env.CI === "true";
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION === "true" || process.env.CI === "true";
 
 const DEFAULT_TASK_GROUP = "toxiproxy-test-group";
 
@@ -99,9 +90,7 @@ async function waitForClusterConvergence(
     }
 
     if (attempt === maxAttempts) {
-      throw new Error(
-        `Cluster did not converge after ${maxAttempts} attempts.`,
-      );
+      throw new Error(`Cluster did not converge after ${maxAttempts} attempts.`);
     }
 
     await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -351,9 +340,7 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
       await toxic2.remove();
 
       // Retry until gRPC reconnects instead of a fixed sleep
-      const job = await retryUntilSuccess(() =>
-        proxyClient.getJob(handle.id, tenant),
-      );
+      const job = await retryUntilSuccess(() => proxyClient.getJob(handle.id, tenant));
       expect(job?.id).toBe(handle.id);
     });
   });
@@ -394,9 +381,7 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
       });
 
       // Retry until gRPC reconnects instead of a fixed sleep
-      const job = await retryUntilSuccess(() =>
-        proxyClient.getJob(handle.id, tenant),
-      );
+      const job = await retryUntilSuccess(() => proxyClient.getJob(handle.id, tenant));
       expect(job?.id).toBe(handle.id);
     });
   });
@@ -597,6 +582,133 @@ describe.skipIf(!RUN_INTEGRATION)("Toxiproxy gRPC client integration", () => {
         items: [1, 2, 3, 4, 5],
       });
     });
+  });
+
+  describe("high concurrency enqueue", () => {
+    it("handles many concurrent enqueues without losing requests", async () => {
+      // Simulate a burst of concurrent enqueues similar to the production
+      // incident where 99K+ enqueues overwhelmed a single connection.
+      // @grpc/grpc-js handles HTTP/2 stream multiplexing natively; this
+      // test verifies that all requests complete under concurrent load.
+      const concurrency = 200;
+      const tenant = `high-concurrency-${Date.now()}`;
+
+      const promises = Array.from({ length: concurrency }, (_, i) =>
+        proxyClient.enqueue({
+          tenant: `${tenant}-${i}`,
+          taskGroup: DEFAULT_TASK_GROUP,
+          payload: { index: i, test: "high-concurrency" },
+        }),
+      );
+
+      const results = await Promise.allSettled(promises);
+      const succeeded = results.filter((r) => r.status === "fulfilled");
+      const failed = results.filter((r) => r.status === "rejected");
+
+      // All requests should succeed under concurrent load.
+      expect(succeeded.length).toBe(concurrency);
+      expect(failed.length).toBe(0);
+    }, 30_000);
+  });
+
+  describe("connection reset recovery", () => {
+    it("recovers from connection reset during enqueue", async () => {
+      const tenant = `reset-recovery-${Date.now()}`;
+
+      // First enqueue should succeed
+      const handle1 = await proxyClient.enqueue({
+        tenant,
+        taskGroup: DEFAULT_TASK_GROUP,
+        payload: { phase: "before-reset" },
+      });
+      expect(handle1.id).toBeTruthy();
+
+      // Add a reset_peer toxic to simulate RST_STREAM-like behavior.
+      // This causes the proxy to reset connections, producing errors
+      // similar to what happens during HTTP/2 stream exhaustion.
+      const toxic1 = await silo1.addToxic<ResetPeer>({
+        name: "reset-peer",
+        type: "reset_peer",
+        stream: "downstream",
+        toxicity: 1.0,
+        attributes: { timeout: 100 },
+      });
+      const toxic2 = await silo2.addToxic<ResetPeer>({
+        name: "reset-peer",
+        type: "reset_peer",
+        stream: "downstream",
+        toxicity: 1.0,
+        attributes: { timeout: 100 },
+      });
+
+      // Operations during the toxic should fail
+      await expect(
+        proxyClient.enqueue({
+          tenant: `${tenant}-during`,
+          taskGroup: DEFAULT_TASK_GROUP,
+          payload: { phase: "during-reset" },
+        }),
+      ).rejects.toThrow();
+
+      // Remove the toxic
+      await toxic1.remove();
+      await toxic2.remove();
+
+      // After recovery, operations should succeed
+      const handle3 = await retryUntilSuccess(() =>
+        proxyClient.enqueue({
+          tenant: `${tenant}-after`,
+          taskGroup: DEFAULT_TASK_GROUP,
+          payload: { phase: "after-reset" },
+        }),
+      );
+      expect(handle3.id).toBeTruthy();
+    });
+
+    it("retries and recovers from intermittent connection resets", async () => {
+      // Use a low toxicity to simulate intermittent RST_STREAM errors
+      // (only a fraction of requests are affected). The client's retry
+      // logic should recover transparently.
+      await silo1.addToxic<ResetPeer>({
+        name: "intermittent-reset",
+        type: "reset_peer",
+        stream: "downstream",
+        toxicity: 0.3, // 30% of connections get reset
+        attributes: { timeout: 200 },
+      });
+      await silo2.addToxic<ResetPeer>({
+        name: "intermittent-reset",
+        type: "reset_peer",
+        stream: "downstream",
+        toxicity: 0.3,
+        attributes: { timeout: 200 },
+      });
+
+      // With retry logic, most operations should eventually succeed
+      const results: string[] = [];
+      const errors: Error[] = [];
+
+      for (let i = 0; i < 10; i++) {
+        try {
+          const handle = await retryUntilSuccess(
+            () =>
+              proxyClient.enqueue({
+                tenant: `intermittent-${Date.now()}-${i}`,
+                taskGroup: DEFAULT_TASK_GROUP,
+                payload: { index: i },
+              }),
+            10,
+            200,
+          );
+          results.push(handle.id);
+        } catch (e) {
+          errors.push(e as Error);
+        }
+      }
+
+      // Most should succeed thanks to retries
+      expect(results.length).toBeGreaterThanOrEqual(8);
+    }, 30_000);
   });
 
   describe("topology refresh under network issues", () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches gRPC transport tuning and client retry classification for transient INTERNAL (RST_STREAM) failures, which can alter runtime behavior under load. Also adds new metrics and test changes with relatively low functional risk.
> 
> **Overview**
> Adds new Prometheus per-shard `lease_tasks` *poll count* and *poll duration* metrics, and records them in `lease_tasks` handling.
> 
> Tunes the Rust gRPC server’s HTTP/2 settings (larger flow-control windows and higher `http2_max_pending_accept_reset_streams`) to reduce `RST_STREAM`/`INTERNAL` errors under high concurrency.
> 
> Updates the TypeScript client to treat `INTERNAL` `RST_STREAM` errors as connectivity failures (exporting `isConnectivityError`), and expands tests (unit + toxiproxy integration) to cover high-concurrency bursts and connection reset recovery; also stabilizes a shard enqueue ordering test and adds local `sccache` to the Nix devshell.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cabc1c2ca24ee58d3e0451f269763cd5f68545c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->