### PR TITLE
Speed up /tenants and /tenant webui pages

### DIFF
--- a/src/cluster_query.rs
+++ b/src/cluster_query.rs
@@ -39,7 +39,8 @@ use crate::job_store_shard::JobStoreShard;
 use crate::pb::QueryArrowRequest;
 use crate::pb::silo_client::SiloClient;
 use crate::query::{
-    JobsScanner, QueuesScanner, ScannerRef, TenantCountsScanner, explain_dataframe,
+    JobsScanner, QueueCountsScanner, QueuesScanner, ScannerRef, TenantCountsScanner,
+    explain_dataframe,
 };
 use crate::shard_range::ShardId;
 
@@ -112,12 +113,23 @@ impl ClusterQueryEngine {
         let tenant_counts_schema = TenantCountsScanner::base_schema();
         let tenant_counts_provider = Arc::new(ClusterTableProvider::new(
             tenant_counts_schema,
-            factory,
-            coordinator,
+            factory.clone(),
+            coordinator.clone(),
             TableKind::TenantCounts,
-            auth_token,
+            auth_token.clone(),
         ));
         ctx.register_table("tenant_counts", tenant_counts_provider)?;
+
+        // Register cluster-wide queue_counts table
+        let queue_counts_schema = QueueCountsScanner::base_schema();
+        let queue_counts_provider = Arc::new(ClusterTableProvider::new(
+            queue_counts_schema,
+            factory,
+            coordinator,
+            TableKind::QueueCounts,
+            auth_token,
+        ));
+        ctx.register_table("queue_counts", queue_counts_provider)?;
 
         Ok(Self { ctx })
     }
@@ -202,6 +214,7 @@ enum TableKind {
     Jobs,
     Queues,
     TenantCounts,
+    QueueCounts,
 }
 
 /// A TableProvider that spans multiple shards in the cluster.
@@ -461,6 +474,9 @@ impl ExecutionPlan for ClusterExecutionPlan {
                         TableKind::TenantCounts => {
                             Arc::new(TenantCountsScanner::new(Arc::clone(&shard)))
                         }
+                        TableKind::QueueCounts => {
+                            Arc::new(QueueCountsScanner::new(Arc::clone(&shard)))
+                        }
                     };
 
                     // Execute the scan - scanner handles projection via schema
@@ -570,6 +586,7 @@ async fn query_remote_shard_batches(
         TableKind::Jobs => "jobs",
         TableKind::Queues => "queues",
         TableKind::TenantCounts => "tenant_counts",
+        TableKind::QueueCounts => "queue_counts",
     };
 
     let sql = build_sql_query(table_name, filters, limit);

--- a/src/job_store_shard/counters.rs
+++ b/src/job_store_shard/counters.rs
@@ -22,7 +22,8 @@ use slatedb::{MergeOperator, MergeOperatorError};
 use crate::job_store_shard::helpers::WriteBatcher;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
-    concurrency_requester_counter_key, shard_completed_jobs_counter_key,
+    concurrency_requester_counter_key, concurrency_requester_counter_tenant_prefix, end_bound,
+    parse_concurrency_requester_counter_key, shard_completed_jobs_counter_key,
     shard_total_jobs_counter_key,
 };
 
@@ -268,5 +269,58 @@ impl JobStoreShard {
             Some(bytes) => Ok(decode_counter(&bytes)),
             None => Ok(0),
         }
+    }
+
+    /// Scan all concurrency requester counters for a specific tenant.
+    /// Returns a list of (queue_name, count) pairs.
+    pub async fn scan_concurrency_requester_counters(
+        &self,
+        tenant: &str,
+    ) -> Result<Vec<(String, i64)>, JobStoreShardError> {
+        let prefix = concurrency_requester_counter_tenant_prefix(tenant);
+        let end = end_bound(&prefix);
+        let mut iter = self.db.scan::<Vec<u8>, _>(prefix..end).await?;
+        let mut results = Vec::new();
+        loop {
+            match iter.next().await {
+                Ok(Some(kv)) => {
+                    if let Some(parsed) = parse_concurrency_requester_counter_key(&kv.key) {
+                        let count = decode_counter(&kv.value);
+                        if count > 0 {
+                            results.push((parsed.queue, count));
+                        }
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => return Err(JobStoreShardError::Slate(e)),
+            }
+        }
+        Ok(results)
+    }
+
+    /// Scan all concurrency requester counters across all tenants.
+    /// Returns a list of (tenant, queue_name, count) tuples.
+    pub async fn scan_all_concurrency_requester_counters(
+        &self,
+    ) -> Result<Vec<(String, String, i64)>, JobStoreShardError> {
+        let prefix = vec![crate::keys::prefix::COUNTER_CONCURRENCY_REQUESTERS];
+        let end = end_bound(&prefix);
+        let mut iter = self.db.scan::<Vec<u8>, _>(prefix..end).await?;
+        let mut results = Vec::new();
+        loop {
+            match iter.next().await {
+                Ok(Some(kv)) => {
+                    if let Some(parsed) = parse_concurrency_requester_counter_key(&kv.key) {
+                        let count = decode_counter(&kv.value);
+                        if count > 0 {
+                            results.push((parsed.tenant, parsed.queue, count));
+                        }
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => return Err(JobStoreShardError::Slate(e)),
+            }
+        }
+        Ok(results)
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -575,6 +575,11 @@ pub fn concurrency_requester_counter_key(tenant: &str, queue: &str) -> Vec<u8> {
     encode_with_prefix(prefix::COUNTER_CONCURRENCY_REQUESTERS, &(tenant, queue))
 }
 
+/// Prefix for scanning all concurrency requester counters for a specific tenant.
+pub fn concurrency_requester_counter_tenant_prefix(tenant: &str) -> Vec<u8> {
+    encode_with_prefix(prefix::COUNTER_CONCURRENCY_REQUESTERS, &(tenant,))
+}
+
 /// Parsed concurrency requester counter key components.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedConcurrencyRequesterCounterKey {

--- a/src/query.rs
+++ b/src/query.rs
@@ -103,6 +103,17 @@ impl ShardQueryEngine {
         ));
         ctx.register_table("tenant_counts", tenant_counts_provider)?;
 
+        // Register queue_counts table for pre-computed per-queue concurrency counters
+        let queue_counts_schema = QueueCountsScanner::base_schema();
+        let queue_counts_scanner: ScannerRef = Arc::new(QueueCountsScanner {
+            shard: Arc::clone(&shard),
+        });
+        let queue_counts_provider = Arc::new(SiloTableProvider::new(
+            queue_counts_schema,
+            queue_counts_scanner,
+        ));
+        ctx.register_table("queue_counts", queue_counts_provider)?;
+
         Ok(Self { ctx })
     }
 
@@ -1787,6 +1798,211 @@ impl Scan for TenantCountsScanner {
         Box::pin(RecordBatchStreamAdapter::new(
             Arc::clone(&projection),
             ReceiverStream::new(rx).map(|r| r),
+        ))
+    }
+}
+
+/// Scanner for the queue_counts table - reads pre-computed per-queue concurrency requester
+/// counters and scans holder entries (which are bounded by concurrency limits and thus fast).
+pub struct QueueCountsScanner {
+    pub(crate) shard: Arc<JobStoreShard>,
+}
+
+impl QueueCountsScanner {
+    pub fn new(shard: Arc<JobStoreShard>) -> Self {
+        Self { shard }
+    }
+
+    pub fn base_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("shard_id", DataType::Utf8, false),
+            Field::new("tenant", DataType::Utf8, false),
+            Field::new("queue_name", DataType::Utf8, false),
+            Field::new("holders", DataType::Int64, false),
+            Field::new("requesters", DataType::Int64, false),
+        ]))
+    }
+}
+
+impl std::fmt::Debug for QueueCountsScanner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("QueueCountsScanner")
+    }
+}
+
+impl Scan for QueueCountsScanner {
+    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+        let mut tenant = None;
+        for f in filters {
+            if let Some((col, val)) = parse_eq_filter(f)
+                && col == "tenant"
+            {
+                tenant = Some(val);
+            }
+        }
+        format!("queue_counts[tenant={:?}], limit={:?}", tenant, limit)
+    }
+
+    fn scan(
+        &self,
+        projection: SchemaRef,
+        filters: &[Expr],
+        _batch_size: usize,
+        _limit: Option<usize>,
+    ) -> SendableRecordBatchStream {
+        let mut tenant_filter: Option<String> = None;
+        for f in filters {
+            if let Some((col, val)) = parse_eq_filter(f)
+                && col == "tenant"
+            {
+                tenant_filter = Some(val);
+            }
+        }
+
+        let shard = Arc::clone(&self.shard);
+        let proj = Arc::clone(&projection);
+        let (tx, rx) = mpsc::channel::<DfResult<RecordBatch>>(2);
+
+        tokio::spawn(async move {
+            // Collect requester counts from pre-computed counters (fast)
+            // and holder counts by scanning holder entries (bounded by concurrency limits)
+            let mut queue_data: HashMap<(String, String), (i64, i64)> = HashMap::new();
+
+            // Scan requester counters
+            let requester_results = if let Some(ref tenant) = tenant_filter {
+                shard
+                    .scan_concurrency_requester_counters(tenant)
+                    .await
+                    .map(|entries| {
+                        entries
+                            .into_iter()
+                            .map(|(queue, count)| (tenant.clone(), queue, count))
+                            .collect::<Vec<_>>()
+                    })
+            } else {
+                shard.scan_all_concurrency_requester_counters().await
+            };
+
+            match requester_results {
+                Ok(entries) => {
+                    for (tenant, queue, count) in entries {
+                        queue_data.entry((tenant, queue)).or_insert((0, 0)).1 = count;
+                    }
+                }
+                Err(e) => {
+                    let _ = tx
+                        .send(Err(DataFusionError::Execution(e.to_string())))
+                        .await;
+                    return;
+                }
+            }
+
+            // Scan holder entries (bounded by concurrency limits, so fast)
+            let holders_start = match &tenant_filter {
+                Some(t) => crate::keys::concurrency_holders_tenant_prefix(t),
+                None => crate::keys::concurrency_holders_prefix(),
+            };
+            let holders_end = crate::keys::end_bound(&holders_start);
+
+            match shard
+                .db()
+                .scan::<Vec<u8>, _>(holders_start..holders_end)
+                .await
+            {
+                Ok(mut iter) => loop {
+                    match iter.next().await {
+                        Ok(Some(kv)) => {
+                            if let Some(parsed) = crate::keys::parse_concurrency_holder_key(&kv.key)
+                            {
+                                queue_data
+                                    .entry((parsed.tenant, parsed.queue))
+                                    .or_insert((0, 0))
+                                    .0 += 1;
+                            }
+                        }
+                        Ok(None) => break,
+                        Err(e) => {
+                            let _ = tx
+                                .send(Err(DataFusionError::Execution(e.to_string())))
+                                .await;
+                            return;
+                        }
+                    }
+                },
+                Err(e) => {
+                    let _ = tx
+                        .send(Err(DataFusionError::Execution(e.to_string())))
+                        .await;
+                    return;
+                }
+            }
+
+            let shard_id = shard.name().to_string();
+            let entries: Vec<_> = queue_data.into_iter().collect();
+            let n = entries.len();
+
+            if proj.fields().is_empty() {
+                match make_empty_projection_batch(&proj, n) {
+                    Ok(batch) => {
+                        let _ = tx.send(Ok(batch)).await;
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Err(e)).await;
+                    }
+                }
+                return;
+            }
+
+            let mut cols: Vec<ArrayRef> = Vec::with_capacity(proj.fields().len());
+            for f in proj.fields() {
+                let col: ArrayRef = match f.name().as_str() {
+                    "shard_id" => Arc::new(StringArray::from(vec![shard_id.as_str(); n])),
+                    "tenant" => Arc::new(StringArray::from(
+                        entries
+                            .iter()
+                            .map(|((t, _), _)| t.as_str())
+                            .collect::<Vec<_>>(),
+                    )),
+                    "queue_name" => Arc::new(StringArray::from(
+                        entries
+                            .iter()
+                            .map(|((_, q), _)| q.as_str())
+                            .collect::<Vec<_>>(),
+                    )),
+                    "holders" => Arc::new(Int64Array::from(
+                        entries.iter().map(|(_, (h, _))| *h).collect::<Vec<_>>(),
+                    )),
+                    "requesters" => Arc::new(Int64Array::from(
+                        entries.iter().map(|(_, (_, r))| *r).collect::<Vec<_>>(),
+                    )),
+                    other => {
+                        let _ = tx
+                            .send(Err(DataFusionError::Execution(format!(
+                                "unknown column {}",
+                                other
+                            ))))
+                            .await;
+                        return;
+                    }
+                };
+                cols.push(col);
+            }
+
+            match RecordBatch::try_new(proj, cols) {
+                Ok(batch) => {
+                    let _ = tx.send(Ok(batch)).await;
+                }
+                Err(e) => {
+                    let _ = tx
+                        .send(Err(DataFusionError::Execution(e.to_string())))
+                        .await;
+                }
+            }
+        });
+
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&projection),
+            ReceiverStream::new(rx),
         ))
     }
 }

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -67,7 +67,12 @@ pub struct TenantSummaryRow {
     pub scheduled_count: usize,
     pub running_count: usize,
     pub terminal_count: usize,
-    pub top_queues: String,
+}
+
+#[derive(Clone)]
+pub struct TenantWaitingJobRow {
+    pub id: String,
+    pub shard: String,
 }
 
 #[derive(Clone)]
@@ -76,15 +81,6 @@ pub struct TenantQueueRow {
     pub holders: usize,
     pub requesters: usize,
     pub total: usize,
-}
-
-#[derive(Clone)]
-pub struct TenantUpcomingJobRow {
-    pub id: String,
-    pub shard: String,
-    pub status: String,
-    pub priority: u8,
-    pub enqueue_time: String,
 }
 
 #[derive(Clone)]
@@ -316,7 +312,7 @@ struct TenantTemplate {
     running_count: usize,
     terminal_count: usize,
     top_queues: Vec<TenantQueueRow>,
-    upcoming_jobs: Vec<TenantUpcomingJobRow>,
+    waiting_jobs: Vec<TenantWaitingJobRow>,
     error: Option<String>,
 }
 
@@ -1022,7 +1018,6 @@ async fn tenants_handler(
     }
 
     let mut status_by_tenant: HashMap<String, TenantStatusCounts> = HashMap::new();
-    let mut queue_counts: HashMap<String, Vec<(String, usize)>> = HashMap::new();
     let mut errors: Vec<String> = Vec::new();
 
     let jobs_sql = "SELECT tenant, status_kind, cnt FROM tenant_counts";
@@ -1081,59 +1076,8 @@ async fn tenants_handler(
         }
     }
 
-    let queues_sql =
-        "SELECT tenant, queue_name, COUNT(*) as cnt FROM queues GROUP BY tenant, queue_name";
-    match state.query_engine.sql(queues_sql).await {
-        Ok(df) => match df.collect().await {
-            Ok(batches) => {
-                for batch in batches {
-                    let tenant_col = batch.column_by_name("tenant").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::StringArray>()
-                    });
-                    let queue_col = batch.column_by_name("queue_name").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::StringArray>()
-                    });
-                    let count_col = batch.column_by_name("cnt").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::Int64Array>()
-                    });
-
-                    if let (Some(tenants), Some(queues), Some(counts)) =
-                        (tenant_col, queue_col, count_col)
-                    {
-                        for i in 0..batch.num_rows() {
-                            if tenants.is_null(i) || queues.is_null(i) {
-                                continue;
-                            }
-                            let tenant = tenants.value(i).to_string();
-                            let queue = queues.value(i).to_string();
-                            let count = counts.value(i).max(0) as usize;
-                            if queue.is_empty() {
-                                continue;
-                            }
-                            queue_counts.entry(tenant).or_default().push((queue, count));
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                warn!(error = %e, "failed to collect tenant queue query results");
-                errors.push(format!("Queue aggregation failed: {}", e));
-            }
-        },
-        Err(e) => {
-            warn!(error = %e, "failed to query tenant queue aggregates");
-            errors.push(format!("Queue query failed: {}", e));
-        }
-    }
-
     let mut tenant_names = std::collections::BTreeSet::new();
     for tenant in status_by_tenant.keys() {
-        tenant_names.insert(tenant.clone());
-    }
-    for tenant in queue_counts.keys() {
         tenant_names.insert(tenant.clone());
     }
 
@@ -1141,19 +1085,6 @@ async fn tenants_handler(
     let mut tenants: Vec<TenantSummaryRow> = Vec::with_capacity(tenant_names.len());
     for tenant in tenant_names {
         let counts = status_by_tenant.get(&tenant).cloned().unwrap_or_default();
-        let mut queues = queue_counts.remove(&tenant).unwrap_or_default();
-        queues.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-
-        let top_queues = if queues.is_empty() {
-            "-".to_string()
-        } else {
-            queues
-                .iter()
-                .take(3)
-                .map(|(name, count)| format!("{} ({})", name, count))
-                .collect::<Vec<String>>()
-                .join(", ")
-        };
 
         tenants.push(TenantSummaryRow {
             name: tenant.clone(),
@@ -1162,7 +1093,6 @@ async fn tenants_handler(
             scheduled_count: counts.scheduled,
             running_count: counts.running,
             terminal_count: counts.terminal,
-            top_queues,
         });
     }
 
@@ -1236,7 +1166,6 @@ async fn tenant_handler(
     let tenant_escaped = sql_string_literal(&params.name);
     let mut counts = TenantStatusCounts::default();
     let mut top_queues: Vec<TenantQueueRow> = Vec::new();
-    let mut upcoming_jobs: Vec<TenantUpcomingJobRow> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
 
     let count_sql = format!(
@@ -1287,77 +1216,70 @@ async fn tenant_handler(
     }
 
     let queue_sql = format!(
-        "SELECT queue_name, entry_type, COUNT(*) as cnt FROM queues WHERE tenant = '{}' GROUP BY queue_name, entry_type",
+        "SELECT queue_name, SUM(holders) as holders, SUM(requesters) as requesters FROM queue_counts WHERE tenant = '{}' GROUP BY queue_name",
         tenant_escaped
     );
     match state.query_engine.sql(&queue_sql).await {
         Ok(df) => match df.collect().await {
             Ok(batches) => {
-                let mut queue_map: HashMap<String, (usize, usize)> = HashMap::new();
                 for batch in batches {
                     let name_col = batch.column_by_name("queue_name").and_then(|c| {
                         c.as_any()
                             .downcast_ref::<datafusion::arrow::array::StringArray>()
                     });
-                    let type_col = batch.column_by_name("entry_type").and_then(|c| {
+                    let holders_col = batch.column_by_name("holders").and_then(|c| {
                         c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::StringArray>()
+                            .downcast_ref::<datafusion::arrow::array::Int64Array>()
                     });
-                    let count_col = batch.column_by_name("cnt").and_then(|c| {
+                    let requesters_col = batch.column_by_name("requesters").and_then(|c| {
                         c.as_any()
                             .downcast_ref::<datafusion::arrow::array::Int64Array>()
                     });
 
-                    if let (Some(names), Some(types), Some(counts_col)) =
-                        (name_col, type_col, count_col)
+                    if let (Some(names), Some(holders), Some(requesters)) =
+                        (name_col, holders_col, requesters_col)
                     {
                         for i in 0..batch.num_rows() {
-                            if names.is_null(i) || types.is_null(i) {
+                            if names.is_null(i) {
                                 continue;
                             }
                             let queue_name = names.value(i).to_string();
                             if queue_name.is_empty() {
                                 continue;
                             }
-                            let entry_type = types.value(i);
-                            let count = counts_col.value(i).max(0) as usize;
-                            let entry = queue_map.entry(queue_name).or_insert((0, 0));
-                            match entry_type {
-                                "holder" => entry.0 += count,
-                                "requester" => entry.1 += count,
-                                _ => {}
-                            }
+                            let h = holders.value(i).max(0) as usize;
+                            let r = requesters.value(i).max(0) as usize;
+                            top_queues.push(TenantQueueRow {
+                                name: queue_name,
+                                holders: h,
+                                requesters: r,
+                                total: h + r,
+                            });
                         }
                     }
                 }
-
-                top_queues = queue_map
-                    .into_iter()
-                    .map(|(name, (holders, requesters))| TenantQueueRow {
-                        name,
-                        holders,
-                        requesters,
-                        total: holders + requesters,
-                    })
-                    .collect();
                 top_queues.sort_by(|a, b| b.total.cmp(&a.total).then_with(|| a.name.cmp(&b.name)));
             }
             Err(e) => {
-                warn!(error = %e, tenant = %params.name, "failed to collect tenant queue results");
-                errors.push(format!("Tenant queue query failed: {}", e));
+                warn!(error = %e, tenant = %params.name, "failed to collect queue counts results");
+                errors.push(format!("Queue counts query failed: {}", e));
             }
         },
         Err(e) => {
-            warn!(error = %e, tenant = %params.name, "failed to query tenant queues");
-            errors.push(format!("Tenant queue query failed: {}", e));
+            warn!(error = %e, tenant = %params.name, "failed to query queue counts");
+            errors.push(format!("Queue counts query failed: {}", e));
         }
     }
 
-    let upcoming_sql = format!(
-        "SELECT shard_id, id, status_kind, priority, enqueue_time_ms FROM jobs WHERE tenant = '{}' AND (status_kind = 'Scheduled' OR status_kind = 'Waiting') ORDER BY enqueue_time_ms ASC LIMIT 100",
+    // Query waiting jobs (ready to run) using the status index fast path.
+    // Uses status_kind = 'Waiting' (single eq filter) so the scanner uses the bounded
+    // scan_jobs_waiting range scan. Only projects shard_id and id to avoid job_info lookups.
+    let mut waiting_jobs: Vec<TenantWaitingJobRow> = Vec::new();
+    let waiting_sql = format!(
+        "SELECT shard_id, id FROM jobs WHERE tenant = '{}' AND status_kind = 'Waiting' LIMIT 100",
         tenant_escaped
     );
-    match state.query_engine.sql(&upcoming_sql).await {
+    match state.query_engine.sql(&waiting_sql).await {
         Ok(df) => match df.collect().await {
             Ok(batches) => {
                 for batch in batches {
@@ -1369,54 +1291,28 @@ async fn tenant_handler(
                         c.as_any()
                             .downcast_ref::<datafusion::arrow::array::StringArray>()
                     });
-                    let status_col = batch.column_by_name("status_kind").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::StringArray>()
-                    });
-                    let priority_col = batch.column_by_name("priority").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::UInt8Array>()
-                    });
-                    let time_col = batch.column_by_name("enqueue_time_ms").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::Int64Array>()
-                    });
 
-                    if let (
-                        Some(shards),
-                        Some(ids),
-                        Some(statuses),
-                        Some(priorities),
-                        Some(times),
-                    ) = (shard_col, id_col, status_col, priority_col, time_col)
-                    {
+                    if let (Some(shards), Some(ids)) = (shard_col, id_col) {
                         for i in 0..batch.num_rows() {
-                            if ids.is_null(i) || shards.is_null(i) || priorities.is_null(i) {
+                            if ids.is_null(i) || shards.is_null(i) {
                                 continue;
                             }
-                            upcoming_jobs.push(TenantUpcomingJobRow {
+                            waiting_jobs.push(TenantWaitingJobRow {
                                 id: ids.value(i).to_string(),
                                 shard: shards.value(i).to_string(),
-                                status: if statuses.is_null(i) {
-                                    "Scheduled".to_string()
-                                } else {
-                                    statuses.value(i).to_string()
-                                },
-                                priority: priorities.value(i),
-                                enqueue_time: format_timestamp(times.value(i)),
                             });
                         }
                     }
                 }
             }
             Err(e) => {
-                warn!(error = %e, tenant = %params.name, "failed to collect upcoming jobs");
-                errors.push(format!("Upcoming jobs query failed: {}", e));
+                warn!(error = %e, tenant = %params.name, "failed to collect waiting jobs");
+                errors.push(format!("Waiting jobs query failed: {}", e));
             }
         },
         Err(e) => {
-            warn!(error = %e, tenant = %params.name, "failed to query upcoming jobs");
-            errors.push(format!("Upcoming jobs query failed: {}", e));
+            warn!(error = %e, tenant = %params.name, "failed to query waiting jobs");
+            errors.push(format!("Waiting jobs query failed: {}", e));
         }
     }
 
@@ -1437,7 +1333,7 @@ async fn tenant_handler(
         running_count: counts.running,
         terminal_count: counts.terminal,
         top_queues,
-        upcoming_jobs,
+        waiting_jobs,
         error,
     };
 

--- a/templates/tenant.html
+++ b/templates/tenant.html
@@ -73,11 +73,11 @@
 
     <div class="bg-zinc-800 border border-zinc-700 overflow-hidden">
         <div class="bg-zinc-850 border-b border-zinc-700 px-4 py-2">
-            <h2 class="text-sm font-semibold text-zinc-300">Upcoming Scheduled Jobs</h2>
+            <h2 class="text-sm font-semibold text-zinc-300">Waiting Jobs</h2>
         </div>
         <div class="p-4">
-            {% if upcoming_jobs.is_empty() %}
-            <div class="text-zinc-500 text-center py-6">No scheduled jobs for this tenant</div>
+            {% if waiting_jobs.is_empty() %}
+            <div class="text-zinc-500 text-center py-6">No waiting jobs for this tenant</div>
             {% else %}
             <div class="overflow-x-auto">
                 <table class="min-w-full divide-y divide-zinc-700">
@@ -85,21 +85,15 @@
                         <tr>
                             <th class="px-3 py-2 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">Job ID</th>
                             <th class="px-3 py-2 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">Shard</th>
-                            <th class="px-3 py-2 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">Status</th>
-                            <th class="px-3 py-2 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">Priority</th>
-                            <th class="px-3 py-2 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">Enqueue Time</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-zinc-700">
-                        {% for job in upcoming_jobs %}
+                        {% for job in waiting_jobs %}
                         <tr class="border-b border-zinc-700 hover:bg-zinc-750">
                             <td class="px-3 py-2 text-sm text-zinc-300 whitespace-nowrap">
                                 <a href="/job?shard={{ job.shard }}&tenant={{ tenant_name_url }}&id={{ job.id }}" class="text-emerald-400 hover:underline">{{ job.id }}</a>
                             </td>
                             <td class="px-3 py-2 text-sm text-zinc-300 whitespace-nowrap">{{ job.shard }}</td>
-                            <td class="px-3 py-2 text-sm text-zinc-300 whitespace-nowrap">{{ job.status }}</td>
-                            <td class="px-3 py-2 text-sm text-zinc-300 whitespace-nowrap">P{{ job.priority }}</td>
-                            <td class="px-3 py-2 text-sm text-zinc-300 whitespace-nowrap">{{ job.enqueue_time }}</td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/templates/tenants.html
+++ b/templates/tenants.html
@@ -33,7 +33,6 @@
                             <th class="px-3 py-2 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">Scheduled</th>
                             <th class="px-3 py-2 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">Running</th>
                             <th class="px-3 py-2 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">Terminal</th>
-                            <th class="px-3 py-2 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">Top Queues</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-zinc-700">
@@ -46,7 +45,6 @@
                             <td class="px-3 py-2 text-sm text-zinc-300 whitespace-nowrap">{{ tenant.scheduled_count }}</td>
                             <td class="px-3 py-2 text-sm text-zinc-300 whitespace-nowrap">{{ tenant.running_count }}</td>
                             <td class="px-3 py-2 text-sm text-zinc-300 whitespace-nowrap">{{ tenant.terminal_count }}</td>
-                            <td class="px-3 py-2 text-sm text-zinc-400">{{ tenant.top_queues }}</td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -2707,6 +2707,44 @@ async fn explain_bench_count_waiting() {
     );
 }
 
+// Tenant detail page waiting jobs query → Status(Waiting) strategy with narrow projection
+// This is the query used by the /tenant webui page to show waiting jobs.
+// It must resolve to the Status(Waiting) strategy (bounded range scan) and avoid
+// projecting job_info columns (priority, enqueue_time_ms) which would trigger point lookups.
+#[silo::test]
+async fn explain_tenant_detail_waiting_jobs_query() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    enqueue_job(&shard, "j1", 10, now).await;
+
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let (explain, strategy) = explain_and_strategy(
+        &engine,
+        "SELECT shard_id, id FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting' LIMIT 100",
+    )
+    .await;
+
+    let plan_line = extract_silo_plan_line(&explain);
+    assert!(
+        plan_line.contains("Status(tenant=Some(\"-\"), status=Waiting)"),
+        "Expected Status(Waiting) strategy, got: {}",
+        plan_line
+    );
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::Status {
+            tenant: Some("-".to_string()),
+            status: QueryStatusFilter::Waiting,
+        }
+    );
+    // Verify the plan includes a limit (DataFusion pushes LIMIT as fetch= on CoalesceBatchesExec)
+    assert!(
+        explain.contains("fetch=100"),
+        "Expected LIMIT 100 in plan, got:\n{}",
+        explain
+    );
+}
+
 // Benchmark query: SELECT COUNT(*) FROM jobs WHERE tenant = '{t}' AND status_kind = 'Succeeded'
 #[silo::test]
 async fn explain_bench_count_succeeded() {

--- a/tests/webui_tests.rs
+++ b/tests/webui_tests.rs
@@ -1141,14 +1141,10 @@ async fn test_tenants_index_shows_tenant_data() {
         body.contains("/tenant?name=tenant-alpha"),
         "tenant links should point to tenant detail pages"
     );
-    assert!(
-        body.contains("alpha-queue") || body.contains("beta-queue"),
-        "tenant overview should include top queue names"
-    );
 }
 
 #[silo::test]
-async fn test_tenant_detail_shows_upcoming_jobs_and_queues() {
+async fn test_tenant_detail_shows_queues_and_waiting_jobs() {
     use silo::job::{ConcurrencyLimit, Limit};
 
     let (_tmp, state, shard_map) = setup_multi_shard_state_with_tenancy(2, true).await;
@@ -1190,6 +1186,22 @@ async fn test_tenant_detail_shows_upcoming_jobs_and_queues() {
         .await
         .expect("enqueue detail job 2");
 
+    // Enqueue a job with start_time in the past so it shows as "Waiting"
+    let _ = shard0
+        .enqueue(
+            "tenant-detail",
+            Some("tenant-detail-waiting-job".to_string()),
+            50,
+            test_helpers::now_ms() - 1_000,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k":"v3"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue waiting job");
+
     let (status, body) = make_request(state, "GET", "/tenant?name=tenant-detail").await;
 
     assert_eq!(status, StatusCode::OK);
@@ -1198,12 +1210,12 @@ async fn test_tenant_detail_shows_upcoming_jobs_and_queues() {
         "tenant detail heading should render"
     );
     assert!(
-        body.contains("tenant-detail-job-1") || body.contains("tenant-detail-job-2"),
-        "tenant detail should show upcoming jobs"
+        body.contains("detail-queue"),
+        "tenant detail should show queue activity via queue_counts"
     );
     assert!(
-        body.contains("detail-queue"),
-        "tenant detail should show queue activity"
+        body.contains("tenant-detail-waiting-job"),
+        "tenant detail should show waiting jobs"
     );
     assert!(
         !body.contains("Tenant counts query failed"),


### PR DESCRIPTION
## Summary
- Remove slow `queues` table full-scan from `/tenants` index page (was scanning all concurrency entries across all shards)
- Add new `queue_counts` SQL table backed by pre-computed requester counters + bounded holder entry scans for the `/tenant` detail page
- Replace slow "Upcoming Scheduled Jobs" query with fast "Waiting Jobs" query that uses the status index fast path (`Status(Waiting)` strategy → bounded `scan_jobs_waiting` range scan)

## Context
The `/tenants` page was taking ~4s to load and the `/tenant` detail page was timing out (5s deadline exceeded) for tenants with 1M+ jobs. Two root causes:

1. The `queues` table query scanned all concurrency holder + requester entries (potentially millions) just to count them by queue name
2. The "upcoming jobs" query used `status_kind = 'Scheduled' OR status_kind = 'Waiting'` — the OR prevented filter pushdown (falls to FullScan), and projecting `priority`/`enqueue_time_ms` forced job_info point lookups for every matching job

## Changes
- **`/tenants` index**: Only runs the `tenant_counts` query (pre-computed counters). Removed top queues column.
- **`/tenant` detail**: 
  - Queue data now comes from `queue_counts` table (requester counts from counter keys, holder counts from bounded entry scan)
  - Waiting jobs query uses single `status_kind = 'Waiting'` eq filter → `Status(Waiting)` strategy → `scan_jobs_waiting` bounded range scan. Only projects `shard_id, id` to avoid job_info lookups.
- **New infrastructure**: `QueueCountsScanner`, `scan_concurrency_requester_counters()`, `scan_all_concurrency_requester_counters()`, `concurrency_requester_counter_tenant_prefix()`

## Test plan
- [x] All 99 query tests pass including new `explain_tenant_detail_waiting_jobs_query` proving the waiting jobs query hits the Status(Waiting) fast path
- [x] All 39 webui tests pass including updated `test_tenant_detail_shows_queues_and_waiting_jobs`
- [x] `cargo clippy` clean
- [ ] Manual verification on staging with large tenants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new DataFusion table/scanner and new SlateDB range-scan helpers that change how queue/concurrency data is queried across shards; correctness and performance depend on key parsing and scan bounds.
> 
> **Overview**
> Speeds up `/tenants` and `/tenant` pages by removing the expensive `queues` aggregation from the tenants index and by switching tenant detail queue activity to a new `queue_counts` SQL table.
> 
> Adds `queue_counts` to both shard and cluster query engines, backed by a new `QueueCountsScanner` that combines pre-computed requester counters with a bounded scan of holder entries, plus new shard counter scan APIs and key prefixes to support fast counter range scans.
> 
> Replaces the tenant detail “upcoming jobs” listing with a narrow “waiting jobs” query (`status_kind = 'Waiting'` projecting only `shard_id`/`id`) to hit the status-index fast path; updates templates and tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec25ccc34486bc270af0e22cc5f21399c9a87d07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->