### PR TITLE
Fix membership lease renewal reconciliation thrashing

### DIFF
--- a/src/coordination/k8s.rs
+++ b/src/coordination/k8s.rs
@@ -5,6 +5,7 @@ use k8s_openapi::api::core::v1::ConfigMap;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::MicroTime;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::sync::{Mutex, Notify, watch};
 use tokio_stream::StreamExt;
@@ -61,6 +62,12 @@ pub struct K8sCoordinator<B: K8sBackend> {
     membership_changed: Arc<Notify>,
     /// Notifier for shard map changes (from watcher)
     shard_map_changed: Arc<Notify>,
+    /// Last member list that triggered a membership_changed notification.
+    /// Used to deduplicate — lease renewals fire watch events but don't change membership.
+    last_notified_members: Arc<Mutex<Vec<MemberInfo>>>,
+    /// Counter for how many times the membership watcher actually notified a change.
+    /// Used in tests to verify deduplication is working.
+    membership_notify_count: Arc<AtomicU64>,
     /// Per-shard notifiers for when a shard lease becomes available (holder released).
     /// Guards waiting to acquire a shard can subscribe to these instead of blind retrying.
     shard_available_notifiers: Arc<Mutex<HashMap<ShardId, Arc<Notify>>>>,
@@ -167,6 +174,8 @@ impl<B: K8sBackend> K8sCoordinator<B> {
             members_cache,
             membership_changed,
             shard_map_changed,
+            last_notified_members: Arc::new(Mutex::new(Vec::new())),
+            membership_notify_count: Arc::new(AtomicU64::new(0)),
             shard_available_notifiers,
         };
 
@@ -349,14 +358,10 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                                 LeaseWatchEvent::Applied(lease) => {
                                     let lease_name = lease.metadata.name.as_deref().unwrap_or("unknown");
                                     debug!(node_id = %self.base.node_id, lease = %lease_name, "membership lease changed");
-                                    // Refresh the full member list from cache
                                     if let Err(e) = self.refresh_members_cache().await {
                                         warn!(node_id = %self.base.node_id, error = %e, "failed to refresh members cache");
                                     }
-                                    // Use notify_one (not notify_waiters) so the permit is stored
-                                    // if the coordination loop is busy. notify_waiters drops the
-                                    // notification when no task is currently awaiting .notified().
-                                    self.membership_changed.notify_one();
+                                    self.notify_if_members_changed().await;
                                 }
                                 LeaseWatchEvent::Deleted(lease) => {
                                     let lease_name = lease.metadata.name.as_deref().unwrap_or("unknown");
@@ -364,7 +369,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                                     if let Err(e) = self.refresh_members_cache().await {
                                         warn!(node_id = %self.base.node_id, error = %e, "failed to refresh members cache");
                                     }
-                                    self.membership_changed.notify_one();
+                                    self.notify_if_members_changed().await;
                                 }
                                 LeaseWatchEvent::Init => {
                                     debug!(node_id = %self.base.node_id, "membership watcher initialized");
@@ -374,7 +379,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                                     if let Err(e) = self.refresh_members_cache().await {
                                         warn!(node_id = %self.base.node_id, error = %e, "failed to refresh members cache on init");
                                     }
-                                    self.membership_changed.notify_one();
+                                    self.notify_if_members_changed().await;
                                 }
                             }
                         }
@@ -455,6 +460,12 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                 }
             }
         }
+    }
+
+    /// Number of times the membership watcher detected an actual membership change
+    /// (as opposed to a lease renewal with no membership change).
+    pub fn membership_notify_count(&self) -> u64 {
+        self.membership_notify_count.load(Ordering::Relaxed)
     }
 
     /// Get or create a notifier for when a specific shard lease becomes available.
@@ -636,6 +647,24 @@ impl<B: K8sBackend> K8sCoordinator<B> {
         let mut cache = self.members_cache.lock().await;
         *cache = members;
         Ok(())
+    }
+
+    /// Only notify the coordination loop if the member list actually changed.
+    /// This prevents lease renewals (which update renewTime but not membership)
+    /// from triggering unnecessary reconciliation cycles.
+    async fn notify_if_members_changed(&self) {
+        let current_members = self.members_cache.lock().await.clone();
+        let mut last = self.last_notified_members.lock().await;
+        if *last != current_members {
+            *last = current_members;
+            self.membership_notify_count.fetch_add(1, Ordering::Relaxed);
+            // Use notify_one (not notify_waiters) so the permit is stored
+            // if the coordination loop is busy. notify_waiters drops the
+            // notification when no task is currently awaiting .notified().
+            self.membership_changed.notify_one();
+        } else {
+            debug!(node_id = %self.base.node_id, "membership lease renewed but member list unchanged, skipping reconciliation");
+        }
     }
 
     /// List all active (non-expired) members from K8s

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -63,7 +63,7 @@ pub use k8s_backend::{
 pub use none::NoneCoordinator;
 
 /// Information about a cluster member
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct MemberInfo {
     pub node_id: String,
     pub grpc_addr: String,

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -5583,3 +5583,81 @@ async fn k8s_shard_close_failure_during_shutdown_keeps_lease() {
     handle.abort();
     let _ = std::fs::remove_dir_all(&tmpdir);
 }
+
+/// Test that lease renewals don't trigger spurious membership change notifications.
+///
+/// Regression test: previously, every K8s lease renewal (which updates renewTime)
+/// fired a MODIFIED watch event that was unconditionally forwarded to the
+/// coordination loop as a membership change. With short TTLs this caused ~180
+/// no-op reconciliations per minute per node.
+///
+/// The fix deduplicates by comparing the actual member list before notifying.
+/// This test verifies that during steady state with frequent lease renewals,
+/// the membership_notify_count stays at 1 (from initialization only).
+#[silo::test(flavor = "multi_thread", worker_threads = 2)]
+async fn k8s_lease_renewals_do_not_trigger_membership_notifications() {
+    let prefix = unique_prefix();
+    let namespace = get_namespace();
+    let num_shards: u32 = 4;
+    // Short TTL = renewals every ~1.67s, so in 10s we get ~6 renewals
+    let short_ttl: i64 = 5;
+
+    let (c1, h1) = match K8sCoordinator::start(
+        make_coordinator_config(
+            &namespace,
+            &prefix,
+            "renew-dedup-1",
+            "http://127.0.0.1:7450",
+            num_shards,
+            short_ttl,
+        ),
+        make_test_factory("renew-dedup-1"),
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Skipping lease renewal dedup test: {}", e);
+            return;
+        }
+    };
+
+    // Wait for initial convergence (triggers 1 membership notification from InitDone)
+    assert!(
+        c1.wait_converged(Duration::from_secs(15)).await,
+        "should converge"
+    );
+
+    // Record notification count after convergence
+    let count_after_convergence = c1.membership_notify_count();
+    assert!(
+        count_after_convergence >= 1,
+        "should have at least 1 notification from initial membership discovery"
+    );
+
+    // Wait long enough for multiple lease renewals to occur.
+    // With TTL=5s, renewals happen every ~1.67s, so 10s = ~6 renewals.
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    // The notification count should not have increased — all those lease renewals
+    // should have been deduplicated since the member list didn't change.
+    let count_after_renewals = c1.membership_notify_count();
+    assert_eq!(
+        count_after_convergence, count_after_renewals,
+        "lease renewals should not trigger additional membership notifications \
+         (before={}, after={})",
+        count_after_convergence, count_after_renewals
+    );
+
+    // Sanity check: ownership should also be stable
+    let owned: HashSet<ShardId> = c1.owned_shards().await.into_iter().collect();
+    assert_eq!(
+        owned.len(),
+        num_shards as usize,
+        "single node should own all shards"
+    );
+
+    // Cleanup
+    c1.shutdown().await.unwrap();
+    h1.abort();
+}


### PR DESCRIPTION
## Summary

- Lease renewals in the K8s coordinator were triggering full shard reconciliation on every node (~180 no-op cycles/min/node with 3 nodes and `lease_ttl_secs=5`)
- Added deduplication: track the last notified member list and only notify the coordination loop when membership actually changes
- Added `PartialEq` to `MemberInfo` to support the comparison

## Root Cause

Every K8s lease renewal updates `renewTime`, generating a `MODIFIED` watch event. The membership watcher forwarded all events unconditionally to the coordination loop via `notify_one()`, causing ~775K unnecessary INFO log lines per day and wasted CPU on no-op reconciliations.

## Test plan

- [x] All 74 K8s coordination tests pass (`cargo test --test k8s_coordination_tests -- --test-threads=1`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the K8s coordinator’s reconciliation trigger behavior, which could delay/skip reconciliation if the member list comparison is wrong or incomplete. Scope is limited and covered by a new regression test.
> 
> **Overview**
> Prevents K8s membership lease renewals from causing no-op shard reconciliation cycles by **deduplicating membership watcher notifications** based on the actual `Vec<MemberInfo>` content.
> 
> `K8sCoordinator` now tracks `last_notified_members` and only calls `membership_changed.notify_one()` when membership truly changes; it also exposes a `membership_notify_count()` counter for verification. `MemberInfo` derives `PartialEq`, and a new test asserts renewals don’t increase the notification count during steady state with short TTLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f84c4b0aa3dc721833d16b3514027ac5f085f58b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->