### PR TITLE
Retry on SlateDB InvalidClockTick errors to fix bench flake

### DIFF
--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -164,6 +164,12 @@ pub(crate) fn put_task<W: WriteBatcher>(
 ///
 /// Encapsulates the MAX_RETRIES=5 loop with exponential backoff and
 /// `TransactionConflict` error return on exhaustion.
+///
+/// Also retries on SlateDB `InvalidClockTick` errors, which occur under heavy
+/// concurrent write load due to a TOCTOU race in SlateDB's MonotonicClock: one
+/// thread reads the wall-clock, gets preempted, another thread commits a later
+/// tick, then the first thread's earlier tick is rejected. These are transient
+/// and resolve on retry once the clock advances.
 pub(crate) async fn retry_on_txn_conflict<T, F, Fut>(
     operation_name: &str,
     mut f: F,
@@ -178,7 +184,8 @@ where
         match f().await {
             Ok(val) => return Ok(val),
             Err(JobStoreShardError::Slate(ref e))
-                if e.kind() == slatedb::ErrorKind::Transaction =>
+                if e.kind() == slatedb::ErrorKind::Transaction
+                    || is_clock_tick_error(e) =>
             {
                 if attempt + 1 < MAX_RETRIES {
                     let delay_ms = 10 * (1 << attempt); // 10ms, 20ms, 40ms, 80ms
@@ -198,6 +205,14 @@ where
     Err(JobStoreShardError::TransactionConflict(
         operation_name.to_string(),
     ))
+}
+
+/// Check if a SlateDB error is an InvalidClockTick error.
+///
+/// SlateDB maps InvalidClockTick to ErrorKind::Invalid (a broad category), so we
+/// check the error message to identify this specific transient error.
+fn is_clock_tick_error(e: &slatedb::Error) -> bool {
+    e.kind() == slatedb::ErrorKind::Invalid && e.to_string().contains("invalid clock tick")
 }
 
 /// Load a `JobView` for the given tenant/job from a transaction or DB reader.

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -184,8 +184,7 @@ where
         match f().await {
             Ok(val) => return Ok(val),
             Err(JobStoreShardError::Slate(ref e))
-                if e.kind() == slatedb::ErrorKind::Transaction
-                    || is_clock_tick_error(e) =>
+                if e.kind() == slatedb::ErrorKind::Transaction || is_clock_tick_error(e) =>
             {
                 if attempt + 1 < MAX_RETRIES {
                     let delay_ms = 10 * (1 << attempt); // 10ms, 20ms, 40ms, 80ms


### PR DESCRIPTION
## Summary
- Fixes benchmark CI failure where concurrent import tasks trigger a TOCTOU race in SlateDB's `MonotonicClock::now()`, causing `InvalidClockTick` panics
- Extends `retry_on_txn_conflict` to also retry on transient clock tick errors using the existing exponential backoff
- Adds `is_clock_tick_error()` helper that narrows the match to `ErrorKind::Invalid` + "invalid clock tick" message string

## Test plan
- [ ] `cargo check` and `cargo check --benches` pass
- [ ] CI benchmark job passes without `InvalidClockTick` panic
- [ ] Existing tests pass (retry logic is additive, no behavioral change for transaction conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared retry logic used across many job-store transactions, so behavior changes can affect enqueue/lease/cancel/import under load. Risk is mitigated by narrowly targeting `ErrorKind::Invalid` errors that contain the specific "invalid clock tick" message, but it relies on string matching.
> 
> **Overview**
> Updates `retry_on_txn_conflict` to retry not only on SlateDB transaction conflicts but also on transient `InvalidClockTick` errors, using the same capped exponential backoff.
> 
> Adds an `is_clock_tick_error` helper to detect this condition (via `ErrorKind::Invalid` + matching the error message) and documents why this retry is safe under concurrent write load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dd0191831204e7132e6a32713034aad8a5a5c3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->