### PR TITLE
Add worker poll tasks_returned counter metric

### DIFF
--- a/typescript_client/src/metrics.ts
+++ b/typescript_client/src/metrics.ts
@@ -12,6 +12,8 @@ export class WorkerMetrics {
   readonly pollCounter: Counter<Attributes>;
   /** Counter incremented when a poll returns zero tasks. */
   readonly emptyPollCounter: Counter<Attributes>;
+  /** Counter tracking the total number of tasks returned from polls. */
+  readonly pollTasksReturnedCounter: Counter<Attributes>;
   /** Gauge reporting the number of available task slots (maxConcurrentTasks - active - queued). */
   readonly availableTaskSlots: ObservableGauge<Attributes>;
   /** Default attributes applied to all metric recordings. */
@@ -26,6 +28,10 @@ export class WorkerMetrics {
 
     this.emptyPollCounter = meter.createCounter("silo.worker.polls.empty", {
       description: "Number of polls that returned zero tasks",
+    });
+
+    this.pollTasksReturnedCounter = meter.createCounter("silo.worker.polls.tasks_returned", {
+      description: "Total number of tasks returned from polls",
     });
 
     this.availableTaskSlots = meter.createObservableGauge("silo.worker.available_task_slots", {

--- a/typescript_client/src/worker.ts
+++ b/typescript_client/src/worker.ts
@@ -484,8 +484,11 @@ export class SiloWorker<
 
     // Record poll metrics
     this._metrics.pollCounter.add(1, this._metrics.defaultAttributes);
-    if (result.tasks.length === 0 && result.refreshTasks.length === 0) {
+    const totalTasksReturned = result.tasks.length + result.refreshTasks.length;
+    if (totalTasksReturned === 0) {
       this._metrics.emptyPollCounter.add(1, this._metrics.defaultAttributes);
+    } else {
+      this._metrics.pollTasksReturnedCounter.add(totalTasksReturned, this._metrics.defaultAttributes);
     }
 
     // Add regular job tasks to the queue


### PR DESCRIPTION
## Summary
- Adds a new `silo.worker.polls.tasks_returned` counter metric to the TypeScript worker that tracks the total number of tasks (regular + refresh) returned from each non-empty poll
- Complements the existing `polls` and `polls.empty` counters with visibility into poll throughput

## Test plan
- [ ] Verify existing worker metric tests still pass
- [ ] Confirm metric is emitted via OpenTelemetry when polls return tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new OpenTelemetry counter and increments it during polling without changing task leasing or execution behavior.
> 
> **Overview**
> Adds a new worker metric, `silo.worker.polls.tasks_returned`, to count the total number of tasks (regular + refresh) returned by non-empty polls.
> 
> Updates the poll loop to compute `totalTasksReturned` and record either `polls.empty` when zero or increment the new counter by the number of tasks returned when non-zero.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 366adad630444cdc281c90818cb2b78794a160af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->