### PR TITLE
Enable DataFusion LIMIT pushdown for jobs queries

### DIFF
--- a/benches/query_performance.rs
+++ b/benches/query_performance.rs
@@ -243,6 +243,31 @@ async fn run_tenant_queries(engine: &ShardQueryEngine, tenant: &str) {
     .await;
     r.print();
 
+    // This is the exact query used by the tenant view page to list waiting jobs.
+    // It only projects shard_id and id to avoid expensive job_info lookups.
+    let r = bench_query(
+        engine,
+        "list_waiting_jobs_tenant_view",
+        &format!(
+            "SELECT shard_id, id FROM jobs WHERE tenant = '{}' AND status_kind = 'Waiting' LIMIT 100",
+            tenant
+        ),
+    )
+    .await;
+    r.print();
+
+    // SELECT * variant - what remote shards receive from cluster query engine.
+    let r = bench_query(
+        engine,
+        "list_waiting_select_star",
+        &format!(
+            "SELECT * FROM jobs WHERE tenant = '{}' AND status_kind = 'Waiting' LIMIT 100",
+            tenant
+        ),
+    )
+    .await;
+    r.print();
+
     let r = bench_query(
         engine,
         "count_succeeded",

--- a/src/cluster_query.rs
+++ b/src/cluster_query.rs
@@ -40,7 +40,7 @@ use crate::pb::QueryArrowRequest;
 use crate::pb::silo_client::SiloClient;
 use crate::query::{
     JobsScanner, QueueCountsScanner, QueuesScanner, ScannerRef, TenantCountsScanner,
-    explain_dataframe,
+    classify_jobs_filters, explain_dataframe,
 };
 use crate::shard_range::ShardId;
 
@@ -318,8 +318,12 @@ impl TableProvider for ClusterTableProvider {
         &self,
         filters: &[&Expr],
     ) -> DfResult<Vec<TableProviderFilterPushDown>> {
-        // Pass all filters through - we'll push them down to each shard
-        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+        // For Jobs table, use the jobs-specific filter classification to enable
+        // LIMIT pushdown by marking handled filters as Exact.
+        match self.table_kind {
+            TableKind::Jobs => Ok(classify_jobs_filters(filters)),
+            _ => Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()]),
+        }
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -468,9 +468,11 @@ fn classify_filter_pushdown(
     strategy: &JobsScanStrategy,
 ) -> TableProviderFilterPushDown {
     match strategy {
-        // ExactId: tenant and id are both used to look up the exact record.
+        // ExactId with tenant: both filters are handled exactly (direct pair construction).
+        // ExactId without tenant: the scan falls back to scan_all_jobs + in-memory filter,
+        // so neither filter is exact (limit pushdown would truncate before filtering).
         JobsScanStrategy::ExactId { tenant, .. } => match col_name {
-            "id" => TableProviderFilterPushDown::Exact,
+            "id" if tenant.is_some() => TableProviderFilterPushDown::Exact,
             "tenant" if tenant.is_some() => TableProviderFilterPushDown::Exact,
             _ => TableProviderFilterPushDown::Inexact,
         },

--- a/src/query.rs
+++ b/src/query.rs
@@ -197,6 +197,14 @@ pub trait Scan: std::fmt::Debug + Send + Sync + 'static {
     fn describe(&self, _filters: &[Expr], _limit: Option<usize>) -> String {
         "CustomScan".to_string()
     }
+
+    /// Classify each filter as Exact (fully handled by the scan) or Inexact.
+    /// Returning Exact prevents DataFusion from adding a post-filter FilterExec,
+    /// which enables LIMIT pushdown into the scan.
+    /// Default: all Inexact (safe fallback).
+    fn classify_filters(&self, _filters: &[&Expr]) -> Vec<TableProviderFilterPushDown> {
+        vec![TableProviderFilterPushDown::Inexact; _filters.len()]
+    }
 }
 
 /// Reference to a scanner implementing the Scan trait
@@ -251,16 +259,11 @@ impl TableProvider for SiloTableProvider {
         )))
     }
 
-    // Tell data fusion we support all filter pushdowns, but that it still needs to filter on its side after we've scanned.
     fn supports_filters_pushdown(
         &self,
         filters: &[&Expr],
     ) -> DfResult<Vec<TableProviderFilterPushDown>> {
-        // All filters are Inexact - we use them for scan optimization (index lookups)
-        // but DataFusion still applies them as post-filters for correctness.
-        // This is important because our scan only handles one metadata filter at a time,
-        // and DataFusion may call this method multiple times with different filter subsets.
-        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+        Ok(self.scanner.classify_filters(filters))
     }
 
     fn statistics(&self) -> Option<Statistics> {
@@ -423,6 +426,75 @@ impl std::fmt::Display for JobsScanStrategy {
 
 /// Parse DataFusion filter expressions into a scan strategy.
 /// This determines which index-backed scan path will be used.
+/// Classify jobs table filters for use by both ShardQueryEngine and ClusterQueryEngine.
+pub fn classify_jobs_filters(filters: &[&Expr]) -> Vec<TableProviderFilterPushDown> {
+    // Strip table qualifiers from filter expressions before parsing the strategy,
+    // because supports_filters_pushdown receives qualified names (e.g. "jobs.tenant")
+    // while parse_jobs_scan_strategy expects unqualified names ("tenant").
+    let unqualified_filters: Vec<Expr> = filters.iter().map(|f| unqualify_expr(f)).collect();
+    let strategy = parse_jobs_scan_strategy(&unqualified_filters);
+
+    filters
+        .iter()
+        .map(|f| {
+            if let Some((col, _)) = parse_eq_filter(f) {
+                let col_name = col.rsplit('.').next().unwrap_or(&col);
+                classify_filter_pushdown(col_name, &strategy)
+            } else {
+                TableProviderFilterPushDown::Inexact
+            }
+        })
+        .collect()
+}
+
+/// Strip table qualifiers from column references in an expression.
+/// Converts e.g. `jobs.tenant = 'X'` to `tenant = 'X'`.
+fn unqualify_expr(expr: &Expr) -> Expr {
+    match expr {
+        Expr::BinaryExpr(BinaryExpr { left, op, right }) => Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(unqualify_expr(left)),
+            op: *op,
+            right: Box::new(unqualify_expr(right)),
+        }),
+        Expr::Column(col) => Expr::Column(datafusion::common::Column::new_unqualified(&col.name)),
+        other => other.clone(),
+    }
+}
+
+/// Determine if a specific filter column is Exact (fully handled) for the given strategy.
+/// A filter is Exact when the scan guarantees correct results without post-filtering.
+fn classify_filter_pushdown(
+    col_name: &str,
+    strategy: &JobsScanStrategy,
+) -> TableProviderFilterPushDown {
+    match strategy {
+        // ExactId: tenant and id are both used to look up the exact record.
+        JobsScanStrategy::ExactId { tenant, .. } => match col_name {
+            "id" => TableProviderFilterPushDown::Exact,
+            "tenant" if tenant.is_some() => TableProviderFilterPushDown::Exact,
+            _ => TableProviderFilterPushDown::Inexact,
+        },
+        // Status: tenant scopes the scan, status_kind selects the index range.
+        JobsScanStrategy::Status { tenant, .. } => match col_name {
+            "status_kind" => TableProviderFilterPushDown::Exact,
+            "tenant" if tenant.is_some() => TableProviderFilterPushDown::Exact,
+            _ => TableProviderFilterPushDown::Inexact,
+        },
+        // Metadata strategies: tenant is handled, but status_kind is NOT filtered
+        // by the metadata index scan, so it must remain Inexact.
+        JobsScanStrategy::MetadataExact { tenant, .. }
+        | JobsScanStrategy::MetadataPrefix { tenant, .. } => match col_name {
+            "tenant" if tenant.is_some() => TableProviderFilterPushDown::Exact,
+            _ => TableProviderFilterPushDown::Inexact,
+        },
+        // FullScan: tenant scopes the scan range but no other filters are handled.
+        JobsScanStrategy::FullScan { tenant } => match col_name {
+            "tenant" if tenant.is_some() => TableProviderFilterPushDown::Exact,
+            _ => TableProviderFilterPushDown::Inexact,
+        },
+    }
+}
+
 pub fn parse_jobs_scan_strategy(filters: &[Expr]) -> JobsScanStrategy {
     let mut tenant_filter: Option<String> = None;
     let mut status_filter: Option<QueryStatusFilter> = None;
@@ -601,6 +673,10 @@ impl Scan for JobsScanner {
     fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
         let strategy = parse_jobs_scan_strategy(filters);
         format!("jobs[{}], limit={:?}", strategy, limit)
+    }
+
+    fn classify_filters(&self, filters: &[&Expr]) -> Vec<TableProviderFilterPushDown> {
+        classify_jobs_filters(filters)
     }
 
     fn scan(

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -2805,9 +2805,7 @@ async fn explain_bench_count_scheduled() {
 
 // Benchmark query: SELECT * FROM jobs WHERE tenant = '{t}' AND status_kind = 'Failed' LIMIT 20
 // Status filter with limit → Status(Failed) strategy.
-// NOTE: DataFusion does NOT push LIMIT down because our filters are Inexact
-// (DataFusion adds FilterExec above, and LIMIT can't be pushed through a filter).
-// This means we scan ALL matching rows from the status index, then DataFusion truncates.
+// Tenant and status_kind filters are Exact, so DataFusion pushes LIMIT into the scan.
 #[silo::test]
 async fn explain_bench_first_page_failed() {
     let (_tmp, shard) = open_temp_shard().await;
@@ -2827,17 +2825,11 @@ async fn explain_bench_first_page_failed() {
         "Expected Status(Failed) strategy, got: {}",
         plan_line
     );
-    // Limit is NOT pushed down because Inexact filters cause FilterExec above our scan
+    // Limit IS pushed down because tenant+status_kind filters are Exact (no FilterExec blocking)
     assert!(
-        plan_line.contains("limit=None"),
-        "Expected limit=None (not pushed through FilterExec), got: {}",
+        plan_line.contains("limit=Some(20)"),
+        "Expected limit=Some(20) pushed into scan, got: {}",
         plan_line
-    );
-    // DataFusion handles limit above our scan (Limit in logical plan, GlobalLimitExec in physical)
-    assert!(
-        explain.contains("Limit") || explain.contains("GlobalLimitExec"),
-        "Expected limit handling in plan:\n{}",
-        explain
     );
     assert_eq!(
         strategy,
@@ -2849,8 +2841,7 @@ async fn explain_bench_first_page_failed() {
 }
 
 // Benchmark query: SELECT * FROM jobs WHERE tenant = '{t}' AND status_kind = 'Failed' LIMIT 20 OFFSET 180
-// Same as first_page: limit is NOT pushed down because of Inexact filters.
-// DataFusion handles both OFFSET and LIMIT with GlobalLimitExec.
+// With Exact filters, DataFusion pushes LIMIT+OFFSET (fetch=200) into the scan.
 #[silo::test]
 async fn explain_bench_10th_page_failed() {
     let (_tmp, shard) = open_temp_shard().await;
@@ -2870,17 +2861,11 @@ async fn explain_bench_10th_page_failed() {
         "Expected Status(Failed) strategy, got: {}",
         plan_line
     );
-    // Limit is NOT pushed through FilterExec
+    // Limit IS pushed down (OFFSET 180 + LIMIT 20 = fetch 200)
     assert!(
-        plan_line.contains("limit=None"),
-        "Expected limit=None (not pushed through FilterExec), got: {}",
+        plan_line.contains("limit=Some(200)"),
+        "Expected limit=Some(200) pushed into scan, got: {}",
         plan_line
-    );
-    // DataFusion handles offset+limit above our scan (Limit in logical plan, GlobalLimitExec in physical)
-    assert!(
-        explain.contains("Limit") || explain.contains("GlobalLimitExec"),
-        "Expected limit/offset handling in plan:\n{}",
-        explain
     );
     assert_eq!(
         strategy,

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -2932,6 +2932,77 @@ async fn explain_bench_exact_id_no_tenant() {
     );
 }
 
+// ExactId WITH tenant gets limit pushed down (both tenant and id are Exact).
+#[silo::test]
+async fn exact_id_with_tenant_pushes_limit() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    enqueue_job(&shard, "j1", 10, now).await;
+
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let (explain, _) = explain_and_strategy(
+        &engine,
+        "SELECT * FROM jobs WHERE tenant = '-' AND id = 'j1' LIMIT 1",
+    )
+    .await;
+
+    let plan_line = extract_silo_plan_line(&explain);
+    assert!(
+        plan_line.contains("limit=Some(1)"),
+        "ExactId with tenant should push limit into scan, got: {}",
+        plan_line
+    );
+}
+
+// ExactId WITHOUT tenant must NOT push limit down — the scan falls back to
+// scan_all_jobs(limit) then filters by id in memory, so limit pushdown would
+// truncate before the filter and silently drop matching jobs.
+#[silo::test]
+async fn exact_id_without_tenant_does_not_push_limit() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    enqueue_job(&shard, "j1", 10, now).await;
+
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let (explain, _) =
+        explain_and_strategy(&engine, "SELECT * FROM jobs WHERE id = 'j1' LIMIT 1").await;
+
+    let plan_line = extract_silo_plan_line(&explain);
+    assert!(
+        plan_line.contains("limit=None"),
+        "ExactId without tenant must NOT push limit (would truncate before id filter), got: {}",
+        plan_line
+    );
+}
+
+// Correctness: ExactId without tenant + LIMIT must still find a job that isn't
+// first in scan order. This guards against the bug where limit pushdown would
+// cause scan_all_jobs(limit=1) to return only the first job, missing the target.
+#[silo::test]
+async fn exact_id_without_tenant_limit_returns_correct_job() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Enqueue several jobs — "target" won't be first in lexicographic scan order
+    enqueue_job(&shard, "aaa-first", 10, now).await;
+    enqueue_job(&shard, "bbb-second", 10, now).await;
+    enqueue_job(&shard, "zzz-target", 10, now).await;
+
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let df = engine
+        .sql("SELECT id FROM jobs WHERE id = 'zzz-target' LIMIT 1")
+        .await
+        .expect("sql");
+    let batches = df.collect().await.expect("collect");
+
+    let ids = extract_string_column(&batches, 0);
+    assert_eq!(
+        ids,
+        vec!["zzz-target"],
+        "ExactId without tenant + LIMIT should still find the correct job"
+    );
+}
+
 // Benchmark query: SELECT * FROM jobs WHERE tenant = '{t}'
 //   AND array_contains(element_at(metadata, 'region'), 'us-east-1')
 //   AND status_kind = 'Waiting'


### PR DESCRIPTION
## Summary
- Fix tenant view page timeout for large tenants (1M+ jobs) by enabling DataFusion LIMIT pushdown into silo's custom scan
- Root cause: all filters were `Inexact`, causing DataFusion to insert a `FilterExec` that blocked LIMIT propagation — queries scanned ALL matching rows before truncating
- Add `classify_filters` to the `Scan` trait so each scanner reports which filters it fully handles as `Exact`, eliminating the redundant `FilterExec`

## Benchmark results (large tenant, ~80K jobs)
| Query | Before | After | Speedup |
|---|---|---|---|
| `list_waiting_jobs_tenant_view` (LIMIT 100) | 16.6ms | 600us | **28x** |
| `count_waiting` | 152ms | 10ms | **15x** |
| `count_succeeded` | 1.34s | 71ms | **19x** |
| `first_page_failed` (LIMIT 20) | 42ms | 1.5ms | **28x** |

## Test plan
- [x] All 99 query tests pass (including updated explain plan assertions)
- [x] Full test suite passes (skipping k8s/etcd/DST)
- [x] Benchmark validates performance improvement
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DataFusion filter pushdown semantics for `jobs` by marking some predicates as `Exact`, which can affect query planning and LIMIT/OFFSET behavior; incorrect classification could truncate results, though new tests cover key correctness cases.
> 
> **Overview**
> Improves performance of `jobs` queries with `LIMIT`/`OFFSET` by introducing per-scanner filter classification (`Scan::classify_filters`) so DataFusion can treat some predicates as *fully handled* and push `LIMIT` into the custom scan instead of inserting a blocking `FilterExec`.
> 
> Adds shared `jobs` filter classification (`classify_jobs_filters`) and applies it in both shard and cluster table providers, with explicit safeguards for cases like `id` lookups without `tenant` where limit pushdown would be incorrect. Updates benchmarks and query tests to assert the new explain-plan behavior and adds regression tests for the tricky exact-id-without-tenant LIMIT case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 234971a268eca2dcf87030b525804e8564fff591. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->