### PR TITLE
Refactor TaskBroker to per-task-group scanning

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -61,7 +61,7 @@ use crate::keys::{
 };
 use crate::shard_range::ShardRange;
 use crate::task::{ConcurrencyAction, HolderRecord, Task};
-use crate::task_broker::TaskBroker;
+use crate::task_broker::TaskBrokerRegistry;
 
 /// Error type for concurrency operations that can fail due to storage or encoding errors.
 #[derive(Debug, thiserror::Error)]
@@ -577,7 +577,7 @@ impl ConcurrencyManager {
     pub fn start_grant_scanner(
         self: &Arc<Self>,
         db: Arc<Db>,
-        broker: Arc<TaskBroker>,
+        brokers: Arc<TaskBrokerRegistry>,
         range: ShardRange,
     ) {
         self.grant_running.store(true, Ordering::SeqCst);
@@ -602,19 +602,17 @@ impl ConcurrencyManager {
                         break;
                     }
 
-                    let mut any_granted = false;
+                    let mut granted_groups: Vec<String> = Vec::new();
                     for (_key, (tenant, queue, count)) in work {
-                        let granted = mgr
+                        let groups = mgr
                             .process_grants(&db, &range, &tenant, &queue, count)
                             .await;
-                        if granted {
-                            any_granted = true;
-                        }
+                        granted_groups.extend(groups);
                     }
 
-                    // Wake broker if any grants were made (new tasks in DB)
-                    if any_granted {
-                        broker.wakeup();
+                    // Wake only the brokers whose task groups received grants
+                    if !granted_groups.is_empty() {
+                        brokers.wakeup_groups(&granted_groups);
                     }
                 }
             }
@@ -685,6 +683,8 @@ impl ConcurrencyManager {
     /// Process pending grant requests for a single (tenant, queue).
     /// Scans up to `count` pending requests and grants those for which capacity exists.
     /// Returns true if any grants were made.
+    /// Process pending grant requests for a single (tenant, queue).
+    /// Returns the task groups that received grants.
     async fn process_grants(
         &self,
         db: &Db,
@@ -692,7 +692,7 @@ impl ConcurrencyManager {
         tenant: &str,
         queue: &str,
         count: u32,
-    ) -> bool {
+    ) -> Vec<String> {
         if let Err(e) = self.counts.ensure_hydrated(db, range, tenant, queue).await {
             tracing::warn!(
                 error = %e,
@@ -700,7 +700,7 @@ impl ConcurrencyManager {
                 queue = %queue,
                 "grant scanner: failed to hydrate queue"
             );
-            return false;
+            return Vec::new();
         }
 
         let now_ms = crate::job_store_shard::now_epoch_ms();
@@ -711,11 +711,12 @@ impl ConcurrencyManager {
             Ok(i) => i,
             Err(e) => {
                 tracing::warn!(error = %e, "grant scanner: failed to scan requests");
-                return false;
+                return Vec::new();
             }
         };
 
         let mut granted_count = 0u32;
+        let mut granted_task_groups: Vec<String> = Vec::new();
         let mut max_concurrency: Option<usize> = None;
 
         while granted_count < count {
@@ -924,13 +925,15 @@ impl ConcurrencyManager {
                 queue = %queue,
                 request_id = %request_id,
                 job_id = %job_id_str,
+                task_group = %task_group_str,
                 "grant scanner: granted concurrency ticket"
             );
 
+            granted_task_groups.push(task_group_str.to_string());
             granted_count += 1;
         }
 
-        granted_count > 0
+        granted_task_groups
     }
 }
 

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -191,7 +191,7 @@ impl JobStoreShard {
 
         // Evict the deleted task from the broker buffer
         if let Some(ref key) = deleted_task_key {
-            self.broker.evict_keys(std::slice::from_ref(key));
+            self.brokers.evict_keys(std::slice::from_ref(key));
         }
 
         // Release concurrency holders from in-memory counts and signal grant scanner

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -95,7 +95,7 @@ impl JobStoreShard {
 
             // [SILO-DEQ-1] Claim from the broker buffer for the specified task_group
             let claimed: Vec<BrokerTask> = self
-                .broker
+                .brokers
                 .claim_ready_or_nudge(task_group, remaining)
                 .await;
 
@@ -218,7 +218,7 @@ impl JobStoreShard {
                     self.concurrency.rollback_grant(tenant, queue, task_id);
                 }
                 // Put back all claimed entries since we didn't lease them durably
-                self.broker.requeue(claimed);
+                self.brokers.requeue(claimed);
                 return Err(JobStoreShardError::Slate(e));
             }
             dst_events::confirm_write(write_op);
@@ -232,15 +232,15 @@ impl JobStoreShard {
             // [SILO-DEQ-3] Ack durable and evict from buffer.
             // TaskBroker tracks all release keys for inflight cleanup, but only
             // installs tombstones for keys that were durably deleted.
-            self.broker
-                .ack_durable(&state.release_keys, &state.tombstone_keys);
-            self.broker.evict_keys(&state.release_keys);
+            self.brokers
+                .ack_durable(task_group, &state.release_keys, &state.tombstone_keys);
+            self.brokers.evict_keys(&state.release_keys);
             tracing::debug!(
                 release_keys = state.release_keys.len(),
                 tombstone_keys = state.tombstone_keys.len(),
                 pending_attempts = pending_attempts.len(),
-                buffer_size = self.broker.buffer_len(),
-                inflight = self.broker.inflight_len(),
+                buffer_size = self.brokers.group_buffer_len(task_group),
+                inflight = self.brokers.group_inflight_len(task_group),
                 processed_internal = state.processed_internal,
                 "dequeue: acked and evicted keys"
             );

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -193,7 +193,8 @@ impl JobStoreShard {
         }
         dst_events::confirm_write(write_op);
 
-        self.finish_enqueue(job_id, task_group, start_at_ms, &grants).await
+        self.finish_enqueue(job_id, task_group, start_at_ms, &grants)
+            .await
     }
 
     /// Transaction-path enqueue for user-provided job IDs that need deduplication.
@@ -294,7 +295,8 @@ impl JobStoreShard {
         }
         dst_events::confirm_write(write_op);
 
-        self.finish_enqueue(job_id, task_group, start_at_ms, &grants).await
+        self.finish_enqueue(job_id, task_group, start_at_ms, &grants)
+            .await
     }
 
     /// Write all enqueue data (job info, metadata, status, limit tasks) to the writer.

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -193,7 +193,7 @@ impl JobStoreShard {
         }
         dst_events::confirm_write(write_op);
 
-        self.finish_enqueue(job_id, start_at_ms, &grants).await
+        self.finish_enqueue(job_id, task_group, start_at_ms, &grants).await
     }
 
     /// Transaction-path enqueue for user-provided job IDs that need deduplication.
@@ -294,7 +294,7 @@ impl JobStoreShard {
         }
         dst_events::confirm_write(write_op);
 
-        self.finish_enqueue(job_id, start_at_ms, &grants).await
+        self.finish_enqueue(job_id, task_group, start_at_ms, &grants).await
     }
 
     /// Write all enqueue data (job info, metadata, status, limit tasks) to the writer.
@@ -369,10 +369,11 @@ impl JobStoreShard {
     }
 
     /// Complete an enqueue after successful write/commit and DST event emission.
-    /// Logs grants and wakes up the broker.
+    /// Logs grants and wakes up the broker for the given task group.
     pub(crate) async fn finish_enqueue(
         &self,
         job_id: &str,
+        task_group: &str,
         start_at_ms: i64,
         grants: &[(String, String)],
     ) -> Result<(), JobStoreShardError> {
@@ -383,7 +384,7 @@ impl JobStoreShard {
         }
 
         if start_at_ms <= now_epoch_ms() {
-            self.broker.wakeup();
+            self.brokers.wakeup(task_group);
         }
 
         Ok(())
@@ -463,7 +464,7 @@ impl JobStoreShard {
                         .concurrency
                         .handle_enqueue(
                             &self.db,
-                            &self.broker.get_range(),
+                            &self.get_range(),
                             writer,
                             tenant,
                             &current_task_id,
@@ -511,7 +512,7 @@ impl JobStoreShard {
                         .concurrency
                         .handle_enqueue(
                             &self.db,
-                            &self.broker.get_range(),
+                            &self.get_range(),
                             writer,
                             tenant,
                             &current_task_id,

--- a/src/job_store_shard/expedite.rs
+++ b/src/job_store_shard/expedite.rs
@@ -174,7 +174,7 @@ impl JobStoreShard {
         txn.commit().await?;
 
         // Wake the broker to pick up the expedited task promptly
-        self.broker.wakeup();
+        self.brokers.wakeup(&task_group);
 
         Ok(())
     }

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -316,7 +316,7 @@ impl JobStoreShard {
 
         // For non-terminal, finish enqueue (flush + broker wakeup)
         if !is_terminal {
-            self.finish_enqueue(job_id, effective_start_at_ms, &grants)
+            self.finish_enqueue(job_id, &params.task_group, effective_start_at_ms, &grants)
                 .await?;
         }
 
@@ -702,7 +702,7 @@ impl JobStoreShard {
 
         // [SILO-REIMP-6] Remove buffered tasks for this job.
         // Must happen after commit so the scanner cannot re-buffer old tasks from DB.
-        self.broker.evict_keys(&matched_task_keys);
+        self.brokers.evict_keys(&matched_task_keys);
 
         // Release in-memory holders and immediately request grant scanning.
         // This avoids waiting for periodic reconciliation when slots free up.
@@ -717,7 +717,7 @@ impl JobStoreShard {
 
         // For non-terminal, finish enqueue (flush + broker wakeup)
         if !is_terminal {
-            self.finish_enqueue(job_id, effective_start_at_ms, &grants)
+            self.finish_enqueue(job_id, &task_group, effective_start_at_ms, &grants)
                 .await?;
         }
 

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -348,7 +348,7 @@ impl JobStoreShard {
         if let Some(nt) = followup_next_time
             && nt <= now_epoch_ms()
         {
-            self.broker.wakeup();
+            self.brokers.wakeup(&task_group);
         }
         if let Some(err) = job_missing_error {
             return Err(err);

--- a/src/job_store_shard/lease_task.rs
+++ b/src/job_store_shard/lease_task.rs
@@ -218,8 +218,8 @@ impl JobStoreShard {
         .await?;
 
         // Post-commit: evict old task key from broker buffer and wake broker
-        self.broker.evict_keys(&[old_task_key]);
-        self.broker.wakeup();
+        self.brokers.evict_keys(&[old_task_key]);
+        self.brokers.wakeup(&task_group);
 
         // Build and return the LeasedTask
         let attempt_view = JobAttemptView::new(attempt_val)?;

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -45,7 +45,7 @@ use crate::settings::DatabaseConfig;
 use crate::shard_range::ShardRange;
 use crate::storage::resolve_object_store;
 use crate::task::{LeasedRefreshTask, LeasedTask};
-use crate::task_broker::TaskBroker;
+use crate::task_broker::TaskBrokerRegistry;
 
 /// Configuration for WAL cleanup during shard close
 #[derive(Debug, Clone)]
@@ -88,7 +88,7 @@ pub struct DequeueResult {
 pub struct JobStoreShard {
     pub(crate) name: String,
     pub(crate) db: Arc<Db>,
-    pub(crate) broker: Arc<TaskBroker>,
+    pub(crate) brokers: Arc<TaskBrokerRegistry>,
     pub(crate) concurrency: Arc<ConcurrencyManager>,
     query_engine: OnceLock<ShardQueryEngine>,
     pub(crate) rate_limiter: Arc<dyn RateLimitClient>,
@@ -105,6 +105,8 @@ pub struct JobStoreShard {
     store: Arc<dyn slatedb::object_store::ObjectStore>,
     /// Database path relative to the object store root (needed for Admin API).
     db_path: String,
+    /// The shard's tenant range, immutable after opening.
+    range: ShardRange,
 }
 
 #[derive(Debug, Error)]
@@ -334,21 +336,20 @@ impl JobStoreShard {
         // Note: concurrency counts are hydrated lazily on first access to each queue.
         // This avoids blocking shard startup while scanning potentially large holder sets.
 
-        let broker = TaskBroker::new(
+        let brokers = TaskBrokerRegistry::new(
             Arc::clone(&db),
             name.clone(),
             metrics.clone(),
             range.clone(),
         );
-        broker.start();
 
-        // Start the grant scanner after both ConcurrencyManager and TaskBroker are ready
-        concurrency.start_grant_scanner(Arc::clone(&db), Arc::clone(&broker), range.clone());
+        // Start the grant scanner after both ConcurrencyManager and TaskBrokerRegistry are ready
+        concurrency.start_grant_scanner(Arc::clone(&db), Arc::clone(&brokers), range.clone());
 
         let shard = Arc::new(Self {
             name,
             db,
-            broker,
+            brokers,
             concurrency,
             query_engine: OnceLock::new(),
             rate_limiter,
@@ -358,11 +359,12 @@ impl JobStoreShard {
             cancellation: CancellationToken::new(),
             store,
             db_path: db_path.to_string(),
+            range: range.clone(),
         });
 
         // Periodically reconcile pending concurrency requests to self-heal from
         // missed in-memory notifications or transient scanner failures.
-        shard.spawn_concurrency_reconcile_task(range.clone());
+        shard.spawn_concurrency_reconcile_task(range);
 
         // Set the shard creation timestamp if this is the first time opening
         shard.set_created_at_ms_if_unset().await?;
@@ -391,7 +393,7 @@ impl JobStoreShard {
     /// allowing the shard to be safely reopened elsewhere (e.g., on a different node).
     pub async fn close(&self) -> Result<(), JobStoreShardError> {
         self.cancellation.cancel();
-        self.broker.stop();
+        self.brokers.stop();
         self.concurrency.stop_grant_scanner();
 
         // If we have a local WAL with flush_on_close enabled, flush memtable to SSTs first
@@ -558,7 +560,7 @@ impl JobStoreShard {
     /// The range is immutable after the shard is opened. When shards split,
     /// new child shards are created with new identities and ranges.
     pub fn get_range(&self) -> ShardRange {
-        self.broker.get_range()
+        self.range.clone()
     }
 
     /// Run one pass of pending concurrency-request reconciliation.

--- a/src/job_store_shard/restart.rs
+++ b/src/job_store_shard/restart.rs
@@ -194,7 +194,7 @@ impl JobStoreShard {
 
         // Wake the broker to pick up the new task promptly
         if start_at_ms <= now_epoch_ms() {
-            self.broker.wakeup();
+            self.brokers.wakeup(&task_group);
         }
 
         Ok(())

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -7,11 +7,12 @@ use std::sync::{
 use std::time::Duration;
 
 use crossbeam_skiplist::SkipMap;
+use dashmap::DashMap;
 use slatedb::{Db, WriteBatch};
 use tokio::sync::Notify;
 
 use crate::codec::{DecodedTask, decode_task_validated};
-use crate::keys::{end_bound, parse_task_key, tasks_prefix};
+use crate::keys::{end_bound, parse_task_key, task_group_prefix};
 use crate::metrics::Metrics;
 use crate::shard_range::ShardRange;
 use tracing::debug;
@@ -27,12 +28,14 @@ pub struct BrokerTask {
     pub decoded: DecodedTask,
 }
 
-/// Lock-free in-memory task broker backed by SlateDB.
+/// A single per-task-group broker that scans only its own key range.
 ///
 /// - Maintains a sorted buffer of ready tasks using a skiplist keyed by the task key bytes.
 /// - Populates from SlateDB in the background with exponential backoff when no work is found.
 /// - Ensures tasks claimed but not yet durably leased are tracked as in-flight and not reinserted.
 pub struct TaskBroker {
+    // The task group this broker is responsible for
+    task_group: String,
     // The SlateDB database to read tasks from
     db: Arc<Db>,
     // The buffer of tasks read out of the DB and ready to be claimed by a dequeue-ing worker
@@ -68,13 +71,15 @@ impl TaskBroker {
     // refresh the tombstone generation whenever a stale key is observed again.
     const ACK_TOMBSTONE_RETAIN_GENERATIONS: u64 = 64;
 
-    pub fn new(
+    fn new(
+        task_group: String,
         db: Arc<Db>,
         shard_name: String,
         metrics: Option<Metrics>,
         range: ShardRange,
     ) -> Arc<Self> {
         Arc::new(Self {
+            task_group,
             db,
             buffer: Arc::new(SkipMap::new()),
             inflight: Arc::new(Mutex::new(HashSet::new())),
@@ -90,11 +95,6 @@ impl TaskBroker {
             metrics,
             range,
         })
-    }
-
-    /// Get the shard's tenant range.
-    pub fn get_range(&self) -> ShardRange {
-        self.range.clone()
     }
 
     pub fn buffer_len(&self) -> usize {
@@ -121,8 +121,8 @@ impl TaskBroker {
 
     /// Scan tasks from DB and insert into buffer, skipping future tasks and inflight ones.
     async fn scan_tasks(&self, now_ms: i64, generation: u64) -> usize {
-        // [SILO-SCAN-1] Tasks use binary storekey encoding with prefix byte
-        let start = tasks_prefix();
+        // [SILO-SCAN-1] Scan only this task group's key range
+        let start = task_group_prefix(&self.task_group);
         let end = end_bound(&start);
 
         let Ok(mut iter) = self.db.scan::<Vec<u8>, _>(start..end).await else {
@@ -228,17 +228,13 @@ impl TaskBroker {
     }
 
     /// Start the background scanning loop.
-    pub fn start(self: &Arc<Self>) {
+    fn start(self: &Arc<Self>) {
         if self.running.swap(true, Ordering::SeqCst) {
             return;
         }
 
         let broker = Arc::clone(self);
         tokio::spawn(async move {
-            // Note: Concurrency holders are hydrated synchronously in
-            // JobStoreShard::open_with_resolved_store() before this broker starts.
-            // This ensures concurrent limits are enforced correctly from the first request.
-
             let min_sleep_ms = 5;
             let max_sleep_ms = 1000;
             let mut sleep_ms = min_sleep_ms;
@@ -292,7 +288,7 @@ impl TaskBroker {
                         // Reset backoff on explicit wakeup so the next scan
                         // runs aggressively (e.g. after a dequeue claim).
                         sleep_ms = min_sleep_ms;
-                        debug!("broker woken by notification");
+                        debug!(task_group = %broker.task_group, "broker woken by notification");
                     }
                     _ = &mut delay => {},
                 }
@@ -301,17 +297,15 @@ impl TaskBroker {
     }
 
     /// Stop the background loop.
-    pub fn stop(&self) {
+    fn stop(&self) {
         self.running.store(false, Ordering::SeqCst);
+        self.notify.notify_one();
     }
 
-    /// Claim up to `max` ready tasks from the head of the buffer for a specific task_group.
-    pub fn claim_ready(&self, task_group: &str, max: usize) -> Vec<BrokerTask> {
-        use crate::keys::task_group_prefix;
-        let prefix = task_group_prefix(task_group);
-
-        // Collect candidate keys in a single scan while holding the inflight lock once.
-        // This avoids O(N*M) repeated full scans from the beginning and reduces mutex acquisitions.
+    /// Claim up to `max` ready tasks from the buffer.
+    ///
+    /// Since each broker is scoped to a single task group, no prefix filtering is needed.
+    fn claim_ready(&self, max: usize) -> Vec<BrokerTask> {
         let candidate_keys: Vec<Vec<u8>> = {
             let mut inflight = self.inflight.lock().unwrap();
             let mut keys = Vec::with_capacity(max);
@@ -320,9 +314,6 @@ impl TaskBroker {
                     break;
                 }
                 let key = entry.key();
-                if !key.starts_with(&prefix) {
-                    continue;
-                }
                 if inflight.contains(key) {
                     continue;
                 }
@@ -346,10 +337,10 @@ impl TaskBroker {
         claimed
     }
 
-    /// Try to claim tasks for a task_group. If none available, wait briefly for scanner to populate.
-    pub async fn claim_ready_or_nudge(&self, task_group: &str, max: usize) -> Vec<BrokerTask> {
+    /// Try to claim tasks. If none available, wait briefly for scanner to populate.
+    async fn claim_ready_or_nudge(&self, max: usize) -> Vec<BrokerTask> {
         // Try fast path first
-        let claimed = self.claim_ready(task_group, max);
+        let claimed = self.claim_ready(max);
         if !claimed.is_empty() {
             return claimed;
         }
@@ -358,7 +349,7 @@ impl TaskBroker {
         self.wakeup();
         for _ in 0..5 {
             tokio::time::sleep(Duration::from_millis(5)).await;
-            let claimed = self.claim_ready(task_group, max);
+            let claimed = self.claim_ready(max);
             if !claimed.is_empty() {
                 return claimed;
             }
@@ -368,7 +359,7 @@ impl TaskBroker {
     }
 
     /// Requeue tasks back into the buffer after a failed durable write.
-    pub fn requeue(&self, tasks: Vec<BrokerTask>) {
+    fn requeue(&self, tasks: Vec<BrokerTask>) {
         let mut inflight = self.inflight.lock().unwrap();
         let mut tombstones = self.ack_tombstones.lock().unwrap();
         for entry in tasks {
@@ -382,7 +373,7 @@ impl TaskBroker {
     /// - `release_keys`: keys to release from in-flight tracking.
     /// - `tombstone_keys`: subset of keys that were durably deleted and should be
     ///   protected from stale-scan re-inserts.
-    pub fn ack_durable(&self, release_keys: &[Vec<u8>], tombstone_keys: &[Vec<u8>]) {
+    fn ack_durable(&self, release_keys: &[Vec<u8>], tombstone_keys: &[Vec<u8>]) {
         let mut inflight = self.inflight.lock().unwrap();
         let mut tombstones = self.ack_tombstones.lock().unwrap();
         let generation = self.scan_generation_started.load(Ordering::SeqCst);
@@ -395,14 +386,14 @@ impl TaskBroker {
     }
 
     /// Remove any buffered entries that match the provided keys.
-    pub fn evict_keys(&self, keys: &[Vec<u8>]) {
+    fn evict_keys(&self, keys: &[Vec<u8>]) {
         for k in keys {
             self.buffer.remove(k);
         }
     }
 
     /// Wake the scanner to refill promptly.
-    pub fn wakeup(&self) {
+    fn wakeup(&self) {
         self.scan_requested.store(true, Ordering::SeqCst);
         self.notify.notify_one();
     }
@@ -411,5 +402,151 @@ impl TaskBroker {
 impl Drop for TaskBroker {
     fn drop(&mut self) {
         self.stop();
+    }
+}
+
+/// Registry of per-task-group brokers. Lazily creates a broker for each task group
+/// on first access, scoping each broker's DB scan to its task group's key range.
+pub struct TaskBrokerRegistry {
+    db: Arc<Db>,
+    shard_name: String,
+    metrics: Option<Metrics>,
+    range: ShardRange,
+    brokers: DashMap<String, Arc<TaskBroker>>,
+}
+
+impl TaskBrokerRegistry {
+    pub fn new(
+        db: Arc<Db>,
+        shard_name: String,
+        metrics: Option<Metrics>,
+        range: ShardRange,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            db,
+            shard_name,
+            metrics,
+            range,
+            brokers: DashMap::new(),
+        })
+    }
+
+    /// Get or create a broker for the given task group.
+    fn get_or_create(&self, task_group: &str) -> Arc<TaskBroker> {
+        if let Some(broker) = self.brokers.get(task_group) {
+            return Arc::clone(broker.value());
+        }
+
+        // Use entry API to avoid race between check and insert
+        let broker = self
+            .brokers
+            .entry(task_group.to_string())
+            .or_insert_with(|| {
+                let b = TaskBroker::new(
+                    task_group.to_string(),
+                    Arc::clone(&self.db),
+                    self.shard_name.clone(),
+                    self.metrics.clone(),
+                    self.range.clone(),
+                );
+                b.start();
+                b
+            });
+        Arc::clone(broker.value())
+    }
+
+    /// Claim up to `max` ready tasks for a task group.
+    pub fn claim_ready(&self, task_group: &str, max: usize) -> Vec<BrokerTask> {
+        self.get_or_create(task_group).claim_ready(max)
+    }
+
+    /// Try to claim tasks for a task group. If none available, wait briefly for scanner to populate.
+    pub async fn claim_ready_or_nudge(&self, task_group: &str, max: usize) -> Vec<BrokerTask> {
+        self.get_or_create(task_group).claim_ready_or_nudge(max).await
+    }
+
+    /// Wake the scanner for a specific task group.
+    /// Creates the broker if it doesn't exist, since a wakeup implies tasks were just written.
+    pub fn wakeup(&self, task_group: &str) {
+        self.get_or_create(task_group).wakeup();
+    }
+
+    /// Wake specific task group brokers that already exist.
+    /// Does not create brokers — only wakes groups that have an active scanner.
+    pub fn wakeup_groups(&self, task_groups: &[String]) {
+        for group in task_groups {
+            if let Some(broker) = self.brokers.get(group.as_str()) {
+                broker.wakeup();
+            }
+        }
+    }
+
+    /// Requeue tasks back into the appropriate broker's buffer after a failed durable write.
+    pub fn requeue(&self, tasks: Vec<BrokerTask>) {
+        // Group tasks by task group to batch requeue into the right broker
+        let mut by_group: HashMap<String, Vec<BrokerTask>> = HashMap::new();
+        for task in tasks {
+            let group = task.decoded.task_group().to_string();
+            by_group.entry(group).or_default().push(task);
+        }
+        for (group, group_tasks) in by_group {
+            self.get_or_create(&group).requeue(group_tasks);
+        }
+    }
+
+    /// Acknowledge durable dequeue outcomes for a specific task group.
+    pub fn ack_durable(
+        &self,
+        task_group: &str,
+        release_keys: &[Vec<u8>],
+        tombstone_keys: &[Vec<u8>],
+    ) {
+        self.get_or_create(task_group)
+            .ack_durable(release_keys, tombstone_keys);
+    }
+
+    /// Remove any buffered entries that match the provided keys.
+    /// Keys may belong to different task groups; only evicts from brokers that already exist.
+    pub fn evict_keys(&self, keys: &[Vec<u8>]) {
+        for k in keys {
+            if let Some(parsed) = parse_task_key(k) {
+                if let Some(broker) = self.brokers.get(&parsed.task_group) {
+                    broker.evict_keys(std::slice::from_ref(k));
+                }
+            }
+        }
+    }
+
+    /// Get the total buffer length across all brokers.
+    pub fn buffer_len(&self) -> usize {
+        self.brokers.iter().map(|e| e.value().buffer_len()).sum()
+    }
+
+    /// Get the total inflight count across all brokers.
+    pub fn inflight_len(&self) -> usize {
+        self.brokers.iter().map(|e| e.value().inflight_len()).sum()
+    }
+
+    /// Get the buffer length for a specific task group.
+    pub fn group_buffer_len(&self, task_group: &str) -> usize {
+        self.brokers
+            .get(task_group)
+            .map(|e| e.value().buffer_len())
+            .unwrap_or(0)
+    }
+
+    /// Get the inflight count for a specific task group.
+    pub fn group_inflight_len(&self, task_group: &str) -> usize {
+        self.brokers
+            .get(task_group)
+            .map(|e| e.value().inflight_len())
+            .unwrap_or(0)
+    }
+
+    /// Stop all brokers.
+    pub fn stop(&self) {
+        for entry in self.brokers.iter() {
+            entry.value().stop();
+        }
     }
 }

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -462,7 +462,9 @@ impl TaskBrokerRegistry {
 
     /// Try to claim tasks for a task group. If none available, wait briefly for scanner to populate.
     pub async fn claim_ready_or_nudge(&self, task_group: &str, max: usize) -> Vec<BrokerTask> {
-        self.get_or_create(task_group).claim_ready_or_nudge(max).await
+        self.get_or_create(task_group)
+            .claim_ready_or_nudge(max)
+            .await
     }
 
     /// Wake the scanner for a specific task group.


### PR DESCRIPTION
## Summary
- Refactors `TaskBroker` from one-per-shard to one-per-task-group via a new `TaskBrokerRegistry`, so each broker scans only its task group's key range instead of the entire task keyspace
- Replaces `Mutex<HashMap>` with `DashMap` for lock-free broker lookups
- `ConcurrencyManager` grant scanner now wakes only the specific task group brokers that received grants
- `evict_keys`/`wakeup_groups` skip broker creation for non-existent groups to avoid spurious background scan loops
- `ShardRange` moved from `TaskBroker` to `JobStoreShard` directly (was misplaced)

## Motivation
CPU profiling showed ~21% of CPU spent in `TaskBroker::start` scanning the entire task keyspace every cycle. With per-group scanning, each broker's range scan is narrowed from O(all_tasks) to O(tasks_in_group), and `claim_ready()` no longer needs prefix filtering since the buffer is group-scoped.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo build` clean with no warnings
- [x] Full test suite passes (only pre-existing flaky k8s coordination test fails)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core dequeue/broker/concurrency wakeup paths and changes task scanning behavior, which could impact scheduling latency or cause missed/extra wakeups if task-group routing is wrong.
> 
> **Overview**
> Refactors the in-memory task broker from a single shard-wide scanner into a `TaskBrokerRegistry` that lazily creates **per-task-group** `TaskBroker` instances, each scanning only `task_group_prefix(task_group)`.
> 
> Updates shard operations (`dequeue`, enqueue/expedite/restart/lease/cancel/import flows) and the concurrency grant scanner to interact with the registry, including **waking only the affected task-group brokers** after grants and routing `ack_durable`/requeue/eviction to the appropriate group. Also moves the shard `ShardRange` onto `JobStoreShard` (instead of deriving it via the broker) and adjusts logging/metrics to report per-group buffer/inflight sizes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c7b84f040d6494ddb31ab5e916f6af33422a286. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->