### PR TITLE
Fix main test flakes: grpc timeouts and dequeue race

### DIFF
--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -18,7 +18,7 @@ use tonic_health::pb::health_client::HealthClient;
 
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_health_check_returns_serving() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let (_client, shutdown_tx, server, addr) =
             setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
@@ -66,7 +66,7 @@ async fn grpc_health_check_returns_serving() -> anyhow::Result<()> {
 /// This specifically tests that the `remaining` counter is decremented correctly across shards.
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_lease_tasks_multi_shard() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let tmp = tempfile::tempdir()?;
         let template = DatabaseTemplate {
             backend: Backend::Fs,
@@ -160,7 +160,7 @@ async fn grpc_server_lease_tasks_multi_shard() -> anyhow::Result<()> {
 
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_tenant_validation_when_enabled() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
 
         // Enable tenancy in config
@@ -344,7 +344,7 @@ async fn grpc_enqueue_rejects_tenant_when_tenancy_disabled() -> anyhow::Result<(
 
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_reset_shards_requires_dev_mode() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
 
         // dev_mode = false (default)
@@ -379,7 +379,7 @@ async fn grpc_server_reset_shards_requires_dev_mode() -> anyhow::Result<()> {
 
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_reset_shards_works_in_dev_mode() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
 
         // Enable dev mode
@@ -457,7 +457,7 @@ async fn grpc_server_reset_shards_works_in_dev_mode() -> anyhow::Result<()> {
 
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_report_outcome_missing_outcome() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let (mut client, shutdown_tx, server, _addr) =
             setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
@@ -494,7 +494,7 @@ async fn grpc_server_report_outcome_missing_outcome() -> anyhow::Result<()> {
 
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_report_refresh_outcome_missing_outcome() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let (mut client, shutdown_tx, server, _addr) =
             setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
@@ -532,7 +532,7 @@ async fn grpc_server_report_refresh_outcome_missing_outcome() -> anyhow::Result<
 /// Test that GetNodeInfo returns correct counts for empty shard
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_get_node_info_empty() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let (mut client, shutdown_tx, server, _addr) =
             setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
@@ -580,7 +580,7 @@ fn get_shard_counters_from_node_info(resp: &GetNodeInfoResponse, shard_id: &str)
 /// Test that GetNodeInfo correctly tracks job lifecycle
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_get_node_info_tracks_lifecycle() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let (mut client, shutdown_tx, server, _addr) =
             setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
@@ -1509,7 +1509,7 @@ async fn grpc_server_reset_shards_eight_shards_immediately_available() -> anyhow
 
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_force_release_shard_succeeds() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let (mut client, shutdown_tx, server, _addr) =
             setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
@@ -1533,7 +1533,7 @@ async fn grpc_force_release_shard_succeeds() -> anyhow::Result<()> {
 
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_force_release_shard_invalid_id_returns_error() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let (mut client, shutdown_tx, server, _addr) =
             setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
@@ -1563,7 +1563,7 @@ async fn grpc_force_release_shard_invalid_id_returns_error() -> anyhow::Result<(
 /// When tenancy is enabled, report_outcome/heartbeat/report_refresh_outcome must include tenant_id.
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_worker_rpcs_require_tenant_when_tenancy_enabled() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let mut cfg = AppConfig::load(None).unwrap();
         cfg.tenancy.enabled = true;
@@ -1656,7 +1656,7 @@ async fn grpc_worker_rpcs_require_tenant_when_tenancy_enabled() -> anyhow::Resul
 /// When tenancy is disabled, worker RPCs should work without tenant_id.
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_worker_rpcs_skip_tenant_validation_when_tenancy_disabled() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let mut cfg = AppConfig::load(None).unwrap();
         cfg.tenancy.enabled = false;
@@ -1740,7 +1740,7 @@ async fn grpc_worker_rpcs_skip_tenant_validation_when_tenancy_disabled() -> anyh
 /// When tenancy is enabled, worker RPCs should accept valid tenant_id and succeed.
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_worker_rpcs_accept_valid_tenant_when_tenancy_enabled() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let mut cfg = AppConfig::load(None).unwrap();
         cfg.tenancy.enabled = true;

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -1473,6 +1473,9 @@ async fn retry_with_concurrent_jobs_respects_limit() {
         .await
         .expect("enqueue B");
 
+    // Give the task broker scanner time to pick up both tasks from the DB
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
     // Dequeue both A and B (max_concurrency=2 allows both)
     let tasks = shard
         .dequeue("w", "default", 10)

--- a/tests/split_aware_processing_tests.rs
+++ b/tests/split_aware_processing_tests.rs
@@ -651,6 +651,8 @@ async fn concurrency_hydration_ignores_uncleaned_holders() {
                 .unwrap();
         }
         shard.db().flush().await.unwrap();
+        // Give the task broker scanner time to pick up both tasks from the DB
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // Dequeue to create holders
         let result = shard.dequeue("worker-1", "default", 10).await.unwrap();


### PR DESCRIPTION
Three fixes:

1. grpc_misc_tests: Increase all 5s test timeouts to 10s. Three tests timed out simultaneously on iteration 1 of a grind run due to cold-start overhead (tonic connection setup, SlateDB initialization, tokio thread pool warm-up). Other tests in the file were already at 10-15s.

2. split_aware_processing_tests: Add 50ms sleep before multi-task dequeue. The task broker scanner runs asynchronously after enqueue, and under CI load may not have populated its buffer with both tasks before dequeue's claim_ready_or_nudge returns.

3. job_store_shard_concurrency_tests: Same scanner race fix. The retry_with_concurrent_jobs_respects_limit test enqueues 2 jobs then immediately dequeues expecting both, but the scanner may only have picked up 1 task by the time the dequeue loop exhausts its retries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are test-only and primarily adjust timing to avoid flakiness; main risk is slightly longer/fixed delays masking real performance regressions.
> 
> **Overview**
> Reduces CI flakiness in integration tests by **doubling gRPC test timeouts** in `grpc_misc_tests.rs` from 5s to 10s to better tolerate cold-start overhead.
> 
> Adds a small **50ms wait after enqueue** in two concurrency-related tests (`job_store_shard_concurrency_tests.rs` and `split_aware_processing_tests.rs`) to avoid a race where the async task broker scanner hasn’t populated tasks before an immediate multi-task dequeue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c4b6d48e3cb9140e72e72ba3b310286f800248c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->