### PR TITLE
Reduce TaskBroker scan frequency to lower CPU usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 AGENTS.md
 tests/turmoil/AGENTS.md
 # end lnai-generated
+profiles/

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -89,7 +89,7 @@ impl TaskBroker {
             running: Arc::new(AtomicBool::new(false)),
             notify: Arc::new(Notify::new()),
             scan_requested: Arc::new(AtomicBool::new(false)),
-            target_buffer: 4096,
+            target_buffer: 8192,
             scan_batch: 1024,
             shard_name,
             metrics,
@@ -235,18 +235,20 @@ impl TaskBroker {
 
         let broker = Arc::clone(self);
         tokio::spawn(async move {
-            let min_sleep_ms = 5;
-            let max_sleep_ms = 1000;
+            let min_sleep_ms = 50;
+            let max_sleep_ms = 2000;
             let mut sleep_ms = min_sleep_ms;
+            let scan_low_watermark = broker.target_buffer / 2;
 
             loop {
                 if !broker.running.load(Ordering::SeqCst) {
                     break;
                 }
 
-                // Wait if buffer is full
-                if broker.buffer.len() >= broker.target_buffer {
-                    tokio::time::sleep(Duration::from_millis(50)).await;
+                // Only scan when buffer drops below low watermark to avoid
+                // hammering SlateDB with repeated SST index reads.
+                if broker.buffer.len() >= scan_low_watermark {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
                     continue;
                 }
 
@@ -285,9 +287,10 @@ impl TaskBroker {
                 tokio::select! {
                     biased;
                     _ = broker.notify.notified() => {
-                        // Reset backoff on explicit wakeup so the next scan
-                        // runs aggressively (e.g. after a dequeue claim).
-                        sleep_ms = min_sleep_ms;
+                        // Halve backoff on explicit wakeup instead of
+                        // resetting to min — keeps scan rate reasonable
+                        // while still responding to demand.
+                        sleep_ms = (sleep_ms / 2).max(min_sleep_ms);
                         debug!(task_group = %broker.task_group, "broker woken by notification");
                     }
                     _ = &mut delay => {},

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -239,15 +239,23 @@ impl TaskBroker {
             let max_sleep_ms = 2000;
             let mut sleep_ms = min_sleep_ms;
             let scan_low_watermark = broker.target_buffer / 2;
+            let mut scanning = false;
 
             loop {
                 if !broker.running.load(Ordering::SeqCst) {
                     break;
                 }
 
-                // Only scan when buffer drops below low watermark to avoid
-                // hammering SlateDB with repeated SST index reads.
-                if broker.buffer.len() >= scan_low_watermark {
+                // Hysteresis: start scanning when buffer drops below low
+                // watermark, keep scanning until it reaches target_buffer.
+                let buf_len = broker.buffer.len();
+                if buf_len < scan_low_watermark {
+                    scanning = true;
+                } else if buf_len >= broker.target_buffer {
+                    scanning = false;
+                }
+
+                if !scanning {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                     continue;
                 }


### PR DESCRIPTION
## Summary
- Raise scan loop backoff from 5-1000ms to 50-2000ms to reduce SST index parsing overhead
- Add low-watermark buffer check (50%): only scan when buffer drains below half capacity instead of when completely empty
- Double target_buffer to 8192 to compensate for less frequent scans
- Halve backoff on wakeup instead of resetting to min, preventing notification storms

## Context
Production profiling showed ~45% of CPU in `TaskBroker::start`, dominated by SlateDB SSTable index parsing (`SsTableIndexOwned::new` at 17% flat, `TableStore::read_index` at 35% cumulative). Each `db.scan()` rebuilds the full merge iterator across all SST files. These changes reduce scan frequency for idle and partially-filled brokers.

## Test plan
- [x] `cargo check` passes
- [x] Existing tests pass
- [ ] Monitor production CPU after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `TaskBroker` background scan scheduling and buffer thresholds, which can affect task pickup latency and throughput under different load patterns. No security- or data-integrity-sensitive logic is modified, but runtime performance behavior needs validation in production.
> 
> **Overview**
> Reduces `TaskBroker` background scan CPU by scanning less aggressively: increases scan backoff bounds (now `50..2000ms`), doubles `target_buffer` to `8192`, and introduces a low-watermark hysteresis so scanning only starts when the buffer drops below half and stops once refilled.
> 
> Notification wakeups now *halve* the current backoff instead of resetting to the minimum, reducing the chance of notification-driven scan storms.
> 
> Also adds `profiles/` to `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a1b6d5973e217d7a208bf3e38a46b1ddaa66c0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->