### PR TITLE
Fix webui compact button to route to shard owner

### DIFF
--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -38,8 +38,9 @@ use crate::coordination::{Coordinator, ShardOwnerMap, SplitCleanupStatus};
 use crate::factory::ShardFactory;
 use crate::pb::silo_client::SiloClient;
 use crate::pb::{
-    CancelJobRequest, ColumnInfo, GetJobRequest, GetJobResponse, GetNodeInfoRequest, JobStatus,
-    QueryRequest, RequestSplitRequest, RequestSplitResponse, SerializedBytes, serialized_bytes,
+    CancelJobRequest, ColumnInfo, CompactShardRequest, GetJobRequest, GetJobResponse,
+    GetNodeInfoRequest, JobStatus, QueryRequest, RequestSplitRequest, RequestSplitResponse,
+    SerializedBytes, serialized_bytes,
 };
 use crate::shard_range::ShardId;
 
@@ -793,6 +794,36 @@ impl ClusterClient {
         }
 
         Ok(())
+    }
+
+    /// Trigger a full compaction on a shard (local or remote)
+    pub async fn compact_shard(&self, shard_id: &ShardId) -> Result<String, ClusterClientError> {
+        // Check if shard is local first
+        if let Some(shard) = self.factory.get(shard_id) {
+            debug!(shard_id = %shard_id, "compacting local shard");
+            shard
+                .submit_full_compaction()
+                .await
+                .map_err(|e| ClusterClientError::QueryFailed(e.to_string()))?;
+            return Ok(format!("full compaction submitted for shard {}", shard_id));
+        }
+
+        // Shard is not local, route to remote owner
+        let addr = self.get_shard_addr(shard_id).await?;
+        debug!(shard_id = %shard_id, addr = %addr, "compacting shard on remote node");
+
+        let mut client = self.get_client(&addr).await?;
+        let request = CompactShardRequest {
+            shard: shard_id.to_string(),
+        };
+
+        match client.compact_shard(request).await {
+            Ok(resp) => Ok(resp.into_inner().status),
+            Err(e) => {
+                self.invalidate_connection(&addr);
+                Err(ClusterClientError::RpcFailed(e.to_string()))
+            }
+        }
     }
 
     /// Request a shard split operation

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -1968,16 +1968,8 @@ async fn shard_compact_handler(
         }
     };
 
-    let Some(shard) = state.factory.get(&parsed_shard_id) else {
-        return Redirect::to(&format!(
-            "/shard?id={}&compact_error={}",
-            shard_id,
-            urlencoding::encode("Shard not found on this node")
-        ));
-    };
-
-    match shard.submit_full_compaction().await {
-        Ok(()) => Redirect::to(&format!(
+    match state.cluster_client.compact_shard(&parsed_shard_id).await {
+        Ok(_) => Redirect::to(&format!(
             "/shard?id={}&compact_message={}",
             shard_id,
             urlencoding::encode(


### PR DESCRIPTION
## Summary
- Add `ClusterClient::compact_shard()` method that routes to the shard owner (local or remote), following the same pattern as `cancel_job()`
- Update webui `shard_compact_handler` to use cluster client routing instead of requiring the shard to be local
- The `CompactShard` gRPC RPC already existed server-side, it just wasn't being used from the webui

## Context
The "Trigger Full Compaction" button in the webui only worked if the HTTP request happened to land on the node owning the shard. This fix enables compacting any shard from any node.

## Test plan
- [x] `cargo check` passes
- [ ] Test compaction button on a shard owned by a different node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new cross-node routing for shard compaction and changes the web UI to invoke it, which could affect operational behavior if ownership lookups or the `CompactShard` RPC fail. Scope is small and follows existing `cancel_job` routing patterns.
> 
> **Overview**
> Fixes the WebUI “Trigger Full Compaction” action to work from any node by routing compaction requests to the shard owner.
> 
> Introduces `ClusterClient::compact_shard()` which compacts locally when the shard is present, otherwise resolves the owning node via the coordinator and calls the existing `CompactShard` gRPC RPC (invalidating cached connections on RPC failure). The `shard_compact_handler` is updated to use this new routing instead of requiring the shard to be local.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ed085ea41675a5f90c8c70e7e5d993355f10861. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->