### PR TITLE
simple cpu opt

### DIFF
--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -121,23 +121,26 @@ Silo uses [SlateDB](https://slatedb.io/) as its underlying embedded key-value st
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `silo_slatedb_get_requests_total` | Gauge | `shard` | Total number of GET (read) requests to SlateDB |
-| `silo_slatedb_scan_requests_total` | Gauge | `shard` | Total number of scan (range query) requests |
-| `silo_slatedb_write_ops_total` | Gauge | `shard` | Total number of individual write operations |
-| `silo_slatedb_write_batch_count_total` | Gauge | `shard` | Total number of write batches |
-| `silo_slatedb_backpressure_count_total` | Gauge | `shard` | Number of times writes were blocked by back-pressure |
+| `silo_slatedb_get_requests_total` | Counter | `shard` | Total number of GET (read) requests to SlateDB |
+| `silo_slatedb_scan_requests_total` | Counter | `shard` | Total number of scan (range query) requests |
+| `silo_slatedb_write_ops_total` | Counter | `shard` | Total number of individual write operations |
+| `silo_slatedb_write_batch_count_total` | Counter | `shard` | Total number of write batches |
+| `silo_slatedb_flush_requests_total` | Counter | `shard` | Total number of flush requests to SlateDB |
+| `silo_slatedb_backpressure_count_total` | Counter | `shard` | Number of times writes were blocked by back-pressure |
+| `silo_slatedb_total_mem_size_bytes` | Gauge | `shard` | Total memory usage of SlateDB (memtables, WAL buffers, etc.) |
 
 **Key insights:**
 - High `silo_slatedb_backpressure_count_total` indicates the storage layer is under write pressure
 - Compare `silo_slatedb_write_ops_total` to `silo_slatedb_write_batch_count_total` to understand batching efficiency
+- `silo_slatedb_total_mem_size_bytes` helps track memory pressure per shard — sudden increases may indicate write spikes or slow flushes
 
 #### WAL (Write-Ahead Log) Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `silo_slatedb_wal_buffer_estimated_bytes` | Gauge | `shard` | Estimated bytes buffered in the WAL buffer |
-| `silo_slatedb_wal_buffer_flushes_total` | Gauge | `shard` | Total number of WAL buffer flushes |
-| `silo_slatedb_immutable_memtable_flushes_total` | Gauge | `shard` | Total number of immutable memtable flushes to SSTs |
+| `silo_slatedb_wal_buffer_flushes_total` | Counter | `shard` | Total number of WAL buffer flushes |
+| `silo_slatedb_immutable_memtable_flushes_total` | Counter | `shard` | Total number of immutable memtable flushes to SSTs |
 
 **Key insights:**
 - `silo_slatedb_wal_buffer_estimated_bytes` shows pending writes not yet durably flushed
@@ -150,9 +153,9 @@ SlateDB uses bloom filters to avoid unnecessary SST reads. These metrics track f
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `silo_slatedb_sst_filter_positives_total` | Gauge | `shard` | True positives: key exists and filter said yes |
-| `silo_slatedb_sst_filter_negatives_total` | Gauge | `shard` | True negatives: key absent and filter said no (avoided read) |
-| `silo_slatedb_sst_filter_false_positives_total` | Gauge | `shard` | False positives: key absent but filter said yes (wasted read) |
+| `silo_slatedb_sst_filter_positives_total` | Counter | `shard` | True positives: key exists and filter said yes |
+| `silo_slatedb_sst_filter_negatives_total` | Counter | `shard` | True negatives: key absent and filter said no (avoided read) |
+| `silo_slatedb_sst_filter_false_positives_total` | Counter | `shard` | False positives: key absent but filter said yes (wasted read) |
 
 **Key insights:**
 - High `silo_slatedb_sst_filter_negatives_total` rate indicates filters are effective at avoiding reads
@@ -165,14 +168,35 @@ SlateDB periodically compacts SST files to reclaim space and improve read perfor
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `silo_slatedb_bytes_compacted_total` | Gauge | `shard` | Total number of bytes compacted |
+| `silo_slatedb_bytes_compacted_total` | Counter | `shard` | Total number of bytes compacted |
 | `silo_slatedb_running_compactions` | Gauge | `shard` | Number of compactions currently running |
 | `silo_slatedb_last_compaction_ts_seconds` | Gauge | `shard` | Unix timestamp of the last compaction |
+| `silo_slatedb_l0_sst_count` | Gauge | `shard` | Number of Level-0 SSTs (high values indicate compaction lag) |
 
 **Key insights:**
 - `silo_slatedb_running_compactions` > 0 indicates compaction is actively working
 - Monitor `silo_slatedb_bytes_compacted_total` rate to understand compaction throughput
 - If `silo_slatedb_last_compaction_ts_seconds` is very old, compaction may be stuck or disabled
+- High `silo_slatedb_l0_sst_count` means scans must merge across many unsorted files, directly increasing scan latency. This is the most important metric for diagnosing slow scans
+
+#### Cache Metrics
+
+SlateDB maintains an in-memory block cache for SST data blocks, index blocks, and bloom filters. These metrics track cache effectiveness — low hit rates indicate that reads are falling through to object storage.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `silo_slatedb_cache_data_block_hit_total` | Counter | `shard` | Data block cache hits |
+| `silo_slatedb_cache_data_block_miss_total` | Counter | `shard` | Data block cache misses (requires object storage read) |
+| `silo_slatedb_cache_index_hit_total` | Counter | `shard` | Index block cache hits |
+| `silo_slatedb_cache_index_miss_total` | Counter | `shard` | Index block cache misses |
+| `silo_slatedb_cache_filter_hit_total` | Counter | `shard` | Bloom filter cache hits |
+| `silo_slatedb_cache_filter_miss_total` | Counter | `shard` | Bloom filter cache misses |
+
+**Key insights:**
+- Compute hit rates as `hit / (hit + miss)` for each cache tier
+- Low data block hit rate combined with high L0 SST count strongly suggests compaction isn't keeping up
+- Low filter/index cache hit rates may indicate the cache is too small for the working set — consider increasing SlateDB's block cache size
+- Filter cache misses are especially expensive because they force a full block read to check for key existence
 
 ## Tracing
 

--- a/docs/src/content/docs/reference/server-configuration.mdx
+++ b/docs/src/content/docs/reference/server-configuration.mdx
@@ -191,10 +191,18 @@ max_sst_size = 1073741824
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `flush_interval` | duration | `"100ms"` | How often to flush the memtable to SST files |
-| `l0_sst_size_bytes` | number | `67108864` | Target size for L0 SST files (64MB default) |
+| `flush_interval` | duration | `"100ms"` | How often to flush the WAL to object storage. Also controls how frequently memtable size is checked against `l0_sst_size_bytes`. |
+| `l0_sst_size_bytes` | number | `67108864` | Minimum memtable size before it is frozen and flushed as an L0 SST to object storage (64MB default). See below for tuning guidance. |
 | `l0_max_ssts` | number | `8` | Maximum number of L0 SSTs before compaction triggers |
 | `max_unflushed_bytes` | number | `536870912` | Maximum unflushed data in memory (512MB default) |
+
+#### `l0_sst_size_bytes`
+
+This setting controls the minimum size a memtable must reach before SlateDB freezes it and flushes it to object storage as an L0 SST. The memtable size is checked every `flush_interval`. Writes are always durably persisted to the WAL regardless of this setting — `l0_sst_size_bytes` only affects when data moves from the in-memory memtable into the SST layer that is visible to readers on other nodes.
+
+Silo is a high write-throughput workload — each job enqueue, dequeue, heartbeat, and completion generates multiple key writes. With the default of 64MB, memtables flush frequently, producing many small L0 SSTs that increase object storage PUT costs, read amplification, and compaction pressure. **You should strongly consider raising this value** (e.g. 256MB or higher) to reduce the number of L0 SSTs produced and give the compactor larger, more efficient inputs.
+
+The tradeoff of a higher value is **increased memory usage** (the unflushed memtable grows larger before being flushed) and **higher read latency for other nodes** (data stays in the memtable longer before becoming visible in object storage via SSTs). In practice, Silo nodes are the primary readers of their own shards, so the cross-node visibility delay is rarely a concern.
 
 #### Compactor Options
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -106,11 +106,22 @@ pub struct Metrics {
     slatedb_sst_filter_negatives: CounterVec,
     slatedb_sst_filter_false_positives: CounterVec,
     slatedb_bytes_compacted: CounterVec,
+    slatedb_flush_requests: CounterVec,
 
     // SlateDB storage gauges (per-shard, point-in-time values)
     slatedb_wal_buffer_estimated_bytes: GaugeVec,
     slatedb_running_compactions: GaugeVec,
     slatedb_last_compaction_ts_sec: GaugeVec,
+    slatedb_l0_sst_count: GaugeVec,
+    slatedb_total_mem_size_bytes: GaugeVec,
+
+    // SlateDB cache counters (per-shard, monotonically increasing)
+    slatedb_cache_data_block_hit: CounterVec,
+    slatedb_cache_data_block_miss: CounterVec,
+    slatedb_cache_index_hit: CounterVec,
+    slatedb_cache_index_miss: CounterVec,
+    slatedb_cache_filter_hit: CounterVec,
+    slatedb_cache_filter_miss: CounterVec,
 
     /// Tracks previous SlateDB counter values per (stat_name, shard) for delta computation.
     /// SlateDB exposes counters as absolute values via `stat.get()`, but Prometheus counters
@@ -296,6 +307,19 @@ impl Metrics {
                 &self.slatedb_sst_filter_false_positives,
             ),
             ("compactor/bytes_compacted", &self.slatedb_bytes_compacted),
+            (
+                slatedb::db_stats::FLUSH_REQUESTS,
+                &self.slatedb_flush_requests,
+            ),
+            ("dbcache/data_block_hit", &self.slatedb_cache_data_block_hit),
+            (
+                "dbcache/data_block_miss",
+                &self.slatedb_cache_data_block_miss,
+            ),
+            ("dbcache/index_hit", &self.slatedb_cache_index_hit),
+            ("dbcache/index_miss", &self.slatedb_cache_index_miss),
+            ("dbcache/filter_hit", &self.slatedb_cache_filter_hit),
+            ("dbcache/filter_miss", &self.slatedb_cache_filter_miss),
         ];
 
         // Gauge-type stats: point-in-time values
@@ -311,6 +335,11 @@ impl Metrics {
             (
                 "compactor/last_compaction_timestamp_sec",
                 &self.slatedb_last_compaction_ts_sec,
+            ),
+            (slatedb::db_stats::L0_SST_COUNT, &self.slatedb_l0_sst_count),
+            (
+                slatedb::db_stats::TOTAL_MEM_SIZE_BYTES,
+                &self.slatedb_total_mem_size_bytes,
             ),
         ];
 
@@ -722,6 +751,106 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let slatedb_flush_requests = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_slatedb_flush_requests_total",
+                "Total number of flush requests to SlateDB",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_l0_sst_count = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_slatedb_l0_sst_count",
+                "Number of Level-0 SSTs in SlateDB (high values indicate compaction lag)",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_total_mem_size_bytes = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_slatedb_total_mem_size_bytes",
+                "Total memory usage of SlateDB",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    // SlateDB cache counters
+    let slatedb_cache_data_block_hit = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_slatedb_cache_data_block_hit_total",
+                "Total SlateDB data block cache hits",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_cache_data_block_miss = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_slatedb_cache_data_block_miss_total",
+                "Total SlateDB data block cache misses",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_cache_index_hit = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_slatedb_cache_index_hit_total",
+                "Total SlateDB index block cache hits",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_cache_index_miss = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_slatedb_cache_index_miss_total",
+                "Total SlateDB index block cache misses",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_cache_filter_hit = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_slatedb_cache_filter_hit_total",
+                "Total SlateDB bloom filter cache hits",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_cache_filter_miss = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_slatedb_cache_filter_miss_total",
+                "Total SlateDB bloom filter cache misses",
+            ),
+            &["shard"],
+        )?,
+    );
+
     Ok(Metrics {
         registry: Arc::new(registry),
         jobs_enqueued,
@@ -755,9 +884,18 @@ pub fn init() -> anyhow::Result<Metrics> {
         slatedb_sst_filter_negatives,
         slatedb_sst_filter_false_positives,
         slatedb_bytes_compacted,
+        slatedb_flush_requests,
         slatedb_wal_buffer_estimated_bytes,
         slatedb_running_compactions,
         slatedb_last_compaction_ts_sec,
+        slatedb_l0_sst_count,
+        slatedb_total_mem_size_bytes,
+        slatedb_cache_data_block_hit,
+        slatedb_cache_data_block_miss,
+        slatedb_cache_index_hit,
+        slatedb_cache_index_miss,
+        slatedb_cache_filter_hit,
+        slatedb_cache_filter_miss,
         slatedb_prev_values: Arc::new(Mutex::new(HashMap::new())),
     })
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1968,13 +1968,13 @@ where
         .set_serving::<SiloServer<SiloService>>()
         .await;
 
-    // Periodic reaper that iterates all shards every 100ms for lease reaping,
+    // Periodic reaper that iterates all shards every 1s for lease reaping,
     // and collects SlateDB metrics from each shard.
     let (tick_tx, mut tick_rx) = broadcast::channel::<()>(1);
     let reaper_factory = factory.clone();
     let reaper_metrics = metrics.clone();
     let reaper: JoinHandle<()> = tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_millis(250));
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
         loop {
             tokio::select! {
                 biased;

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -522,10 +522,10 @@ impl TaskBrokerRegistry {
     /// Keys may belong to different task groups; only evicts from brokers that already exist.
     pub fn evict_keys(&self, keys: &[Vec<u8>]) {
         for k in keys {
-            if let Some(parsed) = parse_task_key(k) {
-                if let Some(broker) = self.brokers.get(&parsed.task_group) {
-                    broker.evict_keys(std::slice::from_ref(k));
-                }
+            if let Some(parsed) = parse_task_key(k)
+                && let Some(broker) = self.brokers.get(&parsed.task_group)
+            {
+                broker.evict_keys(std::slice::from_ref(k));
             }
         }
     }


### PR DESCRIPTION
- **Run lease reaper less often**
- **Add more slatedb metrics**
- **Document L0 sst flush option**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the lease-reaping/metrics polling interval from 250ms to 1s, which could affect how quickly expired leases are detected and may alter workload timing under load. Adds multiple new Prometheus metrics and delta-tracking paths that could surface bugs if SlateDB stat names/types don’t match expectations.
> 
> **Overview**
> Reduces background CPU by slowing the periodic shard reaper/SlateDB-metrics poll loop from `250ms` to `1s`.
> 
> Expands SlateDB Prometheus export in `src/metrics.rs` with new counters/gauges (flush requests, L0 SST count, total mem size, and block/index/filter cache hit/miss), and updates documentation to reflect correct metric types and add tuning guidance for `l0_sst_size_bytes`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f17bfe2e0f58480a87d5abae62d768901d24bde0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->