### PR TITLE
Fix webui shard details to show LSM state for remote shards

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -157,6 +157,18 @@ If you're a cloud agent that needs to start background services:
 - `dev` or `process-compose up` starts etcd, gubernator, and two silo nodes with auto-reload
 - `just etcd` starts just etcd for simpler setups
 
+# WebUI: Cross-Shard RPC Pattern
+
+The web UI (`src/webui.rs`) must work correctly regardless of which node serves the HTTP request. **Never read shard-specific data directly from `ShardFactory`** (which only has locally-owned shards). Instead, always go through `ClusterClient` methods which handle local-vs-remote routing automatically.
+
+The pattern is:
+1. Add a gRPC RPC in `proto/silo.proto` for the data you need.
+2. Implement the server handler in `src/server.rs` (reads from the local `ShardFactory`).
+3. Add a routing method in `src/cluster_client.rs` that checks local first, then falls back to remote RPC.
+4. Call the `ClusterClient` method from the webui handler.
+
+Existing examples: `compact_shard`, `request_split`, `get_shard_storage_info`. Actions like split and compact already follow this pattern. Any new shard-specific data shown in the UI must also follow it.
+
 # Alloy Sigils
 
 We use text-based sigils to ensure that the invariants and assertions in the Alloy model have clear corresponding Rust code that enforces them. They look like `SILO-SOMETHING-123`.

--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -586,6 +586,27 @@ message CompactShardResponse {
   string status = 1; // Status message describing the compaction result.
 }
 
+// Request to get a shard's LSM tree / storage state from its owning node.
+message GetShardStorageInfoRequest {
+  string shard = 1; // The shard ID (UUID).
+}
+
+// Information about a single sorted run in the LSM tree.
+message SortedRunInfo {
+  uint32 id = 1;              // Sorted run identifier.
+  uint64 sst_count = 2;       // Number of SSTs in this sorted run.
+  uint64 estimated_size = 3;  // Estimated total size in bytes.
+}
+
+// Response containing the shard's LSM tree / storage state.
+message GetShardStorageInfoResponse {
+  uint64 l0_sst_count = 1;          // Number of L0 SSTs.
+  uint64 total_l0_size = 2;         // Total estimated size of L0 SSTs in bytes.
+  uint64 sorted_run_count = 3;      // Number of sorted runs.
+  uint64 total_sorted_run_size = 4;  // Total estimated size of sorted runs in bytes.
+  repeated SortedRunInfo sorted_runs = 5; // Details of each sorted run.
+}
+
 // The Silo job queue service.
 service Silo {
   // Get cluster topology for client-side routing.
@@ -703,4 +724,9 @@ service Silo {
   // Merges all L0 SSTs and sorted runs into a single sorted run, removing tombstones.
   // This is useful for reclaiming space after bulk deletes or high job throughput.
   rpc CompactShard(CompactShardRequest) returns (CompactShardResponse);
+
+  // Get storage (LSM tree) information for a shard.
+  // Returns details about L0 SSTs, sorted runs, and sizes.
+  // The shard must be owned by this node.
+  rpc GetShardStorageInfo(GetShardStorageInfoRequest) returns (GetShardStorageInfoResponse);
 }

--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -39,8 +39,9 @@ use crate::factory::ShardFactory;
 use crate::pb::silo_client::SiloClient;
 use crate::pb::{
     CancelJobRequest, ColumnInfo, CompactShardRequest, GetJobRequest, GetJobResponse,
-    GetNodeInfoRequest, JobStatus, QueryRequest, RequestSplitRequest, RequestSplitResponse,
-    SerializedBytes, serialized_bytes,
+    GetNodeInfoRequest, GetShardStorageInfoRequest, GetShardStorageInfoResponse, JobStatus,
+    QueryRequest, RequestSplitRequest, RequestSplitResponse, SerializedBytes, SortedRunInfo,
+    serialized_bytes,
 };
 use crate::shard_range::ShardId;
 
@@ -819,6 +820,53 @@ impl ClusterClient {
 
         match client.compact_shard(request).await {
             Ok(resp) => Ok(resp.into_inner().status),
+            Err(e) => {
+                self.invalidate_connection(&addr);
+                Err(ClusterClientError::RpcFailed(e.to_string()))
+            }
+        }
+    }
+
+    /// Get storage (LSM tree) information for a shard (local or remote).
+    pub async fn get_shard_storage_info(
+        &self,
+        shard_id: &ShardId,
+    ) -> Result<GetShardStorageInfoResponse, ClusterClientError> {
+        // Check if shard is local first
+        if let Some(shard) = self.factory.get(shard_id) {
+            debug!(shard_id = %shard_id, "reading LSM state from local shard");
+            let lsm = shard
+                .read_lsm_state()
+                .await
+                .map_err(|e| ClusterClientError::QueryFailed(e.to_string()))?;
+            return Ok(GetShardStorageInfoResponse {
+                l0_sst_count: lsm.l0_ssts.len() as u64,
+                total_l0_size: lsm.total_l0_size,
+                sorted_run_count: lsm.sorted_runs.len() as u64,
+                total_sorted_run_size: lsm.total_sorted_run_size,
+                sorted_runs: lsm
+                    .sorted_runs
+                    .iter()
+                    .map(|sr| SortedRunInfo {
+                        id: sr.id,
+                        sst_count: sr.sst_count as u64,
+                        estimated_size: sr.estimated_size,
+                    })
+                    .collect(),
+            });
+        }
+
+        // Shard is not local, route to remote owner
+        let addr = self.get_shard_addr(shard_id).await?;
+        debug!(shard_id = %shard_id, addr = %addr, "reading LSM state from remote shard");
+
+        let mut client = self.get_client(&addr).await?;
+        let request = GetShardStorageInfoRequest {
+            shard: shard_id.to_string(),
+        };
+
+        match client.get_shard_storage_info(request).await {
+            Ok(resp) => Ok(resp.into_inner()),
             Err(e) => {
                 self.invalidate_connection(&addr);
                 Err(ClusterClientError::RpcFailed(e.to_string()))

--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -40,8 +40,7 @@ use crate::pb::silo_client::SiloClient;
 use crate::pb::{
     CancelJobRequest, ColumnInfo, CompactShardRequest, GetJobRequest, GetJobResponse,
     GetNodeInfoRequest, GetShardStorageInfoRequest, GetShardStorageInfoResponse, JobStatus,
-    QueryRequest, RequestSplitRequest, RequestSplitResponse, SerializedBytes, SortedRunInfo,
-    serialized_bytes,
+    QueryRequest, RequestSplitRequest, RequestSplitResponse, SerializedBytes, serialized_bytes,
 };
 use crate::shard_range::ShardId;
 
@@ -839,21 +838,7 @@ impl ClusterClient {
                 .read_lsm_state()
                 .await
                 .map_err(|e| ClusterClientError::QueryFailed(e.to_string()))?;
-            return Ok(GetShardStorageInfoResponse {
-                l0_sst_count: lsm.l0_ssts.len() as u64,
-                total_l0_size: lsm.total_l0_size,
-                sorted_run_count: lsm.sorted_runs.len() as u64,
-                total_sorted_run_size: lsm.total_sorted_run_size,
-                sorted_runs: lsm
-                    .sorted_runs
-                    .iter()
-                    .map(|sr| SortedRunInfo {
-                        id: sr.id,
-                        sst_count: sr.sst_count as u64,
-                        estimated_size: sr.estimated_size,
-                    })
-                    .collect(),
-            });
+            return Ok(lsm.into());
         }
 
         // Shard is not local, route to remote owner

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -184,6 +184,26 @@ pub struct LsmSortedRunInfo {
     pub estimated_size: u64,
 }
 
+impl From<LsmState> for crate::pb::GetShardStorageInfoResponse {
+    fn from(lsm: LsmState) -> Self {
+        Self {
+            l0_sst_count: lsm.l0_ssts.len() as u64,
+            total_l0_size: lsm.total_l0_size,
+            sorted_run_count: lsm.sorted_runs.len() as u64,
+            total_sorted_run_size: lsm.total_sorted_run_size,
+            sorted_runs: lsm
+                .sorted_runs
+                .iter()
+                .map(|sr| crate::pb::SortedRunInfo {
+                    id: sr.id,
+                    sst_count: sr.sst_count as u64,
+                    estimated_size: sr.estimated_size,
+                })
+                .collect(),
+        }
+    }
+}
+
 impl From<CodecError> for JobStoreShardError {
     fn from(e: CodecError) -> Self {
         JobStoreShardError::Codec(e.to_string())

--- a/src/server.rs
+++ b/src/server.rs
@@ -1912,21 +1912,7 @@ impl Silo for SiloService {
             .await
             .map_err(|e| Status::internal(format!("failed to read LSM state: {}", e)))?;
 
-        Ok(Response::new(GetShardStorageInfoResponse {
-            l0_sst_count: lsm.l0_ssts.len() as u64,
-            total_l0_size: lsm.total_l0_size,
-            sorted_run_count: lsm.sorted_runs.len() as u64,
-            total_sorted_run_size: lsm.total_sorted_run_size,
-            sorted_runs: lsm
-                .sorted_runs
-                .iter()
-                .map(|sr| SortedRunInfo {
-                    id: sr.id,
-                    sst_count: sr.sst_count as u64,
-                    estimated_size: sr.estimated_size,
-                })
-                .collect(),
-        }))
+        Ok(Response::new(lsm.into()))
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1895,6 +1895,39 @@ impl Silo for SiloService {
             status: format!("full compaction submitted for shard {}", r.shard),
         }))
     }
+
+    async fn get_shard_storage_info(
+        &self,
+        req: Request<GetShardStorageInfoRequest>,
+    ) -> Result<Response<GetShardStorageInfoResponse>, Status> {
+        let r = req.into_inner();
+        let shard_id = Self::parse_shard_id(&r.shard)?;
+
+        let shard = self.factory.get(&shard_id).ok_or_else(|| {
+            Status::not_found(format!("shard {} not found on this node", r.shard))
+        })?;
+
+        let lsm = shard
+            .read_lsm_state()
+            .await
+            .map_err(|e| Status::internal(format!("failed to read LSM state: {}", e)))?;
+
+        Ok(Response::new(GetShardStorageInfoResponse {
+            l0_sst_count: lsm.l0_ssts.len() as u64,
+            total_l0_size: lsm.total_l0_size,
+            sorted_run_count: lsm.sorted_runs.len() as u64,
+            total_sorted_run_size: lsm.total_sorted_run_size,
+            sorted_runs: lsm
+                .sorted_runs
+                .iter()
+                .map(|sr| SortedRunInfo {
+                    id: sr.id,
+                    sst_count: sr.sst_count as u64,
+                    estimated_size: sr.estimated_size,
+                })
+                .collect(),
+        }))
+    }
 }
 
 /// Create an auth interceptor that validates Bearer tokens on incoming gRPC requests.

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -522,10 +522,10 @@ impl TaskBrokerRegistry {
     /// Keys may belong to different task groups; only evicts from brokers that already exist.
     pub fn evict_keys(&self, keys: &[Vec<u8>]) {
         for k in keys {
-            if let Some(parsed) = parse_task_key(k) {
-                if let Some(broker) = self.brokers.get(&parsed.task_group) {
-                    broker.evict_keys(std::slice::from_ref(k));
-                }
+            if let Some(parsed) = parse_task_key(k)
+                && let Some(broker) = self.brokers.get(&parsed.task_group)
+            {
+                broker.evict_keys(std::slice::from_ref(k));
             }
         }
     }

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -247,7 +247,7 @@ struct ShardTemplate {
     split_phase: Option<String>,
     split_message: Option<String>,
     split_error: Option<String>,
-    /// LSM tree state (only available for locally-owned shards).
+    /// LSM tree state (fetched via RPC from shard owner).
     lsm_state: Option<LsmStateView>,
     /// Success/error messages for compact operations.
     compact_message: Option<String>,
@@ -1827,32 +1827,28 @@ async fn shard_handler(
         }
     });
 
-    // Read LSM tree state for locally-owned shards
-    let lsm_state = if let Some(shard) = state.factory.get(&shard_id) {
-        match shard.read_lsm_state().await {
-            Ok(lsm) => Some(LsmStateView {
-                l0_sst_count: lsm.l0_ssts.len(),
-                total_l0_size: format_byte_size(lsm.total_l0_size),
-                sorted_run_count: lsm.sorted_runs.len(),
-                total_sorted_run_size: format_byte_size(lsm.total_sorted_run_size),
-                total_size: format_byte_size(lsm.total_l0_size + lsm.total_sorted_run_size),
-                sorted_runs: lsm
-                    .sorted_runs
-                    .iter()
-                    .map(|sr| SortedRunView {
-                        id: sr.id,
-                        sst_count: sr.sst_count,
-                        estimated_size: format_byte_size(sr.estimated_size),
-                    })
-                    .collect(),
-            }),
-            Err(e) => {
-                warn!(shard_id = %params.id, error = %e, "failed to read LSM state");
-                None
-            }
+    // Read LSM tree state via cluster RPC (works for both local and remote shards)
+    let lsm_state = match state.cluster_client.get_shard_storage_info(&shard_id).await {
+        Ok(resp) => Some(LsmStateView {
+            l0_sst_count: resp.l0_sst_count as usize,
+            total_l0_size: format_byte_size(resp.total_l0_size),
+            sorted_run_count: resp.sorted_run_count as usize,
+            total_sorted_run_size: format_byte_size(resp.total_sorted_run_size),
+            total_size: format_byte_size(resp.total_l0_size + resp.total_sorted_run_size),
+            sorted_runs: resp
+                .sorted_runs
+                .iter()
+                .map(|sr| SortedRunView {
+                    id: sr.id,
+                    sst_count: sr.sst_count as usize,
+                    estimated_size: format_byte_size(sr.estimated_size),
+                })
+                .collect(),
+        }),
+        Err(e) => {
+            warn!(shard_id = %params.id, error = %e, "failed to read LSM state");
+            None
         }
-    } else {
-        None
     };
 
     let template = ShardTemplate {

--- a/tests/routing_client_tests.rs
+++ b/tests/routing_client_tests.rs
@@ -215,6 +215,13 @@ impl Silo for CountingClusterInfoService {
     ) -> Result<Response<CompactShardResponse>, Status> {
         Self::unimplemented("compact_shard")
     }
+
+    async fn get_shard_storage_info(
+        &self,
+        _request: Request<GetShardStorageInfoRequest>,
+    ) -> Result<Response<GetShardStorageInfoResponse>, Status> {
+        Self::unimplemented("get_shard_storage_info")
+    }
 }
 
 async fn setup_counting_cluster_info_server(

--- a/typescript_client/src/pb/silo.client.ts
+++ b/typescript_client/src/pb/silo.client.ts
@@ -4,6 +4,8 @@
 import type { RpcTransport } from "@protobuf-ts/runtime-rpc";
 import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import { Silo } from "./silo";
+import type { GetShardStorageInfoResponse } from "./silo";
+import type { GetShardStorageInfoRequest } from "./silo";
 import type { CompactShardResponse } from "./silo";
 import type { CompactShardRequest } from "./silo";
 import type { ForceReleaseShardResponse } from "./silo";
@@ -250,6 +252,14 @@ export interface ISiloClient {
      * @generated from protobuf rpc: CompactShard
      */
     compactShard(input: CompactShardRequest, options?: RpcOptions): UnaryCall<CompactShardRequest, CompactShardResponse>;
+    /**
+     * Get storage (LSM tree) information for a shard.
+     * Returns details about L0 SSTs, sorted runs, and sizes.
+     * The shard must be owned by this node.
+     *
+     * @generated from protobuf rpc: GetShardStorageInfo
+     */
+    getShardStorageInfo(input: GetShardStorageInfoRequest, options?: RpcOptions): UnaryCall<GetShardStorageInfoRequest, GetShardStorageInfoResponse>;
 }
 /**
  * The Silo job queue service.
@@ -521,5 +531,16 @@ export class SiloClient implements ISiloClient, ServiceInfo {
     compactShard(input: CompactShardRequest, options?: RpcOptions): UnaryCall<CompactShardRequest, CompactShardResponse> {
         const method = this.methods[23], opt = this._transport.mergeOptions(options);
         return stackIntercept<CompactShardRequest, CompactShardResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * Get storage (LSM tree) information for a shard.
+     * Returns details about L0 SSTs, sorted runs, and sizes.
+     * The shard must be owned by this node.
+     *
+     * @generated from protobuf rpc: GetShardStorageInfo
+     */
+    getShardStorageInfo(input: GetShardStorageInfoRequest, options?: RpcOptions): UnaryCall<GetShardStorageInfoRequest, GetShardStorageInfoResponse> {
+        const method = this.methods[24], opt = this._transport.mergeOptions(options);
+        return stackIntercept<GetShardStorageInfoRequest, GetShardStorageInfoResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -1591,6 +1591,63 @@ export interface CompactShardResponse {
     status: string; // Status message describing the compaction result.
 }
 /**
+ * Request to get a shard's LSM tree / storage state from its owning node.
+ *
+ * @generated from protobuf message silo.v1.GetShardStorageInfoRequest
+ */
+export interface GetShardStorageInfoRequest {
+    /**
+     * @generated from protobuf field: string shard = 1
+     */
+    shard: string; // The shard ID (UUID).
+}
+/**
+ * Information about a single sorted run in the LSM tree.
+ *
+ * @generated from protobuf message silo.v1.SortedRunInfo
+ */
+export interface SortedRunInfo {
+    /**
+     * @generated from protobuf field: uint32 id = 1
+     */
+    id: number; // Sorted run identifier.
+    /**
+     * @generated from protobuf field: uint64 sst_count = 2
+     */
+    sstCount: bigint; // Number of SSTs in this sorted run.
+    /**
+     * @generated from protobuf field: uint64 estimated_size = 3
+     */
+    estimatedSize: bigint; // Estimated total size in bytes.
+}
+/**
+ * Response containing the shard's LSM tree / storage state.
+ *
+ * @generated from protobuf message silo.v1.GetShardStorageInfoResponse
+ */
+export interface GetShardStorageInfoResponse {
+    /**
+     * @generated from protobuf field: uint64 l0_sst_count = 1
+     */
+    l0SstCount: bigint; // Number of L0 SSTs.
+    /**
+     * @generated from protobuf field: uint64 total_l0_size = 2
+     */
+    totalL0Size: bigint; // Total estimated size of L0 SSTs in bytes.
+    /**
+     * @generated from protobuf field: uint64 sorted_run_count = 3
+     */
+    sortedRunCount: bigint; // Number of sorted runs.
+    /**
+     * @generated from protobuf field: uint64 total_sorted_run_size = 4
+     */
+    totalSortedRunSize: bigint; // Total estimated size of sorted runs in bytes.
+    /**
+     * @generated from protobuf field: repeated silo.v1.SortedRunInfo sorted_runs = 5
+     */
+    sortedRuns: SortedRunInfo[]; // Details of each sorted run.
+}
+/**
  * Rate limiting algorithm for Gubernator-based limits.
  *
  * @generated from protobuf enum silo.v1.GubernatorAlgorithm
@@ -6566,6 +6623,195 @@ class CompactShardResponse$Type extends MessageType<CompactShardResponse> {
  * @generated MessageType for protobuf message silo.v1.CompactShardResponse
  */
 export const CompactShardResponse = new CompactShardResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class GetShardStorageInfoRequest$Type extends MessageType<GetShardStorageInfoRequest> {
+    constructor() {
+        super("silo.v1.GetShardStorageInfoRequest", [
+            { no: 1, name: "shard", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<GetShardStorageInfoRequest>): GetShardStorageInfoRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.shard = "";
+        if (value !== undefined)
+            reflectionMergePartial<GetShardStorageInfoRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: GetShardStorageInfoRequest): GetShardStorageInfoRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string shard */ 1:
+                    message.shard = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: GetShardStorageInfoRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string shard = 1; */
+        if (message.shard !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.shard);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.GetShardStorageInfoRequest
+ */
+export const GetShardStorageInfoRequest = new GetShardStorageInfoRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class SortedRunInfo$Type extends MessageType<SortedRunInfo> {
+    constructor() {
+        super("silo.v1.SortedRunInfo", [
+            { no: 1, name: "id", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 2, name: "sst_count", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 3, name: "estimated_size", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
+        ]);
+    }
+    create(value?: PartialMessage<SortedRunInfo>): SortedRunInfo {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.id = 0;
+        message.sstCount = 0n;
+        message.estimatedSize = 0n;
+        if (value !== undefined)
+            reflectionMergePartial<SortedRunInfo>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SortedRunInfo): SortedRunInfo {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* uint32 id */ 1:
+                    message.id = reader.uint32();
+                    break;
+                case /* uint64 sst_count */ 2:
+                    message.sstCount = reader.uint64().toBigInt();
+                    break;
+                case /* uint64 estimated_size */ 3:
+                    message.estimatedSize = reader.uint64().toBigInt();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: SortedRunInfo, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* uint32 id = 1; */
+        if (message.id !== 0)
+            writer.tag(1, WireType.Varint).uint32(message.id);
+        /* uint64 sst_count = 2; */
+        if (message.sstCount !== 0n)
+            writer.tag(2, WireType.Varint).uint64(message.sstCount);
+        /* uint64 estimated_size = 3; */
+        if (message.estimatedSize !== 0n)
+            writer.tag(3, WireType.Varint).uint64(message.estimatedSize);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.SortedRunInfo
+ */
+export const SortedRunInfo = new SortedRunInfo$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class GetShardStorageInfoResponse$Type extends MessageType<GetShardStorageInfoResponse> {
+    constructor() {
+        super("silo.v1.GetShardStorageInfoResponse", [
+            { no: 1, name: "l0_sst_count", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "total_l0_size", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 3, name: "sorted_run_count", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 4, name: "total_sorted_run_size", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 5, name: "sorted_runs", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => SortedRunInfo }
+        ]);
+    }
+    create(value?: PartialMessage<GetShardStorageInfoResponse>): GetShardStorageInfoResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.l0SstCount = 0n;
+        message.totalL0Size = 0n;
+        message.sortedRunCount = 0n;
+        message.totalSortedRunSize = 0n;
+        message.sortedRuns = [];
+        if (value !== undefined)
+            reflectionMergePartial<GetShardStorageInfoResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: GetShardStorageInfoResponse): GetShardStorageInfoResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* uint64 l0_sst_count */ 1:
+                    message.l0SstCount = reader.uint64().toBigInt();
+                    break;
+                case /* uint64 total_l0_size */ 2:
+                    message.totalL0Size = reader.uint64().toBigInt();
+                    break;
+                case /* uint64 sorted_run_count */ 3:
+                    message.sortedRunCount = reader.uint64().toBigInt();
+                    break;
+                case /* uint64 total_sorted_run_size */ 4:
+                    message.totalSortedRunSize = reader.uint64().toBigInt();
+                    break;
+                case /* repeated silo.v1.SortedRunInfo sorted_runs */ 5:
+                    message.sortedRuns.push(SortedRunInfo.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: GetShardStorageInfoResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* uint64 l0_sst_count = 1; */
+        if (message.l0SstCount !== 0n)
+            writer.tag(1, WireType.Varint).uint64(message.l0SstCount);
+        /* uint64 total_l0_size = 2; */
+        if (message.totalL0Size !== 0n)
+            writer.tag(2, WireType.Varint).uint64(message.totalL0Size);
+        /* uint64 sorted_run_count = 3; */
+        if (message.sortedRunCount !== 0n)
+            writer.tag(3, WireType.Varint).uint64(message.sortedRunCount);
+        /* uint64 total_sorted_run_size = 4; */
+        if (message.totalSortedRunSize !== 0n)
+            writer.tag(4, WireType.Varint).uint64(message.totalSortedRunSize);
+        /* repeated silo.v1.SortedRunInfo sorted_runs = 5; */
+        for (let i = 0; i < message.sortedRuns.length; i++)
+            SortedRunInfo.internalBinaryWrite(message.sortedRuns[i], writer.tag(5, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.GetShardStorageInfoResponse
+ */
+export const GetShardStorageInfoResponse = new GetShardStorageInfoResponse$Type();
 /**
  * @generated ServiceType for protobuf service silo.v1.Silo
  */
@@ -6593,5 +6839,6 @@ export const Silo = new ServiceType("silo.v1.Silo", [
     { name: "ImportJobs", options: {}, I: ImportJobsRequest, O: ImportJobsResponse },
     { name: "ResetShards", options: {}, I: ResetShardsRequest, O: ResetShardsResponse },
     { name: "ForceReleaseShard", options: {}, I: ForceReleaseShardRequest, O: ForceReleaseShardResponse },
-    { name: "CompactShard", options: {}, I: CompactShardRequest, O: CompactShardResponse }
+    { name: "CompactShard", options: {}, I: CompactShardRequest, O: CompactShardResponse },
+    { name: "GetShardStorageInfo", options: {}, I: GetShardStorageInfoRequest, O: GetShardStorageInfoResponse }
 ]);


### PR DESCRIPTION
## Summary
- Adds `GetShardStorageInfo` gRPC RPC so any node can fetch a shard's LSM tree state from its owner
- Updates the webui `shard_handler` to use `ClusterClient::get_shard_storage_info()` instead of reading directly from the local `ShardFactory`
- The Storage (LSM Tree) section now displays correctly regardless of which node serves the HTTP request

## Test plan
- [ ] Verify shard details page shows LSM tree info when viewing a shard owned by a different node
- [ ] Verify shard details page still shows LSM tree info for locally-owned shards
- [ ] Verify Trigger Full Compaction button works for remote shards (already routed via RPC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new gRPC API and cross-node routing path to fetch shard storage metadata; risk is mainly around RPC compatibility/regeneration and potential UI regressions when shard ownership/topology is stale.
> 
> **Overview**
> Fixes the shard details WebUI to display LSM/storage state even when the HTTP request lands on a node that does **not** own the shard by fetching the data from the shard owner.
> 
> This introduces a new gRPC method `GetShardStorageInfo` (plus request/response types) with server-side implementation in `src/server.rs`, a routed helper `ClusterClient::get_shard_storage_info()` that serves local shards without an RPC hop and otherwise calls the owner, and updates the WebUI handler to use that client method instead of reading directly from `ShardFactory`. TypeScript protobuf client bindings are regenerated, and a small `TaskBrokerRegistry::evict_keys` refactor simplifies conditional logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89ef2b8bb61da73007bd790ee07f78a6260981aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->