### PR TITLE
Add per-task-group broker buffer and inflight metrics

### DIFF
--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -64,13 +64,14 @@ The task broker maintains an in-memory buffer of ready tasks for efficient deque
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `silo_broker_buffer_size` | Gauge | `shard` | Number of tasks in the broker's in-memory buffer |
-| `silo_broker_inflight_size` | Gauge | `shard` | Tasks claimed but not yet durably leased |
+| `silo_broker_buffer_size` | Gauge | `shard`, `task_group` | Number of tasks in the broker's in-memory buffer per task group |
+| `silo_broker_inflight_size` | Gauge | `shard`, `task_group` | Tasks claimed but not yet durably leased per task group |
 | `silo_broker_scan_duration_seconds` | Histogram | `shard` | Duration of broker task scanning operations |
 | `silo_broker_scans_total` | Counter | `shard` | Total number of broker task scan operations |
 
 **Key insights:**
 - `silo_broker_buffer_size` near 0 with pending work may indicate scan issues
+- Break down `silo_broker_buffer_size` by `task_group` to identify which queues are starved vs saturated
 - High `silo_broker_scan_duration_seconds` suggests database pressure
 - `silo_broker_inflight_size` should be transiently low; persistent high values indicate dequeue bottlenecks
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -194,17 +194,17 @@ impl Metrics {
         self.coordination_shards_open.set(count as f64);
     }
 
-    /// Update broker buffer size for a shard.
-    pub fn set_broker_buffer_size(&self, shard: &str, size: u64) {
+    /// Update broker buffer size for a shard and task group.
+    pub fn set_broker_buffer_size(&self, shard: &str, task_group: &str, size: u64) {
         self.broker_buffer_size
-            .with_label_values(&[shard])
+            .with_label_values(&[shard, task_group])
             .set(size as f64);
     }
 
-    /// Update broker inflight size for a shard.
-    pub fn set_broker_inflight_size(&self, shard: &str, size: u64) {
+    /// Update broker inflight size for a shard and task group.
+    pub fn set_broker_inflight_size(&self, shard: &str, task_group: &str, size: u64) {
         self.broker_inflight_size
-            .with_label_values(&[shard])
+            .with_label_values(&[shard, task_group])
             .set(size as f64);
     }
 
@@ -477,7 +477,7 @@ pub fn init() -> anyhow::Result<Metrics> {
                 "silo_broker_buffer_size",
                 "Number of tasks in the broker buffer",
             ),
-            &["shard"],
+            &["shard", "task_group"],
         )?,
     );
 
@@ -488,7 +488,7 @@ pub fn init() -> anyhow::Result<Metrics> {
                 "silo_broker_inflight_size",
                 "Number of tasks currently in-flight (claimed but not durably leased)",
             ),
-            &["shard"],
+            &["shard", "task_group"],
         )?,
     );
 

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -271,6 +271,16 @@ impl TaskBroker {
                         &broker.shard_name,
                         scan_start.elapsed().as_secs_f64(),
                     );
+                    m.set_broker_buffer_size(
+                        &broker.shard_name,
+                        &broker.task_group,
+                        broker.buffer.len() as u64,
+                    );
+                    m.set_broker_inflight_size(
+                        &broker.shard_name,
+                        &broker.task_group,
+                        broker.inflight.lock().unwrap().len() as u64,
+                    );
                 }
 
                 // Adjust backoff: stay aggressive when buffer needs filling

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -144,9 +144,9 @@ async fn test_metrics_gauge_values() {
 
     // Set some gauge values
     metrics.set_shards_owned(3);
-    metrics.set_broker_buffer_size("0", 100);
-    metrics.set_broker_buffer_size("1", 50);
-    metrics.set_broker_inflight_size("0", 10);
+    metrics.set_broker_buffer_size("0", "default", 100);
+    metrics.set_broker_buffer_size("1", "default", 50);
+    metrics.set_broker_inflight_size("0", "default", 10);
 
     let request = Request::builder()
         .method("GET")
@@ -180,13 +180,33 @@ async fn test_metrics_gauge_values() {
         body_str.contains("silo_shards_owned 3"),
         "shards_owned should be 3"
     );
+    // Use find_line helper since label order may vary
+    let find_line = |substrings: &[&str]| -> Option<String> {
+        body_str
+            .lines()
+            .find(|l| substrings.iter().all(|s| l.contains(s)))
+            .map(|s| s.to_string())
+    };
+
+    let buf0 = find_line(&[
+        "silo_broker_buffer_size",
+        "shard=\"0\"",
+        "task_group=\"default\"",
+    ]);
     assert!(
-        body_str.contains("silo_broker_buffer_size{shard=\"0\"} 100"),
-        "buffer size for shard 0 should be 100"
+        buf0.as_ref().map_or(false, |l| l.ends_with(" 100")),
+        "buffer size for shard 0 should be 100, found: {:?}",
+        buf0
     );
+    let buf1 = find_line(&[
+        "silo_broker_buffer_size",
+        "shard=\"1\"",
+        "task_group=\"default\"",
+    ]);
     assert!(
-        body_str.contains("silo_broker_buffer_size{shard=\"1\"} 50"),
-        "buffer size for shard 1 should be 50"
+        buf1.as_ref().map_or(false, |l| l.ends_with(" 50")),
+        "buffer size for shard 1 should be 50, found: {:?}",
+        buf1
     );
 }
 


### PR DESCRIPTION
## Summary
- Added `task_group` label to `silo_broker_buffer_size` and `silo_broker_inflight_size` gauges so operators can see buffer depth per queue
- Actually emit these metrics in production — they were previously defined but never recorded outside tests
- Updated observability docs to reflect the new labels

## Test plan
- [x] `cargo test --test metrics_tests` passes (all 8 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Prometheus label sets for `silo_broker_buffer_size`/`silo_broker_inflight_size`, which can break existing dashboards/alerts and increases metric cardinality. Also starts emitting these gauges during broker scans, adding minor runtime overhead.
> 
> **Overview**
> Adds per-`task_group` visibility for broker queue health by changing `silo_broker_buffer_size` and `silo_broker_inflight_size` to include a `task_group` label and updating the setter APIs accordingly.
> 
> Begins recording these gauges during `TaskBroker` scan iterations (previously they were defined but not produced in normal execution), updates metric tests to assert labeled output robustly, and refreshes observability docs to describe the new labels and usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 844964dd0634cae4c28ad58696d7615b64106243. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->