### PR TITLE
Add tasks table to SQL query engine

### DIFF
--- a/docs/src/content/docs/guides/querying.mdx
+++ b/docs/src/content/docs/guides/querying.mdx
@@ -80,7 +80,7 @@ Use `siloctl cluster info` to see all shards and their owners. If you know the t
 
 ## Tables
 
-Silo exposes three tables: `jobs`, `queues`, and `tenant_counts`.
+Silo exposes five tables: `jobs`, `tasks`, `queues`, `tenant_counts`, and `queue_counts`.
 
 ### `jobs` Table
 
@@ -100,6 +100,25 @@ The primary table containing all job data.
 | `current_attempt` | UInt32 (nullable) | Current attempt number (1-indexed). Present for `Waiting`/`Scheduled` jobs, null for `Running` and terminal statuses |
 | `next_attempt_starts_after_ms` | Int64 (nullable) | Unix timestamp in milliseconds when the next attempt is scheduled to start. Present for `Waiting`/`Scheduled` jobs, null otherwise |
 | `metadata` | Map&lt;String, String&gt; (nullable) | Key-value metadata attached to the job |
+
+### `tasks` Table
+
+Exposes the internal task execution queue for **debugging purposes**. Tasks are the ephemeral work items that drive job execution — they are created when jobs are enqueued and deleted when workers lease them.
+
+<Aside type="caution" title="Debugging only">
+This table scans the raw task queue storage. Performance may be poor for large datasets unless queries include a `task_group` filter, which enables an efficient key prefix scan matching the task broker's access pattern. For best results, always filter by `task_group` and optionally narrow by `start_time_ms`.
+</Aside>
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `shard_id` | String | UUID of the shard storing this task |
+| `tenant` | String | Tenant identifier |
+| `task_group` | String | Task group (worker routing key) |
+| `start_time_ms` | Int64 | Scheduled execution time in milliseconds |
+| `priority` | UInt8 | Task priority (0 = highest) |
+| `job_id` | String | The job this task belongs to |
+| `attempt` | UInt32 | Attempt number |
+| `variant_type` | String | Task type: `RunAttempt`, `RequestTicket`, `CheckRateLimit`, `RefreshFloatingLimit` |
 
 ### `queues` Table
 
@@ -130,6 +149,18 @@ Pre-computed per-tenant, per-status job counts. Backed by merge-operator counter
 `tenant_counts` is a sparse aggregation. It returns one row per `(tenant, status_kind)` pair with a positive count. Statuses with zero jobs are omitted rather than returned as `cnt = 0`, so a missing row should be interpreted as zero.
 
 For example, if a tenant has 12 `Scheduled` jobs and no `Running` jobs, `tenant_counts` returns a `Scheduled` row and no `Running` row.
+
+### `queue_counts` Table
+
+Pre-computed per-queue concurrency counters. Fast for checking queue utilization without scanning individual holder/requester entries.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `shard_id` | String | UUID of the shard |
+| `tenant` | String | Tenant identifier |
+| `queue_name` | String | Concurrency queue name |
+| `holders` | Int64 | Number of concurrency slots currently held |
+| `requesters` | Int64 | Number of tasks waiting for a slot |
 
 ## Status Values
 
@@ -303,6 +334,30 @@ GROUP BY queue_name
 ORDER BY waiting DESC
 ```
 
+### Debugging the Task Queue
+
+```sql
+-- Count pending tasks per task group
+SELECT task_group, COUNT(*) as count
+FROM tasks
+GROUP BY task_group
+ORDER BY count DESC
+
+-- Inspect tasks in a specific group within a time window (recommended pattern)
+SELECT job_id, start_time_ms, priority, variant_type
+FROM tasks
+WHERE task_group = 'emails'
+  AND start_time_ms >= 1700000000000
+  AND start_time_ms <= 1700001000000
+ORDER BY start_time_ms
+
+-- Find stuck internal tasks (non-RunAttempt tasks indicate concurrency/rate-limit waits)
+SELECT task_group, variant_type, COUNT(*) as count
+FROM tasks
+GROUP BY task_group, variant_type
+ORDER BY count DESC
+```
+
 ### Looking Up a Specific Job
 
 ```sql
@@ -349,6 +404,24 @@ SELECT * FROM jobs WHERE tenant = 'customer-123' AND array_contains(element_at(m
 
 -- Uses Status scan (priority 4)
 SELECT * FROM jobs WHERE tenant = 'customer-123' AND status_kind = 'Failed'
+```
+
+### Tasks table: always filter by task_group
+
+The `tasks` table performs best when filtered by `task_group`, which uses a key prefix scan matching the task broker's internal access pattern. Adding a `start_time_ms` range narrows the scan further with early termination.
+
+```sql
+-- Fast: scans only one task group's key range
+SELECT * FROM tasks WHERE task_group = 'emails' LIMIT 100
+
+-- Faster: scans a narrow time window within the group
+SELECT * FROM tasks
+WHERE task_group = 'emails'
+  AND start_time_ms >= 1700000000000
+  AND start_time_ms <= 1700001000000
+
+-- Slow: full scan across all task groups
+SELECT * FROM tasks
 ```
 
 ### Use LIMIT

--- a/src/cluster_query.rs
+++ b/src/cluster_query.rs
@@ -39,8 +39,8 @@ use crate::job_store_shard::JobStoreShard;
 use crate::pb::QueryArrowRequest;
 use crate::pb::silo_client::SiloClient;
 use crate::query::{
-    JobsScanner, QueueCountsScanner, QueuesScanner, ScannerRef, TenantCountsScanner,
-    classify_jobs_filters, explain_dataframe,
+    JobsScanner, QueueCountsScanner, QueuesScanner, ScannerRef, TasksScanner, TenantCountsScanner,
+    classify_jobs_filters, classify_tasks_filters, explain_dataframe,
 };
 use crate::shard_range::ShardId;
 
@@ -124,12 +124,23 @@ impl ClusterQueryEngine {
         let queue_counts_schema = QueueCountsScanner::base_schema();
         let queue_counts_provider = Arc::new(ClusterTableProvider::new(
             queue_counts_schema,
-            factory,
-            coordinator,
+            factory.clone(),
+            coordinator.clone(),
             TableKind::QueueCounts,
-            auth_token,
+            auth_token.clone(),
         ));
         ctx.register_table("queue_counts", queue_counts_provider)?;
+
+        // Register cluster-wide tasks table for debugging the internal task queue
+        let tasks_schema = TasksScanner::base_schema();
+        let tasks_provider = Arc::new(ClusterTableProvider::new(
+            tasks_schema,
+            factory,
+            coordinator,
+            TableKind::Tasks,
+            auth_token,
+        ));
+        ctx.register_table("tasks", tasks_provider)?;
 
         Ok(Self { ctx })
     }
@@ -215,6 +226,7 @@ enum TableKind {
     Queues,
     TenantCounts,
     QueueCounts,
+    Tasks,
 }
 
 /// A TableProvider that spans multiple shards in the cluster.
@@ -322,6 +334,7 @@ impl TableProvider for ClusterTableProvider {
         // LIMIT pushdown by marking handled filters as Exact.
         match self.table_kind {
             TableKind::Jobs => Ok(classify_jobs_filters(filters)),
+            TableKind::Tasks => Ok(classify_tasks_filters(filters)),
             _ => Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()]),
         }
     }
@@ -481,6 +494,7 @@ impl ExecutionPlan for ClusterExecutionPlan {
                         TableKind::QueueCounts => {
                             Arc::new(QueueCountsScanner::new(Arc::clone(&shard)))
                         }
+                        TableKind::Tasks => Arc::new(TasksScanner::new(Arc::clone(&shard))),
                     };
 
                     // Execute the scan - scanner handles projection via schema
@@ -591,6 +605,7 @@ async fn query_remote_shard_batches(
         TableKind::Queues => "queues",
         TableKind::TenantCounts => "tenant_counts",
         TableKind::QueueCounts => "queue_counts",
+        TableKind::Tasks => "tasks",
     };
 
     let sql = build_sql_query(table_name, filters, limit);

--- a/src/query.rs
+++ b/src/query.rs
@@ -114,6 +114,14 @@ impl ShardQueryEngine {
         ));
         ctx.register_table("queue_counts", queue_counts_provider)?;
 
+        // Register tasks table for debugging the internal task queue
+        let tasks_schema = TasksScanner::base_schema();
+        let tasks_scanner: ScannerRef = Arc::new(TasksScanner {
+            shard: Arc::clone(&shard),
+        });
+        let tasks_provider = Arc::new(SiloTableProvider::new(tasks_schema, tasks_scanner));
+        ctx.register_table("tasks", tasks_provider)?;
+
         Ok(Self { ctx })
     }
 
@@ -2082,6 +2090,430 @@ impl Scan for QueueCountsScanner {
             Arc::clone(&projection),
             ReceiverStream::new(rx),
         ))
+    }
+}
+
+/// Scanner for the tasks table - reads task queue entries from a single shard.
+///
+/// This table exposes the internal task queue for debugging purposes. Performance may be
+/// poor for large datasets unless queries are carefully constructed. For best performance,
+/// filter by `task_group` and optionally a `start_time_ms` range, which mirrors the
+/// access pattern used by the task broker.
+///
+/// Schema: shard_id, tenant, task_group, start_time_ms, priority, job_id, attempt, variant_type
+pub struct TasksScanner {
+    pub(crate) shard: Arc<JobStoreShard>,
+}
+
+impl TasksScanner {
+    pub fn new(shard: Arc<JobStoreShard>) -> Self {
+        Self { shard }
+    }
+
+    pub fn base_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("shard_id", DataType::Utf8, false),
+            Field::new("tenant", DataType::Utf8, false),
+            Field::new("task_group", DataType::Utf8, false),
+            Field::new("start_time_ms", DataType::Int64, false),
+            Field::new("priority", DataType::UInt8, false),
+            Field::new("job_id", DataType::Utf8, false),
+            Field::new("attempt", DataType::UInt32, false),
+            Field::new("variant_type", DataType::Utf8, false),
+        ]))
+    }
+}
+
+impl std::fmt::Debug for TasksScanner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TasksScanner")
+    }
+}
+
+/// Scan strategy for the tasks table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TasksScanStrategy {
+    /// Scan a specific task group, optionally bounded by a time range.
+    /// This is the fast path matching the task broker's access pattern.
+    TaskGroupScan {
+        task_group: String,
+        start_time_lower: Option<i64>,
+        start_time_upper: Option<i64>,
+    },
+    /// Full scan across all task groups, optionally filtered by tenant (post-filter).
+    FullScan,
+}
+
+impl std::fmt::Display for TasksScanStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TasksScanStrategy::TaskGroupScan {
+                task_group,
+                start_time_lower,
+                start_time_upper,
+            } => {
+                write!(
+                    f,
+                    "TaskGroupScan(task_group={:?}, time_lower={:?}, time_upper={:?})",
+                    task_group, start_time_lower, start_time_upper
+                )
+            }
+            TasksScanStrategy::FullScan => write!(f, "FullScan"),
+        }
+    }
+}
+
+/// Parse filters into a TasksScanStrategy.
+pub fn parse_tasks_scan_strategy(filters: &[Expr]) -> TasksScanStrategy {
+    let mut task_group: Option<String> = None;
+    let mut time_lower: Option<i64> = None;
+    let mut time_upper: Option<i64> = None;
+
+    for f in filters {
+        if let Some((col, val)) = parse_eq_filter(f) {
+            if col == "task_group" {
+                task_group = Some(val);
+            }
+        } else if let Some((col, op, val)) = parse_i64_comparison_filter(f)
+            && col == "start_time_ms"
+        {
+            match op {
+                I64ComparisonOp::Eq => {
+                    time_lower = Some(val);
+                    time_upper = Some(val);
+                }
+                I64ComparisonOp::Gt => {
+                    time_lower = Some(val.saturating_add(1));
+                }
+                I64ComparisonOp::GtEq => {
+                    time_lower = Some(val);
+                }
+                I64ComparisonOp::Lt => {
+                    time_upper = Some(val.saturating_sub(1));
+                }
+                I64ComparisonOp::LtEq => {
+                    time_upper = Some(val);
+                }
+            }
+        }
+    }
+
+    if let Some(task_group) = task_group {
+        TasksScanStrategy::TaskGroupScan {
+            task_group,
+            start_time_lower: time_lower,
+            start_time_upper: time_upper,
+        }
+    } else {
+        TasksScanStrategy::FullScan
+    }
+}
+
+/// Classify task filters for pushdown.
+pub fn classify_tasks_filters(filters: &[&Expr]) -> Vec<TableProviderFilterPushDown> {
+    let unqualified_filters: Vec<Expr> = filters.iter().map(|f| unqualify_expr(f)).collect();
+    let strategy = parse_tasks_scan_strategy(&unqualified_filters);
+
+    filters
+        .iter()
+        .map(|f| {
+            let unqualified = unqualify_expr(f);
+            if let Some((col, _)) = parse_eq_filter(&unqualified) {
+                match strategy {
+                    TasksScanStrategy::TaskGroupScan { .. } if col == "task_group" => {
+                        TableProviderFilterPushDown::Exact
+                    }
+                    _ => TableProviderFilterPushDown::Inexact,
+                }
+            } else if let Some((col, ..)) = parse_i64_comparison_filter(&unqualified) {
+                match strategy {
+                    TasksScanStrategy::TaskGroupScan { .. } if col == "start_time_ms" => {
+                        TableProviderFilterPushDown::Exact
+                    }
+                    _ => TableProviderFilterPushDown::Inexact,
+                }
+            } else {
+                TableProviderFilterPushDown::Inexact
+            }
+        })
+        .collect()
+}
+
+fn variant_type_name(vt: crate::fb::silo::fb::TaskVariant) -> &'static str {
+    use crate::fb::silo::fb::TaskVariant;
+    match vt {
+        TaskVariant::RunAttempt => "RunAttempt",
+        TaskVariant::RequestTicket => "RequestTicket",
+        TaskVariant::CheckRateLimit => "CheckRateLimit",
+        TaskVariant::RefreshFloatingLimit => "RefreshFloatingLimit",
+        _ => "Unknown",
+    }
+}
+
+impl Scan for TasksScanner {
+    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+        let strategy = parse_tasks_scan_strategy(filters);
+        format!("tasks[{}], limit={:?}", strategy, limit)
+    }
+
+    fn classify_filters(&self, filters: &[&Expr]) -> Vec<TableProviderFilterPushDown> {
+        classify_tasks_filters(filters)
+    }
+
+    fn scan(
+        &self,
+        projection: SchemaRef,
+        filters: &[Expr],
+        batch_size: usize,
+        limit: Option<usize>,
+    ) -> SendableRecordBatchStream {
+        let strategy = parse_tasks_scan_strategy(filters);
+        let shard = Arc::clone(&self.shard);
+        let proj = Arc::clone(&projection);
+        let (tx, rx) = mpsc::channel::<DfResult<RecordBatch>>(4);
+
+        tokio::spawn(async move {
+            // Determine scan range based on strategy
+            let (start, end) = match &strategy {
+                TasksScanStrategy::TaskGroupScan {
+                    task_group,
+                    start_time_lower,
+                    ..
+                } => {
+                    let start = if let Some(lower) = start_time_lower {
+                        // Encode a key with the lower time bound (priority=0, empty job_id, attempt=0)
+                        crate::keys::task_key(task_group, *lower, 0, "", 0)
+                    } else {
+                        crate::keys::task_group_prefix(task_group)
+                    };
+                    let end = crate::keys::end_bound(&crate::keys::task_group_prefix(task_group));
+                    (start, end)
+                }
+                TasksScanStrategy::FullScan => {
+                    let start = crate::keys::tasks_prefix();
+                    let end = crate::keys::end_bound(&start);
+                    (start, end)
+                }
+            };
+
+            // Extract upper time bound for early termination in TaskGroupScan
+            let time_upper = match &strategy {
+                TasksScanStrategy::TaskGroupScan {
+                    start_time_upper, ..
+                } => *start_time_upper,
+                _ => None,
+            };
+
+            let iter_result = shard.db().scan::<Vec<u8>, _>(start..end).await;
+            let mut iter = match iter_result {
+                Ok(i) => i,
+                Err(e) => {
+                    let _ = tx
+                        .send(Err(DataFusionError::Execution(format!(
+                            "failed to scan tasks: {}",
+                            e
+                        ))))
+                        .await;
+                    return;
+                }
+            };
+
+            let shard_id = shard.name().to_string();
+            let mut total_emitted: usize = 0;
+
+            // Collect rows in batches
+            loop {
+                if limit.is_some_and(|l| total_emitted >= l) {
+                    break;
+                }
+
+                let remaining = limit.map(|l| l - total_emitted).unwrap_or(batch_size);
+                let target = remaining.min(batch_size);
+
+                let mut shard_ids = Vec::with_capacity(target);
+                let mut tenants = Vec::with_capacity(target);
+                let mut task_groups = Vec::with_capacity(target);
+                let mut start_times = Vec::with_capacity(target);
+                let mut priorities = Vec::with_capacity(target);
+                let mut job_ids = Vec::with_capacity(target);
+                let mut attempts = Vec::with_capacity(target);
+                let mut variant_types = Vec::with_capacity(target);
+
+                let mut batch_count: usize = 0;
+
+                while batch_count < target {
+                    let kv = match iter.next().await {
+                        Ok(Some(kv)) => kv,
+                        Ok(None) => break,
+                        Err(e) => {
+                            let _ = tx
+                                .send(Err(DataFusionError::Execution(format!(
+                                    "task scan iteration error: {}",
+                                    e
+                                ))))
+                                .await;
+                            return;
+                        }
+                    };
+
+                    let Some(parsed) = crate::keys::parse_task_key(&kv.key) else {
+                        continue;
+                    };
+
+                    // Early termination: if we have an upper time bound and the key's
+                    // time exceeds it, stop scanning (keys are ordered by time within a group)
+                    if let Some(upper) = time_upper
+                        && parsed.start_time_ms > upper as u64
+                    {
+                        break;
+                    }
+
+                    // Decode the task value to get tenant and variant_type
+                    let decoded = match crate::codec::decode_task_validated(
+                        bytes::Bytes::copy_from_slice(&kv.value),
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => continue,
+                    };
+
+                    shard_ids.push(shard_id.clone());
+                    tenants.push(decoded.tenant().to_string());
+                    task_groups.push(parsed.task_group.clone());
+                    start_times.push(parsed.start_time_ms as i64);
+                    priorities.push(parsed.priority);
+                    job_ids.push(parsed.job_id.clone());
+                    attempts.push(parsed.attempt);
+                    variant_types.push(variant_type_name(decoded.variant_type()).to_string());
+
+                    batch_count += 1;
+                }
+
+                if batch_count == 0 {
+                    break;
+                }
+
+                total_emitted += batch_count;
+
+                if proj.fields().is_empty() {
+                    match make_empty_projection_batch(&proj, batch_count) {
+                        Ok(batch) => {
+                            if tx.send(Ok(batch)).await.is_err() {
+                                return;
+                            }
+                        }
+                        Err(e) => {
+                            let _ = tx.send(Err(e)).await;
+                            return;
+                        }
+                    }
+                    continue;
+                }
+
+                let mut cols: Vec<ArrayRef> = Vec::with_capacity(proj.fields().len());
+                for f in proj.fields() {
+                    let col: ArrayRef = match f.name().as_str() {
+                        "shard_id" => Arc::new(StringArray::from(shard_ids.clone())),
+                        "tenant" => Arc::new(StringArray::from(tenants.clone())),
+                        "task_group" => Arc::new(StringArray::from(task_groups.clone())),
+                        "start_time_ms" => Arc::new(Int64Array::from(start_times.clone())),
+                        "priority" => Arc::new(UInt8Array::from(priorities.clone())),
+                        "job_id" => Arc::new(StringArray::from(job_ids.clone())),
+                        "attempt" => Arc::new(UInt32Array::from(attempts.clone())),
+                        "variant_type" => Arc::new(StringArray::from(variant_types.clone())),
+                        other => {
+                            let _ = tx
+                                .send(Err(DataFusionError::Execution(format!(
+                                    "unknown tasks column: {}",
+                                    other
+                                ))))
+                                .await;
+                            return;
+                        }
+                    };
+                    cols.push(col);
+                }
+
+                match RecordBatch::try_new(Arc::clone(&proj), cols) {
+                    Ok(batch) => {
+                        if tx.send(Ok(batch)).await.is_err() {
+                            return;
+                        }
+                    }
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(DataFusionError::Execution(e.to_string())))
+                            .await;
+                        return;
+                    }
+                }
+            }
+        });
+
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&projection),
+            ReceiverStream::new(rx),
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum I64ComparisonOp {
+    Eq,
+    Lt,
+    LtEq,
+    Gt,
+    GtEq,
+}
+
+fn parse_i64_comparison_filter(expr: &Expr) -> Option<(String, I64ComparisonOp, i64)> {
+    match expr {
+        Expr::BinaryExpr(BinaryExpr { left, op, right }) => match (&**left, &**right) {
+            (Expr::Column(c), Expr::Literal(s, _)) => i64_comparison_op(op)
+                .zip(literal_to_i64(s))
+                .map(|(cmp, value)| (c.flat_name().to_string(), cmp, value)),
+            (Expr::Literal(s, _), Expr::Column(c)) => inverted_i64_comparison_op(op)
+                .zip(literal_to_i64(s))
+                .map(|(cmp, value)| (c.flat_name().to_string(), cmp, value)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn i64_comparison_op(op: &Operator) -> Option<I64ComparisonOp> {
+    match op {
+        Operator::Eq => Some(I64ComparisonOp::Eq),
+        Operator::Lt => Some(I64ComparisonOp::Lt),
+        Operator::LtEq => Some(I64ComparisonOp::LtEq),
+        Operator::Gt => Some(I64ComparisonOp::Gt),
+        Operator::GtEq => Some(I64ComparisonOp::GtEq),
+        _ => None,
+    }
+}
+
+fn inverted_i64_comparison_op(op: &Operator) -> Option<I64ComparisonOp> {
+    match op {
+        Operator::Eq => Some(I64ComparisonOp::Eq),
+        Operator::Lt => Some(I64ComparisonOp::Gt),
+        Operator::LtEq => Some(I64ComparisonOp::GtEq),
+        Operator::Gt => Some(I64ComparisonOp::Lt),
+        Operator::GtEq => Some(I64ComparisonOp::LtEq),
+        _ => None,
+    }
+}
+
+fn literal_to_i64(s: &datafusion::scalar::ScalarValue) -> Option<i64> {
+    use datafusion::scalar::ScalarValue;
+    match s {
+        ScalarValue::Int8(Some(v)) => Some(*v as i64),
+        ScalarValue::Int16(Some(v)) => Some(*v as i64),
+        ScalarValue::Int32(Some(v)) => Some(*v as i64),
+        ScalarValue::Int64(Some(v)) => Some(*v),
+        ScalarValue::UInt8(Some(v)) => Some(*v as i64),
+        ScalarValue::UInt16(Some(v)) => Some(*v as i64),
+        ScalarValue::UInt32(Some(v)) => Some(*v as i64),
+        ScalarValue::UInt64(Some(v)) => i64::try_from(*v).ok(),
+        _ => None,
     }
 }
 

--- a/tests/cluster_query_tests.rs
+++ b/tests/cluster_query_tests.rs
@@ -1789,3 +1789,160 @@ async fn cluster_query_tenants_page_counts_all_scheduled_statuses() {
         scheduled_count + running_count
     );
 }
+
+// ===== Tasks table cluster query tests =====
+
+#[silo::test]
+async fn cluster_query_tasks_table_single_shard() {
+    let (_temps, factory, shard_map) = create_multi_shard_factory(1).await;
+    let now = now_ms();
+
+    let shard = get_shard(&factory, &shard_map, 0);
+    for id in ["t1", "t2", "t3"] {
+        shard
+            .enqueue(
+                "-",
+                Some(id.to_string()),
+                10,
+                now,
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+    }
+
+    let engine = ClusterQueryEngine::new(factory.clone(), None)
+        .await
+        .expect("create engine");
+
+    // Count tasks
+    let batches = query_collect(&engine, "SELECT COUNT(*) as cnt FROM tasks").await;
+    let counts = extract_i64_column(&batches, 0);
+    assert_eq!(counts, vec![3]);
+
+    // Query with task_group filter
+    let batches = query_collect(
+        &engine,
+        "SELECT job_id FROM tasks WHERE task_group = 'default' ORDER BY job_id",
+    )
+    .await;
+    let job_ids = extract_string_column(&batches, 0);
+    assert_eq!(job_ids, vec!["t1", "t2", "t3"]);
+}
+
+#[silo::test]
+async fn cluster_query_tasks_table_across_shards() {
+    let (_temps, factory, shard_map) = create_multi_shard_factory(3).await;
+    let now = now_ms();
+
+    // Find the shard that owns tenant "-" (based on tenant hash routing).
+    // Tasks are ephemeral and the broker deletes tasks for tenants outside
+    // the shard's range, so we must enqueue to the correct shard.
+    let owning_shard = shard_map
+        .shards()
+        .iter()
+        .find(|s| s.range.contains_tenant("-"))
+        .expect("some shard should own tenant '-'");
+    let shard = factory.get(&owning_shard.id).unwrap();
+
+    for id in ["task_a", "task_b", "task_c"] {
+        shard
+            .enqueue(
+                "-",
+                Some(id.to_string()),
+                10,
+                now,
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+    }
+
+    let engine = ClusterQueryEngine::new(factory.clone(), None)
+        .await
+        .expect("create engine");
+
+    // Count tasks across all shards (only the owning shard has data, but query spans all)
+    let batches = query_collect(&engine, "SELECT COUNT(*) as cnt FROM tasks").await;
+    let counts = extract_i64_column(&batches, 0);
+    let total: i64 = counts.iter().sum();
+    assert_eq!(total, 3, "Should see 3 tasks across cluster");
+
+    // Query with task_group filter across cluster
+    let batches = query_collect(
+        &engine,
+        "SELECT job_id FROM tasks WHERE task_group = 'default' ORDER BY job_id",
+    )
+    .await;
+    let job_ids = extract_string_column(&batches, 0);
+    assert_eq!(job_ids, vec!["task_a", "task_b", "task_c"]);
+}
+
+#[silo::test]
+async fn cluster_query_tasks_table_group_by_across_shards() {
+    let (_temps, factory, shard_map) = create_multi_shard_factory(2).await;
+    let now = now_ms();
+
+    // Enqueue tasks into different groups on shard 0 (which owns tenant "-").
+    // Tasks are deleted by the broker on shards that don't own the tenant,
+    // so we enqueue all to the correct shard.
+    let shard0 = get_shard(&factory, &shard_map, 0);
+
+    for i in 0..3 {
+        shard0
+            .enqueue(
+                "-",
+                Some(format!("s0_a{}", i)),
+                10,
+                now,
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({})),
+                vec![],
+                None,
+                "alpha",
+            )
+            .await
+            .expect("enqueue");
+    }
+
+    for i in 0..2 {
+        shard0
+            .enqueue(
+                "-",
+                Some(format!("s0_b{}", i)),
+                10,
+                now,
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({})),
+                vec![],
+                None,
+                "beta",
+            )
+            .await
+            .expect("enqueue");
+    }
+
+    let engine = ClusterQueryEngine::new(factory.clone(), None)
+        .await
+        .expect("create engine");
+
+    let batches = query_collect(
+        &engine,
+        "SELECT task_group, COUNT(*) as cnt FROM tasks GROUP BY task_group ORDER BY task_group",
+    )
+    .await;
+
+    let groups = extract_string_column(&batches, 0);
+    let counts = extract_i64_column(&batches, 1);
+
+    assert_eq!(groups, vec!["alpha", "beta"]);
+    assert_eq!(counts, vec![3, 2]);
+}

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -2,12 +2,12 @@ mod test_helpers;
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, Int64Array, StringArray};
+use datafusion::arrow::array::{Array, Int64Array, StringArray, UInt8Array, UInt32Array};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::ScalarValue;
 use datafusion::physical_plan::ExecutionPlan;
 use silo::job_store_shard::JobStoreShard;
-use silo::query::ShardQueryEngine;
+use silo::query::{ShardQueryEngine, TasksScanStrategy, parse_tasks_scan_strategy};
 use test_helpers::*;
 
 // Helper to extract string column values from batches
@@ -3766,4 +3766,549 @@ async fn sql_tenant_counts_count_star_preserves_row_count() {
             "tenant_counts should expose one row per tenant/status pair"
         );
     });
+}
+
+// ===== Tasks table tests =====
+
+/// Helper: enqueue a job into a specific task group and return the job ID
+async fn enqueue_job_in_group(
+    shard: &JobStoreShard,
+    id: &str,
+    priority: u8,
+    now: i64,
+    task_group: &str,
+) -> String {
+    shard
+        .enqueue(
+            "-",
+            Some(id.to_string()),
+            priority,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![],
+            None,
+            task_group,
+        )
+        .await
+        .expect("enqueue")
+}
+
+#[silo::test]
+async fn tasks_table_basic_scan() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Enqueue jobs - each creates a RunAttempt task in the task queue
+    for id in ["t1", "t2", "t3"] {
+        enqueue_job_in_group(&shard, id, 10, now, "default").await;
+    }
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT job_id, task_group, variant_type FROM tasks ORDER BY job_id")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    let job_ids = extract_string_column(&batches, 0);
+    assert_eq!(job_ids, vec!["t1", "t2", "t3"]);
+
+    let task_groups = extract_string_column(&batches, 1);
+    assert!(task_groups.iter().all(|g| g == "default"));
+
+    let variant_types = extract_string_column(&batches, 2);
+    assert!(variant_types.iter().all(|v| v == "RunAttempt"));
+}
+
+#[silo::test]
+async fn tasks_table_filter_by_task_group() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    enqueue_job_in_group(&shard, "j1", 10, now, "group_a").await;
+    enqueue_job_in_group(&shard, "j2", 10, now, "group_b").await;
+    enqueue_job_in_group(&shard, "j3", 10, now, "group_a").await;
+    enqueue_job_in_group(&shard, "j4", 10, now, "group_c").await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT job_id FROM tasks WHERE task_group = 'group_a' ORDER BY job_id")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    let job_ids = extract_string_column(&batches, 0);
+    assert_eq!(job_ids, vec!["j1", "j3"]);
+}
+
+#[silo::test]
+async fn tasks_table_filter_by_task_group_and_time_range() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let base_time = 1000000i64;
+
+    // Enqueue jobs at different times within the same task group
+    enqueue_job_in_group(&shard, "early", 10, base_time, "workers").await;
+    enqueue_job_in_group(&shard, "mid1", 10, base_time + 100, "workers").await;
+    enqueue_job_in_group(&shard, "mid2", 10, base_time + 200, "workers").await;
+    enqueue_job_in_group(&shard, "late", 10, base_time + 500, "workers").await;
+
+    // Also enqueue in a different group to ensure it's excluded
+    enqueue_job_in_group(&shard, "other", 10, base_time + 150, "other_group").await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+
+    // Query with task_group + time range
+    let query = format!(
+        "SELECT job_id FROM tasks WHERE task_group = 'workers' AND start_time_ms >= {} AND start_time_ms <= {} ORDER BY job_id",
+        base_time + 50,
+        base_time + 300,
+    );
+    let batches = sql
+        .sql(&query)
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    let job_ids = extract_string_column(&batches, 0);
+    assert_eq!(job_ids, vec!["mid1", "mid2"]);
+}
+
+#[silo::test]
+async fn tasks_table_returns_all_columns() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = 5000000i64;
+
+    enqueue_job_in_group(&shard, "full_col_job", 42, now, "my_group").await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT shard_id, tenant, task_group, start_time_ms, priority, job_id, attempt, variant_type FROM tasks WHERE task_group = 'my_group'")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    assert_eq!(batches.len(), 1);
+    let batch = &batches[0];
+    assert_eq!(batch.num_rows(), 1);
+
+    // shard_id
+    let shard_ids = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(shard_ids.value(0), "test");
+
+    // tenant
+    let tenants = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(tenants.value(0), "-");
+
+    // task_group
+    let groups = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(groups.value(0), "my_group");
+
+    // start_time_ms
+    let times = batch
+        .column(3)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(times.value(0), now);
+
+    // priority
+    let priorities = batch
+        .column(4)
+        .as_any()
+        .downcast_ref::<UInt8Array>()
+        .unwrap();
+    assert_eq!(priorities.value(0), 42);
+
+    // job_id
+    let job_ids = batch
+        .column(5)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(job_ids.value(0), "full_col_job");
+
+    // attempt
+    let attempts = batch
+        .column(6)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .unwrap();
+    assert_eq!(attempts.value(0), 1);
+
+    // variant_type
+    let variants = batch
+        .column(7)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(variants.value(0), "RunAttempt");
+}
+
+#[silo::test]
+async fn tasks_table_empty_when_no_tasks() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT COUNT(*) as cnt FROM tasks")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    let count = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(count, 0);
+}
+
+#[silo::test]
+async fn tasks_table_count_by_task_group() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    for i in 0..5 {
+        enqueue_job_in_group(&shard, &format!("a{}", i), 10, now, "alpha").await;
+    }
+    for i in 0..3 {
+        enqueue_job_in_group(&shard, &format!("b{}", i), 10, now, "beta").await;
+    }
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql(
+            "SELECT task_group, COUNT(*) as cnt FROM tasks GROUP BY task_group ORDER BY task_group",
+        )
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    let groups = extract_string_column(&batches, 0);
+    assert_eq!(groups, vec!["alpha", "beta"]);
+
+    let mut counts = Vec::new();
+    for batch in &batches {
+        let arr = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        for i in 0..arr.len() {
+            counts.push(arr.value(i));
+        }
+    }
+    assert_eq!(counts, vec![5, 3]);
+}
+
+#[silo::test]
+async fn tasks_table_tasks_disappear_after_dequeue() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    enqueue_job_in_group(&shard, "d1", 10, now, "default").await;
+    enqueue_job_in_group(&shard, "d2", 10, now, "default").await;
+
+    // Verify tasks exist before dequeue
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT COUNT(*) as cnt FROM tasks WHERE task_group = 'default'")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    let count_before = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(count_before, 2);
+
+    // Dequeue one task (transitions it from task queue to leased state)
+    shard
+        .dequeue("worker1", "default", 1)
+        .await
+        .expect("dequeue");
+
+    // After dequeue, task is removed from the tasks table
+    let batches = sql
+        .sql("SELECT COUNT(*) as cnt FROM tasks WHERE task_group = 'default'")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    let count_after = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(count_after, 1, "one task should remain after dequeuing one");
+}
+
+#[silo::test]
+async fn tasks_table_multiple_task_groups_isolation() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    enqueue_job_in_group(&shard, "w1", 10, now, "workers").await;
+    enqueue_job_in_group(&shard, "w2", 10, now, "workers").await;
+    enqueue_job_in_group(&shard, "e1", 10, now, "emails").await;
+    enqueue_job_in_group(&shard, "c1", 10, now, "cron").await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+
+    // Query workers group
+    let batches = sql
+        .sql("SELECT job_id FROM tasks WHERE task_group = 'workers' ORDER BY job_id")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    assert_eq!(extract_string_column(&batches, 0), vec!["w1", "w2"]);
+
+    // Query emails group
+    let batches = sql
+        .sql("SELECT job_id FROM tasks WHERE task_group = 'emails' ORDER BY job_id")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    assert_eq!(extract_string_column(&batches, 0), vec!["e1"]);
+
+    // Count all tasks across all groups
+    let batches = sql
+        .sql("SELECT COUNT(*) as cnt FROM tasks")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    let total = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(total, 4);
+}
+
+#[silo::test]
+async fn tasks_table_time_ordering_within_group() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let base = 2000000i64;
+
+    // Enqueue at different times - tasks should be ordered by start_time_ms within a group
+    enqueue_job_in_group(&shard, "late_job", 10, base + 300, "ordered").await;
+    enqueue_job_in_group(&shard, "early_job", 10, base + 100, "ordered").await;
+    enqueue_job_in_group(&shard, "mid_job", 10, base + 200, "ordered").await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT job_id, start_time_ms FROM tasks WHERE task_group = 'ordered' ORDER BY start_time_ms")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    let job_ids = extract_string_column(&batches, 0);
+    assert_eq!(job_ids, vec!["early_job", "mid_job", "late_job"]);
+}
+
+#[silo::test]
+async fn tasks_table_with_limit() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    for i in 0..10 {
+        enqueue_job_in_group(&shard, &format!("lim{}", i), 10, now + i, "default").await;
+    }
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT job_id FROM tasks WHERE task_group = 'default' LIMIT 3")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    let job_ids = extract_string_column(&batches, 0);
+    assert_eq!(job_ids.len(), 3);
+}
+
+// ===== Tasks table scan strategy tests =====
+
+#[silo::test]
+async fn tasks_scan_strategy_full_scan_no_filters() {
+    use datafusion::logical_expr::Expr;
+    let filters: Vec<Expr> = vec![];
+    let strategy = parse_tasks_scan_strategy(&filters);
+    assert_eq!(strategy, TasksScanStrategy::FullScan);
+}
+
+#[silo::test]
+async fn tasks_scan_strategy_task_group_only() {
+    use datafusion::logical_expr::{col, lit};
+    let filters = vec![col("task_group").eq(lit("workers"))];
+    let strategy = parse_tasks_scan_strategy(&filters);
+    assert_eq!(
+        strategy,
+        TasksScanStrategy::TaskGroupScan {
+            task_group: "workers".to_string(),
+            start_time_lower: None,
+            start_time_upper: None,
+        }
+    );
+}
+
+#[silo::test]
+async fn tasks_scan_strategy_task_group_with_time_range() {
+    use datafusion::logical_expr::{col, lit};
+    let filters = vec![
+        col("task_group").eq(lit("workers")),
+        col("start_time_ms").gt_eq(lit(1000i64)),
+        col("start_time_ms").lt_eq(lit(2000i64)),
+    ];
+    let strategy = parse_tasks_scan_strategy(&filters);
+    assert_eq!(
+        strategy,
+        TasksScanStrategy::TaskGroupScan {
+            task_group: "workers".to_string(),
+            start_time_lower: Some(1000),
+            start_time_upper: Some(2000),
+        }
+    );
+}
+
+// ===== Tasks table EXPLAIN tests =====
+
+/// Helper: extract the SiloExecutionPlan line from EXPLAIN output for tasks
+fn extract_tasks_silo_plan_line(explain: &str) -> String {
+    explain
+        .lines()
+        .find(|l| l.contains("SiloExecutionPlan:") && l.contains("tasks["))
+        .unwrap_or_else(|| panic!("No SiloExecutionPlan tasks line in EXPLAIN:\n{}", explain))
+        .trim()
+        .to_string()
+}
+
+#[silo::test]
+async fn explain_tasks_full_scan() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let explain = engine
+        .explain("SELECT * FROM tasks")
+        .await
+        .expect("explain");
+
+    let plan_line = extract_tasks_silo_plan_line(&explain);
+    assert!(
+        plan_line.contains("FullScan"),
+        "Expected FullScan strategy, got: {}",
+        plan_line
+    );
+}
+
+#[silo::test]
+async fn explain_tasks_task_group_scan() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let explain = engine
+        .explain("SELECT * FROM tasks WHERE task_group = 'workers'")
+        .await
+        .expect("explain");
+
+    let plan_line = extract_tasks_silo_plan_line(&explain);
+    assert!(
+        plan_line.contains("TaskGroupScan(task_group=\"workers\""),
+        "Expected TaskGroupScan with task_group, got: {}",
+        plan_line
+    );
+}
+
+#[silo::test]
+async fn explain_tasks_task_group_with_time_range() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let explain = engine
+        .explain("SELECT * FROM tasks WHERE task_group = 'workers' AND start_time_ms >= 1000 AND start_time_ms <= 2000")
+        .await
+        .expect("explain");
+
+    let plan_line = extract_tasks_silo_plan_line(&explain);
+    assert!(
+        plan_line.contains(
+            "TaskGroupScan(task_group=\"workers\", time_lower=Some(1000), time_upper=Some(2000))"
+        ),
+        "Expected TaskGroupScan with time bounds, got: {}",
+        plan_line
+    );
+    // This is the optimized path: no FilterExec should appear for task_group or start_time_ms
+    // because they are pushed down as Exact
+    assert!(
+        !explain.contains("FilterExec"),
+        "Filters should be fully pushed down (no FilterExec), got:\n{}",
+        explain
+    );
+}
+
+#[silo::test]
+async fn explain_tasks_tenant_filter_not_pushed_down() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let explain = engine
+        .explain("SELECT * FROM tasks WHERE task_group = 'workers' AND tenant = '-'")
+        .await
+        .expect("explain");
+
+    let plan_line = extract_tasks_silo_plan_line(&explain);
+    // task_group is pushed down, but tenant is post-filtered
+    assert!(
+        plan_line.contains("TaskGroupScan"),
+        "Expected TaskGroupScan strategy, got: {}",
+        plan_line
+    );
+    // tenant filter should remain as a FilterExec since it's Inexact
+    assert!(
+        explain.contains("FilterExec"),
+        "Tenant filter should NOT be pushed down, expected FilterExec in:\n{}",
+        explain
+    );
 }


### PR DESCRIPTION
## Summary

- Adds a `tasks` virtual table to the SQL query engine exposing the internal task execution queue for debugging
- Supports filter pushdown for `task_group` (key prefix scan) and `start_time_ms` range filters, matching the task broker's access pattern
- Works cross-shard via `ClusterQueryEngine` like all other query tables
- Adds comprehensive documentation for all SQL query engine tables

## Schema

`shard_id`, `tenant`, `task_group`, `start_time_ms`, `priority`, `job_id`, `attempt`, `variant_type`

## Scan strategies

- **TaskGroupScan**: `WHERE task_group = '...'` scans only that group's key prefix. Combined with `start_time_ms` range for narrower scans with early termination. Both filters pushed down as Exact.
- **FullScan**: No `task_group` filter — scans all task keys.

## Test plan

- [x] 10 single-shard query tests (basic scan, filters, all columns, dequeue behavior, limits, ordering)
- [x] 3 scan strategy unit tests
- [x] 4 EXPLAIN tests verifying optimized scan paths and filter pushdown
- [x] 3 cluster query tests (single shard, multi-shard, group by)
- [x] All 119 existing query tests still pass
- [x] All 35 existing cluster query tests still pass
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new DataFusion-backed table that scans raw task-queue storage and introduces new filter-pushdown logic; mistakes could impact query performance or return unexpected results under certain filters.
> 
> **Overview**
> Adds a new SQL virtual table, `tasks`, to both shard and cluster query engines to expose pending internal task-queue entries for debugging (schema includes `task_group`, `start_time_ms`, `priority`, `job_id`, `attempt`, `variant_type`).
> 
> Implements a dedicated `TasksScanner` with a `TaskGroupScan` fast path (key-prefix scan with optional `start_time_ms` bounds and early termination) plus `supports_filters_pushdown` classification so `task_group`/time-range predicates are treated as *Exact*.
> 
> Updates docs to list the new `tasks` table and `queue_counts`, adds usage/performance guidance and example debugging queries, and adds comprehensive unit + cluster query tests validating results, LIMIT behavior, and EXPLAIN/pushdown behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f3bcf9313166845982e3b74491dfd773d8815dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->