### PR TITLE
Use a patched slatedb that lets us clone db's with a separate wal store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tmp/golden-bench-shard
-          key: golden-bench-shard-v1-${{ hashFiles('benches/bench_helpers.rs') }}
+          key: golden-bench-shard-v2-${{ hashFiles('benches/bench_helpers.rs') }}
       - name: Run throughput benchmark
         shell: bash
         run: cargo bench --bench job_shard_throughput

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5478,8 +5478,8 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slatedb"
-version = "0.10.0"
-source = "git+https://github.com/slatedb/slatedb.git?branch=main#5f1703652e05d792a9f9bb17b163a7e60100f397"
+version = "0.11.1"
+source = "git+https://github.com/gadget-inc/slatedb.git?branch=gadget#91aca69be4cfe7d2642aace000d374d8f088a70f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5524,17 +5524,19 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.10.0"
-source = "git+https://github.com/slatedb/slatedb.git?branch=main#5f1703652e05d792a9f9bb17b163a7e60100f397"
+version = "0.11.1"
+source = "git+https://github.com/gadget-inc/slatedb.git?branch=gadget#91aca69be4cfe7d2642aace000d374d8f088a70f"
 dependencies = [
  "chrono",
+ "log",
+ "serde",
  "tokio",
 ]
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.10.0"
-source = "git+https://github.com/slatedb/slatedb.git?branch=main#5f1703652e05d792a9f9bb17b163a7e60100f397"
+version = "0.11.1"
+source = "git+https://github.com/gadget-inc/slatedb.git?branch=gadget#91aca69be4cfe7d2642aace000d374d8f088a70f"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.2.0"
 [dependencies]
 clap = { version = "4.3.14", features = ["derive", "env"] }
 futures = "0.3"
-slatedb = { git = "https://github.com/slatedb/slatedb.git", branch = "main" }
+slatedb = { git = "https://github.com/gadget-inc/slatedb.git", branch = "gadget" }
 object_store = { version = "0.12", features = ["gcp"] }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -401,7 +401,7 @@ impl JobStoreShard {
         let sources: Vec<SourceId> = manifest
             .l0
             .iter()
-            .map(|sst| SourceId::Sst(sst.id.unwrap_compacted_id()))
+            .map(|sst| SourceId::SstView(sst.sst.id.unwrap_compacted_id()))
             .chain(
                 manifest
                     .compacted

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -202,24 +202,26 @@ impl JobStoreShard {
 
             // Commit durable state — write_with_options with await_durable:true blocks
             // until the WAL is flushed to object storage, so no separate flush is needed.
-            if let Err(e) = self
-                .db
-                .write_with_options(
-                    state.batch,
-                    &WriteOptions {
-                        await_durable: true,
-                    },
-                )
-                .await
-            {
-                dst_events::cancel_write(write_op);
-                // Rollback all grants made during this iteration
-                for (tenant, queue, task_id) in &grants_to_rollback {
-                    self.concurrency.rollback_grant(tenant, queue, task_id);
+            if !state.batch.is_empty() {
+                if let Err(e) = self
+                    .db
+                    .write_with_options(
+                        state.batch,
+                        &WriteOptions {
+                            await_durable: true,
+                        },
+                    )
+                    .await
+                {
+                    dst_events::cancel_write(write_op);
+                    // Rollback all grants made during this iteration
+                    for (tenant, queue, task_id) in &grants_to_rollback {
+                        self.concurrency.rollback_grant(tenant, queue, task_id);
+                    }
+                    // Put back all claimed entries since we didn't lease them durably
+                    self.brokers.requeue(claimed);
+                    return Err(JobStoreShardError::Slate(e));
                 }
-                // Put back all claimed entries since we didn't lease them durably
-                self.brokers.requeue(claimed);
-                return Err(JobStoreShardError::Slate(e));
             }
             dst_events::confirm_write(write_op);
 

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -346,7 +346,7 @@ impl JobStoreShard {
                 .with_meta_cache(Some(meta_cache))
                 .build();
 
-            db_builder = db_builder.with_memory_cache(Arc::new(cache));
+            db_builder = db_builder.with_db_cache(Arc::new(cache));
         }
 
         let db = db_builder.build().await?;
@@ -550,7 +550,7 @@ impl JobStoreShard {
             .iter()
             .map(|sst| LsmSstInfo {
                 id: format!("{:?}", sst.id),
-                estimated_size: sst.info.index_offset + sst.info.index_len,
+                estimated_size: sst.estimate_size(),
             })
             .collect();
 
@@ -559,7 +559,7 @@ impl JobStoreShard {
             .iter()
             .map(|sr| LsmSortedRunInfo {
                 id: sr.id,
-                sst_count: sr.ssts.len(),
+                sst_count: sr.sst_views.len(),
                 estimated_size: sr.estimate_size(),
             })
             .collect();

--- a/src/job_store_shard/restart.rs
+++ b/src/job_store_shard/restart.rs
@@ -185,7 +185,7 @@ impl JobStoreShard {
 
         // Commit the transaction
         match txn.commit().await {
-            Ok(()) => dst_events::confirm_write(write_op),
+            Ok(_) => dst_events::confirm_write(write_op),
             Err(e) => {
                 dst_events::cancel_write(write_op);
                 return Err(e.into());

--- a/tests/grpc_query_tests.rs
+++ b/tests/grpc_query_tests.rs
@@ -152,7 +152,7 @@ async fn grpc_server_query_basic() -> anyhow::Result<()> {
 
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_query_statement_timeout_aborts_execution() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(15000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(30000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let config = config_with_statement_timeout_ms(100);
         let (mut client, shutdown_tx, server, _addr) =
@@ -212,7 +212,7 @@ async fn grpc_server_query_statement_timeout_aborts_execution() -> anyhow::Resul
 
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_server_query_arrow_statement_timeout() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(15000), async {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(30000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let config = config_with_statement_timeout_ms(100);
         let (mut client, shutdown_tx, server, _addr) =


### PR DESCRIPTION
Switches slatedb to the gadget-inc fork (gadget branch, 0.11.1) which adds support for cloning databases with a separate WAL store — needed for shard splitting.

  Why changes beyond the version bump

  The gadget fork is based on a much newer upstream slatedb that introduced several breaking API changes. These required updates across the shard code:

  API renames/restructures (cleanup.rs, mod.rs, restart.rs):
  - DbBuilder::with_memory_cache() → with_db_cache()
  - SourceId::Sst → SourceId::SstView, and SST id access is now sst.sst.id (through the new SsTableView wrapper) instead of sst.id
  - SortedRun.ssts → SortedRun.sst_views
  - SsTableView fields restructured — used estimate_size() instead of direct info.index_offset + info.index_len access
  - txn.commit() return type changed from Result<()> to Result<Option<WriteHandle>>

  Behavioral change (dequeue.rs):
  - New slatedb rejects empty write batches (old version silently accepted them). Added a guard in the dequeue path where all claimed tasks can end up as concurrency Requested outcomes, leaving the batch empty.

  CI fixes (ci.yml, grpc_query_tests.rs):
  - Bumped bench golden shard cache key (v1 → v2) because the cached shard was written by old slatedb and is unreadable by the new version
  - Increased statement timeout test outer timeouts (15s → 30s) since enqueuing 120 jobs is slightly slower with the new slatedb

  ⚠️ Data layout incompatibility

  This upgrade requires a fresh data layout for any existing silo deployments. The old slatedb (0.10.0) wrote SST blocks in V2 format by default and stored the format version in each SST file's footer, but not in the manifest. The new slatedb reads the format version from the manifest instead of the file footer, and defaults to V1 when the manifest field is missing. This means SSTs written by the old version will be misidentified as V1 and cause panics when read:

  assertion failed: first key overlap should be 0
    left: 36
    right: 0

  Since there is no production data, this is not a migration concern today, but it means existing test/dev data created with the old slatedb version must be discarded. We will use a new prefix version for slatedb.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the underlying storage engine dependency (SlateDB fork/version) and updates compaction/LSM and write/lease paths to match new APIs, which could affect durability and storage behavior.
> 
> **Overview**
> Switches `slatedb` to the `gadget-inc` fork (0.11.1) and updates CI/lockfiles accordingly.
> 
> Adjusts shard code to match new SlateDB APIs: compaction source IDs (`SstView`), LSM size/count reporting (`estimate_size`, `sst_views`), and cache configuration (`with_db_cache`).
> 
> Tweaks runtime behavior around durability and tests: `dequeue` now skips `write_with_options` when the batch is empty, and gRPC query timeout tests get longer outer timeouts; benchmark cache key is bumped to invalidate old artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ab46c6225f3cfb35c28bf6d6171d055e9dcee90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->