### PR TITLE
Shard splits still failing in production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,7 +4461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -4494,7 +4494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -5500,7 +5500,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 [[package]]
 name = "slatedb"
 version = "0.11.1"
-source = "git+https://github.com/gadget-inc/slatedb.git?branch=yo%2Fadd-read-only-wal-write-wal#801c1e111cf541d03c5905c25ed9043bc4cf904f"
+source = "git+https://github.com/gadget-inc/slatedb.git?branch=yo%2Fadd-read-only-wal-write-wal#fcc8a7e8b7148b6a83ec746d5b94fd0502e996fd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5546,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.11.1"
-source = "git+https://github.com/gadget-inc/slatedb.git?branch=yo%2Fadd-read-only-wal-write-wal#801c1e111cf541d03c5905c25ed9043bc4cf904f"
+source = "git+https://github.com/gadget-inc/slatedb.git?branch=yo%2Fadd-read-only-wal-write-wal#fcc8a7e8b7148b6a83ec746d5b94fd0502e996fd"
 dependencies = [
  "chrono",
  "log",
@@ -5557,7 +5557,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.11.1"
-source = "git+https://github.com/gadget-inc/slatedb.git?branch=yo%2Fadd-read-only-wal-write-wal#801c1e111cf541d03c5905c25ed9043bc4cf904f"
+source = "git+https://github.com/gadget-inc/slatedb.git?branch=yo%2Fadd-read-only-wal-write-wal#fcc8a7e8b7148b6a83ec746d5b94fd0502e996fd"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5424,6 +5424,7 @@ dependencies = [
  "serde_json",
  "silo-macros",
  "slatedb",
+ "slatedb-common",
  "storekey",
  "tempfile",
  "thiserror 1.0.69",
@@ -5499,7 +5500,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 [[package]]
 name = "slatedb"
 version = "0.11.1"
-source = "git+https://github.com/gadget-inc/slatedb.git?branch=gadget#91aca69be4cfe7d2642aace000d374d8f088a70f"
+source = "git+https://github.com/gadget-inc/slatedb.git?branch=yo%2Fadd-read-only-wal-write-wal#801c1e111cf541d03c5905c25ed9043bc4cf904f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5545,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.11.1"
-source = "git+https://github.com/gadget-inc/slatedb.git?branch=gadget#91aca69be4cfe7d2642aace000d374d8f088a70f"
+source = "git+https://github.com/gadget-inc/slatedb.git?branch=yo%2Fadd-read-only-wal-write-wal#801c1e111cf541d03c5905c25ed9043bc4cf904f"
 dependencies = [
  "chrono",
  "log",
@@ -5556,7 +5557,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.11.1"
-source = "git+https://github.com/gadget-inc/slatedb.git?branch=gadget#91aca69be4cfe7d2642aace000d374d8f088a70f"
+source = "git+https://github.com/gadget-inc/slatedb.git?branch=yo%2Fadd-read-only-wal-write-wal#801c1e111cf541d03c5905c25ed9043bc4cf904f"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ version = "0.2.0"
 [dependencies]
 clap = { version = "4.3.14", features = ["derive", "env"] }
 futures = "0.3"
-slatedb = { git = "https://github.com/gadget-inc/slatedb.git", branch = "gadget" }
+slatedb = { git = "https://github.com/gadget-inc/slatedb.git", branch = "yo/add-read-only-wal-write-wal" }
+slatedb-common = { git = "https://github.com/gadget-inc/slatedb.git", branch = "yo/add-read-only-wal-write-wal" }
 object_store = { version = "0.12", features = ["gcp"] }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -590,7 +590,7 @@ pub async fn clone_golden_shard(
     let admin =
         slatedb::admin::Admin::builder(clone_dir_name.as_str(), Arc::clone(&root_store)).build();
     admin
-        .create_clone(golden_dir_name.as_str(), Some(metadata.checkpoint_id))
+        .create_clone(golden_dir_name.as_str(), Some(metadata.checkpoint_id), None)
         .await
         .expect("create clone");
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -548,13 +548,37 @@ impl ShardFactory {
             &right_child_name,
         )?;
 
+        // Resolve separate WAL object stores if configured. Each shard (parent and
+        // children) gets its own WAL store so that the clone's wal_object_store_uri
+        // is correctly recorded in the manifest.
+        let resolve_wal_store = |shard_name: &str| -> Result<Option<Arc<dyn ObjectStore>>, ShardFactoryError> {
+            if let Some(wal_template) = &self.template.wal {
+                let wal_path = wal_template
+                    .path
+                    .replace("%shard%", shard_name)
+                    .replace("{shard}", shard_name);
+                let wal_resolved = resolve_object_store(&wal_template.backend, &wal_path)?;
+                Ok(Some(wal_resolved.store))
+            } else {
+                Ok(None)
+            }
+        };
+        let parent_wal_store = resolve_wal_store(&parent_name)?;
+        let left_child_wal_store = resolve_wal_store(&left_child_name)?;
+        let right_child_wal_store = resolve_wal_store(&right_child_name)?;
+
         // Open a raw SlateDB database at the parent's path. The parent shard has been
-        // fully closed (data flushed, WAL cleaned up), so we don't need a WAL. We still
-        // need the merge operator because the parent may contain counter merge entries
-        // that haven't been fully compacted yet.
-        let db =
+        // fully closed (data flushed, WAL cleaned up), but we still need the WAL store
+        // configured so that slatedb can validate the wal_object_store_uri in the manifest.
+        // We still need the merge operator because the parent may contain counter merge
+        // entries that haven't been fully compacted yet.
+        let mut parent_db_builder =
             slatedb::DbBuilder::new(parent_db_path.as_str(), Arc::clone(&parent_resolved.store))
-                .with_merge_operator(crate::job_store_shard::counter_merge_operator())
+                .with_merge_operator(crate::job_store_shard::counter_merge_operator());
+        if let Some(wal) = &parent_wal_store {
+            parent_db_builder = parent_db_builder.with_wal_object_store(Arc::clone(wal));
+        }
+        let db = parent_db_builder
                 .build()
                 .await
                 .map_err(|e| {
@@ -592,14 +616,17 @@ impl ShardFactory {
         );
 
         // Clone for left child
-        let left_admin = slatedb::admin::Admin::builder(
+        let mut left_admin_builder = slatedb::admin::Admin::builder(
             left_child_db_path.as_str(),
             Arc::clone(&parent_resolved.store),
-        )
-        .build();
+        );
+        if let Some(wal) = &left_child_wal_store {
+            left_admin_builder = left_admin_builder.with_wal_object_store(Arc::clone(wal));
+        }
+        let left_admin = left_admin_builder.build();
 
         left_admin
-            .create_clone(parent_db_path.as_str(), Some(checkpoint.id))
+            .create_clone(parent_db_path.as_str(), Some(checkpoint.id), parent_wal_store.clone())
             .await
             .map_err(|e| {
                 ShardFactoryError::CloneError(format!(
@@ -609,14 +636,17 @@ impl ShardFactory {
             })?;
 
         // Clone for right child
-        let right_admin = slatedb::admin::Admin::builder(
+        let mut right_admin_builder = slatedb::admin::Admin::builder(
             right_child_db_path.as_str(),
             Arc::clone(&parent_resolved.store),
-        )
-        .build();
+        );
+        if let Some(wal) = &right_child_wal_store {
+            right_admin_builder = right_admin_builder.with_wal_object_store(Arc::clone(wal));
+        }
+        let right_admin = right_admin_builder.build();
 
         right_admin
-            .create_clone(parent_db_path.as_str(), Some(checkpoint.id))
+            .create_clone(parent_db_path.as_str(), Some(checkpoint.id), parent_wal_store)
             .await
             .map_err(|e| {
                 ShardFactoryError::CloneError(format!(

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -551,18 +551,19 @@ impl ShardFactory {
         // Resolve separate WAL object stores if configured. Each shard (parent and
         // children) gets its own WAL store so that the clone's wal_object_store_uri
         // is correctly recorded in the manifest.
-        let resolve_wal_store = |shard_name: &str| -> Result<Option<Arc<dyn ObjectStore>>, ShardFactoryError> {
-            if let Some(wal_template) = &self.template.wal {
-                let wal_path = wal_template
-                    .path
-                    .replace("%shard%", shard_name)
-                    .replace("{shard}", shard_name);
-                let wal_resolved = resolve_object_store(&wal_template.backend, &wal_path)?;
-                Ok(Some(wal_resolved.store))
-            } else {
-                Ok(None)
-            }
-        };
+        let resolve_wal_store =
+            |shard_name: &str| -> Result<Option<Arc<dyn ObjectStore>>, ShardFactoryError> {
+                if let Some(wal_template) = &self.template.wal {
+                    let wal_path = wal_template
+                        .path
+                        .replace("%shard%", shard_name)
+                        .replace("{shard}", shard_name);
+                    let wal_resolved = resolve_object_store(&wal_template.backend, &wal_path)?;
+                    Ok(Some(wal_resolved.store))
+                } else {
+                    Ok(None)
+                }
+            };
         let parent_wal_store = resolve_wal_store(&parent_name)?;
         let left_child_wal_store = resolve_wal_store(&left_child_name)?;
         let right_child_wal_store = resolve_wal_store(&right_child_name)?;
@@ -578,15 +579,9 @@ impl ShardFactory {
         if let Some(wal) = &parent_wal_store {
             parent_db_builder = parent_db_builder.with_wal_object_store(Arc::clone(wal));
         }
-        let db = parent_db_builder
-                .build()
-                .await
-                .map_err(|e| {
-                    ShardFactoryError::CloneError(format!(
-                        "failed to reopen parent DB for cloning: {}",
-                        e
-                    ))
-                })?;
+        let db = parent_db_builder.build().await.map_err(|e| {
+            ShardFactoryError::CloneError(format!("failed to reopen parent DB for cloning: {}", e))
+        })?;
 
         // Flush to ensure all data is in object storage before checkpointing
         db.flush().await.map_err(|e| {
@@ -626,7 +621,11 @@ impl ShardFactory {
         let left_admin = left_admin_builder.build();
 
         left_admin
-            .create_clone(parent_db_path.as_str(), Some(checkpoint.id), parent_wal_store.clone())
+            .create_clone(
+                parent_db_path.as_str(),
+                Some(checkpoint.id),
+                parent_wal_store.clone(),
+            )
             .await
             .map_err(|e| {
                 ShardFactoryError::CloneError(format!(
@@ -646,7 +645,11 @@ impl ShardFactory {
         let right_admin = right_admin_builder.build();
 
         right_admin
-            .create_clone(parent_db_path.as_str(), Some(checkpoint.id), parent_wal_store)
+            .create_clone(
+                parent_db_path.as_str(),
+                Some(checkpoint.id),
+                parent_wal_store,
+            )
             .await
             .map_err(|e| {
                 ShardFactoryError::CloneError(format!(

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -28,6 +28,7 @@ use helpers::WriteBatcher;
 pub use helpers::now_epoch_ms;
 
 use slatedb::Db;
+use slatedb_common::metrics::DefaultMetricsRecorder;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use thiserror::Error;
@@ -107,6 +108,8 @@ pub struct JobStoreShard {
     db_path: String,
     /// The shard's tenant range, immutable after opening.
     range: ShardRange,
+    /// Metrics recorder for SlateDB, passed to DbBuilder and used for stats collection.
+    slatedb_metrics_recorder: Arc<DefaultMetricsRecorder>,
 }
 
 #[derive(Debug, Error)]
@@ -306,8 +309,10 @@ impl JobStoreShard {
             concurrency_reconcile_interval,
         } = options;
 
+        let slatedb_metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
         let mut db_builder = slatedb::DbBuilder::new(db_path, store.clone())
-            .with_merge_operator(counters::counter_merge_operator());
+            .with_merge_operator(counters::counter_merge_operator())
+            .with_metrics_recorder(slatedb_metrics_recorder.clone());
 
         // Configure separate WAL object store if provided
         if let Some(wal) = wal_store {
@@ -380,6 +385,7 @@ impl JobStoreShard {
             store,
             db_path: db_path.to_string(),
             range: range.clone(),
+            slatedb_metrics_recorder,
         });
 
         // Periodically reconcile pending concurrency requests to self-heal from
@@ -524,10 +530,10 @@ impl JobStoreShard {
         &self.db
     }
 
-    /// Get the SlateDB metrics registry for this shard.
+    /// Get the SlateDB metrics recorder for this shard.
     /// Use this to collect storage-level statistics for observability.
-    pub fn slatedb_stats(&self) -> std::sync::Arc<slatedb::stats::StatRegistry> {
-        self.db.metrics()
+    pub fn slatedb_metrics_recorder(&self) -> &Arc<DefaultMetricsRecorder> {
+        &self.slatedb_metrics_recorder
     }
 
     /// Read LSM tree state from the SlateDB manifest.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,7 +31,7 @@ use prometheus::{
     Counter, CounterVec, Encoder, Gauge, GaugeVec, HistogramOpts, HistogramVec, Opts, Registry,
     TextEncoder, core::Collector,
 };
-use slatedb::stats::StatRegistry;
+use slatedb_common::metrics::{DefaultMetricsRecorder, MetricValue};
 use tokio::sync::broadcast;
 use tracing::{debug, error};
 
@@ -269,7 +269,7 @@ impl Metrics {
     /// Call this periodically (e.g., every second) to sync SlateDB's internal
     /// statistics to Prometheus metrics. Counter-type stats are tracked via deltas
     /// since Prometheus counters only support `inc_by()`, not `set()`.
-    pub fn update_slatedb_stats(&self, shard: &str, stats: &Arc<StatRegistry>) {
+    pub fn update_slatedb_stats(&self, shard: &str, recorder: &DefaultMetricsRecorder) {
         // Counter-type stats: monotonically increasing in SlateDB
         let counter_mappings: &[(&str, &CounterVec)] = &[
             (slatedb::db_stats::GET_REQUESTS, &self.slatedb_get_requests),
@@ -343,11 +343,18 @@ impl Metrics {
             ),
         ];
 
+        let snapshot = recorder.snapshot();
+
         {
             let mut prev_values = self.slatedb_prev_values.lock().expect("lock poisoned");
             for (stat_name, counter) in counter_mappings {
-                if let Some(stat) = stats.lookup(stat_name) {
-                    let current = stat.get() as f64;
+                if let Some(metric) = snapshot.by_name(stat_name).first() {
+                    let current = match &metric.value {
+                        MetricValue::Counter(v) => *v as f64,
+                        MetricValue::Gauge(v) => *v as f64,
+                        MetricValue::UpDownCounter(v) => *v as f64,
+                        MetricValue::Histogram { .. } => continue,
+                    };
                     let key = (stat_name.to_string(), shard.to_string());
                     let prev = prev_values.get(&key).copied().unwrap_or(0.0);
                     if current > prev {
@@ -359,8 +366,14 @@ impl Metrics {
         }
 
         for (stat_name, gauge) in gauge_mappings {
-            if let Some(stat) = stats.lookup(stat_name) {
-                gauge.with_label_values(&[shard]).set(stat.get() as f64);
+            if let Some(metric) = snapshot.by_name(stat_name).first() {
+                let value = match &metric.value {
+                    MetricValue::Counter(v) => *v as f64,
+                    MetricValue::Gauge(v) => *v as f64,
+                    MetricValue::UpDownCounter(v) => *v as f64,
+                    MetricValue::Histogram { .. } => continue,
+                };
+                gauge.with_label_values(&[shard]).set(value);
             }
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2018,8 +2018,8 @@ where
 
                         // Collect SlateDB storage metrics for this shard
                         if let Some(ref m) = reaper_metrics {
-                            let stats = shard.slatedb_stats();
-                            m.update_slatedb_stats(&shard_id.to_string(), &stats);
+                            let recorder = shard.slatedb_metrics_recorder();
+                            m.update_slatedb_stats(&shard_id.to_string(), recorder);
                         }
                     }
                 }

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -363,12 +363,15 @@ async fn test_metrics_all_recording_methods() {
 async fn test_metrics_slatedb_stats() {
     let (metrics, _app) = create_metrics_router();
 
-    // Create a real SlateDB to get a StatRegistry with actual stats
+    // Create a real SlateDB with a metrics recorder
     let tmpdir = tempfile::tempdir().unwrap();
     let object_store = std::sync::Arc::new(
         object_store::local::LocalFileSystem::new_with_prefix(tmpdir.path()).unwrap(),
     );
-    let db = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store)
+    let recorder = std::sync::Arc::new(slatedb_common::metrics::DefaultMetricsRecorder::new());
+    let db = slatedb::DbBuilder::new("test-db", object_store)
+        .with_metrics_recorder(recorder.clone())
+        .build()
         .await
         .unwrap();
 
@@ -377,8 +380,7 @@ async fn test_metrics_slatedb_stats() {
     db.put(b"key2", b"value2").await.unwrap();
     let _ = db.get(b"key1").await;
 
-    let stat_registry = db.metrics();
-    metrics.update_slatedb_stats("0", &stat_registry);
+    metrics.update_slatedb_stats("0", &recorder);
 
     let body_str = gather_metrics_text(&metrics);
 
@@ -443,14 +445,16 @@ async fn test_metrics_slatedb_counter_delta_tracking() {
     let object_store = std::sync::Arc::new(
         object_store::local::LocalFileSystem::new_with_prefix(tmpdir.path()).unwrap(),
     );
-    let db = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store)
+    let recorder = std::sync::Arc::new(slatedb_common::metrics::DefaultMetricsRecorder::new());
+    let db = slatedb::DbBuilder::new("test-db", object_store)
+        .with_metrics_recorder(recorder.clone())
+        .build()
         .await
         .unwrap();
 
     // First batch of writes
     db.put(b"key1", b"value1").await.unwrap();
-    let stat_registry = db.metrics();
-    metrics.update_slatedb_stats("0", &stat_registry);
+    metrics.update_slatedb_stats("0", &recorder);
 
     let body1 = gather_metrics_text(&metrics);
     let write_ops_1 =
@@ -460,7 +464,7 @@ async fn test_metrics_slatedb_counter_delta_tracking() {
     // Second batch of writes — delta tracking should accumulate, not reset
     db.put(b"key2", b"value2").await.unwrap();
     db.put(b"key3", b"value3").await.unwrap();
-    metrics.update_slatedb_stats("0", &stat_registry);
+    metrics.update_slatedb_stats("0", &recorder);
 
     let body2 = gather_metrics_text(&metrics);
     let write_ops_2 =
@@ -473,7 +477,7 @@ async fn test_metrics_slatedb_counter_delta_tracking() {
     );
 
     // Calling update again without new writes should not change the counter
-    metrics.update_slatedb_stats("0", &stat_registry);
+    metrics.update_slatedb_stats("0", &recorder);
     let body3 = gather_metrics_text(&metrics);
     let write_ops_3 =
         extract_metric_value(&body3, &["silo_slatedb_write_ops_total", "shard=\"0\""]);
@@ -493,7 +497,10 @@ async fn test_metrics_slatedb_multiple_shards() {
     let object_store1 = std::sync::Arc::new(
         object_store::local::LocalFileSystem::new_with_prefix(tmpdir1.path()).unwrap(),
     );
-    let db1 = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store1)
+    let recorder1 = std::sync::Arc::new(slatedb_common::metrics::DefaultMetricsRecorder::new());
+    let db1 = slatedb::DbBuilder::new("test-db", object_store1)
+        .with_metrics_recorder(recorder1.clone())
+        .build()
         .await
         .unwrap();
 
@@ -501,7 +508,10 @@ async fn test_metrics_slatedb_multiple_shards() {
     let object_store2 = std::sync::Arc::new(
         object_store::local::LocalFileSystem::new_with_prefix(tmpdir2.path()).unwrap(),
     );
-    let db2 = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store2)
+    let recorder2 = std::sync::Arc::new(slatedb_common::metrics::DefaultMetricsRecorder::new());
+    let db2 = slatedb::DbBuilder::new("test-db", object_store2)
+        .with_metrics_recorder(recorder2.clone())
+        .build()
         .await
         .unwrap();
 
@@ -510,8 +520,8 @@ async fn test_metrics_slatedb_multiple_shards() {
     db2.put(b"b", b"2").await.unwrap();
     db2.put(b"c", b"3").await.unwrap();
 
-    metrics.update_slatedb_stats("shard-a", &db1.metrics());
-    metrics.update_slatedb_stats("shard-b", &db2.metrics());
+    metrics.update_slatedb_stats("shard-a", &recorder1);
+    metrics.update_slatedb_stats("shard-b", &recorder2);
 
     let body = gather_metrics_text(&metrics);
     let shard_a_writes = extract_metric_value(


### PR DESCRIPTION
  Fix shard splits with separate WAL storage

  Shard clones were broken when split WAL storage was configured because
  clone_closed_shard didn't propagate WAL object stores. The parent DB was
  opened without its WAL store (so slatedb couldn't validate the manifest's
  wal_object_store_uri), child Admin builders had no WAL configured (so
  clones wouldn't record their own wal_object_store_uri), and create_clone
  had no way to locate the parent's WAL SSTs.

  Now each clone operation:
  - Opens the parent DB with its WAL store for manifest validation
  - Builds each child's Admin with its own WAL store from the template
  - Passes the parent's WAL store to create_clone so it can copy WAL SSTs

  Also migrates from the removed slatedb stats API (StatRegistry/Db::metrics)
  to the new MetricsRecorder trait system in slatedb_common, and adds
  slatedb-common as a direct dependency since DbBuilder::with_metrics_recorder
  takes Arc<dyn slatedb_common::metrics::MetricsRecorder>.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes shard split/clone behavior and WAL object-store wiring, which impacts durability and correctness of storage during production resharding. Also updates the SlateDB metrics integration to a new recorder API, affecting observability and tests.
> 
> **Overview**
> **Fixes shard split cloning with separate WAL storage.** `clone_closed_shard` now resolves per-shard WAL object stores from the template, reopens the closed parent DB with its WAL store for manifest validation, configures each child `Admin` with its own WAL store, and passes the parent WAL store into `Admin::create_clone` so WAL SSTs can be found/copied.
> 
> **Updates SlateDB metrics plumbing.** Adds `slatedb-common` as a direct dependency, switches shard stats collection from `Db::metrics()`/`StatRegistry` to `DefaultMetricsRecorder` snapshots, and updates the periodic metrics poller plus tests/benches to the new `create_clone` and metrics APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa95a0c8cdb8c52ff5dc777fad6303f41e298a68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->