### PR TITLE
Populate status.selector on SiloAutoscaler for HPA

### DIFF
--- a/deploy/local-test/crd.yaml
+++ b/deploy/local-test/crd.yaml
@@ -105,6 +105,9 @@ spec:
                 description: Current replica count read from the StatefulSet.
                 format: int32
                 type: integer
+              selector:
+                description: Label selector string for the managed pods (e.g. "app=silo"). Used by the HPA via the /scale subresource.
+                type: string
             type: object
         required:
         - spec
@@ -114,6 +117,7 @@ spec:
     storage: true
     subresources:
       scale:
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/deploy/local-test/hpa.yaml
+++ b/deploy/local-test/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: silo-hpa
+  namespace: silo-test
+spec:
+  scaleTargetRef:
+    apiVersion: silo.dev/v1alpha1
+    kind: SiloAutoscaler
+    name: silo-autoscaler
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/silo-autoscaler/src/controller.rs
+++ b/silo-autoscaler/src/controller.rs
@@ -143,6 +143,7 @@ async fn reconcile(
                     make_condition("Ready", "False", "StatefulSetNotFound",
                         &format!("StatefulSet {} not found", spec.target_stateful_set)),
                 ],
+                "",
             ).await?;
             return Ok(Action::requeue(Duration::from_secs(30)));
         }
@@ -153,18 +154,7 @@ async fn reconcile(
 
     // List pods for this StatefulSet
     let pod_api: Api<Pod> = Api::namespaced(client.clone(), namespace);
-    let label_selector = sts
-        .spec
-        .as_ref()
-        .and_then(|s| s.selector.match_labels.as_ref())
-        .map(|labels| {
-            labels
-                .iter()
-                .map(|(k, v)| format!("{}={}", k, v))
-                .collect::<Vec<_>>()
-                .join(",")
-        })
-        .unwrap_or_default();
+    let label_selector = label_selector_from_sts(&sts);
     let pods = pod_api
         .list(&ListParams::default().labels(&label_selector))
         .await
@@ -196,7 +186,7 @@ async fn reconcile(
     } else {
         vec![make_condition("Ready", "True", "Idle", "replicas match desired count")]
     };
-    update_status(client, namespace, name, sts_replicas, orphaned_leases, conditions).await?;
+    update_status(client, namespace, name, sts_replicas, orphaned_leases, conditions, &label_selector).await?;
 
     // Requeue interval
     let interval = requeue_interval(sts_replicas, desired, termination_active);
@@ -398,15 +388,22 @@ async fn update_status(
     replicas: i32,
     orphaned_leases: Vec<OrphanedLeaseInfo>,
     conditions: Vec<AutoscalerCondition>,
+    label_selector: &str,
 ) -> Result<(), ReconcileError> {
     let autoscaler_api: Api<SiloAutoscaler> = Api::namespaced(client.clone(), namespace);
 
     let orphaned_lease_count = orphaned_leases.len() as i32;
+    let selector = if label_selector.is_empty() {
+        None
+    } else {
+        Some(label_selector.to_string())
+    };
     let status = SiloAutoscalerStatus {
         replicas,
         orphaned_lease_count,
         conditions,
         orphaned_leases,
+        selector,
     };
 
     let patch = serde_json::json!({
@@ -425,6 +422,20 @@ async fn update_status(
         .map_err(|e| ReconcileError(format!("failed to update status: {e}")))?;
 
     Ok(())
+}
+
+fn label_selector_from_sts(sts: &StatefulSet) -> String {
+    sts.spec
+        .as_ref()
+        .and_then(|s| s.selector.match_labels.as_ref())
+        .map(|labels| {
+            labels
+                .iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .unwrap_or_default()
 }
 
 fn make_condition(
@@ -535,5 +546,46 @@ mod tests {
         assert_eq!(requeue_interval(3, 5, false), 10); // scaling
         assert_eq!(requeue_interval(3, 3, true), 5);   // termination active
         assert_eq!(requeue_interval(5, 3, true), 5);   // termination active overrides scaling
+    }
+
+    fn make_sts(match_labels: Option<std::collections::BTreeMap<String, String>>) -> StatefulSet {
+        use k8s_openapi::api::apps::v1::StatefulSetSpec;
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+
+        StatefulSet {
+            spec: Some(StatefulSetSpec {
+                selector: LabelSelector {
+                    match_labels,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_label_selector_from_sts() {
+        let labels: std::collections::BTreeMap<String, String> =
+            [("app".to_string(), "silo-staging".to_string())].into();
+        let sts = make_sts(Some(labels));
+        assert_eq!(label_selector_from_sts(&sts), "app=silo-staging");
+    }
+
+    #[test]
+    fn test_label_selector_from_sts_empty() {
+        let sts = make_sts(None);
+        assert_eq!(label_selector_from_sts(&sts), "");
+    }
+
+    #[test]
+    fn test_label_selector_from_sts_multiple_labels() {
+        let labels: std::collections::BTreeMap<String, String> = [
+            ("app".to_string(), "silo".to_string()),
+            ("env".to_string(), "staging".to_string()),
+        ].into();
+        let sts = make_sts(Some(labels));
+        // BTreeMap is sorted by key
+        assert_eq!(label_selector_from_sts(&sts), "app=silo,env=staging");
     }
 }

--- a/silo-autoscaler/src/crd.rs
+++ b/silo-autoscaler/src/crd.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
     kind = "SiloAutoscaler",
     namespaced,
     status = "SiloAutoscalerStatus",
-    scale = r#"{"specReplicasPath":".spec.replicas","statusReplicasPath":".status.replicas"}"#,
+    scale = r#"{"specReplicasPath":".spec.replicas","statusReplicasPath":".status.replicas","labelSelectorPath":".status.selector"}"#,
     printcolumn = r#"{"name":"Replicas","type":"integer","jsonPath":".spec.replicas"}"#,
     printcolumn = r#"{"name":"Current","type":"integer","jsonPath":".status.replicas"}"#,
     printcolumn = r#"{"name":"Orphans","type":"integer","jsonPath":".status.orphanedLeaseCount"}"#
@@ -51,6 +51,11 @@ pub struct SiloAutoscalerStatus {
     /// Orphaned shard leases currently detected.
     #[serde(default)]
     pub orphaned_leases: Vec<OrphanedLeaseInfo>,
+
+    /// Label selector string for the managed pods (e.g. "app=silo").
+    /// Used by the HPA via the /scale subresource's labelSelectorPath.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]


### PR DESCRIPTION
## Summary
- The HPA requires `status.selector` on the `/scale` subresource to discover pods for computing CPU/memory metrics. Without it, the HPA can read replica counts but cannot find the actual pods to scrape metrics from — making autoscaling on resource utilization impossible.
- Sets `status.selector` from the target StatefulSet's `matchLabels` (e.g. `app=silo-staging`) and wires it through `labelSelectorPath` on the CRD's scale subresource.
- Adds a dummy HPA to `deploy/local-test` for local validation.

## Test plan
- [x] Unit tests for `label_selector_from_sts` (single label, multiple labels, empty)
- [x] Deployed to OrbStack, verified `status.selector` is set on the SiloAutoscaler resource
- [x] Verified `/scale` subresource returns `selector` field
- [x] HPA reports `AbleToScale: True` / `SucceededGetScale` and finds 3 pods