### PR TITLE
Use cargo fmt --check for CI formatting lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: Swatinem/rust-cache@v2
       - name: Check Rust formatting
-        run: rustfmt --check --edition=2024 **/*.rs
+        run: cargo fmt --check
       - name: Validate SILO sigils synchronized
         run: node scripts/validate-silo-sigils.js
 

--- a/silo-autoscaler/src/controller.rs
+++ b/silo-autoscaler/src/controller.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 use futures::StreamExt;
 use k8s_openapi::api::apps::v1::StatefulSet;
 use k8s_openapi::api::core::v1::Pod;
+use kube::Client;
 use kube::api::{Api, ListParams, Patch, PatchParams};
 use kube::runtime::controller::Action;
 use kube::runtime::{Controller, watcher};
-use kube::Client;
 use tracing::{debug, error, info, warn};
 
 use crate::crd::{AutoscalerCondition, OrphanedLeaseInfo, SiloAutoscaler, SiloAutoscalerStatus};
@@ -36,7 +36,9 @@ enum TerminationStatus {
     /// At least one pod is still terminating (container running or awaiting finalizer removal).
     Pending,
     /// Recovery was triggered: orphaned leases were found on a SIGKILL'd pod.
-    Recovery { orphaned_leases: Vec<OrphanedLeaseInfo> },
+    Recovery {
+        orphaned_leases: Vec<OrphanedLeaseInfo>,
+    },
 }
 
 impl TerminationStatus {
@@ -93,19 +95,12 @@ pub async fn run_controller(client: Client) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn error_policy(
-    _obj: Arc<SiloAutoscaler>,
-    error: &ReconcileError,
-    _ctx: Arc<Context>,
-) -> Action {
+fn error_policy(_obj: Arc<SiloAutoscaler>, error: &ReconcileError, _ctx: Arc<Context>) -> Action {
     warn!(error = %error, "reconcile error, retrying in 15s");
     Action::requeue(Duration::from_secs(15))
 }
 
-async fn reconcile(
-    obj: Arc<SiloAutoscaler>,
-    ctx: Arc<Context>,
-) -> Result<Action, ReconcileError> {
+async fn reconcile(obj: Arc<SiloAutoscaler>, ctx: Arc<Context>) -> Result<Action, ReconcileError> {
     let client = &ctx.client;
     let namespace = obj
         .metadata
@@ -139,12 +134,20 @@ async fn reconcile(
                 "target StatefulSet not found"
             );
             update_status(
-                client, namespace, name, 0, vec![], vec![
-                    make_condition("Ready", "False", "StatefulSetNotFound",
-                        &format!("StatefulSet {} not found", spec.target_stateful_set)),
-                ],
+                client,
+                namespace,
+                name,
+                0,
+                vec![],
+                vec![make_condition(
+                    "Ready",
+                    "False",
+                    "StatefulSetNotFound",
+                    &format!("StatefulSet {} not found", spec.target_stateful_set),
+                )],
                 "",
-            ).await?;
+            )
+            .await?;
             return Ok(Action::requeue(Duration::from_secs(30)));
         }
         Err(e) => return Err(e.into()),
@@ -162,8 +165,15 @@ async fn reconcile(
 
     // Process any terminating pods, handling finalizer removal and recovery
     let termination_status = handle_terminating_pods(
-        client, namespace, &pod_api, &sts_api, &pods.items, spec, sts_replicas,
-    ).await?;
+        client,
+        namespace,
+        &pod_api,
+        &sts_api,
+        &pods.items,
+        spec,
+        sts_replicas,
+    )
+    .await?;
 
     // Only adjust replicas when no pods are mid-termination
     let termination_active = termination_status.is_active();
@@ -175,18 +185,39 @@ async fn reconcile(
     let orphaned_leases = termination_status.orphaned_leases();
     let conditions = if !orphaned_leases.is_empty() {
         vec![make_condition(
-            "OrphanedLeases", "True", "Recovering",
-            &format!("{} orphaned leases, scaling up for recovery", orphaned_leases.len()),
+            "OrphanedLeases",
+            "True",
+            "Recovering",
+            &format!(
+                "{} orphaned leases, scaling up for recovery",
+                orphaned_leases.len()
+            ),
         )]
     } else if sts_replicas != desired {
         vec![make_condition(
-            "Ready", "False", "Scaling",
+            "Ready",
+            "False",
+            "Scaling",
             &format!("replicas: {} desired: {}", sts_replicas, desired),
         )]
     } else {
-        vec![make_condition("Ready", "True", "Idle", "replicas match desired count")]
+        vec![make_condition(
+            "Ready",
+            "True",
+            "Idle",
+            "replicas match desired count",
+        )]
     };
-    update_status(client, namespace, name, sts_replicas, orphaned_leases, conditions, &label_selector).await?;
+    update_status(
+        client,
+        namespace,
+        name,
+        sts_replicas,
+        orphaned_leases,
+        conditions,
+        &label_selector,
+    )
+    .await?;
 
     // Requeue interval
     let interval = requeue_interval(sts_replicas, desired, termination_active);
@@ -228,17 +259,15 @@ async fn handle_terminating_pods(
         }
 
         // Container is dead — check if leases were released
-        let held_leases = orphan::leases_held_by_pod(
-            client, namespace, &spec.cluster_prefix, pod_name,
-        ).await?;
+        let held_leases =
+            orphan::leases_held_by_pod(client, namespace, &spec.cluster_prefix, pod_name).await?;
 
         if held_leases.is_empty() {
             info!(pod = %pod_name, "leases released, removing finalizer");
             remove_finalizer(pod_api, pod_name).await?;
         } else {
-            recover_orphaned_pod(
-                pod_api, sts_api, pod_name, &held_leases, spec, sts_replicas,
-            ).await?;
+            recover_orphaned_pod(pod_api, sts_api, pod_name, &held_leases, spec, sts_replicas)
+                .await?;
             orphaned_leases.extend(held_leases);
         }
     }
@@ -296,9 +325,9 @@ async fn apply_desired_replicas(
 ) -> Result<(), ReconcileError> {
     if sts_replicas > desired {
         // Recovery just completed — wait for all pods to be ready before scaling back down
-        let all_ready = pods.iter().all(|p| {
-            p.metadata.deletion_timestamp.is_none() && is_pod_ready(p)
-        });
+        let all_ready = pods
+            .iter()
+            .all(|p| p.metadata.deletion_timestamp.is_none() && is_pod_ready(p));
         if all_ready {
             info!(name = %name, current = sts_replicas, desired = desired, "recovery complete, scaling back down");
             patch_statefulset_replicas(sts_api, &spec.target_stateful_set, desired).await?;
@@ -330,15 +359,17 @@ fn has_finalizer(pod: &Pod) -> bool {
 }
 
 fn is_container_terminated(pod: &Pod) -> bool {
-    let statuses = match pod.status.as_ref().and_then(|s| s.container_statuses.as_ref()) {
+    let statuses = match pod
+        .status
+        .as_ref()
+        .and_then(|s| s.container_statuses.as_ref())
+    {
         Some(s) => s,
         None => return true, // No container statuses means containers never ran or were evicted
     };
-    statuses.iter().all(|cs| {
-        cs.state
-            .as_ref()
-            .is_some_and(|s| s.terminated.is_some())
-    })
+    statuses
+        .iter()
+        .all(|cs| cs.state.as_ref().is_some_and(|s| s.terminated.is_some()))
 }
 
 fn is_pod_ready(pod: &Pod) -> bool {
@@ -346,7 +377,9 @@ fn is_pod_ready(pod: &Pod) -> bool {
         .as_ref()
         .and_then(|s| s.conditions.as_ref())
         .is_some_and(|conditions| {
-            conditions.iter().any(|c| c.type_ == "Ready" && c.status == "True")
+            conditions
+                .iter()
+                .any(|c| c.type_ == "Ready" && c.status == "True")
         })
 }
 
@@ -359,7 +392,11 @@ async fn remove_finalizer(pod_api: &Api<Pod>, pod_name: &str) -> Result<(), Reco
     pod_api
         .patch(pod_name, &PatchParams::default(), &Patch::Merge(&patch))
         .await
-        .map_err(|e| ReconcileError(format!("failed to remove finalizer from pod {pod_name}: {e}")))?;
+        .map_err(|e| {
+            ReconcileError(format!(
+                "failed to remove finalizer from pod {pod_name}: {e}"
+            ))
+        })?;
     debug!(pod = %pod_name, "removed finalizer");
     Ok(())
 }
@@ -517,7 +554,10 @@ mod tests {
         let running = make_pod("silo-0", vec![], false, true);
         let terminated = make_pod("silo-0", vec![], true, false);
         let no_status = Pod {
-            metadata: ObjectMeta { name: Some("silo-0".into()), ..Default::default() },
+            metadata: ObjectMeta {
+                name: Some("silo-0".into()),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -531,7 +571,10 @@ mod tests {
         let ready = make_pod("silo-0", vec![], false, true);
         let not_ready = make_pod("silo-0", vec![], false, false);
         let no_status = Pod {
-            metadata: ObjectMeta { name: Some("silo-0".into()), ..Default::default() },
+            metadata: ObjectMeta {
+                name: Some("silo-0".into()),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -544,8 +587,8 @@ mod tests {
     fn test_requeue_interval() {
         assert_eq!(requeue_interval(3, 3, false), 60); // steady state
         assert_eq!(requeue_interval(3, 5, false), 10); // scaling
-        assert_eq!(requeue_interval(3, 3, true), 5);   // termination active
-        assert_eq!(requeue_interval(5, 3, true), 5);   // termination active overrides scaling
+        assert_eq!(requeue_interval(3, 3, true), 5); // termination active
+        assert_eq!(requeue_interval(5, 3, true), 5); // termination active overrides scaling
     }
 
     fn make_sts(match_labels: Option<std::collections::BTreeMap<String, String>>) -> StatefulSet {
@@ -583,7 +626,8 @@ mod tests {
         let labels: std::collections::BTreeMap<String, String> = [
             ("app".to_string(), "silo".to_string()),
             ("env".to_string(), "staging".to_string()),
-        ].into();
+        ]
+        .into();
         let sts = make_sts(Some(labels));
         // BTreeMap is sorted by key
         assert_eq!(label_selector_from_sts(&sts), "app=silo,env=staging");

--- a/silo-autoscaler/src/crd.rs
+++ b/silo-autoscaler/src/crd.rs
@@ -78,6 +78,7 @@ pub struct OrphanedLeaseInfo {
 }
 
 /// Generate the CRD definition for installation.
-pub fn crd_definition() -> k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition {
+pub fn crd_definition()
+-> k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition {
     SiloAutoscaler::crd()
 }

--- a/silo-autoscaler/src/main.rs
+++ b/silo-autoscaler/src/main.rs
@@ -2,7 +2,10 @@ use clap::{Parser, Subcommand};
 use tracing::info;
 
 #[derive(Parser)]
-#[command(name = "silo-autoscaler", about = "Kubernetes controller for safe Silo StatefulSet scaling")]
+#[command(
+    name = "silo-autoscaler",
+    about = "Kubernetes controller for safe Silo StatefulSet scaling"
+)]
 struct Args {
     #[command(subcommand)]
     command: Option<Command>,
@@ -28,8 +31,9 @@ async fn main() -> anyhow::Result<()> {
     // Initialize tracing
     tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,silo_autoscaler=debug")),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("info,silo_autoscaler=debug")
+            }),
         )
         .json()
         .init();

--- a/silo-autoscaler/src/orphan.rs
+++ b/silo-autoscaler/src/orphan.rs
@@ -15,10 +15,7 @@ pub async fn leases_held_by_pod(
     pod_name: &str,
 ) -> Result<Vec<OrphanedLeaseInfo>, Error> {
     let lease_api: Api<Lease> = Api::namespaced(client.clone(), namespace);
-    let label_selector = format!(
-        "silo.dev/type=shard,silo.dev/cluster={}",
-        cluster_prefix
-    );
+    let label_selector = format!("silo.dev/type=shard,silo.dev/cluster={}", cluster_prefix);
     let leases = lease_api
         .list(&ListParams::default().labels(&label_selector))
         .await?;

--- a/silo-autoscaler/src/validation.rs
+++ b/silo-autoscaler/src/validation.rs
@@ -57,7 +57,10 @@ mod tests {
             ..valid_spec()
         };
         let err = validate_spec(&spec).unwrap_err();
-        assert!(err.iter().any(|e| e.contains("spec.targetStatefulSet must be non-empty")));
+        assert!(
+            err.iter()
+                .any(|e| e.contains("spec.targetStatefulSet must be non-empty"))
+        );
     }
 
     #[test]
@@ -67,7 +70,10 @@ mod tests {
             ..valid_spec()
         };
         let err = validate_spec(&spec).unwrap_err();
-        assert!(err.iter().any(|e| e.contains("spec.clusterPrefix must be non-empty")));
+        assert!(
+            err.iter()
+                .any(|e| e.contains("spec.clusterPrefix must be non-empty"))
+        );
     }
 
     #[test]

--- a/silo-autoscaler/tests/autoscaler_integration_tests.rs
+++ b/silo-autoscaler/tests/autoscaler_integration_tests.rs
@@ -23,8 +23,8 @@ use std::time::{Duration, Instant};
 use k8s_openapi::api::apps::v1::StatefulSet;
 use k8s_openapi::api::coordination::v1::Lease;
 use k8s_openapi::api::core::v1::Pod;
-use kube::api::{Api, ListParams, Patch, PatchParams, PostParams};
 use kube::Client;
+use kube::api::{Api, ListParams, Patch, PatchParams, PostParams};
 
 use silo_autoscaler::crd::{SiloAutoscaler, SiloAutoscalerSpec};
 
@@ -50,13 +50,20 @@ async fn get_sts_replicas(client: &Client) -> i32 {
 
 async fn get_ready_pod_count(client: &Client) -> i32 {
     let pod_api: Api<Pod> = Api::namespaced(client.clone(), &namespace());
-    let pods = pod_api.list(&ListParams::default().labels("app=silo")).await.unwrap();
-    pods.items.iter().filter(|p| {
-        p.metadata.deletion_timestamp.is_none()
-            && p.status.as_ref()
-                .and_then(|s| s.conditions.as_ref())
-                .is_some_and(|c| c.iter().any(|c| c.type_ == "Ready" && c.status == "True"))
-    }).count() as i32
+    let pods = pod_api
+        .list(&ListParams::default().labels("app=silo"))
+        .await
+        .unwrap();
+    pods.items
+        .iter()
+        .filter(|p| {
+            p.metadata.deletion_timestamp.is_none()
+                && p.status
+                    .as_ref()
+                    .and_then(|s| s.conditions.as_ref())
+                    .is_some_and(|c| c.iter().any(|c| c.type_ == "Ready" && c.status == "True"))
+        })
+        .count() as i32
 }
 
 async fn get_autoscaler_status(client: &Client) -> (i32, i32) {
@@ -87,12 +94,17 @@ async fn setup(client: &Client, expected_replicas: i32) {
 
     // Clear finalizers on any stuck terminating pods
     let pod_api: Api<Pod> = Api::namespaced(client.clone(), &ns);
-    let pods = pod_api.list(&ListParams::default().labels("app=silo")).await.unwrap();
+    let pods = pod_api
+        .list(&ListParams::default().labels("app=silo"))
+        .await
+        .unwrap();
     for pod in &pods.items {
         if pod.metadata.deletion_timestamp.is_some() {
             if let Some(name) = &pod.metadata.name {
                 let patch = serde_json::json!({"metadata": {"finalizers": []}});
-                let _ = pod_api.patch(name, &PatchParams::default(), &Patch::Merge(&patch)).await;
+                let _ = pod_api
+                    .patch(name, &PatchParams::default(), &Patch::Merge(&patch))
+                    .await;
             }
         }
     }
@@ -100,11 +112,14 @@ async fn setup(client: &Client, expected_replicas: i32) {
     // Restore StatefulSet to expected replicas
     let sts_api: Api<StatefulSet> = Api::namespaced(client.clone(), &ns);
     let patch = serde_json::json!({"spec": {"replicas": expected_replicas}});
-    let _ = sts_api.patch(&sts_name(), &PatchParams::default(), &Patch::Merge(&patch)).await;
+    let _ = sts_api
+        .patch(&sts_name(), &PatchParams::default(), &Patch::Merge(&patch))
+        .await;
 
     assert!(
         wait_for_replicas(client, expected_replicas, Duration::from_secs(120)).await,
-        "setup: StatefulSet did not stabilize at {} replicas", expected_replicas
+        "setup: StatefulSet did not stabilize at {} replicas",
+        expected_replicas
     );
 }
 
@@ -112,18 +127,25 @@ async fn ensure_autoscaler(client: &Client, replicas: i32) {
     let ns = namespace();
     let api: Api<SiloAutoscaler> = Api::namespaced(client.clone(), &ns);
 
-    let sa = SiloAutoscaler::new(AUTOSCALER_NAME, SiloAutoscalerSpec {
-        replicas,
-        target_stateful_set: sts_name(),
-        cluster_prefix: cluster_prefix(),
-    });
+    let sa = SiloAutoscaler::new(
+        AUTOSCALER_NAME,
+        SiloAutoscalerSpec {
+            replicas,
+            target_stateful_set: sts_name(),
+            cluster_prefix: cluster_prefix(),
+        },
+    );
 
     match api.get(AUTOSCALER_NAME).await {
         Ok(_) => {
             let patch = serde_json::json!({"spec": {"replicas": replicas}});
-            api.patch(AUTOSCALER_NAME, &PatchParams::default(), &Patch::Merge(&patch))
-                .await
-                .unwrap();
+            api.patch(
+                AUTOSCALER_NAME,
+                &PatchParams::default(),
+                &Patch::Merge(&patch),
+            )
+            .await
+            .unwrap();
         }
         Err(_) => {
             api.create(&PostParams::default(), &sa).await.unwrap();
@@ -162,7 +184,9 @@ async fn cleanup(client: &Client, restore_replicas: i32) {
 
     let sts_api: Api<StatefulSet> = Api::namespaced(client.clone(), &ns);
     let patch = serde_json::json!({"spec": {"replicas": restore_replicas}});
-    let _ = sts_api.patch(&sts_name(), &PatchParams::default(), &Patch::Merge(&patch)).await;
+    let _ = sts_api
+        .patch(&sts_name(), &PatchParams::default(), &Patch::Merge(&patch))
+        .await;
 }
 
 #[tokio::test]
@@ -197,8 +221,13 @@ async fn test_scale_down() {
     );
 
     let pod_api: Api<Pod> = Api::namespaced(client.clone(), &namespace());
-    let pods = pod_api.list(&ListParams::default().labels("app=silo")).await.unwrap();
-    let running: Vec<_> = pods.items.iter()
+    let pods = pod_api
+        .list(&ListParams::default().labels("app=silo"))
+        .await
+        .unwrap();
+    let running: Vec<_> = pods
+        .items
+        .iter()
         .filter(|p| p.metadata.deletion_timestamp.is_none())
         .collect();
     assert_eq!(running.len(), 2);
@@ -235,21 +264,33 @@ async fn test_scale_down_with_orphaned_lease_triggers_recovery() {
             "holderIdentity": highest_pod,
             "leaseDurationSeconds": 99999
         }
-    })).unwrap();
+    }))
+    .unwrap();
 
-    let _ = lease_api.delete(&fake_lease_name, &Default::default()).await;
+    let _ = lease_api
+        .delete(&fake_lease_name, &Default::default())
+        .await;
     tokio::time::sleep(Duration::from_secs(1)).await;
-    lease_api.create(&PostParams::default(), &lease).await.unwrap();
+    lease_api
+        .create(&PostParams::default(), &lease)
+        .await
+        .unwrap();
 
     // Scale down — controller should detect orphaned lease and scale back up
     ensure_autoscaler(&client, 2).await;
 
     // Wait for the controller to detect the orphan and scale back up
     let recovered = wait_for_sts_replicas_gte(&client, 3, Duration::from_secs(60)).await;
-    assert!(recovered, "expected StatefulSet to scale back up for recovery");
+    assert!(
+        recovered,
+        "expected StatefulSet to scale back up for recovery"
+    );
 
     // Clean up fake lease — allows recovery to complete
-    lease_api.delete(&fake_lease_name, &Default::default()).await.unwrap();
+    lease_api
+        .delete(&fake_lease_name, &Default::default())
+        .await
+        .unwrap();
 
     // Wait for scale-down to complete
     assert!(


### PR DESCRIPTION
## Summary
- Replace direct `rustfmt --check --edition=2024 **/*.rs` with `cargo fmt --check` in CI
- `cargo fmt --check` respects workspace configuration and Cargo.toml edition settings automatically

## Test plan
- [ ] Verify the `fmt` CI job passes on this PR
- [ ] Confirm it would fail on unformatted code by testing locally with `cargo fmt --check`