### PR TITLE
During shard splits reopening the DB causes a gap in available WALs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5424,6 +5424,7 @@ dependencies = [
  "serde_json",
  "silo-macros",
  "slatedb",
+ "slatedb-common",
  "storekey",
  "tempfile",
  "thiserror 1.0.69",
@@ -5499,9 +5500,10 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 [[package]]
 name = "slatedb"
 version = "0.11.1"
-source = "git+https://github.com/gadget-inc/slatedb.git?branch=gadget#91aca69be4cfe7d2642aace000d374d8f088a70f"
+source = "git+https://github.com/slatedb/slatedb.git?branch=main#a69999a8d1326947d56faa8ba0fd6a47683ba91a"
 dependencies = [
  "anyhow",
+ "async-channel",
  "async-trait",
  "atomic",
  "backon",
@@ -5545,7 +5547,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.11.1"
-source = "git+https://github.com/gadget-inc/slatedb.git?branch=gadget#91aca69be4cfe7d2642aace000d374d8f088a70f"
+source = "git+https://github.com/slatedb/slatedb.git?branch=main#a69999a8d1326947d56faa8ba0fd6a47683ba91a"
 dependencies = [
  "chrono",
  "log",
@@ -5556,7 +5558,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.11.1"
-source = "git+https://github.com/gadget-inc/slatedb.git?branch=gadget#91aca69be4cfe7d2642aace000d374d8f088a70f"
+source = "git+https://github.com/slatedb/slatedb.git?branch=main#a69999a8d1326947d56faa8ba0fd6a47683ba91a"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ version = "0.2.0"
 [dependencies]
 clap = { version = "4.3.14", features = ["derive", "env"] }
 futures = "0.3"
-slatedb = { git = "https://github.com/gadget-inc/slatedb.git", branch = "gadget" }
+slatedb = { git = "https://github.com/slatedb/slatedb.git", branch = "main" }
+slatedb-common = { git = "https://github.com/slatedb/slatedb.git", branch = "main" }
 object_store = { version = "0.12", features = ["gcp"] }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -583,6 +583,9 @@ impl ShardFactory {
         db.put(sentinel_key.as_bytes(), b"").await.map_err(|e| {
             ShardFactoryError::CloneError(format!("failed to write clone sentinel: {}", e))
         })?;
+        db.delete(sentinel_key.as_bytes()).await.map_err(|e| {
+            ShardFactoryError::CloneError(format!("failed to delete clone sentinel: {}", e))
+        })?;
 
         // Create a single checkpoint shared by both children. Use no lifetime so
         // the checkpoint persists until the children have fully compacted away their

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -583,13 +583,13 @@ impl ShardFactory {
         db.put(sentinel_key.as_bytes(), b"").await.map_err(|e| {
             ShardFactoryError::CloneError(format!("failed to write clone sentinel: {}", e))
         })?;
-        db.flush().await.map_err(|e| {
-            ShardFactoryError::CloneError(format!("failed to flush after sentinel write: {}", e))
-        })?;
 
         // Create a single checkpoint shared by both children. Use no lifetime so
         // the checkpoint persists until the children have fully compacted away their
         // dependency on the parent's SSTs.
+        // CheckpointScope::All calls flush_wals() + flush_memtables() internally,
+        // which flushes the sentinel to L0 and advances replay_after_wal_id past
+        // all WAL SSTs. This ensures clones don't inherit a WAL gap.
         let checkpoint_options = slatedb::config::CheckpointOptions {
             lifetime: None,
             ..Default::default()

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -548,40 +548,21 @@ impl ShardFactory {
             &right_child_name,
         )?;
 
-        // Resolve separate WAL object stores if configured. Each shard (parent and
-        // children) gets its own WAL store so that the clone's wal_object_store_uri
-        // is correctly recorded in the manifest.
-        let resolve_wal_store =
-            |shard_name: &str| -> Result<Option<Arc<dyn ObjectStore>>, ShardFactoryError> {
-                if let Some(wal_template) = &self.template.wal {
-                    let wal_path = wal_template
-                        .path
-                        .replace("%shard%", shard_name)
-                        .replace("{shard}", shard_name);
-                    let wal_resolved = resolve_object_store(&wal_template.backend, &wal_path)?;
-                    Ok(Some(wal_resolved.store))
-                } else {
-                    Ok(None)
-                }
-            };
-        let parent_wal_store = resolve_wal_store(&parent_name)?;
-        let left_child_wal_store = resolve_wal_store(&left_child_name)?;
-        let right_child_wal_store = resolve_wal_store(&right_child_name)?;
-
         // Open a raw SlateDB database at the parent's path. The parent shard has been
-        // fully closed (data flushed, WAL cleaned up), but we still need the WAL store
-        // configured so that slatedb can validate the wal_object_store_uri in the manifest.
-        // We still need the merge operator because the parent may contain counter merge
-        // entries that haven't been fully compacted yet.
-        let mut parent_db_builder =
+        // fully closed (data flushed, WAL cleaned up), so we don't need a WAL. We still
+        // need the merge operator because the parent may contain counter merge entries
+        // that haven't been fully compacted yet.
+        let db =
             slatedb::DbBuilder::new(parent_db_path.as_str(), Arc::clone(&parent_resolved.store))
-                .with_merge_operator(crate::job_store_shard::counter_merge_operator());
-        if let Some(wal) = &parent_wal_store {
-            parent_db_builder = parent_db_builder.with_wal_object_store(Arc::clone(wal));
-        }
-        let db = parent_db_builder.build().await.map_err(|e| {
-            ShardFactoryError::CloneError(format!("failed to reopen parent DB for cloning: {}", e))
-        })?;
+                .with_merge_operator(crate::job_store_shard::counter_merge_operator())
+                .build()
+                .await
+                .map_err(|e| {
+                    ShardFactoryError::CloneError(format!(
+                        "failed to reopen parent DB for cloning: {}",
+                        e
+                    ))
+                })?;
 
         // Flush to ensure all data is in object storage before checkpointing
         db.flush().await.map_err(|e| {
@@ -632,14 +613,11 @@ impl ShardFactory {
         );
 
         // Clone for left child
-        let mut left_admin_builder = slatedb::admin::Admin::builder(
+        let left_admin = slatedb::admin::Admin::builder(
             left_child_db_path.as_str(),
             Arc::clone(&parent_resolved.store),
-        );
-        if let Some(wal) = &left_child_wal_store {
-            left_admin_builder = left_admin_builder.with_wal_object_store(Arc::clone(wal));
-        }
-        let left_admin = left_admin_builder.build();
+        )
+        .build();
 
         left_admin
             .create_clone(parent_db_path.as_str(), Some(checkpoint.id))
@@ -652,14 +630,11 @@ impl ShardFactory {
             })?;
 
         // Clone for right child
-        let mut right_admin_builder = slatedb::admin::Admin::builder(
+        let right_admin = slatedb::admin::Admin::builder(
             right_child_db_path.as_str(),
             Arc::clone(&parent_resolved.store),
-        );
-        if let Some(wal) = &right_child_wal_store {
-            right_admin_builder = right_admin_builder.with_wal_object_store(Arc::clone(wal));
-        }
-        let right_admin = right_admin_builder.build();
+        )
+        .build();
 
         right_admin
             .create_clone(parent_db_path.as_str(), Some(checkpoint.id))

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -280,6 +280,23 @@ impl ShardFactory {
         }
     }
 
+    /// Resolve the WAL object store for a shard, if split WAL storage is configured.
+    fn resolve_wal_store(
+        &self,
+        shard_name: &str,
+    ) -> Result<Option<Arc<dyn ObjectStore>>, JobStoreShardError> {
+        if let Some(wal_template) = &self.template.wal {
+            let wal_path = wal_template
+                .path
+                .replace("%shard%", shard_name)
+                .replace("{shard}", shard_name);
+            let wal_resolved = resolve_object_store(&wal_template.backend, &wal_path)?;
+            Ok(Some(wal_resolved.store))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Get the filesystem path where a shard's data is stored.
     /// This is only valid for local filesystem backends (Fs, TurmoilFs).
     fn get_shard_data_path(
@@ -548,21 +565,26 @@ impl ShardFactory {
             &right_child_name,
         )?;
 
-        // Open a raw SlateDB database at the parent's path. The parent shard has been
-        // fully closed (data flushed, WAL cleaned up), so we don't need a WAL. We still
-        // need the merge operator because the parent may contain counter merge entries
-        // that haven't been fully compacted yet.
-        let db =
+        // Resolve separate WAL object stores if configured. Each shard (parent and
+        // children) gets its own WAL store so that the clone's wal_object_store_uri
+        // is correctly recorded in the manifest.
+        let parent_wal_store = self.resolve_wal_store(&parent_name)?;
+        let left_child_wal_store = self.resolve_wal_store(&left_child_name)?;
+        let right_child_wal_store = self.resolve_wal_store(&right_child_name)?;
+
+        // Open a raw SlateDB database at the parent's path. We need the WAL store
+        // configured so slatedb can validate the wal_object_store_uri in the manifest.
+        // We still need the merge operator because the parent may contain counter merge
+        // entries that haven't been fully compacted yet.
+        let mut parent_db_builder =
             slatedb::DbBuilder::new(parent_db_path.as_str(), Arc::clone(&parent_resolved.store))
-                .with_merge_operator(crate::job_store_shard::counter_merge_operator())
-                .build()
-                .await
-                .map_err(|e| {
-                    ShardFactoryError::CloneError(format!(
-                        "failed to reopen parent DB for cloning: {}",
-                        e
-                    ))
-                })?;
+                .with_merge_operator(crate::job_store_shard::counter_merge_operator());
+        if let Some(wal) = &parent_wal_store {
+            parent_db_builder = parent_db_builder.with_wal_object_store(Arc::clone(wal));
+        }
+        let db = parent_db_builder.build().await.map_err(|e| {
+            ShardFactoryError::CloneError(format!("failed to reopen parent DB for cloning: {}", e))
+        })?;
 
         // Flush to ensure all data is in object storage before checkpointing
         db.flush().await.map_err(|e| {
@@ -613,11 +635,14 @@ impl ShardFactory {
         );
 
         // Clone for left child
-        let left_admin = slatedb::admin::Admin::builder(
+        let mut left_admin_builder = slatedb::admin::Admin::builder(
             left_child_db_path.as_str(),
             Arc::clone(&parent_resolved.store),
-        )
-        .build();
+        );
+        if let Some(wal) = &left_child_wal_store {
+            left_admin_builder = left_admin_builder.with_wal_object_store(Arc::clone(wal));
+        }
+        let left_admin = left_admin_builder.build();
 
         left_admin
             .create_clone(parent_db_path.as_str(), Some(checkpoint.id))
@@ -630,11 +655,14 @@ impl ShardFactory {
             })?;
 
         // Clone for right child
-        let right_admin = slatedb::admin::Admin::builder(
+        let mut right_admin_builder = slatedb::admin::Admin::builder(
             right_child_db_path.as_str(),
             Arc::clone(&parent_resolved.store),
-        )
-        .build();
+        );
+        if let Some(wal) = &right_child_wal_store {
+            right_admin_builder = right_admin_builder.with_wal_object_store(Arc::clone(wal));
+        }
+        let right_admin = right_admin_builder.build();
 
         right_admin
             .create_clone(parent_db_path.as_str(), Some(checkpoint.id))

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -569,6 +569,24 @@ impl ShardFactory {
             ShardFactoryError::CloneError(format!("failed to flush before checkpoint: {}", e))
         })?;
 
+        // Write a sentinel key to force WAL advancement. This ensures
+        // replay_after_wal_id advances to next_wal_sst_id - 1, so clones
+        // don't inherit a WAL gap that references SSTs on the parent's
+        // (now gone) local WAL storage.
+        let sentinel_key = format!(
+            "clone_sentinel_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+        );
+        db.put(sentinel_key.as_bytes(), b"").await.map_err(|e| {
+            ShardFactoryError::CloneError(format!("failed to write clone sentinel: {}", e))
+        })?;
+        db.flush().await.map_err(|e| {
+            ShardFactoryError::CloneError(format!("failed to flush after sentinel write: {}", e))
+        })?;
+
         // Create a single checkpoint shared by both children. Use no lifetime so
         // the checkpoint persists until the children have fully compacted away their
         // dependency on the parent's SSTs.

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -548,21 +548,40 @@ impl ShardFactory {
             &right_child_name,
         )?;
 
+        // Resolve separate WAL object stores if configured. Each shard (parent and
+        // children) gets its own WAL store so that the clone's wal_object_store_uri
+        // is correctly recorded in the manifest.
+        let resolve_wal_store =
+            |shard_name: &str| -> Result<Option<Arc<dyn ObjectStore>>, ShardFactoryError> {
+                if let Some(wal_template) = &self.template.wal {
+                    let wal_path = wal_template
+                        .path
+                        .replace("%shard%", shard_name)
+                        .replace("{shard}", shard_name);
+                    let wal_resolved = resolve_object_store(&wal_template.backend, &wal_path)?;
+                    Ok(Some(wal_resolved.store))
+                } else {
+                    Ok(None)
+                }
+            };
+        let parent_wal_store = resolve_wal_store(&parent_name)?;
+        let left_child_wal_store = resolve_wal_store(&left_child_name)?;
+        let right_child_wal_store = resolve_wal_store(&right_child_name)?;
+
         // Open a raw SlateDB database at the parent's path. The parent shard has been
-        // fully closed (data flushed, WAL cleaned up), so we don't need a WAL. We still
-        // need the merge operator because the parent may contain counter merge entries
-        // that haven't been fully compacted yet.
-        let db =
+        // fully closed (data flushed, WAL cleaned up), but we still need the WAL store
+        // configured so that slatedb can validate the wal_object_store_uri in the manifest.
+        // We still need the merge operator because the parent may contain counter merge
+        // entries that haven't been fully compacted yet.
+        let mut parent_db_builder =
             slatedb::DbBuilder::new(parent_db_path.as_str(), Arc::clone(&parent_resolved.store))
-                .with_merge_operator(crate::job_store_shard::counter_merge_operator())
-                .build()
-                .await
-                .map_err(|e| {
-                    ShardFactoryError::CloneError(format!(
-                        "failed to reopen parent DB for cloning: {}",
-                        e
-                    ))
-                })?;
+                .with_merge_operator(crate::job_store_shard::counter_merge_operator());
+        if let Some(wal) = &parent_wal_store {
+            parent_db_builder = parent_db_builder.with_wal_object_store(Arc::clone(wal));
+        }
+        let db = parent_db_builder.build().await.map_err(|e| {
+            ShardFactoryError::CloneError(format!("failed to reopen parent DB for cloning: {}", e))
+        })?;
 
         // Flush to ensure all data is in object storage before checkpointing
         db.flush().await.map_err(|e| {
@@ -613,11 +632,14 @@ impl ShardFactory {
         );
 
         // Clone for left child
-        let left_admin = slatedb::admin::Admin::builder(
+        let mut left_admin_builder = slatedb::admin::Admin::builder(
             left_child_db_path.as_str(),
             Arc::clone(&parent_resolved.store),
-        )
-        .build();
+        );
+        if let Some(wal) = &left_child_wal_store {
+            left_admin_builder = left_admin_builder.with_wal_object_store(Arc::clone(wal));
+        }
+        let left_admin = left_admin_builder.build();
 
         left_admin
             .create_clone(parent_db_path.as_str(), Some(checkpoint.id))
@@ -630,11 +652,14 @@ impl ShardFactory {
             })?;
 
         // Clone for right child
-        let right_admin = slatedb::admin::Admin::builder(
+        let mut right_admin_builder = slatedb::admin::Admin::builder(
             right_child_db_path.as_str(),
             Arc::clone(&parent_resolved.store),
-        )
-        .build();
+        );
+        if let Some(wal) = &right_child_wal_store {
+            right_admin_builder = right_admin_builder.with_wal_object_store(Arc::clone(wal));
+        }
+        let right_admin = right_admin_builder.build();
 
         right_admin
             .create_clone(parent_db_path.as_str(), Some(checkpoint.id))

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -28,6 +28,7 @@ use helpers::WriteBatcher;
 pub use helpers::now_epoch_ms;
 
 use slatedb::Db;
+use slatedb_common::metrics::DefaultMetricsRecorder;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use thiserror::Error;
@@ -107,6 +108,8 @@ pub struct JobStoreShard {
     db_path: String,
     /// The shard's tenant range, immutable after opening.
     range: ShardRange,
+    /// Metrics recorder for SlateDB, passed to DbBuilder and used for stats collection.
+    slatedb_metrics_recorder: Arc<DefaultMetricsRecorder>,
 }
 
 #[derive(Debug, Error)]
@@ -306,8 +309,10 @@ impl JobStoreShard {
             concurrency_reconcile_interval,
         } = options;
 
+        let slatedb_metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
         let mut db_builder = slatedb::DbBuilder::new(db_path, store.clone())
-            .with_merge_operator(counters::counter_merge_operator());
+            .with_merge_operator(counters::counter_merge_operator())
+            .with_metrics_recorder(slatedb_metrics_recorder.clone());
 
         // Configure separate WAL object store if provided
         if let Some(wal) = wal_store {
@@ -380,6 +385,7 @@ impl JobStoreShard {
             store,
             db_path: db_path.to_string(),
             range: range.clone(),
+            slatedb_metrics_recorder,
         });
 
         // Periodically reconcile pending concurrency requests to self-heal from
@@ -531,8 +537,8 @@ impl JobStoreShard {
 
     /// Get the SlateDB metrics registry for this shard.
     /// Use this to collect storage-level statistics for observability.
-    pub fn slatedb_stats(&self) -> std::sync::Arc<slatedb::stats::StatRegistry> {
-        self.db.metrics()
+    pub fn slatedb_metrics_recorder(&self) -> &Arc<DefaultMetricsRecorder> {
+        &self.slatedb_metrics_recorder
     }
 
     /// Read LSM tree state from the SlateDB manifest.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,7 +31,7 @@ use prometheus::{
     Counter, CounterVec, Encoder, Gauge, GaugeVec, HistogramOpts, HistogramVec, Opts, Registry,
     TextEncoder, core::Collector,
 };
-use slatedb::stats::StatRegistry;
+use slatedb_common::metrics::{DefaultMetricsRecorder, MetricValue};
 use tokio::sync::broadcast;
 use tracing::{debug, error};
 
@@ -269,14 +269,15 @@ impl Metrics {
     /// Call this periodically (e.g., every second) to sync SlateDB's internal
     /// statistics to Prometheus metrics. Counter-type stats are tracked via deltas
     /// since Prometheus counters only support `inc_by()`, not `set()`.
-    pub fn update_slatedb_stats(&self, shard: &str, stats: &Arc<StatRegistry>) {
+    pub fn update_slatedb_stats(&self, shard: &str, recorder: &DefaultMetricsRecorder) {
         // Counter-type stats: monotonically increasing in SlateDB
+        // REQUEST_COUNT uses an "op" label to distinguish get/scan/flush
+        let labeled_counter_mappings: &[(&str, &[(&str, &str)], &CounterVec)] = &[
+            (slatedb::db_stats::REQUEST_COUNT, &[("op", "get")], &self.slatedb_get_requests),
+            (slatedb::db_stats::REQUEST_COUNT, &[("op", "scan")], &self.slatedb_scan_requests),
+            (slatedb::db_stats::REQUEST_COUNT, &[("op", "flush")], &self.slatedb_flush_requests),
+        ];
         let counter_mappings: &[(&str, &CounterVec)] = &[
-            (slatedb::db_stats::GET_REQUESTS, &self.slatedb_get_requests),
-            (
-                slatedb::db_stats::SCAN_REQUESTS,
-                &self.slatedb_scan_requests,
-            ),
             (slatedb::db_stats::WRITE_OPS, &self.slatedb_write_ops),
             (
                 slatedb::db_stats::WRITE_BATCH_COUNT,
@@ -295,22 +296,18 @@ impl Metrics {
                 &self.slatedb_immutable_memtable_flushes,
             ),
             (
-                slatedb::db_stats::SST_FILTER_POSITIVES,
+                slatedb::db_stats::SST_FILTER_POSITIVE_COUNT,
                 &self.slatedb_sst_filter_positives,
             ),
             (
-                slatedb::db_stats::SST_FILTER_NEGATIVES,
+                slatedb::db_stats::SST_FILTER_NEGATIVE_COUNT,
                 &self.slatedb_sst_filter_negatives,
             ),
             (
-                slatedb::db_stats::SST_FILTER_FALSE_POSITIVES,
+                slatedb::db_stats::SST_FILTER_FALSE_POSITIVE_COUNT,
                 &self.slatedb_sst_filter_false_positives,
             ),
             ("compactor/bytes_compacted", &self.slatedb_bytes_compacted),
-            (
-                slatedb::db_stats::FLUSH_REQUESTS,
-                &self.slatedb_flush_requests,
-            ),
             ("dbcache/data_block_hit", &self.slatedb_cache_data_block_hit),
             (
                 "dbcache/data_block_miss",
@@ -343,24 +340,61 @@ impl Metrics {
             ),
         ];
 
+        let snapshot = recorder.snapshot();
+
         {
             let mut prev_values = self.slatedb_prev_values.lock().expect("lock poisoned");
-            for (stat_name, counter) in counter_mappings {
-                if let Some(stat) = stats.lookup(stat_name) {
-                    let current = stat.get() as f64;
-                    let key = (stat_name.to_string(), shard.to_string());
-                    let prev = prev_values.get(&key).copied().unwrap_or(0.0);
-                    if current > prev {
-                        counter.with_label_values(&[shard]).inc_by(current - prev);
+
+            // Helper to extract a numeric value from a metric
+            let extract_value = |metric: &slatedb_common::metrics::Metric| -> Option<f64> {
+                match &metric.value {
+                    MetricValue::Counter(v) => Some(*v as f64),
+                    MetricValue::Gauge(v) => Some(*v as f64),
+                    MetricValue::UpDownCounter(v) => Some(*v as f64),
+                    MetricValue::Histogram { .. } => None,
+                }
+            };
+
+            // Labeled counters (REQUEST_COUNT with op label)
+            for (stat_name, labels, counter) in labeled_counter_mappings {
+                if let Some(metric) = snapshot.by_name_and_labels(stat_name, labels) {
+                    if let Some(current) = extract_value(metric) {
+                        // Use stat_name + labels as key to distinguish get/scan/flush
+                        let label_suffix = labels.iter().map(|(k, v)| format!("{k}={v}")).collect::<Vec<_>>().join(",");
+                        let key = (format!("{stat_name}/{label_suffix}"), shard.to_string());
+                        let prev = prev_values.get(&key).copied().unwrap_or(0.0);
+                        if current > prev {
+                            counter.with_label_values(&[shard]).inc_by(current - prev);
+                        }
+                        prev_values.insert(key, current);
                     }
-                    prev_values.insert(key, current);
+                }
+            }
+
+            // Unlabeled counters
+            for (stat_name, counter) in counter_mappings {
+                if let Some(metric) = snapshot.by_name(stat_name).first() {
+                    if let Some(current) = extract_value(metric) {
+                        let key = (stat_name.to_string(), shard.to_string());
+                        let prev = prev_values.get(&key).copied().unwrap_or(0.0);
+                        if current > prev {
+                            counter.with_label_values(&[shard]).inc_by(current - prev);
+                        }
+                        prev_values.insert(key, current);
+                    }
                 }
             }
         }
 
         for (stat_name, gauge) in gauge_mappings {
-            if let Some(stat) = stats.lookup(stat_name) {
-                gauge.with_label_values(&[shard]).set(stat.get() as f64);
+            if let Some(metric) = snapshot.by_name(stat_name).first() {
+                let value = match &metric.value {
+                    MetricValue::Counter(v) => *v as f64,
+                    MetricValue::Gauge(v) => *v as f64,
+                    MetricValue::UpDownCounter(v) => *v as f64,
+                    MetricValue::Histogram { .. } => continue,
+                };
+                gauge.with_label_values(&[shard]).set(value);
             }
         }
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -273,9 +273,21 @@ impl Metrics {
         // Counter-type stats: monotonically increasing in SlateDB
         // REQUEST_COUNT uses an "op" label to distinguish get/scan/flush
         let labeled_counter_mappings: &[(&str, &[(&str, &str)], &CounterVec)] = &[
-            (slatedb::db_stats::REQUEST_COUNT, &[("op", "get")], &self.slatedb_get_requests),
-            (slatedb::db_stats::REQUEST_COUNT, &[("op", "scan")], &self.slatedb_scan_requests),
-            (slatedb::db_stats::REQUEST_COUNT, &[("op", "flush")], &self.slatedb_flush_requests),
+            (
+                slatedb::db_stats::REQUEST_COUNT,
+                &[("op", "get")],
+                &self.slatedb_get_requests,
+            ),
+            (
+                slatedb::db_stats::REQUEST_COUNT,
+                &[("op", "scan")],
+                &self.slatedb_scan_requests,
+            ),
+            (
+                slatedb::db_stats::REQUEST_COUNT,
+                &[("op", "flush")],
+                &self.slatedb_flush_requests,
+            ),
         ];
         let counter_mappings: &[(&str, &CounterVec)] = &[
             (slatedb::db_stats::WRITE_OPS, &self.slatedb_write_ops),
@@ -307,16 +319,44 @@ impl Metrics {
                 slatedb::db_stats::SST_FILTER_FALSE_POSITIVE_COUNT,
                 &self.slatedb_sst_filter_false_positives,
             ),
-            ("compactor/bytes_compacted", &self.slatedb_bytes_compacted),
-            ("dbcache/data_block_hit", &self.slatedb_cache_data_block_hit),
             (
-                "dbcache/data_block_miss",
+                slatedb::compactor::stats::BYTES_COMPACTED,
+                &self.slatedb_bytes_compacted,
+            ),
+        ];
+
+        // Labeled cache counters (ACCESS_COUNT with entry_kind + result labels)
+        let labeled_counter_mappings_cache: &[(&str, &[(&str, &str)], &CounterVec)] = &[
+            (
+                slatedb::db_cache_stats::ACCESS_COUNT,
+                &[("entry_kind", "data_block"), ("result", "hit")],
+                &self.slatedb_cache_data_block_hit,
+            ),
+            (
+                slatedb::db_cache_stats::ACCESS_COUNT,
+                &[("entry_kind", "data_block"), ("result", "miss")],
                 &self.slatedb_cache_data_block_miss,
             ),
-            ("dbcache/index_hit", &self.slatedb_cache_index_hit),
-            ("dbcache/index_miss", &self.slatedb_cache_index_miss),
-            ("dbcache/filter_hit", &self.slatedb_cache_filter_hit),
-            ("dbcache/filter_miss", &self.slatedb_cache_filter_miss),
+            (
+                slatedb::db_cache_stats::ACCESS_COUNT,
+                &[("entry_kind", "index"), ("result", "hit")],
+                &self.slatedb_cache_index_hit,
+            ),
+            (
+                slatedb::db_cache_stats::ACCESS_COUNT,
+                &[("entry_kind", "index"), ("result", "miss")],
+                &self.slatedb_cache_index_miss,
+            ),
+            (
+                slatedb::db_cache_stats::ACCESS_COUNT,
+                &[("entry_kind", "filter"), ("result", "hit")],
+                &self.slatedb_cache_filter_hit,
+            ),
+            (
+                slatedb::db_cache_stats::ACCESS_COUNT,
+                &[("entry_kind", "filter"), ("result", "miss")],
+                &self.slatedb_cache_filter_miss,
+            ),
         ];
 
         // Gauge-type stats: point-in-time values
@@ -326,11 +366,11 @@ impl Metrics {
                 &self.slatedb_wal_buffer_estimated_bytes,
             ),
             (
-                "compactor/running_compactions",
+                slatedb::compactor::stats::RUNNING_COMPACTIONS,
                 &self.slatedb_running_compactions,
             ),
             (
-                "compactor/last_compaction_timestamp_sec",
+                slatedb::compactor::stats::LAST_COMPACTION_TS_SEC,
                 &self.slatedb_last_compaction_ts_sec,
             ),
             (slatedb::db_stats::L0_SST_COUNT, &self.slatedb_l0_sst_count),
@@ -355,12 +395,19 @@ impl Metrics {
                 }
             };
 
-            // Labeled counters (REQUEST_COUNT with op label)
-            for (stat_name, labels, counter) in labeled_counter_mappings {
+            // Labeled counters (REQUEST_COUNT with op label, ACCESS_COUNT with entry_kind/result labels)
+            for (stat_name, labels, counter) in labeled_counter_mappings
+                .iter()
+                .chain(labeled_counter_mappings_cache.iter())
+            {
                 if let Some(metric) = snapshot.by_name_and_labels(stat_name, labels) {
                     if let Some(current) = extract_value(metric) {
                         // Use stat_name + labels as key to distinguish get/scan/flush
-                        let label_suffix = labels.iter().map(|(k, v)| format!("{k}={v}")).collect::<Vec<_>>().join(",");
+                        let label_suffix = labels
+                            .iter()
+                            .map(|(k, v)| format!("{k}={v}"))
+                            .collect::<Vec<_>>()
+                            .join(",");
                         let key = (format!("{stat_name}/{label_suffix}"), shard.to_string());
                         let prev = prev_values.get(&key).copied().unwrap_or(0.0);
                         if current > prev {

--- a/src/server.rs
+++ b/src/server.rs
@@ -2018,8 +2018,8 @@ where
 
                         // Collect SlateDB storage metrics for this shard
                         if let Some(ref m) = reaper_metrics {
-                            let stats = shard.slatedb_stats();
-                            m.update_slatedb_stats(&shard_id.to_string(), &stats);
+                            let recorder = shard.slatedb_metrics_recorder();
+                            m.update_slatedb_stats(&shard_id.to_string(), recorder);
                         }
                     }
                 }

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -273,6 +273,79 @@ async fn clone_closed_shard_creates_copies() {
     );
 }
 
+/// When the parent shard has a separate WAL configured, cloning should propagate
+/// WAL stores to the children so they can open without hitting
+/// "wal store reconfiguration unsupported".
+#[silo::test]
+async fn clone_closed_shard_with_split_wal() {
+    let data_tmp = tempfile::tempdir().unwrap();
+    let wal_tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory_with_wal(&data_tmp, &wal_tmp);
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+
+    // Write data so the shard has WAL activity
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("wal-test-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"wal": true})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+
+    // Close parent (clone_closed_shard expects it to be closed)
+    parent.close().await.expect("close parent");
+
+    // Clone the shard — this should succeed even with split WAL
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard with WAL");
+
+    // Open the children — this is where "wal store reconfiguration unsupported"
+    // would occur if the clone didn't properly configure the WAL store
+    let left_child = factory
+        .open(&left_child_id, &ShardRange::full())
+        .await
+        .expect("open left child with WAL");
+
+    let left_counters = left_child
+        .get_counters()
+        .await
+        .expect("get left child counters");
+    assert_eq!(
+        left_counters.total_jobs, 1,
+        "left child should have the parent's job"
+    );
+
+    let right_child = factory
+        .open(&right_child_id, &ShardRange::full())
+        .await
+        .expect("open right child with WAL");
+
+    let right_counters = right_child
+        .get_counters()
+        .await
+        .expect("get right child counters");
+    assert_eq!(
+        right_counters.total_jobs, 1,
+        "right child should have the parent's job"
+    );
+}
+
 // --- template path validation tests ---
 
 #[silo::test]

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -403,10 +403,8 @@ async fn test_metrics_slatedb_stats() {
         body_str.contains("# TYPE silo_slatedb_wal_buffer_estimated_bytes gauge"),
         "wal_buffer_estimated_bytes should be a gauge type"
     );
-    assert!(
-        body_str.contains("# TYPE silo_slatedb_running_compactions gauge"),
-        "running_compactions should be a gauge type"
-    );
+    // running_compactions is only emitted when compaction actually runs,
+    // so we can't assert its TYPE line in a short-lived test DB.
 
     // Verify counter values are non-zero after writes and reads
     let find_line = |substrings: &[&str]| -> Option<String> {

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -363,12 +363,15 @@ async fn test_metrics_all_recording_methods() {
 async fn test_metrics_slatedb_stats() {
     let (metrics, _app) = create_metrics_router();
 
-    // Create a real SlateDB to get a StatRegistry with actual stats
+    // Create a real SlateDB with a metrics recorder
     let tmpdir = tempfile::tempdir().unwrap();
     let object_store = std::sync::Arc::new(
         object_store::local::LocalFileSystem::new_with_prefix(tmpdir.path()).unwrap(),
     );
-    let db = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store)
+    let recorder = std::sync::Arc::new(slatedb_common::metrics::DefaultMetricsRecorder::new());
+    let db = slatedb::DbBuilder::new("test-db", object_store)
+        .with_metrics_recorder(recorder.clone())
+        .build()
         .await
         .unwrap();
 
@@ -377,8 +380,7 @@ async fn test_metrics_slatedb_stats() {
     db.put(b"key2", b"value2").await.unwrap();
     let _ = db.get(b"key1").await;
 
-    let stat_registry = db.metrics();
-    metrics.update_slatedb_stats("0", &stat_registry);
+    metrics.update_slatedb_stats("0", &recorder);
 
     let body_str = gather_metrics_text(&metrics);
 
@@ -443,14 +445,16 @@ async fn test_metrics_slatedb_counter_delta_tracking() {
     let object_store = std::sync::Arc::new(
         object_store::local::LocalFileSystem::new_with_prefix(tmpdir.path()).unwrap(),
     );
-    let db = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store)
+    let recorder = std::sync::Arc::new(slatedb_common::metrics::DefaultMetricsRecorder::new());
+    let db = slatedb::DbBuilder::new("test-db", object_store)
+        .with_metrics_recorder(recorder.clone())
+        .build()
         .await
         .unwrap();
 
     // First batch of writes
     db.put(b"key1", b"value1").await.unwrap();
-    let stat_registry = db.metrics();
-    metrics.update_slatedb_stats("0", &stat_registry);
+    metrics.update_slatedb_stats("0", &recorder);
 
     let body1 = gather_metrics_text(&metrics);
     let write_ops_1 =
@@ -460,7 +464,7 @@ async fn test_metrics_slatedb_counter_delta_tracking() {
     // Second batch of writes — delta tracking should accumulate, not reset
     db.put(b"key2", b"value2").await.unwrap();
     db.put(b"key3", b"value3").await.unwrap();
-    metrics.update_slatedb_stats("0", &stat_registry);
+    metrics.update_slatedb_stats("0", &recorder);
 
     let body2 = gather_metrics_text(&metrics);
     let write_ops_2 =
@@ -473,7 +477,7 @@ async fn test_metrics_slatedb_counter_delta_tracking() {
     );
 
     // Calling update again without new writes should not change the counter
-    metrics.update_slatedb_stats("0", &stat_registry);
+    metrics.update_slatedb_stats("0", &recorder);
     let body3 = gather_metrics_text(&metrics);
     let write_ops_3 =
         extract_metric_value(&body3, &["silo_slatedb_write_ops_total", "shard=\"0\""]);
@@ -493,7 +497,10 @@ async fn test_metrics_slatedb_multiple_shards() {
     let object_store1 = std::sync::Arc::new(
         object_store::local::LocalFileSystem::new_with_prefix(tmpdir1.path()).unwrap(),
     );
-    let db1 = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store1)
+    let recorder1 = std::sync::Arc::new(slatedb_common::metrics::DefaultMetricsRecorder::new());
+    let db1 = slatedb::DbBuilder::new("test-db", object_store1)
+        .with_metrics_recorder(recorder1.clone())
+        .build()
         .await
         .unwrap();
 
@@ -501,7 +508,10 @@ async fn test_metrics_slatedb_multiple_shards() {
     let object_store2 = std::sync::Arc::new(
         object_store::local::LocalFileSystem::new_with_prefix(tmpdir2.path()).unwrap(),
     );
-    let db2 = slatedb::Db::open(object_store::path::Path::from("test-db"), object_store2)
+    let recorder2 = std::sync::Arc::new(slatedb_common::metrics::DefaultMetricsRecorder::new());
+    let db2 = slatedb::DbBuilder::new("test-db", object_store2)
+        .with_metrics_recorder(recorder2.clone())
+        .build()
         .await
         .unwrap();
 
@@ -510,8 +520,8 @@ async fn test_metrics_slatedb_multiple_shards() {
     db2.put(b"b", b"2").await.unwrap();
     db2.put(b"c", b"3").await.unwrap();
 
-    metrics.update_slatedb_stats("shard-a", &db1.metrics());
-    metrics.update_slatedb_stats("shard-b", &db2.metrics());
+    metrics.update_slatedb_stats("shard-a", &recorder1);
+    metrics.update_slatedb_stats("shard-b", &recorder2);
 
     let body = gather_metrics_text(&metrics);
     let shard_a_writes = extract_metric_value(


### PR DESCRIPTION
During shard splits, the clone's manifest can inherit a WAL SST gap from the parent (replay_after_wal_id < next_wal_sst_id - 1). When the child opens with a fresh empty WAL directory, slatedb tries to replay WAL SSTs that don't exist and crashes with "file not found."

Writing a sentinel key + flushing before the checkpoint forces replay_after_wal_id to advance past all WAL SSTs, closing the gap. The clone then inherits a clean state with nothing to replay.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes shard split/clone behavior around WAL handling and checkpointing, and upgrades the `slatedb` dependency/metrics APIs which directly affect storage correctness and observability.
> 
> **Overview**
> Fixes shard-split cloning so child shards don’t inherit a parent WAL SST gap: `clone_closed_shard` now writes/deletes a sentinel key and checkpoints with `CheckpointScope::All` to advance `replay_after_wal_id`, and it propagates per-shard WAL object stores (parent + children) when split WAL storage is configured.
> 
> Upgrades `slatedb` to the upstream `main` branch and adds `slatedb-common`, wiring SlateDB metrics through a `DefaultMetricsRecorder` stored on each shard and updating Prometheus collection to read from recorder snapshots (including new labeled request/cache counters). Tests are updated and a new regression test covers cloning with split WAL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c310a850881cad8d0bce775542c9eb657bde0925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->