### PR TITLE
Upgrade slatedb to 0.12.0 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5499,8 +5499,9 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slatedb"
-version = "0.11.1"
-source = "git+https://github.com/slatedb/slatedb.git?branch=main#a69999a8d1326947d56faa8ba0fd6a47683ba91a"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c5a80caa3ae5d5ca404b3c22a4d7ba235798a011641eda24b629d1b7fc203dc"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5546,8 +5547,9 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.11.1"
-source = "git+https://github.com/slatedb/slatedb.git?branch=main#a69999a8d1326947d56faa8ba0fd6a47683ba91a"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f4df716813038071acf5a21046494493dcce21e8d1b90d04035d01a23e45c2"
 dependencies = [
  "chrono",
  "log",
@@ -5557,8 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.11.1"
-source = "git+https://github.com/slatedb/slatedb.git?branch=main#a69999a8d1326947d56faa8ba0fd6a47683ba91a"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be31b387569b0d71ea08b0ad94ed8cb0c2e8cb8b31e737086c79bbe90c978249"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ version = "0.2.0"
 [dependencies]
 clap = { version = "4.3.14", features = ["derive", "env"] }
 futures = "0.3"
-slatedb = { git = "https://github.com/slatedb/slatedb.git", branch = "main" }
-slatedb-common = { git = "https://github.com/slatedb/slatedb.git", branch = "main" }
+slatedb = "0.12.0"
+slatedb-common = "0.12.0"
 object_store = { version = "0.12", features = ["gcp"] }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Upgrade slatedb from git main (0.11.1) to published crates.io release 0.12.0
- Switch from tracking a moving git branch to a stable versioned dependency
- No code changes required — the API is compatible

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes (no new warnings)
- [x] All non-etcd/k8s tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades a core storage dependency (`slatedb`) and switches from a moving git `main` ref to a pinned crates.io release; behavior changes come solely from the new upstream version.
> 
> **Overview**
> Moves `slatedb` and `slatedb-common` dependencies from tracking the git `main` branch to the crates.io `0.12.0` release.
> 
> Updates `Cargo.lock` accordingly (including `slatedb-txn-obj`) to use registry sources and checksums instead of git commit pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e8ecb615359ab84234e54f95b05809911e9c29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->