### PR TITLE
Wire up gRPC request metrics via Tower layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ http-body-util = "0.1"
 axum = "0.7"
 askama = "0.12"
 askama_axum = "0.4"
+tower = "0.4"
 tower-http = { version = "0.5", features = ["fs"] }
 rand = "0.9"
 datafusion-sql = "50"

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -202,8 +202,8 @@ impl JobStoreShard {
 
             // Commit durable state — write_with_options with await_durable:true blocks
             // until the WAL is flushed to object storage, so no separate flush is needed.
-            if !state.batch.is_empty() {
-                if let Err(e) = self
+            if !state.batch.is_empty()
+                && let Err(e) = self
                     .db
                     .write_with_options(
                         state.batch,
@@ -212,16 +212,15 @@ impl JobStoreShard {
                         },
                     )
                     .await
-                {
-                    dst_events::cancel_write(write_op);
-                    // Rollback all grants made during this iteration
-                    for (tenant, queue, task_id) in &grants_to_rollback {
-                        self.concurrency.rollback_grant(tenant, queue, task_id);
-                    }
-                    // Put back all claimed entries since we didn't lease them durably
-                    self.brokers.requeue(claimed);
-                    return Err(JobStoreShardError::Slate(e));
+            {
+                dst_events::cancel_write(write_op);
+                // Rollback all grants made during this iteration
+                for (tenant, queue, task_id) in &grants_to_rollback {
+                    self.concurrency.rollback_grant(tenant, queue, task_id);
                 }
+                // Put back all claimed entries since we didn't lease them durably
+                self.brokers.requeue(claimed);
+                return Err(JobStoreShardError::Slate(e));
             }
             dst_events::confirm_write(write_op);
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -23,8 +23,11 @@
 //! ```
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 
 use axum::{Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
 use prometheus::{
@@ -33,6 +36,7 @@ use prometheus::{
 };
 use slatedb_common::metrics::{DefaultMetricsRecorder, MetricValue};
 use tokio::sync::broadcast;
+use tower::{Layer, Service};
 use tracing::{debug, error};
 
 /// Default histogram buckets for request latencies (in seconds)
@@ -400,35 +404,35 @@ impl Metrics {
                 .iter()
                 .chain(labeled_counter_mappings_cache.iter())
             {
-                if let Some(metric) = snapshot.by_name_and_labels(stat_name, labels) {
-                    if let Some(current) = extract_value(metric) {
-                        // Use stat_name + labels as key to distinguish get/scan/flush
-                        let label_suffix = labels
-                            .iter()
-                            .map(|(k, v)| format!("{k}={v}"))
-                            .collect::<Vec<_>>()
-                            .join(",");
-                        let key = (format!("{stat_name}/{label_suffix}"), shard.to_string());
-                        let prev = prev_values.get(&key).copied().unwrap_or(0.0);
-                        if current > prev {
-                            counter.with_label_values(&[shard]).inc_by(current - prev);
-                        }
-                        prev_values.insert(key, current);
+                if let Some(metric) = snapshot.by_name_and_labels(stat_name, labels)
+                    && let Some(current) = extract_value(metric)
+                {
+                    // Use stat_name + labels as key to distinguish get/scan/flush
+                    let label_suffix = labels
+                        .iter()
+                        .map(|(k, v)| format!("{k}={v}"))
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    let key = (format!("{stat_name}/{label_suffix}"), shard.to_string());
+                    let prev = prev_values.get(&key).copied().unwrap_or(0.0);
+                    if current > prev {
+                        counter.with_label_values(&[shard]).inc_by(current - prev);
                     }
+                    prev_values.insert(key, current);
                 }
             }
 
             // Unlabeled counters
             for (stat_name, counter) in counter_mappings {
-                if let Some(metric) = snapshot.by_name(stat_name).first() {
-                    if let Some(current) = extract_value(metric) {
-                        let key = (stat_name.to_string(), shard.to_string());
-                        let prev = prev_values.get(&key).copied().unwrap_or(0.0);
-                        if current > prev {
-                            counter.with_label_values(&[shard]).inc_by(current - prev);
-                        }
-                        prev_values.insert(key, current);
+                if let Some(metric) = snapshot.by_name(stat_name).first()
+                    && let Some(current) = extract_value(metric)
+                {
+                    let key = (stat_name.to_string(), shard.to_string());
+                    let prev = prev_values.get(&key).copied().unwrap_or(0.0);
+                    if current > prev {
+                        counter.with_label_values(&[shard]).inc_by(current - prev);
                     }
+                    prev_values.insert(key, current);
                 }
             }
         }
@@ -1028,4 +1032,95 @@ pub async fn run_metrics_server(
         .await?;
 
     Ok(())
+}
+
+/// Tower layer that records `silo_grpc_requests_total` and
+/// `silo_grpc_request_duration_seconds` for every gRPC request.
+///
+/// When metrics are `None` the layer is a no-op passthrough.
+#[derive(Clone)]
+pub struct GrpcMetricsLayer {
+    metrics: Option<Metrics>,
+}
+
+impl GrpcMetricsLayer {
+    pub fn new(metrics: Option<Metrics>) -> Self {
+        Self { metrics }
+    }
+}
+
+impl<S> Layer<S> for GrpcMetricsLayer {
+    type Service = GrpcMetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        GrpcMetricsService {
+            inner,
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
+/// Tower service that wraps an inner service and records gRPC metrics.
+#[derive(Clone)]
+pub struct GrpcMetricsService<S> {
+    inner: S,
+    metrics: Option<Metrics>,
+}
+
+type HttpRequest<T> = tonic::codegen::http::Request<T>;
+type HttpResponse<T> = tonic::codegen::http::Response<T>;
+
+impl<S, ReqBody, ResBody> Service<HttpRequest<ReqBody>> for GrpcMetricsService<S>
+where
+    S: Service<HttpRequest<ReqBody>, Response = HttpResponse<ResBody>> + Clone + Send + 'static,
+    <S as Service<HttpRequest<ReqBody>>>::Future: Send + 'static,
+    <S as Service<HttpRequest<ReqBody>>>::Error: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = HttpResponse<ResBody>;
+    type Error = <S as Service<HttpRequest<ReqBody>>>::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: HttpRequest<ReqBody>) -> Self::Future {
+        let metrics = self.metrics.clone();
+        // Extract method name before req is moved into the inner call.
+        // The path string is borrowed from the request URI so we only allocate
+        // when metrics are enabled.
+        let method = if metrics.is_some() {
+            let path = req.uri().path();
+            Some(
+                path.rsplit_once('/')
+                    .map(|(_, m)| m.to_owned())
+                    .unwrap_or_else(|| path.to_owned()),
+            )
+        } else {
+            None
+        };
+        // Clone a fresh service for future poll_ready calls, then swap so we
+        // use the already-ready instance for this call.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        Box::pin(async move {
+            let start = std::time::Instant::now();
+            let result = inner.call(req).await;
+            if let Some(ref m) = metrics {
+                let method = method.as_deref().unwrap_or("unknown");
+                let duration = start.elapsed().as_secs_f64();
+                let status = match &result {
+                    Ok(resp) => tonic::Status::from_header_map(resp.headers())
+                        .map_or(tonic::Code::Ok, |s| s.code())
+                        .description(),
+                    Err(_) => "INTERNAL",
+                };
+                m.record_grpc_request(method, status);
+                m.record_grpc_duration(method, duration);
+            }
+            result
+        })
+    }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1034,6 +1034,30 @@ pub async fn run_metrics_server(
     Ok(())
 }
 
+/// Map a tonic status code to a short uppercase label matching the gRPC spec
+/// (e.g. "OK", "NOT_FOUND", "INTERNAL").
+fn grpc_code_label(code: tonic::Code) -> &'static str {
+    match code {
+        tonic::Code::Ok => "OK",
+        tonic::Code::Cancelled => "CANCELLED",
+        tonic::Code::Unknown => "UNKNOWN",
+        tonic::Code::InvalidArgument => "INVALID_ARGUMENT",
+        tonic::Code::DeadlineExceeded => "DEADLINE_EXCEEDED",
+        tonic::Code::NotFound => "NOT_FOUND",
+        tonic::Code::AlreadyExists => "ALREADY_EXISTS",
+        tonic::Code::PermissionDenied => "PERMISSION_DENIED",
+        tonic::Code::ResourceExhausted => "RESOURCE_EXHAUSTED",
+        tonic::Code::FailedPrecondition => "FAILED_PRECONDITION",
+        tonic::Code::Aborted => "ABORTED",
+        tonic::Code::OutOfRange => "OUT_OF_RANGE",
+        tonic::Code::Unimplemented => "UNIMPLEMENTED",
+        tonic::Code::Internal => "INTERNAL",
+        tonic::Code::Unavailable => "UNAVAILABLE",
+        tonic::Code::DataLoss => "DATA_LOSS",
+        tonic::Code::Unauthenticated => "UNAUTHENTICATED",
+    }
+}
+
 /// Tower layer that records `silo_grpc_requests_total` and
 /// `silo_grpc_request_duration_seconds` for every gRPC request.
 ///
@@ -1111,12 +1135,12 @@ where
             if let Some(ref m) = metrics {
                 let method = method.as_deref().unwrap_or("unknown");
                 let duration = start.elapsed().as_secs_f64();
-                let status = match &result {
+                let code = match &result {
                     Ok(resp) => tonic::Status::from_header_map(resp.headers())
-                        .map_or(tonic::Code::Ok, |s| s.code())
-                        .description(),
-                    Err(_) => "INTERNAL",
+                        .map_or(tonic::Code::Ok, |s| s.code()),
+                    Err(_) => tonic::Code::Internal,
                 };
+                let status = grpc_code_label(code);
                 m.record_grpc_request(method, status);
                 m.record_grpc_duration(method, duration);
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2047,6 +2047,7 @@ where
         // evicted streams cause RST_STREAM with code 5 (STREAM_CLOSED)
         // on late frames, which surfaces as gRPC INTERNAL errors.
         .http2_max_pending_accept_reset_streams(Some(1000))
+        .layer(crate::metrics::GrpcMetricsLayer::new(metrics.clone()))
         .add_service(health_service)
         .add_service(reflection_service)
         .add_service(server)


### PR DESCRIPTION
## Summary
- The `silo_grpc_requests_total` and `silo_grpc_request_duration_seconds` Prometheus metrics were defined but never recorded
- Adds a `GrpcMetricsLayer` Tower layer applied to the tonic server that instruments every gRPC request with method name, status code, and latency
- Uses `tonic::Status::from_header_map()` for status extraction, gates allocations behind metrics-enabled check

## Test plan
- [x] `cargo build` compiles clean
- [x] `cargo clippy` — no new warnings
- [x] Core test suites pass (metrics, enqueue, dequeue, cancel, shard_range)
- [ ] Verify metrics appear in `/metrics` endpoint with a running server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wraps the tonic server with a new Tower layer, affecting the request path for all gRPC calls; while intended to be no-op when metrics are disabled, any middleware bug could impact latency or error handling.
> 
> **Overview**
> Adds a `GrpcMetricsLayer`/`GrpcMetricsService` Tower middleware that records `silo_grpc_requests_total` (labeled by method and gRPC status) and `silo_grpc_request_duration_seconds` for every gRPC request, extracting the status from response headers and minimizing allocations when metrics are disabled.
> 
> Wires this layer into the tonic server builder, and includes small control-flow refactors (Rust `let`-chains) in dequeue commit error handling and SlateDB metric polling logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a864e0b4e42f34e297d14cea56de1b5e6edee7a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->