### PR TITLE
Enable cache_blocks on hot scan paths to cache SST indexes

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -144,7 +144,9 @@ impl ConcurrencyCounts {
         // Scan holders for this specific tenant/queue using the queue prefix
         let start = concurrency_holders_queue_prefix(tenant, queue);
         let end = end_bound(&start);
-        let mut iter: DbIterator = db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut iter: DbIterator = db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
 
         let mut task_ids = Vec::new();
         loop {
@@ -692,7 +694,10 @@ impl ConcurrencyManager {
     pub async fn reconcile_pending_requests(&self, db: &Db, range: &ShardRange) {
         let start = concurrency_requests_prefix();
         let end = end_bound(&start);
-        let mut iter = match db.scan::<Vec<u8>, _>(start..end).await {
+        let mut iter = match db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await
+        {
             Ok(i) => i,
             Err(e) => {
                 tracing::warn!(
@@ -767,7 +772,10 @@ impl ConcurrencyManager {
         // [SILO-GRANT-2] Pre: Scan for pending requests for this queue
         let start = concurrency_request_prefix(tenant, queue);
         let end_key = end_bound(&start);
-        let mut iter = match db.scan::<Vec<u8>, _>(start..end_key).await {
+        let mut iter = match db
+            .scan_with_options::<Vec<u8>, _>(start..end_key, &crate::scan_options())
+            .await
+        {
             Ok(i) => i,
             Err(e) => {
                 tracing::warn!(error = %e, "grant scanner: failed to scan requests");

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -202,8 +202,8 @@ impl JobStoreShard {
 
             // Commit durable state — write_with_options with await_durable:true blocks
             // until the WAL is flushed to object storage, so no separate flush is needed.
-            if !state.batch.is_empty() {
-                if let Err(e) = self
+            if !state.batch.is_empty()
+                && let Err(e) = self
                     .db
                     .write_with_options(
                         state.batch,
@@ -212,16 +212,15 @@ impl JobStoreShard {
                         },
                     )
                     .await
-                {
-                    dst_events::cancel_write(write_op);
-                    // Rollback all grants made during this iteration
-                    for (tenant, queue, task_id) in &grants_to_rollback {
-                        self.concurrency.rollback_grant(tenant, queue, task_id);
-                    }
-                    // Put back all claimed entries since we didn't lease them durably
-                    self.brokers.requeue(claimed);
-                    return Err(JobStoreShardError::Slate(e));
+            {
+                dst_events::cancel_write(write_op);
+                // Rollback all grants made during this iteration
+                for (tenant, queue, task_id) in &grants_to_rollback {
+                    self.concurrency.rollback_grant(tenant, queue, task_id);
                 }
+                // Put back all claimed entries since we didn't lease them durably
+                self.brokers.requeue(claimed);
+                return Err(JobStoreShardError::Slate(e));
             }
             dst_events::confirm_write(write_op);
 
@@ -736,7 +735,10 @@ impl JobStoreShard {
         // Scan tasks under tasks/{task_group}/ using binary storekey encoding
         let start = crate::keys::task_group_prefix(task_group);
         let end = crate::keys::end_bound(&start);
-        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut iter: DbIterator = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
 
         let mut tasks: Vec<Task> = Vec::with_capacity(max_tasks);
         let mut keys: Vec<Vec<u8>> = Vec::with_capacity(max_tasks);

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -365,7 +365,10 @@ impl JobStoreShard {
         // Scan all lease keys using the binary prefix
         let start = crate::keys::leases_prefix();
         let end = crate::keys::end_bound(&start);
-        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut iter: DbIterator = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
 
         let now_ms = now_epoch_ms();
         let mut reaped: usize = 0;

--- a/src/job_store_shard/scan.rs
+++ b/src/job_store_shard/scan.rs
@@ -32,7 +32,9 @@ async fn scan_collect<T>(
         return Ok(Vec::new());
     }
 
-    let mut iter = db.scan::<Vec<u8>, _>(start..end).await?;
+    let mut iter = db
+        .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+        .await?;
     let capacity = limit.unwrap_or(1024).min(1024);
     let mut out = Vec::with_capacity(capacity);
 
@@ -299,7 +301,10 @@ impl JobStoreShard {
         }
         let start = job_info_prefix(tenant);
         let end = end_bound(&start);
-        let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
         let capacity = limit.unwrap_or(1024).min(1024);
         let mut out = Vec::with_capacity(capacity);
         loop {
@@ -328,7 +333,10 @@ impl JobStoreShard {
         }
         let start = jobs_prefix();
         let end = end_bound(&start);
-        let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
         let capacity = limit.unwrap_or(1024).min(1024);
         let mut out = Vec::with_capacity(capacity);
         loop {
@@ -358,7 +366,10 @@ impl JobStoreShard {
         }
         let start = job_status_prefix(tenant);
         let end = end_bound(&start);
-        let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
         let capacity = limit.unwrap_or(1024).min(1024);
         let mut out = Vec::with_capacity(capacity);
         loop {
@@ -390,7 +401,10 @@ impl JobStoreShard {
         }
         let start = jobs_status_prefix();
         let end = end_bound(&start);
-        let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
         let capacity = limit.unwrap_or(1024).min(1024);
         let mut out = Vec::with_capacity(capacity);
         loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,3 +41,14 @@ pub mod pb {
 }
 pub mod server;
 pub mod siloctl;
+
+/// Default scan options for all silo scans.
+///
+/// SlateDB defaults `cache_blocks` to `false` for scans to avoid cache pollution
+/// from large sequential reads. However, silo's scans are repeated, short-range
+/// prefix scans over the same SSTs, so caching SST indexes (and data blocks) is
+/// critical — without it, every scan re-parses the full flatbuffer SST index,
+/// which dominates CPU under load.
+pub fn scan_options() -> slatedb::config::ScanOptions {
+    slatedb::config::ScanOptions::default().with_cache_blocks(true)
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -400,35 +400,35 @@ impl Metrics {
                 .iter()
                 .chain(labeled_counter_mappings_cache.iter())
             {
-                if let Some(metric) = snapshot.by_name_and_labels(stat_name, labels) {
-                    if let Some(current) = extract_value(metric) {
-                        // Use stat_name + labels as key to distinguish get/scan/flush
-                        let label_suffix = labels
-                            .iter()
-                            .map(|(k, v)| format!("{k}={v}"))
-                            .collect::<Vec<_>>()
-                            .join(",");
-                        let key = (format!("{stat_name}/{label_suffix}"), shard.to_string());
-                        let prev = prev_values.get(&key).copied().unwrap_or(0.0);
-                        if current > prev {
-                            counter.with_label_values(&[shard]).inc_by(current - prev);
-                        }
-                        prev_values.insert(key, current);
+                if let Some(metric) = snapshot.by_name_and_labels(stat_name, labels)
+                    && let Some(current) = extract_value(metric)
+                {
+                    // Use stat_name + labels as key to distinguish get/scan/flush
+                    let label_suffix = labels
+                        .iter()
+                        .map(|(k, v)| format!("{k}={v}"))
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    let key = (format!("{stat_name}/{label_suffix}"), shard.to_string());
+                    let prev = prev_values.get(&key).copied().unwrap_or(0.0);
+                    if current > prev {
+                        counter.with_label_values(&[shard]).inc_by(current - prev);
                     }
+                    prev_values.insert(key, current);
                 }
             }
 
             // Unlabeled counters
             for (stat_name, counter) in counter_mappings {
-                if let Some(metric) = snapshot.by_name(stat_name).first() {
-                    if let Some(current) = extract_value(metric) {
-                        let key = (stat_name.to_string(), shard.to_string());
-                        let prev = prev_values.get(&key).copied().unwrap_or(0.0);
-                        if current > prev {
-                            counter.with_label_values(&[shard]).inc_by(current - prev);
-                        }
-                        prev_values.insert(key, current);
+                if let Some(metric) = snapshot.by_name(stat_name).first()
+                    && let Some(current) = extract_value(metric)
+                {
+                    let key = (stat_name.to_string(), shard.to_string());
+                    let prev = prev_values.get(&key).copied().unwrap_or(0.0);
+                    if current > prev {
+                        counter.with_label_values(&[shard]).inc_by(current - prev);
                     }
+                    prev_values.insert(key, current);
                 }
             }
         }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1459,7 +1459,10 @@ impl Scan for QueuesScanner {
                     Ok(None) => {
                         let prefix = crate::keys::concurrency_request_prefix(&tenant, &queue);
                         let end = crate::keys::end_bound(&prefix);
-                        let mut iter = match db.scan::<Vec<u8>, _>(prefix..=end).await {
+                        let mut iter = match db
+                            .scan_with_options::<Vec<u8>, _>(prefix..=end, &crate::scan_options())
+                            .await
+                        {
                             Ok(iter) => iter,
                             Err(e) => {
                                 let _ = tx
@@ -1565,7 +1568,13 @@ impl Scan for QueuesScanner {
             };
             let holders_end = crate::keys::end_bound(&holders_start);
 
-            if let Ok(mut iter) = db.scan::<Vec<u8>, _>(holders_start..=holders_end).await {
+            if let Ok(mut iter) = db
+                .scan_with_options::<Vec<u8>, _>(
+                    holders_start..=holders_end,
+                    &crate::scan_options(),
+                )
+                .await
+            {
                 while let Ok(Some(kv)) = iter.next().await {
                     if limit.is_some_and(|l| entries.len() >= l) {
                         break;
@@ -1600,7 +1609,13 @@ impl Scan for QueuesScanner {
             };
             let requests_end = crate::keys::end_bound(&requests_start);
 
-            if let Ok(mut iter) = db.scan::<Vec<u8>, _>(requests_start..=requests_end).await {
+            if let Ok(mut iter) = db
+                .scan_with_options::<Vec<u8>, _>(
+                    requests_start..=requests_end,
+                    &crate::scan_options(),
+                )
+                .await
+            {
                 while let Ok(Some(kv)) = iter.next().await {
                     if limit.is_some_and(|l| entries.len() >= l) {
                         break;
@@ -1995,7 +2010,7 @@ impl Scan for QueueCountsScanner {
 
             match shard
                 .db()
-                .scan::<Vec<u8>, _>(holders_start..holders_end)
+                .scan_with_options::<Vec<u8>, _>(holders_start..holders_end, &crate::scan_options())
                 .await
             {
                 Ok(mut iter) => loop {
@@ -2339,7 +2354,10 @@ impl Scan for TasksScanner {
                 _ => None,
             };
 
-            let iter_result = shard.db().scan::<Vec<u8>, _>(start..end).await;
+            let iter_result = shard
+                .db()
+                .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+                .await;
             let mut iter = match iter_result {
                 Ok(i) => i,
                 Err(e) => {

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -130,7 +130,11 @@ impl TaskBroker {
         let start = task_group_prefix(&self.task_group);
         let end = end_bound(&start);
 
-        let Ok(mut iter) = self.db.scan::<Vec<u8>, _>(start..end).await else {
+        let Ok(mut iter) = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await
+        else {
             return 0;
         };
 


### PR DESCRIPTION
## Summary

- Production profiling showed ~15% of CPU spent in `SsTableIndexOwned::new` (flatbuffer verification) and ~22% cumulative in `TableStore::read_index` because SlateDB's default `cache_blocks: false` for scans prevents SST indexes from being cached — even when a meta cache is configured.
- Switches hot scan paths (task broker, concurrency, dequeue, lease, scan API, query) to use `scan_with_options` with `cache_blocks: true` so the in-memory meta cache is actually populated.
- Cold/infrequent paths (import, restart, cleanup, cancel, counters) are left with the default to avoid cache pollution.

## Context

SlateDB's `ScanOptions` defaults `cache_blocks` to `false` to avoid cache pollution from large sequential reads. This was originally just about data blocks, but [upstream PR #1088](https://github.com/slatedb/slatedb/pull/1088) extended the flag to also cover SST index and bloom filter reads. This means that with the default, every scan re-fetches and re-verifies the full flatbuffer SST index — even when the same SSTs are scanned repeatedly by the task broker loop.

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `just fmt` passes (clippy + rustfmt)
- [x] All local tests pass (excluding etcd/k8s integration tests that need external services)
- [ ] CI green
- [ ] Review benchmark results for performance impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SlateDB scan behavior across core broker/concurrency/query/lease paths to cache blocks, which may affect memory usage and scan performance characteristics under load. Logic changes are minimal but applied broadly to high-traffic code paths.
> 
> **Overview**
> Introduces a shared `scan_options()` helper that enables SlateDB `cache_blocks` for scans, and switches multiple hot prefix-scan call sites to `scan_with_options` (task broker scanning, concurrency holder/request scans, dequeue task scans, lease reaper, shard job scan APIs, and queue/query scans) to avoid repeatedly re-reading/re-parsing SST indexes.
> 
> Also includes small control-flow refactors (using `if let` chaining) in `dequeue`’s durable write error handling and in SlateDB metrics polling to simplify nested conditionals without changing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8016f193424ab8071d6d62a7e1526317e2202d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->