### PR TITLE
Document broker scan breakdown metrics

### DIFF
--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -68,12 +68,16 @@ The task broker maintains an in-memory buffer of ready tasks for efficient deque
 | `silo_broker_inflight_size` | Gauge | `shard`, `task_group` | Tasks claimed but not yet durably leased per task group |
 | `silo_broker_scan_duration_seconds` | Histogram | `shard` | Duration of broker task scanning operations |
 | `silo_broker_scans_total` | Counter | `shard` | Total number of broker task scan operations |
+| `silo_broker_scan_tasks_read_total` | Counter | `shard`, `task_group`, `outcome` | Tasks read during scans, broken down by outcome: `inserted`, `skipped_future`, `skipped_inflight`, `skipped_tombstone`, `skipped_already_buffered`, `skipped_defunct` |
+| `silo_broker_tombstone_count` | Gauge | `shard`, `task_group` | Number of ack tombstones currently held by the broker |
 
 **Key insights:**
 - `silo_broker_buffer_size` near 0 with pending work may indicate scan issues
 - Break down `silo_broker_buffer_size` by `task_group` to identify which queues are starved vs saturated
 - High `silo_broker_scan_duration_seconds` suggests database pressure
 - `silo_broker_inflight_size` should be transiently low; persistent high values indicate dequeue bottlenecks
+- A high rate of `silo_broker_scan_tasks_read_total` with `outcome="skipped_tombstone"` indicates the scanner is repeatedly encountering recently-acked keys that haven't been compacted away yet
+- Growing `silo_broker_tombstone_count` may signal that dequeued task keys are persisting in the DB longer than expected
 
 ### Shard & Coordination Metrics
 


### PR DESCRIPTION
## Summary
- Add `silo_broker_scan_tasks_read_total` and `silo_broker_tombstone_count` to the broker metrics table in the observability guide
- Add key insights for interpreting the new metrics (tombstone accumulation, skipped task patterns)

These metrics are being added in #215 — this PR documents them.

## Test plan
- [ ] Verify docs build and render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds two broker metrics and interpretation guidance; no runtime behavior or APIs are modified.
> 
> **Overview**
> Updates the observability guide’s **Broker Metrics** section to document two new Prometheus metrics: `silo_broker_scan_tasks_read_total` (scan-read outcomes by `task_group`) and `silo_broker_tombstone_count` (current ack tombstones).
> 
> Adds *key insights* describing how to interpret high `skipped_tombstone` rates and growing tombstone counts as signals of compaction/DB key retention issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd2d8e3ae2bb0af260639f74807a12db3e999bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->