### PR TITLE
List all available tables in SQL console UI

### DIFF
--- a/templates/sql.html
+++ b/templates/sql.html
@@ -39,7 +39,7 @@
                 </div>
                 <div class="flex items-center justify-between">
                     <div class="text-xs text-zinc-500">
-                        Available tables: <code class="text-emerald-400">jobs</code>, <code class="text-emerald-400">queues</code>
+                        Available tables: <code class="text-emerald-400">jobs</code>, <code class="text-emerald-400">queues</code>, <code class="text-emerald-400">tasks</code>, <code class="text-emerald-400">tenant_counts</code>, <code class="text-emerald-400">queue_counts</code>
                     </div>
                     <button type="submit" 
                             class="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium transition-colors flex items-center gap-2">


### PR DESCRIPTION
## Summary
- The SQL console hint text only listed `jobs` and `queues`, but `tasks`, `tenant_counts`, and `queue_counts` are also available for querying
- Updated the available tables list to show all five tables

## Test plan
- [ ] Open the SQL console in the web UI and verify all five tables are listed
- [ ] Confirm each listed table is queryable (e.g. `SELECT * FROM tasks LIMIT 1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only copy change that updates hint text; no backend/query execution logic is modified.
> 
> **Overview**
> Updates the SQL console UI hint in `templates/sql.html` to list all available/queryable tables, adding `tasks`, `tenant_counts`, and `queue_counts` alongside `jobs` and `queues`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc5db1d8ad7525bd8519a4b26d54b9484ed939a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->