### PR TITLE
Optimize grant scanner: batch writes and concurrent status validation

### DIFF
--- a/benches/big_shard_operations.rs
+++ b/benches/big_shard_operations.rs
@@ -295,18 +295,34 @@ async fn bench_concurrency_reconcile_once(metadata: &GoldenShardMetadata) {
     println!();
 }
 
-async fn bench_process_grants_small(metadata: &GoldenShardMetadata) {
-    println!("--- process_grants (5 grants from fresh queue) ---");
-    let queue = "bench-grants-5";
-    let (_guard, shard) = setup_grant_bench("grants-small", metadata, queue, 5, 20).await;
+async fn bench_process_grants(
+    metadata: &GoldenShardMetadata,
+    label: &str,
+    grant_count: usize,
+    waiter_count: usize,
+) {
+    println!(
+        "--- process_grants ({} grants from fresh queue) ---",
+        grant_count
+    );
+    let queue = format!("bench-grants-{}", grant_count);
+    let clone_name = format!("grants-{}", label);
+    let (_guard, shard) =
+        setup_grant_bench(&clone_name, metadata, &queue, grant_count, waiter_count).await;
 
-    let r = bench_op("process_grants(5)", 0, 1, || {
+    let r = bench_op(&format!("process_grants({})", grant_count), 0, 1, || {
         let shard = Arc::clone(&shard);
+        let queue = queue.clone();
         async move {
             let granted = shard
-                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, queue, 5)
+                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, &queue, grant_count as u32)
                 .await;
-            assert_eq!(granted.len(), 5, "expected 5 grants");
+            assert_eq!(
+                granted.len(),
+                grant_count,
+                "expected {} grants",
+                grant_count
+            );
         }
     })
     .await;
@@ -401,48 +417,6 @@ async fn setup_grant_bench(
     }
 
     (_guard, shard)
-}
-
-async fn bench_process_grants_medium(metadata: &GoldenShardMetadata) {
-    println!("--- process_grants (50 grants from fresh queue) ---");
-    let queue = "bench-grants-50";
-    let (_guard, shard) = setup_grant_bench("grants-medium", metadata, queue, 50, 200).await;
-
-    let r = bench_op("process_grants(50)", 0, 1, || {
-        let shard = Arc::clone(&shard);
-        async move {
-            let granted = shard
-                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, queue, 50)
-                .await;
-            assert_eq!(granted.len(), 50, "expected 50 grants");
-        }
-    })
-    .await;
-    r.print();
-
-    shard.close().await.expect("close");
-    println!();
-}
-
-async fn bench_process_grants_large(metadata: &GoldenShardMetadata) {
-    println!("--- process_grants (500 grants from fresh queue) ---");
-    let queue = "bench-grants-500";
-    let (_guard, shard) = setup_grant_bench("grants-large", metadata, queue, 500, 1000).await;
-
-    let r = bench_op("process_grants(500)", 0, 1, || {
-        let shard = Arc::clone(&shard);
-        async move {
-            let granted = shard
-                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, queue, 500)
-                .await;
-            assert_eq!(granted.len(), 500, "expected 500 grants");
-        }
-    })
-    .await;
-    r.print();
-
-    shard.close().await.expect("close");
-    println!();
 }
 
 async fn bench_cancel_no_limit(metadata: &GoldenShardMetadata) {
@@ -702,9 +676,9 @@ async fn main() {
     bench_dequeue_no_limit(&metadata).await;
     bench_dequeue_heavy_concurrency(&metadata).await;
     bench_concurrency_reconcile_once(&metadata).await;
-    bench_process_grants_small(&metadata).await;
-    bench_process_grants_medium(&metadata).await;
-    bench_process_grants_large(&metadata).await;
+    bench_process_grants(&metadata, "small", 5, 20).await;
+    bench_process_grants(&metadata, "medium", 50, 200).await;
+    bench_process_grants(&metadata, "large", 500, 1000).await;
     bench_cancel_no_limit(&metadata).await;
     bench_cancel_with_concurrency(&metadata).await;
     bench_expedite_scheduled(&metadata).await;

--- a/benches/big_shard_operations.rs
+++ b/benches/big_shard_operations.rs
@@ -295,6 +295,133 @@ async fn bench_concurrency_reconcile_once(metadata: &GoldenShardMetadata) {
     println!();
 }
 
+async fn bench_process_grants_small(metadata: &GoldenShardMetadata) {
+    println!("--- process_grants (5 grants from 20K waiters) ---");
+    let (_guard, shard) = clone_golden_shard("grants-small", metadata).await;
+
+    // Free up 5 slots by releasing 5 holders
+    for task_id in &metadata.deep_queue_holder_task_ids {
+        shard
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: Vec::new() })
+            .await
+            .expect("report outcome on holder");
+    }
+
+    let r = bench_op("process_grants(5)", 0, 1, || {
+        let shard = Arc::clone(&shard);
+        async move {
+            let granted = shard
+                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, DEEP_QUEUE_KEY, 5)
+                .await;
+            assert_eq!(granted.len(), 5, "expected 5 grants");
+        }
+    })
+    .await;
+    r.print();
+
+    shard.close().await.expect("close");
+    println!();
+}
+
+async fn bench_process_grants_medium(metadata: &GoldenShardMetadata) {
+    println!("--- process_grants (50 grants from 20K waiters) ---");
+    let (_guard, shard) = clone_golden_shard("grants-medium", metadata).await;
+
+    // Free up 50 slots by raising the concurrency limit:
+    // Release all 5 holders, then process 50 grants (5 slots freed + capacity for more)
+    for task_id in &metadata.deep_queue_holder_task_ids {
+        shard
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: Vec::new() })
+            .await
+            .expect("report outcome on holder");
+    }
+
+    // Enqueue a new job with a higher concurrency limit so process_grants can grant 50
+    let now = now_ms();
+    let higher_limit = Limit::Concurrency(ConcurrencyLimit {
+        key: DEEP_QUEUE_KEY.to_string(),
+        max_concurrency: 100,
+    });
+    shard
+        .enqueue(
+            BENCH_DEEP_QUEUE_TENANT,
+            Some("grants-medium-raiser".to_string()),
+            50,
+            now,
+            None,
+            vec![1, 2, 3],
+            vec![higher_limit],
+            None,
+            "",
+        )
+        .await
+        .expect("enqueue to raise limit");
+
+    let r = bench_op("process_grants(50)", 0, 1, || {
+        let shard = Arc::clone(&shard);
+        async move {
+            let granted = shard
+                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, DEEP_QUEUE_KEY, 50)
+                .await;
+            assert_eq!(granted.len(), 50, "expected 50 grants");
+        }
+    })
+    .await;
+    r.print();
+
+    shard.close().await.expect("close");
+    println!();
+}
+
+async fn bench_process_grants_large(metadata: &GoldenShardMetadata) {
+    println!("--- process_grants (500 grants from 20K waiters) ---");
+    let (_guard, shard) = clone_golden_shard("grants-large", metadata).await;
+
+    // Release all holders
+    for task_id in &metadata.deep_queue_holder_task_ids {
+        shard
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: Vec::new() })
+            .await
+            .expect("report outcome on holder");
+    }
+
+    // Raise the limit high enough to grant 500
+    let now = now_ms();
+    let higher_limit = Limit::Concurrency(ConcurrencyLimit {
+        key: DEEP_QUEUE_KEY.to_string(),
+        max_concurrency: 1000,
+    });
+    shard
+        .enqueue(
+            BENCH_DEEP_QUEUE_TENANT,
+            Some("grants-large-raiser".to_string()),
+            50,
+            now,
+            None,
+            vec![1, 2, 3],
+            vec![higher_limit],
+            None,
+            "",
+        )
+        .await
+        .expect("enqueue to raise limit");
+
+    let r = bench_op("process_grants(500)", 0, 1, || {
+        let shard = Arc::clone(&shard);
+        async move {
+            let granted = shard
+                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, DEEP_QUEUE_KEY, 500)
+                .await;
+            assert_eq!(granted.len(), 500, "expected 500 grants");
+        }
+    })
+    .await;
+    r.print();
+
+    shard.close().await.expect("close");
+    println!();
+}
+
 async fn bench_cancel_no_limit(metadata: &GoldenShardMetadata) {
     println!("--- cancel_job (no limits) ---");
     let (_guard, shard) = clone_golden_shard("cancel-no-limit", metadata).await;
@@ -552,6 +679,9 @@ async fn main() {
     bench_dequeue_no_limit(&metadata).await;
     bench_dequeue_heavy_concurrency(&metadata).await;
     bench_concurrency_reconcile_once(&metadata).await;
+    bench_process_grants_small(&metadata).await;
+    bench_process_grants_medium(&metadata).await;
+    bench_process_grants_large(&metadata).await;
     bench_cancel_no_limit(&metadata).await;
     bench_cancel_with_concurrency(&metadata).await;
     bench_expedite_scheduled(&metadata).await;

--- a/benches/big_shard_operations.rs
+++ b/benches/big_shard_operations.rs
@@ -296,22 +296,15 @@ async fn bench_concurrency_reconcile_once(metadata: &GoldenShardMetadata) {
 }
 
 async fn bench_process_grants_small(metadata: &GoldenShardMetadata) {
-    println!("--- process_grants (5 grants from 20K waiters) ---");
-    let (_guard, shard) = clone_golden_shard("grants-small", metadata).await;
-
-    // Free up 5 slots by releasing 5 holders
-    for task_id in &metadata.deep_queue_holder_task_ids {
-        shard
-            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: Vec::new() })
-            .await
-            .expect("report outcome on holder");
-    }
+    println!("--- process_grants (5 grants from fresh queue) ---");
+    let queue = "bench-grants-5";
+    let (_guard, shard) = setup_grant_bench("grants-small", metadata, queue, 5, 20).await;
 
     let r = bench_op("process_grants(5)", 0, 1, || {
         let shard = Arc::clone(&shard);
         async move {
             let granted = shard
-                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, DEEP_QUEUE_KEY, 5)
+                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, queue, 5)
                 .await;
             assert_eq!(granted.len(), 5, "expected 5 grants");
         }
@@ -323,45 +316,103 @@ async fn bench_process_grants_small(metadata: &GoldenShardMetadata) {
     println!();
 }
 
-async fn bench_process_grants_medium(metadata: &GoldenShardMetadata) {
-    println!("--- process_grants (50 grants from 20K waiters) ---");
-    let (_guard, shard) = clone_golden_shard("grants-medium", metadata).await;
+/// Setup a grant benchmark: create a fresh concurrency queue with `waiter_count`
+/// pending requests and capacity for `grant_count` grants.
+///
+/// Fills the queue to capacity with holders, enqueues the waiters, then releases
+/// all holders so process_grants can grant up to `grant_count`.
+async fn setup_grant_bench(
+    clone_name: &str,
+    metadata: &GoldenShardMetadata,
+    queue: &str,
+    grant_count: usize,
+    waiter_count: usize,
+) -> (CloneGuard, Arc<silo::job_store_shard::JobStoreShard>) {
+    let (_guard, shard) = clone_golden_shard(clone_name, metadata).await;
+    shard.stop_grant_scanner();
 
-    // Free up 50 slots by raising the concurrency limit:
-    // Release all 5 holders, then process 50 grants (5 slots freed + capacity for more)
-    for task_id in &metadata.deep_queue_holder_task_ids {
+    let now = now_ms();
+    let limit = Limit::Concurrency(ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: grant_count as u32,
+    });
+    // Use a unique task group to avoid dequeuing tasks from the deep queue
+    let task_group = format!("bench-{}", clone_name);
+
+    // Step 1: Fill capacity by enqueuing grant_count jobs (all get immediate grants)
+    for i in 0..grant_count {
+        let job_id = format!("bench-{}-holder-{:06}", clone_name, i);
+        shard
+            .enqueue(
+                BENCH_DEEP_QUEUE_TENANT,
+                Some(job_id),
+                50,
+                now,
+                None,
+                vec![1, 2, 3],
+                vec![limit.clone()],
+                None,
+                &task_group,
+            )
+            .await
+            .expect("enqueue holder");
+    }
+
+    // Step 2: Dequeue them all to create running tasks (holders)
+    let mut holder_task_ids = Vec::new();
+    let mut remaining = grant_count;
+    while remaining > 0 {
+        let batch = std::cmp::min(remaining, 50);
+        let result = shard
+            .dequeue("bench-worker", &task_group, batch)
+            .await
+            .expect("dequeue holders");
+        for task in &result.tasks {
+            holder_task_ids.push(task.attempt().task_id().to_string());
+        }
+        remaining -= result.tasks.len();
+    }
+
+    // Step 3: Enqueue waiters — all become pending requests since capacity is full
+    for i in 0..waiter_count {
+        let job_id = format!("bench-{}-waiter-{:06}", clone_name, i);
+        shard
+            .enqueue(
+                BENCH_DEEP_QUEUE_TENANT,
+                Some(job_id),
+                50,
+                now,
+                None,
+                vec![1, 2, 3],
+                vec![limit.clone()],
+                None,
+                &task_group,
+            )
+            .await
+            .expect("enqueue waiter");
+    }
+
+    // Step 4: Release all holders to free capacity for process_grants
+    for task_id in &holder_task_ids {
         shard
             .report_attempt_outcome(task_id, AttemptOutcome::Success { result: Vec::new() })
             .await
-            .expect("report outcome on holder");
+            .expect("release holder");
     }
 
-    // Enqueue a new job with a higher concurrency limit so process_grants can grant 50
-    let now = now_ms();
-    let higher_limit = Limit::Concurrency(ConcurrencyLimit {
-        key: DEEP_QUEUE_KEY.to_string(),
-        max_concurrency: 100,
-    });
-    shard
-        .enqueue(
-            BENCH_DEEP_QUEUE_TENANT,
-            Some("grants-medium-raiser".to_string()),
-            50,
-            now,
-            None,
-            vec![1, 2, 3],
-            vec![higher_limit],
-            None,
-            "",
-        )
-        .await
-        .expect("enqueue to raise limit");
+    (_guard, shard)
+}
+
+async fn bench_process_grants_medium(metadata: &GoldenShardMetadata) {
+    println!("--- process_grants (50 grants from fresh queue) ---");
+    let queue = "bench-grants-50";
+    let (_guard, shard) = setup_grant_bench("grants-medium", metadata, queue, 50, 200).await;
 
     let r = bench_op("process_grants(50)", 0, 1, || {
         let shard = Arc::clone(&shard);
         async move {
             let granted = shard
-                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, DEEP_QUEUE_KEY, 50)
+                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, queue, 50)
                 .await;
             assert_eq!(granted.len(), 50, "expected 50 grants");
         }
@@ -374,43 +425,15 @@ async fn bench_process_grants_medium(metadata: &GoldenShardMetadata) {
 }
 
 async fn bench_process_grants_large(metadata: &GoldenShardMetadata) {
-    println!("--- process_grants (500 grants from 20K waiters) ---");
-    let (_guard, shard) = clone_golden_shard("grants-large", metadata).await;
-
-    // Release all holders
-    for task_id in &metadata.deep_queue_holder_task_ids {
-        shard
-            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: Vec::new() })
-            .await
-            .expect("report outcome on holder");
-    }
-
-    // Raise the limit high enough to grant 500
-    let now = now_ms();
-    let higher_limit = Limit::Concurrency(ConcurrencyLimit {
-        key: DEEP_QUEUE_KEY.to_string(),
-        max_concurrency: 1000,
-    });
-    shard
-        .enqueue(
-            BENCH_DEEP_QUEUE_TENANT,
-            Some("grants-large-raiser".to_string()),
-            50,
-            now,
-            None,
-            vec![1, 2, 3],
-            vec![higher_limit],
-            None,
-            "",
-        )
-        .await
-        .expect("enqueue to raise limit");
+    println!("--- process_grants (500 grants from fresh queue) ---");
+    let queue = "bench-grants-500";
+    let (_guard, shard) = setup_grant_bench("grants-large", metadata, queue, 500, 1000).await;
 
     let r = bench_op("process_grants(500)", 0, 1, || {
         let shard = Arc::clone(&shard);
         async move {
             let granted = shard
-                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, DEEP_QUEUE_KEY, 500)
+                .process_concurrency_grants(BENCH_DEEP_QUEUE_TENANT, queue, 500)
                 .await;
             assert_eq!(granted.len(), 500, "expected 500 grants");
         }

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -804,11 +804,7 @@ impl ConcurrencyManager {
         let mut scanned: Vec<ScannedRequest> = Vec::new();
         let mut max_concurrency: Option<(usize, ConcurrencyLimitType)> = None;
 
-        // Scan up to 2x count to have enough candidates after filtering stale ones,
-        // capped to avoid issuing too many concurrent status reads in phase 2.
-        let scan_limit = (count as usize).saturating_mul(2).min(512);
-
-        while scanned.len() < scan_limit {
+        while scanned.len() < count as usize {
             let kv = match iter.next().await {
                 Ok(Some(kv)) => kv,
                 Ok(None) => break,

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -749,9 +749,11 @@ impl ConcurrencyManager {
     /// Scans up to `count` pending requests and grants those for which capacity exists.
     /// Returns the task groups that received grants.
     ///
-    /// Optimized for throughput: scans candidates, batch-validates their status
-    /// concurrently, then reserves in-memory slots and writes all grants plus stale
-    /// deletions in a single durable batch.
+    /// Optimized for throughput: scans candidates in batches, batch-validates their
+    /// status concurrently, reserves in-memory slots, then writes all grants plus
+    /// stale deletions in a single durable batch. If stale/corrupt requests reduce
+    /// the yield, scanning continues until `count` valid grants are found or the
+    /// request queue is exhausted.
     pub(crate) async fn process_grants(
         &self,
         db: &Db,
@@ -772,9 +774,6 @@ impl ConcurrencyManager {
 
         let now_ms = crate::job_store_shard::now_epoch_ms();
 
-        // --- Phase 1: Scan and decode request candidates ---
-        // We scan more than `count` candidates to account for stale requests that
-        // will be filtered out during validation. This avoids needing to re-scan.
         // [SILO-GRANT-2] Pre: Scan for pending requests for this queue
         let start = concurrency_request_prefix(tenant, queue);
         let end_key = end_bound(&start);
@@ -800,236 +799,247 @@ impl ConcurrencyManager {
             task_group: String,
         }
 
-        let mut corrupt_keys: Vec<Vec<u8>> = Vec::new();
-        let mut scanned: Vec<ScannedRequest> = Vec::new();
         let mut max_concurrency: Option<(usize, ConcurrencyLimitType)> = None;
+        let mut batch = WriteBatch::new();
+        let mut grants: Vec<(String, String)> = Vec::new();
+        let mut stale_and_corrupt_count: usize = 0;
+        let mut iter_exhausted = false;
+        let mut capacity_exhausted = false;
 
-        while scanned.len() < count as usize {
-            let kv = match iter.next().await {
-                Ok(Some(kv)) => kv,
-                Ok(None) => break,
-                Err(e) => {
-                    tracing::warn!(error = %e, "grant scanner: iteration error");
+        // Scan→validate→grant loop: keeps pulling from the iterator until we've
+        // granted `count` requests, or hit the end / capacity limit. Each iteration
+        // scans a batch of candidates, validates them concurrently, then reserves
+        // slots for valid ones. Stale/corrupt entries are cleaned up along the way.
+        while grants.len() < count as usize && !iter_exhausted && !capacity_exhausted {
+            let needed = count as usize - grants.len();
+
+            // --- Scan batch of candidates ---
+            let mut scanned: Vec<ScannedRequest> = Vec::new();
+            while scanned.len() < needed {
+                let kv = match iter.next().await {
+                    Ok(Some(kv)) => kv,
+                    Ok(None) => {
+                        iter_exhausted = true;
+                        break;
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "grant scanner: iteration error");
+                        iter_exhausted = true;
+                        break;
+                    }
+                };
+
+                let parsed_req = parse_concurrency_request_key(&kv.key);
+
+                let decoded = match decode_concurrency_action(kv.value.clone()) {
+                    Ok(d) => d,
+                    Err(_) => {
+                        tracing::warn!(queue = %queue, "grant scanner: failed to decode request, deleting");
+                        batch.delete(&kv.key);
+                        stale_and_corrupt_count += 1;
+                        continue;
+                    }
+                };
+                let a = decoded.fb();
+                let Some(et) = a.variant_as_enqueue_task() else {
+                    tracing::warn!(queue = %queue, "grant scanner: unknown concurrency action variant, deleting");
+                    batch.delete(&kv.key);
+                    stale_and_corrupt_count += 1;
+                    continue;
+                };
+
+                let start_time_ms = et.start_time_ms();
+                let job_id_str = et.job_id().unwrap_or_default();
+
+                if start_time_ms > now_ms {
+                    iter_exhausted = true;
                     break;
                 }
-            };
 
-            let parsed_req = parse_concurrency_request_key(&kv.key);
-
-            // Decode request
-            let decoded = match decode_concurrency_action(kv.value.clone()) {
-                Ok(d) => d,
-                Err(_) => {
-                    tracing::warn!(queue = %queue, "grant scanner: failed to decode request, deleting");
-                    corrupt_keys.push(kv.key.to_vec());
+                let Some(parsed_req) = parsed_req else {
                     continue;
+                };
+                let request_id = parsed_req.request_id();
+
+                // Resolve max_concurrency from the first request whose job info is readable.
+                // Don't cache failures — a stale request's missing job shouldn't lock
+                // the limit to 1 for the rest of the scan.
+                if max_concurrency.is_none() {
+                    let job_key = crate::keys::job_info_key(tenant, job_id_str);
+                    match db.get(&job_key).await {
+                        Ok(Some(bytes)) => match JobView::new(bytes) {
+                            Ok(view) => {
+                                let (l, lt) =
+                                    Self::resolve_queue_capacity(db, tenant, queue, &view).await;
+                                self.cache_queue_limit(tenant, queue, l as u32, lt);
+                                max_concurrency = Some((l, lt));
+                            }
+                            Err(_) => {
+                                tracing::warn!(
+                                    job_id = %job_id_str,
+                                    queue = %queue,
+                                    "grant scanner: undecodable job info, will retry with next request"
+                                );
+                            }
+                        },
+                        Ok(None) => {
+                            tracing::debug!(
+                                job_id = %job_id_str,
+                                queue = %queue,
+                                "grant scanner: job info missing, will retry with next request"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                job_id = %job_id_str,
+                                queue = %queue,
+                                "grant scanner: failed to read job info, will retry with next request"
+                            );
+                        }
+                    };
                 }
-            };
-            let a = decoded.fb();
-            let Some(et) = a.variant_as_enqueue_task() else {
-                tracing::warn!(queue = %queue, "grant scanner: unknown concurrency action variant, deleting");
-                corrupt_keys.push(kv.key.to_vec());
-                continue;
-            };
 
-            let start_time_ms = et.start_time_ms();
-            let job_id_str = et.job_id().unwrap_or_default();
+                scanned.push(ScannedRequest {
+                    request_key: kv.key.to_vec(),
+                    request_id,
+                    job_id: job_id_str.to_string(),
+                    attempt_number: et.attempt_number(),
+                    relative_attempt_number: et.relative_attempt_number(),
+                    start_time_ms,
+                    priority: et.priority(),
+                    task_group: et.task_group().unwrap_or_default().to_string(),
+                });
+            }
 
-            // Check start_time (requests are ordered by time)
-            if start_time_ms > now_ms {
+            if scanned.is_empty() {
                 break;
             }
 
-            let Some(parsed_req) = parsed_req else {
-                continue;
-            };
-            let request_id = parsed_req.request_id();
+            // --- Batch validate status ---
+            let status_futures: Vec<_> = scanned
+                .iter()
+                .map(|c| {
+                    let key = job_status_key(tenant, &c.job_id);
+                    async move { db.get(&key).await }
+                })
+                .collect();
+            let status_results = futures::future::join_all(status_futures).await;
 
-            if max_concurrency.is_none() {
-                let job_key = crate::keys::job_info_key(tenant, job_id_str);
-                let (l, lt) = match db.get(&job_key).await {
-                    Ok(Some(bytes)) => match JobView::new(bytes) {
-                        Ok(view) => Self::resolve_queue_capacity(db, tenant, queue, &view).await,
+            let mut valid_requests: Vec<ScannedRequest> = Vec::new();
+            for (req, status_result) in scanned.into_iter().zip(status_results.into_iter()) {
+                let is_valid = match status_result {
+                    Ok(Some(status_raw)) => match decode_job_status_owned(&status_raw) {
+                        // [SILO-GRANT-5] Request records are only valid for the currently
+                        // scheduled attempt.
+                        Ok(status)
+                            if status.kind != JobStatusKind::Scheduled
+                                || status.current_attempt != Some(req.attempt_number) =>
+                        {
+                            // [SILO-GRANT-6] Drop stale request key without granting work.
+                            tracing::debug!(
+                                job_id = %req.job_id,
+                                queue = %queue,
+                                request_attempt = req.attempt_number,
+                                status_kind = ?status.kind,
+                                status_attempt = ?status.current_attempt,
+                                "grant scanner: skipping stale request for non-current attempt"
+                            );
+                            false
+                        }
+                        Ok(_) => true,
                         Err(_) => {
                             tracing::warn!(
-                                job_id = %job_id_str,
+                                job_id = %req.job_id,
                                 queue = %queue,
-                                "grant scanner: undecodable job info, falling back to limit=1"
+                                "grant scanner: dropping request with unreadable job status"
                             );
-                            (1, ConcurrencyLimitType::Fixed)
+                            false
                         }
                     },
                     Ok(None) => {
-                        tracing::warn!(
-                            job_id = %job_id_str,
+                        tracing::debug!(
+                            job_id = %req.job_id,
                             queue = %queue,
-                            "grant scanner: job info missing, falling back to limit=1"
+                            "grant scanner: dropping request for missing job status"
                         );
-                        (1, ConcurrencyLimitType::Fixed)
+                        false
                     }
                     Err(e) => {
                         tracing::warn!(
                             error = %e,
-                            job_id = %job_id_str,
+                            job_id = %req.job_id,
                             queue = %queue,
-                            "grant scanner: failed to read job info, falling back to limit=1"
+                            "grant scanner: failed to load job status; skipping request this pass"
                         );
-                        (1, ConcurrencyLimitType::Fixed)
+                        continue;
                     }
                 };
-                self.cache_queue_limit(tenant, queue, l as u32, lt);
-                max_concurrency = Some((l, lt));
-            }
 
-            scanned.push(ScannedRequest {
-                request_key: kv.key.to_vec(),
-                request_id,
-                job_id: job_id_str.to_string(),
-                attempt_number: et.attempt_number(),
-                relative_attempt_number: et.relative_attempt_number(),
-                start_time_ms,
-                priority: et.priority(),
-                task_group: et.task_group().unwrap_or_default().to_string(),
-            });
-        }
-
-        if scanned.is_empty() && corrupt_keys.is_empty() {
-            return Vec::new();
-        }
-
-        // --- Phase 2: Batch validate status for all scanned requests ---
-        // Issue all status reads concurrently, then partition into valid vs stale.
-        let status_futures: Vec<_> = scanned
-            .iter()
-            .map(|c| {
-                let key = job_status_key(tenant, &c.job_id);
-                async move { db.get(&key).await }
-            })
-            .collect();
-        let status_results = futures::future::join_all(status_futures).await;
-
-        let mut valid_requests: Vec<ScannedRequest> = Vec::new();
-        let mut stale_request_keys: Vec<Vec<u8>> = Vec::new();
-
-        for (req, status_result) in scanned.into_iter().zip(status_results.into_iter()) {
-            let is_valid = match status_result {
-                Ok(Some(status_raw)) => match decode_job_status_owned(&status_raw) {
-                    // [SILO-GRANT-5] Request records are only valid for the currently
-                    // scheduled attempt.
-                    Ok(status)
-                        if status.kind != JobStatusKind::Scheduled
-                            || status.current_attempt != Some(req.attempt_number) =>
-                    {
-                        // [SILO-GRANT-6] Drop stale request key without granting work.
-                        tracing::debug!(
-                            job_id = %req.job_id,
-                            queue = %queue,
-                            request_attempt = req.attempt_number,
-                            status_kind = ?status.kind,
-                            status_attempt = ?status.current_attempt,
-                            "grant scanner: skipping stale request for non-current attempt"
-                        );
-                        false
-                    }
-                    Ok(_) => true,
-                    Err(_) => {
-                        tracing::warn!(
-                            job_id = %req.job_id,
-                            queue = %queue,
-                            "grant scanner: dropping request with unreadable job status"
-                        );
-                        false
-                    }
-                },
-                Ok(None) => {
-                    tracing::debug!(
-                        job_id = %req.job_id,
-                        queue = %queue,
-                        "grant scanner: dropping request for missing job status"
-                    );
-                    false
+                if is_valid {
+                    valid_requests.push(req);
+                } else {
+                    batch.delete(&req.request_key);
+                    stale_and_corrupt_count += 1;
                 }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        job_id = %req.job_id,
-                        queue = %queue,
-                        "grant scanner: failed to load job status; skipping request this pass"
-                    );
-                    // Don't delete — may be valid, we just couldn't read it
-                    continue;
+            }
+
+            // --- Reserve in-memory slots and accumulate grant edits ---
+            let limit = max_concurrency.map(|(l, _)| l).unwrap_or(1);
+            for req in &valid_requests {
+                if grants.len() >= count as usize {
+                    break;
                 }
-            };
 
-            if is_valid {
-                valid_requests.push(req);
-            } else {
-                stale_request_keys.push(req.request_key);
-            }
-        }
-
-        // --- Phase 3: Reserve in-memory slots and build single WriteBatch ---
-        let limit = max_concurrency.map(|(l, _)| l).unwrap_or(1);
-        let mut batch = WriteBatch::new();
-        // Each grant: (request_id, task_group)
-        let mut grants: Vec<(String, String)> = Vec::new();
-
-        for req in &valid_requests {
-            if grants.len() >= count as usize {
-                break;
-            }
-
-            // [SILO-GRANT-1] Pre: Queue has capacity — try to atomically reserve a slot
-            if !self
-                .counts
-                .try_reserve_internal(tenant, queue, &req.request_id, limit, &req.job_id)
-            {
-                break;
-            }
-
-            // [SILO-GRANT-3] Create holder
-            let holder_val = encode_holder(&HolderRecord {
-                granted_at_ms: now_ms,
-            });
-            batch.put(
-                concurrency_holder_key(tenant, queue, &req.request_id),
-                &holder_val,
-            );
-
-            // [SILO-GRANT-4] Create RunAttempt task
-            let tval = encode_task(&Task::RunAttempt {
-                id: req.request_id.clone(),
-                tenant: tenant.to_string(),
-                job_id: req.job_id.clone(),
-                attempt_number: req.attempt_number,
-                relative_attempt_number: req.relative_attempt_number,
-                held_queues: vec![queue.to_string()],
-                task_group: req.task_group.clone(),
-            });
-            batch.put(
-                task_key(
-                    &req.task_group,
-                    req.start_time_ms,
-                    req.priority,
+                // [SILO-GRANT-1] Pre: Queue has capacity — try to atomically reserve a slot
+                if !self.counts.try_reserve_internal(
+                    tenant,
+                    queue,
+                    &req.request_id,
+                    limit,
                     &req.job_id,
-                    req.attempt_number,
-                ),
-                &tval,
-            );
-            batch.delete(&req.request_key);
+                ) {
+                    capacity_exhausted = true;
+                    break;
+                }
 
-            grants.push((req.request_id.clone(), req.task_group.clone()));
+                // [SILO-GRANT-3] Create holder
+                let holder_val = encode_holder(&HolderRecord {
+                    granted_at_ms: now_ms,
+                });
+                batch.put(
+                    concurrency_holder_key(tenant, queue, &req.request_id),
+                    &holder_val,
+                );
+
+                // [SILO-GRANT-4] Create RunAttempt task
+                let tval = encode_task(&Task::RunAttempt {
+                    id: req.request_id.clone(),
+                    tenant: tenant.to_string(),
+                    job_id: req.job_id.clone(),
+                    attempt_number: req.attempt_number,
+                    relative_attempt_number: req.relative_attempt_number,
+                    held_queues: vec![queue.to_string()],
+                    task_group: req.task_group.clone(),
+                });
+                batch.put(
+                    task_key(
+                        &req.task_group,
+                        req.start_time_ms,
+                        req.priority,
+                        &req.job_id,
+                        req.attempt_number,
+                    ),
+                    &tval,
+                );
+                batch.delete(&req.request_key);
+
+                grants.push((req.request_id.clone(), req.task_group.clone()));
+            }
         }
 
-        for key in &stale_request_keys {
-            batch.delete(key);
-        }
-        for key in &corrupt_keys {
-            batch.delete(key);
-        }
-
-        // Single combined counter decrement for all grants + stale deletions
-        let total_counter_decrement = grants.len() + stale_request_keys.len();
+        // Single combined counter decrement for all grants + stale/corrupt deletions
+        let total_counter_decrement = grants.len() + stale_and_corrupt_count;
         if total_counter_decrement > 0 {
             batch.merge(
                 concurrency_requester_counter_key(tenant, queue),
@@ -1037,11 +1047,11 @@ impl ConcurrencyManager {
             );
         }
 
-        if grants.is_empty() && stale_request_keys.is_empty() && corrupt_keys.is_empty() {
+        if grants.is_empty() && stale_and_corrupt_count == 0 {
             return Vec::new();
         }
 
-        // --- Phase 4: Single durable write ---
+        // --- Single durable write ---
         if let Err(e) = db
             .write_with_options(
                 batch,

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -748,6 +748,10 @@ impl ConcurrencyManager {
     /// Process pending grant requests for a single (tenant, queue).
     /// Scans up to `count` pending requests and grants those for which capacity exists.
     /// Returns the task groups that received grants.
+    ///
+    /// Optimized for throughput: scans candidates, batch-validates their status
+    /// concurrently, then reserves in-memory slots and writes all grants plus stale
+    /// deletions in a single durable batch.
     pub async fn process_grants(
         &self,
         db: &Db,
@@ -767,6 +771,10 @@ impl ConcurrencyManager {
         }
 
         let now_ms = crate::job_store_shard::now_epoch_ms();
+
+        // --- Phase 1: Scan and decode request candidates ---
+        // We scan more than `count` candidates to account for stale requests that
+        // will be filtered out during validation. This avoids needing to re-scan.
         // [SILO-GRANT-2] Pre: Scan for pending requests for this queue
         let start = concurrency_request_prefix(tenant, queue);
         let end_key = end_bound(&start);
@@ -781,11 +789,27 @@ impl ConcurrencyManager {
             }
         };
 
-        let mut granted_count = 0u32;
-        let mut granted_task_groups: Vec<String> = Vec::new();
+        struct ScannedRequest {
+            request_key: Vec<u8>,
+            request_id: String,
+            job_id: String,
+            attempt_number: u32,
+            relative_attempt_number: u32,
+            start_time_ms: i64,
+            priority: u8,
+            task_group: String,
+        }
+
+        let mut corrupt_keys: Vec<Vec<u8>> = Vec::new();
+        let mut scanned: Vec<ScannedRequest> = Vec::new();
         let mut max_concurrency: Option<(usize, ConcurrencyLimitType)> = None;
 
-        while granted_count < count {
+        // Scan up to 2x count to have enough candidates after filtering stale ones.
+        // On the common path (no stale requests), the extra scanning is bounded by
+        // the iterator returning None when requests are exhausted.
+        let scan_limit = (count as usize).saturating_mul(2).max(count as usize + 16);
+
+        while scanned.len() < scan_limit {
             let kv = match iter.next().await {
                 Ok(Some(kv)) => kv,
                 Ok(None) => break,
@@ -802,136 +826,152 @@ impl ConcurrencyManager {
                 Ok(d) => d,
                 Err(_) => {
                     tracing::warn!(queue = %queue, "grant scanner: failed to decode request, deleting");
-                    let _ = db.delete(&kv.key).await;
+                    corrupt_keys.push(kv.key.to_vec());
                     continue;
                 }
             };
             let a = decoded.fb();
             let Some(et) = a.variant_as_enqueue_task() else {
                 tracing::warn!(queue = %queue, "grant scanner: unknown concurrency action variant, deleting");
-                let _ = db.delete(&kv.key).await;
+                corrupt_keys.push(kv.key.to_vec());
                 continue;
             };
 
             let start_time_ms = et.start_time_ms();
-            let priority = et.priority();
             let job_id_str = et.job_id().unwrap_or_default();
-            let attempt_number = et.attempt_number();
-            let relative_attempt_number = et.relative_attempt_number();
-            let task_group_str = et.task_group().unwrap_or_default();
-
-            let status_key = job_status_key(tenant, job_id_str);
-            match db.get(&status_key).await {
-                Ok(Some(status_raw)) => match decode_job_status_owned(&status_raw) {
-                    // [SILO-GRANT-5] Request records are only valid for the currently
-                    // scheduled attempt.
-                    // If status drifted (e.g. reimport/cancel/restart), drop stale requests.
-                    Ok(status)
-                        if status.kind != JobStatusKind::Scheduled
-                            || status.current_attempt != Some(attempt_number) =>
-                    {
-                        // [SILO-GRANT-6] Drop stale request key without granting work.
-                        if delete_stale_request(db, &kv.key, tenant, queue)
-                            .await
-                            .is_err()
-                        {
-                            continue;
-                        }
-                        tracing::debug!(
-                            job_id = %job_id_str,
-                            queue = %queue,
-                            request_attempt = attempt_number,
-                            status_kind = ?status.kind,
-                            status_attempt = ?status.current_attempt,
-                            "grant scanner: skipping stale request for non-current attempt"
-                        );
-                        continue;
-                    }
-                    Ok(_) => {}
-                    Err(_) => {
-                        if delete_stale_request(db, &kv.key, tenant, queue)
-                            .await
-                            .is_err()
-                        {
-                            continue;
-                        }
-                        tracing::warn!(
-                            job_id = %job_id_str,
-                            queue = %queue,
-                            "grant scanner: dropping request with unreadable job status"
-                        );
-                        continue;
-                    }
-                },
-                Ok(None) => {
-                    if delete_stale_request(db, &kv.key, tenant, queue)
-                        .await
-                        .is_err()
-                    {
-                        continue;
-                    }
-                    tracing::debug!(
-                        job_id = %job_id_str,
-                        queue = %queue,
-                        "grant scanner: dropping request for missing job status"
-                    );
-                    continue;
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        job_id = %job_id_str,
-                        queue = %queue,
-                        "grant scanner: failed to load job status; skipping request this pass"
-                    );
-                    continue;
-                }
-            }
 
             // Check start_time (requests are ordered by time)
             if start_time_ms > now_ms {
                 break;
             }
 
-            // Parse request key to get request_id
             let Some(parsed_req) = parsed_req else {
                 continue;
             };
             let request_id = parsed_req.request_id();
 
-            // Get max_concurrency (cached per queue from first successful lookup)
-            let (limit, limit_type) = match max_concurrency {
-                Some((l, lt)) => (l, lt),
-                None => {
-                    let job_key = crate::keys::job_info_key(tenant, job_id_str);
-                    let (l, lt) = match db.get(&job_key).await {
-                        Ok(Some(bytes)) => match JobView::new(bytes) {
-                            Ok(view) => {
-                                Self::resolve_queue_capacity(db, tenant, queue, &view).await
-                            }
-                            Err(_) => (1, ConcurrencyLimitType::Fixed),
-                        },
-                        _ => (1, ConcurrencyLimitType::Fixed),
-                    };
-                    // Cache the resolved limit for the query system
-                    self.cache_queue_limit(tenant, queue, l as u32, lt);
-                    max_concurrency = Some((l, lt));
-                    (l, lt)
+            // Resolve max_concurrency once (cached per queue from first successful lookup)
+            if max_concurrency.is_none() {
+                let job_key = crate::keys::job_info_key(tenant, job_id_str);
+                let (l, lt) = match db.get(&job_key).await {
+                    Ok(Some(bytes)) => match JobView::new(bytes) {
+                        Ok(view) => {
+                            Self::resolve_queue_capacity(db, tenant, queue, &view).await
+                        }
+                        Err(_) => (1, ConcurrencyLimitType::Fixed),
+                    },
+                    _ => (1, ConcurrencyLimitType::Fixed),
+                };
+                self.cache_queue_limit(tenant, queue, l as u32, lt);
+                max_concurrency = Some((l, lt));
+            }
+
+            scanned.push(ScannedRequest {
+                request_key: kv.key.to_vec(),
+                request_id,
+                job_id: job_id_str.to_string(),
+                attempt_number: et.attempt_number(),
+                relative_attempt_number: et.relative_attempt_number(),
+                start_time_ms,
+                priority: et.priority(),
+                task_group: et.task_group().unwrap_or_default().to_string(),
+            });
+        }
+
+        if scanned.is_empty() && corrupt_keys.is_empty() {
+            return Vec::new();
+        }
+
+        // --- Phase 2: Batch validate status for all scanned requests ---
+        // Issue all status reads concurrently, then partition into valid vs stale.
+        let status_futures: Vec<_> = scanned
+            .iter()
+            .map(|c| {
+                let key = job_status_key(tenant, &c.job_id);
+                async move { db.get(&key).await }
+            })
+            .collect();
+        let status_results = futures::future::join_all(status_futures).await;
+
+        let mut valid_requests: Vec<ScannedRequest> = Vec::new();
+        let mut stale_request_keys: Vec<Vec<u8>> = Vec::new();
+
+        for (req, status_result) in scanned.into_iter().zip(status_results.into_iter()) {
+            let is_valid = match status_result {
+                Ok(Some(status_raw)) => match decode_job_status_owned(&status_raw) {
+                    // [SILO-GRANT-5] Request records are only valid for the currently
+                    // scheduled attempt.
+                    Ok(status)
+                        if status.kind != JobStatusKind::Scheduled
+                            || status.current_attempt != Some(req.attempt_number) =>
+                    {
+                        // [SILO-GRANT-6] Drop stale request key without granting work.
+                        tracing::debug!(
+                            job_id = %req.job_id,
+                            queue = %queue,
+                            request_attempt = req.attempt_number,
+                            status_kind = ?status.kind,
+                            status_attempt = ?status.current_attempt,
+                            "grant scanner: skipping stale request for non-current attempt"
+                        );
+                        false
+                    }
+                    Ok(_) => true,
+                    Err(_) => {
+                        tracing::warn!(
+                            job_id = %req.job_id,
+                            queue = %queue,
+                            "grant scanner: dropping request with unreadable job status"
+                        );
+                        false
+                    }
+                },
+                Ok(None) => {
+                    tracing::debug!(
+                        job_id = %req.job_id,
+                        queue = %queue,
+                        "grant scanner: dropping request for missing job status"
+                    );
+                    false
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        job_id = %req.job_id,
+                        queue = %queue,
+                        "grant scanner: failed to load job status; skipping request this pass"
+                    );
+                    // Don't delete — may be valid, we just couldn't read it
+                    continue;
                 }
             };
-            let _ = limit_type; // used for caching above
+
+            if is_valid {
+                valid_requests.push(req);
+            } else {
+                stale_request_keys.push(req.request_key);
+            }
+        }
+
+        // --- Phase 3: Reserve in-memory slots and build single WriteBatch ---
+        let limit = max_concurrency.map(|(l, _)| l).unwrap_or(1);
+        let mut batch = WriteBatch::new();
+        let mut granted_task_groups: Vec<String> = Vec::new();
+        let mut granted_request_ids: Vec<String> = Vec::new();
+
+        for req in &valid_requests {
+            if granted_task_groups.len() >= count as usize {
+                break;
+            }
 
             // [SILO-GRANT-1] Pre: Queue has capacity — try to atomically reserve a slot
             if !self
                 .counts
-                .try_reserve_internal(tenant, queue, &request_id, limit, job_id_str)
+                .try_reserve_internal(tenant, queue, &req.request_id, limit, &req.job_id)
             {
-                // No capacity - stop scanning
+                // No capacity - stop granting
                 break;
             }
-
-            // Build WriteBatch for this grant
-            let mut batch = WriteBatch::new();
 
             // [SILO-GRANT-3] Create holder
             let holder = HolderRecord {
@@ -939,32 +979,32 @@ impl ConcurrencyManager {
             };
             let holder_val = encode_holder(&holder);
             batch.put(
-                concurrency_holder_key(tenant, queue, &request_id),
+                concurrency_holder_key(tenant, queue, &req.request_id),
                 &holder_val,
             );
 
             // [SILO-GRANT-4] Create RunAttempt task
             let task = Task::RunAttempt {
-                id: request_id.clone(),
+                id: req.request_id.clone(),
                 tenant: tenant.to_string(),
-                job_id: job_id_str.to_string(),
-                attempt_number,
-                relative_attempt_number,
+                job_id: req.job_id.clone(),
+                attempt_number: req.attempt_number,
+                relative_attempt_number: req.relative_attempt_number,
                 held_queues: vec![queue.to_string()],
-                task_group: task_group_str.to_string(),
+                task_group: req.task_group.clone(),
             };
             let tval = encode_task(&task);
             batch.put(
                 task_key(
-                    task_group_str,
-                    start_time_ms,
-                    priority,
-                    job_id_str,
-                    attempt_number,
+                    &req.task_group,
+                    req.start_time_ms,
+                    req.priority,
+                    &req.job_id,
+                    req.attempt_number,
                 ),
                 &tval,
             );
-            batch.delete(&kv.key);
+            batch.delete(&req.request_key);
 
             // Decrement the per-queue requester counter (request converted to holder)
             batch.merge(
@@ -972,34 +1012,62 @@ impl ConcurrencyManager {
                 encode_counter(-1),
             );
 
-            // Commit with durability
-            if let Err(e) = db
-                .write_with_options(
-                    batch,
-                    &WriteOptions {
-                        await_durable: true,
-                    },
-                )
-                .await
-            {
-                self.counts.release_reservation(tenant, queue, &request_id);
-                tracing::warn!(
-                    error = %e,
-                    "grant scanner: write failed, rolled back reservation"
-                );
-                break;
-            }
+            granted_request_ids.push(req.request_id.clone());
+            granted_task_groups.push(req.task_group.clone());
+        }
 
+        // Add stale request deletions to the same batch
+        for key in &stale_request_keys {
+            batch.delete(key);
+            batch.merge(
+                concurrency_requester_counter_key(tenant, queue),
+                encode_counter(-1),
+            );
+        }
+
+        // Add corrupt key deletions
+        for key in &corrupt_keys {
+            batch.delete(key);
+        }
+
+        // Skip the write if there's nothing to do
+        if granted_task_groups.is_empty() && stale_request_keys.is_empty() && corrupt_keys.is_empty()
+        {
+            return Vec::new();
+        }
+
+        // --- Phase 4: Single durable write ---
+        if let Err(e) = db
+            .write_with_options(
+                batch,
+                &WriteOptions {
+                    await_durable: true,
+                },
+            )
+            .await
+        {
+            // Roll back all in-memory reservations
+            for request_id in &granted_request_ids {
+                self.counts
+                    .release_reservation(tenant, queue, request_id);
+            }
+            tracing::warn!(
+                error = %e,
+                count = granted_request_ids.len(),
+                "grant scanner: batch write failed, rolled back all reservations"
+            );
+            return Vec::new();
+        }
+
+        for (request_id, task_group) in
+            granted_request_ids.iter().zip(granted_task_groups.iter())
+        {
             tracing::debug!(
                 queue = %queue,
                 request_id = %request_id,
-                job_id = %job_id_str,
-                task_group = %task_group_str,
+                task_group = %task_group,
                 "grant scanner: granted concurrency ticket"
             );
-
-            granted_task_groups.push(task_group_str.to_string());
-            granted_count += 1;
         }
 
         granted_task_groups
@@ -1086,24 +1154,3 @@ fn append_request_edits<W: WriteBatcher>(
     Ok(())
 }
 
-/// Atomically delete a stale concurrency request key and decrement the per-queue
-/// requester counter. Used by the grant scanner when it discovers requests for
-/// jobs that are no longer in the expected state.
-async fn delete_stale_request(
-    db: &Db,
-    request_key: &[u8],
-    tenant: &str,
-    queue: &str,
-) -> Result<(), slatedb::Error> {
-    let mut batch = WriteBatch::new();
-    batch.delete(request_key);
-    batch.merge(
-        concurrency_requester_counter_key(tenant, queue),
-        encode_counter(-1),
-    );
-    if let Err(e) = db.write(batch).await {
-        tracing::warn!(error = %e, "grant scanner: failed to delete stale request");
-        return Err(e);
-    }
-    Ok(())
-}

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -855,9 +855,7 @@ impl ConcurrencyManager {
                 let job_key = crate::keys::job_info_key(tenant, job_id_str);
                 let (l, lt) = match db.get(&job_key).await {
                     Ok(Some(bytes)) => match JobView::new(bytes) {
-                        Ok(view) => {
-                            Self::resolve_queue_capacity(db, tenant, queue, &view).await
-                        }
+                        Ok(view) => Self::resolve_queue_capacity(db, tenant, queue, &view).await,
                         Err(_) => (1, ConcurrencyLimitType::Fixed),
                     },
                     _ => (1, ConcurrencyLimitType::Fixed),
@@ -1031,7 +1029,9 @@ impl ConcurrencyManager {
         }
 
         // Skip the write if there's nothing to do
-        if granted_task_groups.is_empty() && stale_request_keys.is_empty() && corrupt_keys.is_empty()
+        if granted_task_groups.is_empty()
+            && stale_request_keys.is_empty()
+            && corrupt_keys.is_empty()
         {
             return Vec::new();
         }
@@ -1048,8 +1048,7 @@ impl ConcurrencyManager {
         {
             // Roll back all in-memory reservations
             for request_id in &granted_request_ids {
-                self.counts
-                    .release_reservation(tenant, queue, request_id);
+                self.counts.release_reservation(tenant, queue, request_id);
             }
             tracing::warn!(
                 error = %e,
@@ -1059,9 +1058,7 @@ impl ConcurrencyManager {
             return Vec::new();
         }
 
-        for (request_id, task_group) in
-            granted_request_ids.iter().zip(granted_task_groups.iter())
-        {
+        for (request_id, task_group) in granted_request_ids.iter().zip(granted_task_groups.iter()) {
             tracing::debug!(
                 queue = %queue,
                 request_id = %request_id,
@@ -1153,4 +1150,3 @@ fn append_request_edits<W: WriteBatcher>(
 
     Ok(())
 }
-

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -747,10 +747,8 @@ impl ConcurrencyManager {
 
     /// Process pending grant requests for a single (tenant, queue).
     /// Scans up to `count` pending requests and grants those for which capacity exists.
-    /// Returns true if any grants were made.
-    /// Process pending grant requests for a single (tenant, queue).
     /// Returns the task groups that received grants.
-    async fn process_grants(
+    pub async fn process_grants(
         &self,
         db: &Db,
         range: &ShardRange,

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -752,7 +752,7 @@ impl ConcurrencyManager {
     /// Optimized for throughput: scans candidates, batch-validates their status
     /// concurrently, then reserves in-memory slots and writes all grants plus stale
     /// deletions in a single durable batch.
-    pub async fn process_grants(
+    pub(crate) async fn process_grants(
         &self,
         db: &Db,
         range: &ShardRange,
@@ -804,10 +804,9 @@ impl ConcurrencyManager {
         let mut scanned: Vec<ScannedRequest> = Vec::new();
         let mut max_concurrency: Option<(usize, ConcurrencyLimitType)> = None;
 
-        // Scan up to 2x count to have enough candidates after filtering stale ones.
-        // On the common path (no stale requests), the extra scanning is bounded by
-        // the iterator returning None when requests are exhausted.
-        let scan_limit = (count as usize).saturating_mul(2).max(count as usize + 16);
+        // Scan up to 2x count to have enough candidates after filtering stale ones,
+        // capped to avoid issuing too many concurrent status reads in phase 2.
+        let scan_limit = (count as usize).saturating_mul(2).min(512);
 
         while scanned.len() < scan_limit {
             let kv = match iter.next().await {
@@ -850,15 +849,37 @@ impl ConcurrencyManager {
             };
             let request_id = parsed_req.request_id();
 
-            // Resolve max_concurrency once (cached per queue from first successful lookup)
             if max_concurrency.is_none() {
                 let job_key = crate::keys::job_info_key(tenant, job_id_str);
                 let (l, lt) = match db.get(&job_key).await {
                     Ok(Some(bytes)) => match JobView::new(bytes) {
                         Ok(view) => Self::resolve_queue_capacity(db, tenant, queue, &view).await,
-                        Err(_) => (1, ConcurrencyLimitType::Fixed),
+                        Err(_) => {
+                            tracing::warn!(
+                                job_id = %job_id_str,
+                                queue = %queue,
+                                "grant scanner: undecodable job info, falling back to limit=1"
+                            );
+                            (1, ConcurrencyLimitType::Fixed)
+                        }
                     },
-                    _ => (1, ConcurrencyLimitType::Fixed),
+                    Ok(None) => {
+                        tracing::warn!(
+                            job_id = %job_id_str,
+                            queue = %queue,
+                            "grant scanner: job info missing, falling back to limit=1"
+                        );
+                        (1, ConcurrencyLimitType::Fixed)
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            job_id = %job_id_str,
+                            queue = %queue,
+                            "grant scanner: failed to read job info, falling back to limit=1"
+                        );
+                        (1, ConcurrencyLimitType::Fixed)
+                    }
                 };
                 self.cache_queue_limit(tenant, queue, l as u32, lt);
                 max_concurrency = Some((l, lt));
@@ -954,11 +975,11 @@ impl ConcurrencyManager {
         // --- Phase 3: Reserve in-memory slots and build single WriteBatch ---
         let limit = max_concurrency.map(|(l, _)| l).unwrap_or(1);
         let mut batch = WriteBatch::new();
-        let mut granted_task_groups: Vec<String> = Vec::new();
-        let mut granted_request_ids: Vec<String> = Vec::new();
+        // Each grant: (request_id, task_group)
+        let mut grants: Vec<(String, String)> = Vec::new();
 
         for req in &valid_requests {
-            if granted_task_groups.len() >= count as usize {
+            if grants.len() >= count as usize {
                 break;
             }
 
@@ -967,22 +988,20 @@ impl ConcurrencyManager {
                 .counts
                 .try_reserve_internal(tenant, queue, &req.request_id, limit, &req.job_id)
             {
-                // No capacity - stop granting
                 break;
             }
 
             // [SILO-GRANT-3] Create holder
-            let holder = HolderRecord {
+            let holder_val = encode_holder(&HolderRecord {
                 granted_at_ms: now_ms,
-            };
-            let holder_val = encode_holder(&holder);
+            });
             batch.put(
                 concurrency_holder_key(tenant, queue, &req.request_id),
                 &holder_val,
             );
 
             // [SILO-GRANT-4] Create RunAttempt task
-            let task = Task::RunAttempt {
+            let tval = encode_task(&Task::RunAttempt {
                 id: req.request_id.clone(),
                 tenant: tenant.to_string(),
                 job_id: req.job_id.clone(),
@@ -990,8 +1009,7 @@ impl ConcurrencyManager {
                 relative_attempt_number: req.relative_attempt_number,
                 held_queues: vec![queue.to_string()],
                 task_group: req.task_group.clone(),
-            };
-            let tval = encode_task(&task);
+            });
             batch.put(
                 task_key(
                     &req.task_group,
@@ -1004,35 +1022,26 @@ impl ConcurrencyManager {
             );
             batch.delete(&req.request_key);
 
-            // Decrement the per-queue requester counter (request converted to holder)
-            batch.merge(
-                concurrency_requester_counter_key(tenant, queue),
-                encode_counter(-1),
-            );
-
-            granted_request_ids.push(req.request_id.clone());
-            granted_task_groups.push(req.task_group.clone());
+            grants.push((req.request_id.clone(), req.task_group.clone()));
         }
 
-        // Add stale request deletions to the same batch
         for key in &stale_request_keys {
             batch.delete(key);
-            batch.merge(
-                concurrency_requester_counter_key(tenant, queue),
-                encode_counter(-1),
-            );
         }
-
-        // Add corrupt key deletions
         for key in &corrupt_keys {
             batch.delete(key);
         }
 
-        // Skip the write if there's nothing to do
-        if granted_task_groups.is_empty()
-            && stale_request_keys.is_empty()
-            && corrupt_keys.is_empty()
-        {
+        // Single combined counter decrement for all grants + stale deletions
+        let total_counter_decrement = grants.len() + stale_request_keys.len();
+        if total_counter_decrement > 0 {
+            batch.merge(
+                concurrency_requester_counter_key(tenant, queue),
+                encode_counter(-(total_counter_decrement as i64)),
+            );
+        }
+
+        if grants.is_empty() && stale_request_keys.is_empty() && corrupt_keys.is_empty() {
             return Vec::new();
         }
 
@@ -1046,19 +1055,18 @@ impl ConcurrencyManager {
             )
             .await
         {
-            // Roll back all in-memory reservations
-            for request_id in &granted_request_ids {
+            for (request_id, _) in &grants {
                 self.counts.release_reservation(tenant, queue, request_id);
             }
             tracing::warn!(
                 error = %e,
-                count = granted_request_ids.len(),
+                count = grants.len(),
                 "grant scanner: batch write failed, rolled back all reservations"
             );
             return Vec::new();
         }
 
-        for (request_id, task_group) in granted_request_ids.iter().zip(granted_task_groups.iter()) {
+        for (request_id, task_group) in &grants {
             tracing::debug!(
                 queue = %queue,
                 request_id = %request_id,
@@ -1067,7 +1075,7 @@ impl ConcurrencyManager {
             );
         }
 
-        granted_task_groups
+        grants.into_iter().map(|(_, tg)| tg).collect()
     }
 }
 

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -608,6 +608,19 @@ impl JobStoreShard {
             .await;
     }
 
+    /// Get the in-memory concurrency holder count for a queue.
+    pub fn concurrency_holder_count(&self, tenant: &str, queue: &str) -> usize {
+        self.concurrency.counts().holder_count(tenant, queue)
+    }
+
+    /// Stop the background grant scanner without closing the shard.
+    ///
+    /// Intended for benchmarking — prevents the background scanner from racing
+    /// with manual `process_concurrency_grants` calls.
+    pub fn stop_grant_scanner(&self) {
+        self.concurrency.stop_grant_scanner();
+    }
+
     /// Directly process pending concurrency grants for a single queue.
     ///
     /// Bypasses the background grant scanner and processes `count` grants synchronously.

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -608,6 +608,22 @@ impl JobStoreShard {
             .await;
     }
 
+    /// Directly process pending concurrency grants for a single queue.
+    ///
+    /// Bypasses the background grant scanner and processes `count` grants synchronously.
+    /// Intended for benchmarking the grant processing hot path.
+    pub async fn process_concurrency_grants(
+        &self,
+        tenant: &str,
+        queue: &str,
+        count: u32,
+    ) -> Vec<String> {
+        let range = self.get_range();
+        self.concurrency
+            .process_grants(self.db.as_ref(), &range, tenant, queue, count)
+            .await
+    }
+
     /// Fetch a job by id as a zero-copy archived view.
     pub async fn get_job(
         &self,

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -608,11 +608,6 @@ impl JobStoreShard {
             .await;
     }
 
-    /// Get the in-memory concurrency holder count for a queue.
-    pub fn concurrency_holder_count(&self, tenant: &str, queue: &str) -> usize {
-        self.concurrency.counts().holder_count(tenant, queue)
-    }
-
     /// Stop the background grant scanner without closing the shard.
     ///
     /// Intended for benchmarking — prevents the background scanner from racing

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -1,10 +1,11 @@
 mod test_helpers;
 
-use silo::codec::decode_task;
+use silo::codec::{decode_task, encode_concurrency_action};
 use silo::job::Limit;
 use silo::job_attempt::AttemptOutcome;
 use silo::keys::concurrency_holder_key;
 use silo::retry::RetryPolicy;
+use silo::task::ConcurrencyAction;
 use silo::task::Task;
 use std::collections::HashSet;
 use std::sync::{
@@ -1569,4 +1570,267 @@ async fn retry_with_concurrent_jobs_respects_limit() {
         0,
         "No holders should remain after all jobs complete"
     );
+}
+
+/// Tests that process_grants skips stale requests and continues scanning to
+/// fulfill the requested count from valid requests behind them.
+#[silo::test]
+async fn grant_scanner_skips_stale_requests_and_grants_valid_ones() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "stale-skip-q";
+    let tenant = "stale-skip-tenant";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: 3,
+    });
+
+    shard.stop_grant_scanner();
+
+    // Fill the 3 concurrency slots with holders, then enqueue 3 more as waiters
+    let mut holder_tasks = Vec::new();
+    for i in 0..3 {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("holder-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+    for _ in 0..3 {
+        let tasks = shard.dequeue("w", "tg", 1).await.unwrap().tasks;
+        holder_tasks.push(tasks[0].attempt().task_id().to_string());
+    }
+
+    // Enqueue 3 legitimate waiters (queue at capacity 3/3, so these become requests)
+    for i in 0..3 {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("valid-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+
+    // Inject 5 stale requests with earlier start_time so they sort BEFORE the valid ones.
+    // These reference job IDs that don't exist, so they'll be detected as stale.
+    for i in 0..5 {
+        let stale_action = ConcurrencyAction::EnqueueTask {
+            start_time_ms: 0,
+            priority: 50,
+            job_id: format!("nonexistent-job-{}", i),
+            attempt_number: 1,
+            relative_attempt_number: 1,
+            task_group: "tg".to_string(),
+        };
+        let key = silo::keys::concurrency_request_key(
+            tenant,
+            queue,
+            0,
+            50,
+            &format!("nonexistent-job-{}", i),
+            1,
+            &format!("stale{:04}", i),
+        );
+        let val = encode_concurrency_action(&stale_action);
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(&key, &val);
+        shard.db().write(batch).await.unwrap();
+    }
+
+    assert_eq!(count_concurrency_requests(shard.db()).await, 8); // 5 stale + 3 valid
+
+    // Release all holders to free capacity
+    for task_id in &holder_tasks {
+        shard
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .unwrap();
+    }
+
+    // Ask for 3 grants — should skip all 5 stale, then grant all 3 valid
+    let granted = shard.process_concurrency_grants(tenant, queue, 3).await;
+    assert_eq!(
+        granted.len(),
+        3,
+        "should grant all 3 valid requests despite 5 stale ones ahead of them"
+    );
+
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "all requests (stale + granted) should be removed"
+    );
+    assert_eq!(count_concurrency_holders(shard.db()).await, 3);
+}
+
+/// Tests that when all scanned requests are stale and no valid requests exist,
+/// process_grants returns zero grants and cleans up the stale entries.
+#[silo::test]
+async fn grant_scanner_handles_all_stale_requests() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let queue = "all-stale-q";
+    let tenant = "all-stale-tenant";
+
+    shard.stop_grant_scanner();
+
+    // Inject 5 stale requests (no real jobs behind them)
+    for i in 0..5 {
+        let stale_action = ConcurrencyAction::EnqueueTask {
+            start_time_ms: 0,
+            priority: 50,
+            job_id: format!("ghost-{}", i),
+            attempt_number: 1,
+            relative_attempt_number: 1,
+            task_group: "tg".to_string(),
+        };
+        let key = silo::keys::concurrency_request_key(
+            tenant,
+            queue,
+            0,
+            50,
+            &format!("ghost-{}", i),
+            1,
+            &format!("s{:04}", i),
+        );
+        let val = encode_concurrency_action(&stale_action);
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(&key, &val);
+        shard.db().write(batch).await.unwrap();
+    }
+
+    assert_eq!(count_concurrency_requests(shard.db()).await, 5);
+
+    let granted = shard.process_concurrency_grants(tenant, queue, 3).await;
+    assert_eq!(granted.len(), 0, "no valid requests to grant");
+
+    // All stale requests should still be cleaned up
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "stale requests should be deleted even when no grants are made"
+    );
+}
+
+/// Tests that stale requests interleaved with valid ones are handled correctly:
+/// the grant scanner should skip stale ones and keep scanning to find valid ones.
+#[silo::test]
+async fn grant_scanner_interleaved_stale_and_valid_requests() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "interleave-q";
+    let tenant = "interleave-tenant";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: 5,
+    });
+
+    shard.stop_grant_scanner();
+
+    // Fill all 5 slots with holders
+    let mut holder_tasks = Vec::new();
+    for i in 0..5 {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("holder-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+    for _ in 0..5 {
+        let tasks = shard.dequeue("w", "tg", 1).await.unwrap().tasks;
+        holder_tasks.push(tasks[0].attempt().task_id().to_string());
+    }
+
+    // Enqueue 5 valid waiters (capacity 5/5, these become requests)
+    for i in 0..5 {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("real-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+
+    // Inject 10 stale requests with earlier start_time so they sort before valid ones
+    for i in 0..10 {
+        let stale_action = ConcurrencyAction::EnqueueTask {
+            start_time_ms: now - 1000 + i,
+            priority: 50,
+            job_id: format!("phantom-{}", i),
+            attempt_number: 1,
+            relative_attempt_number: 1,
+            task_group: "tg".to_string(),
+        };
+        let key = silo::keys::concurrency_request_key(
+            tenant,
+            queue,
+            now - 1000 + i,
+            50,
+            &format!("phantom-{}", i),
+            1,
+            &format!("x{:04}", i),
+        );
+        let val = encode_concurrency_action(&stale_action);
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(&key, &val);
+        shard.db().write(batch).await.unwrap();
+    }
+
+    assert_eq!(count_concurrency_requests(shard.db()).await, 15); // 10 stale + 5 valid
+
+    // Release all holders to free capacity
+    for task_id in &holder_tasks {
+        shard
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .unwrap();
+    }
+
+    // Ask for 5 grants — should skip 10 stale, grant 5 valid
+    let granted = shard.process_concurrency_grants(tenant, queue, 5).await;
+    assert_eq!(
+        granted.len(),
+        5,
+        "should grant 5 valid requests despite 10 stale ones interleaved"
+    );
+
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "all stale and granted requests should be removed"
+    );
+    assert_eq!(count_concurrency_holders(shard.db()).await, 5);
 }


### PR DESCRIPTION
## Summary

- Restructures `process_grants` from per-grant sequential I/O to a batched pipeline that does a single durable write for all grants
- Batch-validates job status keys concurrently via `futures::join_all` instead of sequential `db.get` per request
- Stale request deletions are folded into the same write batch instead of separate writes
- Adds `process_grants` benchmarks at 5/50/500 grant scales to measure the grant scanner hot path

## Benchmark Results

| Benchmark | Before (per-grant writes) | After (batched) | Speedup |
|---|---|---|---|
| `process_grants(5)` | 11.6ms | 2.8ms | **4.1x** |
| `process_grants(50)` | 118.5ms | 1.6ms | **74x** |
| `process_grants(500)` | 1,140ms | 7.9ms | **144x** |

The improvement scales super-linearly: the old code does N separate durable writes (each waiting for WAL flush), the new code does exactly 1 regardless of batch size.

## How it works

The new `process_grants` pipeline:
1. **Scan & decode** — iterate request queue, decode candidates, resolve concurrency limit once
2. **Batch validate** — issue all job status reads concurrently, partition into valid vs stale
3. **Reserve & build batch** — try in-memory slot reservations for valid candidates, accumulate all edits into a single `WriteBatch`
4. **Single durable write** — one `write_with_options(await_durable: true)` for all grants + stale deletions

## Test plan

- [x] All 298 core shard tests pass (enqueue, dequeue, import, cancel, lease, concurrency, retry, query, cleanup)
- [x] `reimport_failed_to_scheduled_ignores_stale_concurrency_requests` passes (validates stale cleanup still works when queue is at capacity)
- [x] New benchmarks run successfully at all three scales
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core concurrency grant logic and changes request cleanup/counter updates, so bugs could impact capacity enforcement or task scheduling despite added benchmarks/tests.
> 
> **Overview**
> **Grant scanning throughput is significantly improved** by rewriting `ConcurrencyManager::process_grants` into a batched pipeline: scan candidate requests in batches, validate job statuses concurrently, reserve in-memory slots, and commit all holder/task creations plus stale/corrupt request deletions in one durable `WriteBatch` (with a single combined requester-counter decrement).
> 
> Adds shard-level benchmarking hooks (`JobStoreShard::stop_grant_scanner`, `process_concurrency_grants`) and new big-shard benchmarks for `process_grants` at 5/50/500 grant sizes, plus new concurrency tests that inject stale request keys and assert the scanner skips/cleans them while still fulfilling grants from valid requests behind them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 793a45c04123aac905838476881005fb525f2498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->