### PR TITLE
Refresh topology on Unavailable errors in routing client

### DIFF
--- a/src/routing_client.rs
+++ b/src/routing_client.rs
@@ -102,8 +102,9 @@ pub enum ErrorAction {
     /// Server returned FailedPrecondition — tenant not in shard range. Need full topology refresh.
     RefreshTopology,
     /// Server returned UNAVAILABLE — shard is temporarily unavailable (split in progress,
-    /// acquisition pending). Caller should retry with backoff.
-    RetryWithBackoff,
+    /// acquisition pending, or pod gone). Refresh topology to discover new pod addresses,
+    /// then retry with backoff.
+    RefreshTopologyWithBackoff,
     /// Not a routing error — don't retry.
     NotRoutingError,
 }
@@ -130,9 +131,10 @@ pub fn classify_error(status: &tonic::Status, shard_id: &str) -> ErrorAction {
             ErrorAction::RefreshTopology
         }
         tonic::Code::Unavailable => {
-            // Shard is temporarily unavailable: split in progress or acquisition pending.
-            // Retry with backoff — the shard will be ready soon.
-            ErrorAction::RetryWithBackoff
+            // Shard is temporarily unavailable: split in progress, acquisition pending,
+            // or pod completely gone. Refresh topology to discover new addresses, then
+            // retry with backoff.
+            ErrorAction::RefreshTopologyWithBackoff
         }
         _ => ErrorAction::NotRoutingError,
     }
@@ -333,10 +335,12 @@ impl RoutingClient {
                     None
                 }
             }
-            ErrorAction::RetryWithBackoff => {
-                // UNAVAILABLE — shard temporarily down (split/acquisition). Just signal
-                // the caller to retry with backoff; no topology change needed.
-                debug!("Shard temporarily unavailable, retrying with backoff");
+            ErrorAction::RefreshTopologyWithBackoff => {
+                // UNAVAILABLE — shard temporarily down (split/acquisition/pod gone).
+                // Refresh topology so we discover any new pod addresses, then signal
+                // the caller to retry with backoff.
+                info!("Shard unavailable, refreshing topology and retrying with backoff");
+                self.refresh_topology().await;
                 Some(true)
             }
             ErrorAction::NotRoutingError => None,

--- a/tests/routing_client_tests.rs
+++ b/tests/routing_client_tests.rs
@@ -323,14 +323,14 @@ async fn classify_error_failed_precondition() {
     );
 }
 
-/// Test that classify_error returns RetryWithBackoff for UNAVAILABLE errors.
+/// Test that classify_error returns RefreshTopologyWithBackoff for UNAVAILABLE errors.
 #[silo::test(flavor = "multi_thread")]
 async fn classify_error_unavailable() {
     let status = tonic::Status::unavailable("shard temporarily unavailable");
     let action = silo::routing_client::classify_error(&status, "shard-456");
     assert!(
-        matches!(action, ErrorAction::RetryWithBackoff),
-        "expected RetryWithBackoff, got {:?}",
+        matches!(action, ErrorAction::RefreshTopologyWithBackoff),
+        "expected RefreshTopologyWithBackoff, got {:?}",
         action
     );
 }


### PR DESCRIPTION
## Summary

- Renames `ErrorAction::RetryWithBackoff` → `RefreshTopologyWithBackoff` to reflect the new behaviour
- `Unavailable` gRPC errors now trigger a `GetClusterInfo` topology refresh before retrying with backoff, matching how `FailedPrecondition` is handled
- Updates the `classify_error_unavailable` test accordingly

## Motivation

During a gameday we observed that after scaling down pods, silo-bench throughput dropped to 0 and never recovered — even 5 minutes after the topology was stable. The enqueuers were stuck in a loop sending to the dead pod's IP, accumulating 85× `tcp connect error` (Unavailable), with no topology refresh ever triggered.

Root cause: `Unavailable` only retried with backoff; it never called `GetClusterInfo` to discover that the shard had moved to a new pod.

## Behaviour after this fix

Both causes of `Unavailable` are now handled correctly:
- **Pod completely gone** (`tcp connect error`): topology refresh discovers the new pod address; next attempt after backoff goes to the right place
- **Shard in acquisition** (`shard not ready: acquisition in progress`): topology refresh is a no-op (same pod still owns the shard); backoff prevents hammering

Topology refreshes are coalesced, so concurrent `Unavailable` errors from multiple enqueuers/workers only trigger one `GetClusterInfo` RPC.