### PR TITLE
Cache split-paused state locally so is_shard_paused never hits the k8s API

### DIFF
--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -367,6 +367,11 @@ pub struct CoordinatorBase {
     /// Placement rings this node participates in.
     /// Empty means the node participates in the default ring only.
     pub placement_rings: Vec<String>,
+    /// Cache of shards that are currently paused for split operations.
+    /// Updated by the split execution code when phases change.
+    /// Read by `is_shard_paused` on the hot request path to avoid k8s API calls.
+    /// Uses std::sync::RwLock (not tokio) because the critical section is tiny.
+    paused_shards: Arc<std::sync::RwLock<HashSet<ShardId>>>,
 }
 
 impl CoordinatorBase {
@@ -393,6 +398,31 @@ impl CoordinatorBase {
             factory,
             startup_time_ms,
             placement_rings,
+            paused_shards: Arc::new(std::sync::RwLock::new(HashSet::new())),
+        }
+    }
+
+    /// Create a coordinator base with pre-built shared state.
+    /// Used by tests that need to share `shard_map` and `owned` Arcs with mock coordinators.
+    pub fn new_with_shared(
+        node_id: impl Into<String>,
+        grpc_addr: impl Into<String>,
+        shard_map: Arc<Mutex<ShardMap>>,
+        owned: Arc<Mutex<HashSet<ShardId>>>,
+        factory: Arc<ShardFactory>,
+    ) -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        Self {
+            node_id: node_id.into(),
+            grpc_addr: grpc_addr.into(),
+            shard_map,
+            owned,
+            shutdown_tx,
+            shutdown_rx,
+            factory,
+            startup_time_ms: None,
+            placement_rings: Vec::new(),
+            paused_shards: Arc::new(std::sync::RwLock::new(HashSet::new())),
         }
     }
 
@@ -409,6 +439,30 @@ impl CoordinatorBase {
     /// Get all shard IDs from the shard map.
     pub async fn shard_ids(&self) -> Vec<ShardId> {
         self.shard_map.lock().await.shard_ids()
+    }
+
+    /// Mark a shard as paused for split (traffic should be rejected with retryable errors).
+    pub fn mark_shard_paused(&self, shard_id: ShardId) {
+        self.paused_shards
+            .write()
+            .expect("paused_shards lock poisoned")
+            .insert(shard_id);
+    }
+
+    /// Mark a shard as no longer paused for split.
+    pub fn mark_shard_unpaused(&self, shard_id: ShardId) {
+        self.paused_shards
+            .write()
+            .expect("paused_shards lock poisoned")
+            .remove(&shard_id);
+    }
+
+    /// Check if a shard is paused for split (reads from local cache, no I/O).
+    pub fn is_shard_paused(&self, shard_id: &ShardId) -> bool {
+        self.paused_shards
+            .read()
+            .expect("paused_shards lock poisoned")
+            .contains(shard_id)
     }
 
     /// Get owned shards sorted (shared by both backends).
@@ -619,11 +673,11 @@ pub trait Coordinator: SplitStorageBackend + Send + Sync {
     ///
     /// Returns true if the shard has an in-progress split in a traffic-pausing phase.
     /// Callers should return retryable errors when this returns true.
+    ///
+    /// Reads from a local in-memory cache (no I/O). The cache is updated by the
+    /// split execution code when split phases change.
     async fn is_shard_paused(&self, shard_id: ShardId) -> bool {
-        match self.load_split(&shard_id).await {
-            Ok(Some(split)) => split.phase.traffic_paused(),
-            _ => false,
-        }
+        self.base().is_shard_paused(&shard_id)
     }
 
     /// Update a shard's placement ring.

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -404,6 +404,7 @@ impl CoordinatorBase {
 
     /// Create a coordinator base with pre-built shared state.
     /// Used by tests that need to share `shard_map` and `owned` Arcs with mock coordinators.
+    #[doc(hidden)]
     pub fn new_with_shared(
         node_id: impl Into<String>,
         grpc_addr: impl Into<String>,

--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -459,9 +459,7 @@ impl ShardSplitter {
             // This handles resumption after restarts or brief interruptions where
             // the cache may not yet reflect a traffic-pausing phase.
             if split.phase.traffic_paused() {
-                self.coordinator
-                    .base()
-                    .mark_shard_paused(parent_shard_id);
+                self.coordinator.base().mark_shard_paused(parent_shard_id);
             }
 
             // Verify we own the shard (not needed for SplitComplete which is just cleanup)
@@ -483,9 +481,7 @@ impl ShardSplitter {
                         .map_err(SplitExecutionError::PreCommit)?;
                     // Mark shard as paused in local cache so the hot request path
                     // returns UNAVAILABLE without any k8s API calls.
-                    self.coordinator
-                        .base()
-                        .mark_shard_paused(parent_shard_id);
+                    self.coordinator.base().mark_shard_paused(parent_shard_id);
                     info!(
                         parent_shard_id = %parent_shard_id,
                         phase = %split.phase,
@@ -710,9 +706,7 @@ impl ShardSplitter {
                         .delete_split(&parent_shard_id)
                         .await
                         .map_err(SplitExecutionError::PostCommit)?;
-                    self.coordinator
-                        .base()
-                        .mark_shard_unpaused(parent_shard_id);
+                    self.coordinator.base().mark_shard_unpaused(parent_shard_id);
                     info!(
                         parent_shard_id = %parent_shard_id,
                         "split record cleaned up"
@@ -793,6 +787,39 @@ impl ShardSplitter {
         Ok(())
     }
 
+    /// Re-hydrate the local paused-shards cache from persisted split records.
+    ///
+    /// After a process restart the in-memory cache is empty, but split
+    /// ConfigMaps may still exist from a previous incarnation. This method
+    /// scans storage and marks every shard whose split is in a
+    /// traffic-pausing phase so that `is_shard_paused` correctly rejects
+    /// requests until an operator decides what to do with the stale split.
+    ///
+    /// This does NOT delete or modify split records — call
+    /// `recover_stale_splits` (or use siloctl) if you want to abandon them.
+    pub async fn rehydrate_paused_shards(&self) -> Result<(), CoordinationError> {
+        let splits = self.coordinator.list_all_splits().await?;
+
+        for split in splits {
+            if split.initiator_node_id != self.ctx.node_id {
+                continue;
+            }
+
+            if split.phase.traffic_paused() {
+                self.coordinator
+                    .base()
+                    .mark_shard_paused(split.parent_shard_id);
+                info!(
+                    parent_shard_id = %split.parent_shard_id,
+                    phase = %split.phase,
+                    "re-hydrated paused state from persisted split record"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     /// Recover from stale split operations after a node restart.
     ///
     /// [SILO-COORD-INV-11] All incomplete splits are abandoned on crash.
@@ -837,6 +864,9 @@ impl ShardSplitter {
             self.coordinator
                 .delete_split(&split.parent_shard_id)
                 .await?;
+            self.coordinator
+                .base()
+                .mark_shard_unpaused(split.parent_shard_id);
         }
 
         Ok(())

--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -455,6 +455,15 @@ impl ShardSplitter {
                     CoordinationError::NoSplitInProgress(parent_shard_id),
                 ))?;
 
+            // Ensure the local paused cache reflects the persisted split state.
+            // This handles resumption after restarts or brief interruptions where
+            // the cache may not yet reflect a traffic-pausing phase.
+            if split.phase.traffic_paused() {
+                self.coordinator
+                    .base()
+                    .mark_shard_paused(parent_shard_id);
+            }
+
             // Verify we own the shard (not needed for SplitComplete which is just cleanup)
             if split.phase != SplitPhase::SplitComplete
                 && !self.ctx.owns_shard(&parent_shard_id).await
@@ -472,6 +481,11 @@ impl ShardSplitter {
                         .store_split(&split)
                         .await
                         .map_err(SplitExecutionError::PreCommit)?;
+                    // Mark shard as paused in local cache so the hot request path
+                    // returns UNAVAILABLE without any k8s API calls.
+                    self.coordinator
+                        .base()
+                        .mark_shard_paused(parent_shard_id);
                     info!(
                         parent_shard_id = %parent_shard_id,
                         phase = %split.phase,
@@ -696,6 +710,9 @@ impl ShardSplitter {
                         .delete_split(&parent_shard_id)
                         .await
                         .map_err(SplitExecutionError::PostCommit)?;
+                    self.coordinator
+                        .base()
+                        .mark_shard_unpaused(parent_shard_id);
                     info!(
                         parent_shard_id = %parent_shard_id,
                         "split record cleaned up"
@@ -716,7 +733,11 @@ impl ShardSplitter {
             parent_shard_id = %parent_shard_id,
             "abandoning split, deleting split record to restore parent shard"
         );
-        self.coordinator.delete_split(parent_shard_id).await
+        self.coordinator.delete_split(parent_shard_id).await?;
+        self.coordinator
+            .base()
+            .mark_shard_unpaused(*parent_shard_id);
+        Ok(())
     }
 
     /// Recover the parent shard after a failed split left its database closed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,22 @@ async fn main() -> anyhow::Result<()> {
             }
         };
 
+    // Re-hydrate the paused-shards cache from any persisted split records
+    // left behind by a previous incarnation. This ensures is_shard_paused
+    // correctly rejects traffic to shards that were mid-split before the
+    // process restarted. The split records themselves are NOT cleaned up —
+    // an operator must decide whether to abandon them (e.g. via siloctl or
+    // recover_stale_splits).
+    {
+        let splitter = silo::coordination::ShardSplitter::new(coordinator.clone());
+        splitter.rehydrate_paused_shards().await.map_err(|e| {
+            anyhow::anyhow!(
+                "failed to re-hydrate paused shards from split records: {}",
+                e
+            )
+        })?;
+    }
+
     // Start gRPC server and scheduled reaper together
     let addr: SocketAddr = cfg.server.grpc_addr.parse()?;
     let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -1362,6 +1362,280 @@ mod splitter_unit_tests {
         }
     }
 
+    /// Mock coordinator that accepts an external splits map, simulating
+    /// persistent split storage (ConfigMaps) that survives process restarts.
+    /// The CoordinatorBase is always fresh (empty paused_shards cache),
+    /// just like a real coordinator after restart.
+    struct MockSplitBackendWithSharedStorage {
+        base: CoordinatorBase,
+        splits: Arc<Mutex<HashMap<ShardId, SplitInProgress>>>,
+    }
+
+    impl MockSplitBackendWithSharedStorage {
+        fn new(
+            shard_map: Arc<Mutex<ShardMap>>,
+            owned: Arc<Mutex<HashSet<ShardId>>>,
+            factory: Arc<ShardFactory>,
+            splits: Arc<Mutex<HashMap<ShardId, SplitInProgress>>>,
+        ) -> Self {
+            let base = CoordinatorBase::new_with_shared(
+                "mock-node",
+                "http://mock:7450",
+                shard_map,
+                owned,
+                factory,
+            );
+            Self { base, splits }
+        }
+    }
+
+    #[async_trait]
+    impl Coordinator for MockSplitBackendWithSharedStorage {
+        fn base(&self) -> &CoordinatorBase {
+            &self.base
+        }
+
+        async fn shutdown(&self) -> Result<(), CoordinationError> {
+            Ok(())
+        }
+
+        async fn wait_converged(&self, _timeout: Duration) -> bool {
+            true
+        }
+
+        async fn get_members(&self) -> Result<Vec<MemberInfo>, CoordinationError> {
+            Ok(vec![])
+        }
+
+        async fn get_shard_owner_map(&self) -> Result<ShardOwnerMap, CoordinationError> {
+            let shard_map = self.base.shard_map.lock().await.clone();
+            Ok(ShardOwnerMap {
+                shard_map,
+                shard_to_node: HashMap::new(),
+                shard_to_addr: HashMap::new(),
+            })
+        }
+
+        async fn update_shard_placement_ring(
+            &self,
+            _shard_id: &ShardId,
+            _ring: Option<&str>,
+        ) -> Result<(Option<String>, Option<String>), CoordinationError> {
+            Ok((None, None))
+        }
+
+        async fn force_release_shard_lease(
+            &self,
+            _shard_id: &ShardId,
+        ) -> Result<(), CoordinationError> {
+            Ok(())
+        }
+
+        async fn reclaim_existing_leases(&self) -> Result<Vec<ShardId>, CoordinationError> {
+            Ok(vec![])
+        }
+    }
+
+    #[async_trait]
+    impl SplitStorageBackend for MockSplitBackendWithSharedStorage {
+        async fn load_split(
+            &self,
+            parent_shard_id: &ShardId,
+        ) -> Result<Option<SplitInProgress>, CoordinationError> {
+            Ok(self.splits.lock().await.get(parent_shard_id).cloned())
+        }
+
+        async fn store_split(&self, split: &SplitInProgress) -> Result<(), CoordinationError> {
+            self.splits
+                .lock()
+                .await
+                .insert(split.parent_shard_id, split.clone());
+            Ok(())
+        }
+
+        async fn delete_split(&self, parent_shard_id: &ShardId) -> Result<(), CoordinationError> {
+            self.splits.lock().await.remove(parent_shard_id);
+            Ok(())
+        }
+
+        async fn update_shard_map_for_split(
+            &self,
+            split: &SplitInProgress,
+        ) -> Result<(), CoordinationError> {
+            let mut shard_map = self.base.shard_map.lock().await;
+            shard_map.split_shard(
+                &split.parent_shard_id,
+                &split.split_point,
+                split.left_child_id,
+                split.right_child_id,
+            )?;
+            Ok(())
+        }
+
+        async fn reload_shard_map(&self) -> Result<(), CoordinationError> {
+            Ok(())
+        }
+
+        async fn list_all_splits(&self) -> Result<Vec<SplitInProgress>, CoordinationError> {
+            Ok(self.splits.lock().await.values().cloned().collect())
+        }
+    }
+
+    /// After a process restart, the split ConfigMap still exists in storage
+    /// but the local paused_shards cache is empty. This means is_shard_paused
+    /// returns false, allowing traffic through to a shard that was mid-split.
+    #[tokio::test]
+    async fn test_restart_loses_paused_state_for_stuck_split() {
+        let shard_map = Arc::new(Mutex::new(ShardMap::create_initial(4).unwrap()));
+        let owned = Arc::new(Mutex::new(HashSet::new()));
+        let factory = Arc::new(ShardFactory::new_noop());
+
+        // Shared split storage — survives "restarts" like a real ConfigMap would.
+        let splits: Arc<Mutex<HashMap<ShardId, SplitInProgress>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        let shard_id = shard_map.lock().await.shard_ids()[0];
+        owned.lock().await.insert(shard_id);
+
+        // --- First incarnation: request a split and advance to SplitPausing ---
+        let mock1 = Arc::new(MockSplitBackendWithSharedStorage::new(
+            shard_map.clone(),
+            owned.clone(),
+            factory.clone(),
+            splits.clone(),
+        ));
+        let splitter1 = ShardSplitter::new(Arc::clone(&mock1) as Arc<dyn Coordinator>);
+
+        splitter1
+            .request_split(shard_id, "2".to_string())
+            .await
+            .unwrap();
+        splitter1.advance_split_phase(shard_id).await.unwrap();
+
+        // In production, execute_split_inner populates the paused cache when
+        // advancing to SplitPausing. advance_split_phase is a test helper that
+        // only updates the record, so we replicate what execute_split does.
+        mock1.base().mark_shard_paused(shard_id);
+
+        // Split is in SplitPausing — traffic should be paused.
+        let status = splitter1.get_split_status(shard_id).await.unwrap().unwrap();
+        assert_eq!(status.phase, SplitPhase::SplitPausing);
+        assert!(
+            mock1.base().is_shard_paused(&shard_id),
+            "shard should be paused before restart"
+        );
+
+        // The split record exists in storage.
+        assert!(
+            splits.lock().await.contains_key(&shard_id),
+            "split ConfigMap should exist in storage"
+        );
+
+        // --- Simulate process restart: new coordinator, same storage ---
+        // The CoordinatorBase is fresh (empty paused_shards cache),
+        // but the split ConfigMap persists in the shared storage.
+        let mock2 = Arc::new(MockSplitBackendWithSharedStorage::new(
+            shard_map.clone(),
+            owned.clone(),
+            factory.clone(),
+            splits.clone(),
+        ));
+        let splitter2 = ShardSplitter::new(Arc::clone(&mock2) as Arc<dyn Coordinator>);
+
+        // The split record still exists in storage.
+        let status = splitter2.get_split_status(shard_id).await.unwrap().unwrap();
+        assert_eq!(
+            status.phase,
+            SplitPhase::SplitPausing,
+            "split record should survive restart"
+        );
+        assert!(
+            splits.lock().await.contains_key(&shard_id),
+            "split ConfigMap should still exist after restart"
+        );
+
+        // Before re-hydration the local cache is empty.
+        assert!(
+            !mock2.base().is_shard_paused(&shard_id),
+            "paused_shards cache should be empty before re-hydration"
+        );
+
+        // Re-hydrate the cache from persisted split records.
+        splitter2.rehydrate_paused_shards().await.unwrap();
+
+        // The shard should now be paused again.
+        assert!(
+            mock2.base().is_shard_paused(&shard_id),
+            "shard should be paused after re-hydrating from stored split records"
+        );
+
+        // The split ConfigMap must still exist — rehydrate does not clean up.
+        // An operator should decide whether to abandon or retry the split
+        // (e.g. via siloctl or recover_stale_splits).
+        assert!(
+            splits.lock().await.contains_key(&shard_id),
+            "split ConfigMap should not be deleted by rehydrate_paused_shards"
+        );
+        let status = splitter2.get_split_status(shard_id).await.unwrap().unwrap();
+        assert_eq!(
+            status.phase,
+            SplitPhase::SplitPausing,
+            "split record should be untouched"
+        );
+    }
+
+    /// recover_stale_splits must clear the paused-shards cache entry after
+    /// deleting the split record. Without this, a shard stays permanently
+    /// paused with no way to unpause through normal operation.
+    #[tokio::test]
+    async fn test_recover_stale_splits_clears_paused_cache() {
+        let shard_map = Arc::new(Mutex::new(ShardMap::create_initial(4).unwrap()));
+        let owned = Arc::new(Mutex::new(HashSet::new()));
+        let factory = Arc::new(ShardFactory::new_noop());
+        let splits: Arc<Mutex<HashMap<ShardId, SplitInProgress>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        let shard_id = shard_map.lock().await.shard_ids()[0];
+        owned.lock().await.insert(shard_id);
+
+        // Create a split and advance to SplitPausing.
+        let mock = Arc::new(MockSplitBackendWithSharedStorage::new(
+            shard_map.clone(),
+            owned.clone(),
+            factory.clone(),
+            splits.clone(),
+        ));
+        let splitter = ShardSplitter::new(Arc::clone(&mock) as Arc<dyn Coordinator>);
+
+        splitter
+            .request_split(shard_id, "2".to_string())
+            .await
+            .unwrap();
+        splitter.advance_split_phase(shard_id).await.unwrap();
+
+        // Simulate startup: re-hydrate populates the cache.
+        splitter.rehydrate_paused_shards().await.unwrap();
+        assert!(
+            mock.base().is_shard_paused(&shard_id),
+            "shard should be paused after rehydrate"
+        );
+
+        // Operator runs recover_stale_splits to abandon the stuck split.
+        splitter.recover_stale_splits().await.unwrap();
+
+        // The split record should be gone.
+        assert!(
+            splits.lock().await.is_empty(),
+            "split record should be deleted"
+        );
+
+        // The paused cache must also be cleared.
+        assert!(
+            !mock.base().is_shard_paused(&shard_id),
+            "shard must not be paused after recover_stale_splits"
+        );
+    }
+
     #[tokio::test]
     async fn test_request_split_validates_ownership() {
         let shard_map = Arc::new(Mutex::new(ShardMap::create_initial(4).unwrap()));
@@ -1874,5 +2148,4 @@ mod splitter_unit_tests {
             "shard should be usable after factory.close + factory.open"
         );
     }
-
 }

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -1249,19 +1249,13 @@ mod splitter_unit_tests {
             owned: Arc<Mutex<HashSet<ShardId>>>,
             factory: Arc<ShardFactory>,
         ) -> Self {
-            // Create a CoordinatorBase with the provided Arcs
-            let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-            let base = CoordinatorBase {
-                node_id: "mock-node".to_string(),
-                grpc_addr: "http://mock:7450".to_string(),
+            let base = CoordinatorBase::new_with_shared(
+                "mock-node",
+                "http://mock:7450",
                 shard_map,
                 owned,
-                shutdown_tx,
-                shutdown_rx,
                 factory,
-                startup_time_ms: None,
-                placement_rings: Vec::new(),
-            };
+            );
             Self {
                 base,
                 splits: Mutex::new(HashMap::new()),
@@ -1602,18 +1596,13 @@ mod splitter_unit_tests {
             owned: Arc<Mutex<HashSet<ShardId>>>,
             factory: Arc<ShardFactory>,
         ) -> Self {
-            let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-            let base = CoordinatorBase {
-                node_id: "mock-node".to_string(),
-                grpc_addr: "http://mock:7450".to_string(),
+            let base = CoordinatorBase::new_with_shared(
+                "mock-node",
+                "http://mock:7450",
                 shard_map,
                 owned,
-                shutdown_tx,
-                shutdown_rx,
                 factory,
-                startup_time_ms: None,
-                placement_rings: Vec::new(),
-            };
+            );
             Self {
                 base,
                 splits: Mutex::new(HashMap::new()),
@@ -1885,4 +1874,5 @@ mod splitter_unit_tests {
             "shard should be usable after factory.close + factory.open"
         );
     }
+
 }

--- a/tests/server_split_paused_tests.rs
+++ b/tests/server_split_paused_tests.rs
@@ -609,13 +609,8 @@ async fn enqueue_fails_when_k8s_api_unreachable_during_split() {
     ));
 
     let coord = Arc::new(
-        K8sUnreachableCoordinator::new(
-            "test-node",
-            "http://localhost:7450",
-            2,
-            factory.clone(),
-        )
-        .await,
+        K8sUnreachableCoordinator::new("test-node", "http://localhost:7450", 2, factory.clone())
+            .await,
     );
 
     let shard_ids = coord.owned_shards().await;

--- a/tests/server_split_paused_tests.rs
+++ b/tests/server_split_paused_tests.rs
@@ -452,3 +452,243 @@ async fn requests_succeed_after_split_completes() {
     let result = svc.enqueue(req).await;
     assert!(result.is_ok(), "should succeed after split completes");
 }
+
+/// Mock coordinator that simulates a k8s API outage.
+///
+/// All backend/split-storage operations return errors. Crucially, it does NOT
+/// override `is_shard_paused`, so the default trait implementation is used —
+/// which reads from the local `CoordinatorBase` paused-shards cache.
+struct K8sUnreachableCoordinator {
+    base: CoordinatorBase,
+}
+
+impl K8sUnreachableCoordinator {
+    async fn new(
+        node_id: impl Into<String>,
+        grpc_addr: impl Into<String>,
+        num_shards: u32,
+        factory: Arc<ShardFactory>,
+    ) -> Self {
+        let shard_map = ShardMap::create_initial(num_shards).expect("create shard map");
+        let owned_shards: HashSet<ShardId> = shard_map.shard_ids().into_iter().collect();
+        let base = CoordinatorBase::new(node_id, grpc_addr, shard_map, factory, Vec::new());
+        *base.owned.lock().await = owned_shards;
+        Self { base }
+    }
+}
+
+#[tonic::async_trait]
+impl Coordinator for K8sUnreachableCoordinator {
+    fn base(&self) -> &CoordinatorBase {
+        &self.base
+    }
+
+    async fn get_members(&self) -> Result<Vec<MemberInfo>, CoordinationError> {
+        Err(CoordinationError::BackendError(
+            "k8s API unreachable".to_string(),
+        ))
+    }
+
+    async fn get_shard_owner_map(&self) -> Result<ShardOwnerMap, CoordinationError> {
+        Err(CoordinationError::BackendError(
+            "k8s API unreachable".to_string(),
+        ))
+    }
+
+    async fn wait_converged(&self, _timeout: std::time::Duration) -> bool {
+        true
+    }
+
+    async fn shutdown(&self) -> Result<(), CoordinationError> {
+        Ok(())
+    }
+
+    // NOTE: is_shard_paused is intentionally NOT overridden here.
+    // The default trait impl reads from base().paused_shards — this is
+    // exactly the code path we're testing.
+
+    async fn update_shard_placement_ring(
+        &self,
+        _shard_id: &ShardId,
+        _ring: Option<&str>,
+    ) -> Result<(Option<String>, Option<String>), CoordinationError> {
+        Err(CoordinationError::BackendError(
+            "k8s API unreachable".to_string(),
+        ))
+    }
+
+    async fn force_release_shard_lease(
+        &self,
+        _shard_id: &ShardId,
+    ) -> Result<(), CoordinationError> {
+        Err(CoordinationError::BackendError(
+            "k8s API unreachable".to_string(),
+        ))
+    }
+
+    async fn reclaim_existing_leases(&self) -> Result<Vec<ShardId>, CoordinationError> {
+        Err(CoordinationError::BackendError(
+            "k8s API unreachable".to_string(),
+        ))
+    }
+}
+
+#[tonic::async_trait]
+impl SplitStorageBackend for K8sUnreachableCoordinator {
+    async fn load_split(
+        &self,
+        _parent_shard_id: &ShardId,
+    ) -> Result<Option<SplitInProgress>, CoordinationError> {
+        Err(CoordinationError::BackendError(
+            "k8s API unreachable".to_string(),
+        ))
+    }
+
+    async fn store_split(&self, _split: &SplitInProgress) -> Result<(), CoordinationError> {
+        Err(CoordinationError::BackendError(
+            "k8s API unreachable".to_string(),
+        ))
+    }
+
+    async fn delete_split(&self, _parent_shard_id: &ShardId) -> Result<(), CoordinationError> {
+        Err(CoordinationError::BackendError(
+            "k8s API unreachable".to_string(),
+        ))
+    }
+
+    async fn update_shard_map_for_split(
+        &self,
+        _split: &SplitInProgress,
+    ) -> Result<(), CoordinationError> {
+        Err(CoordinationError::BackendError(
+            "k8s API unreachable".to_string(),
+        ))
+    }
+
+    async fn reload_shard_map(&self) -> Result<(), CoordinationError> {
+        Err(CoordinationError::BackendError(
+            "k8s API unreachable".to_string(),
+        ))
+    }
+
+    async fn list_all_splits(&self) -> Result<Vec<SplitInProgress>, CoordinationError> {
+        Err(CoordinationError::BackendError(
+            "k8s API unreachable".to_string(),
+        ))
+    }
+}
+
+/// Enqueue must fail with UNAVAILABLE when the k8s API is unreachable and
+/// the shard has a split in progress. The local paused-shards cache (not
+/// a live API call) must be the source of truth on the hot request path.
+///
+/// Also verifies that a non-paused shard on the same node still accepts
+/// enqueues — an API outage must not block all traffic.
+#[silo::test]
+async fn enqueue_fails_when_k8s_api_unreachable_during_split() {
+    let tmpdir = std::env::temp_dir().join(format!(
+        "silo-k8s-unreachable-test-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+
+    let factory = Arc::new(ShardFactory::new(
+        DatabaseTemplate {
+            backend: Backend::Fs,
+            path: tmpdir.join("%shard%").to_string_lossy().to_string(),
+            wal: None,
+            apply_wal_on_close: true,
+            concurrency_reconcile_interval_ms: 5000,
+            slatedb: None,
+            memory_cache: None,
+        },
+        MockGubernatorClient::new_arc(),
+        None,
+    ));
+
+    let coord = Arc::new(
+        K8sUnreachableCoordinator::new(
+            "test-node",
+            "http://localhost:7450",
+            2,
+            factory.clone(),
+        )
+        .await,
+    );
+
+    let shard_ids = coord.owned_shards().await;
+    let paused_shard = shard_ids[0];
+    let healthy_shard = shard_ids[1];
+
+    // Open both shards in the factory
+    factory
+        .open(&paused_shard, &ShardRange::full())
+        .await
+        .expect("open paused shard");
+    factory
+        .open(&healthy_shard, &ShardRange::full())
+        .await
+        .expect("open healthy shard");
+
+    // Simulate: a split was in progress before the k8s API went down.
+    // The local cache was populated when the split entered a pausing phase.
+    coord.base.mark_shard_paused(paused_shard);
+
+    let cfg = silo::settings::AppConfig::load(None).expect("load config");
+    let svc = SiloService::new(factory, coord, cfg, None);
+
+    // Enqueue to the paused shard — must fail with UNAVAILABLE
+    let req = Request::new(EnqueueRequest {
+        shard: paused_shard.to_string(),
+        tenant: None,
+        id: "job-paused".to_string(),
+        priority: 0,
+        start_at_ms: 0,
+        retry_policy: None,
+        payload: Some(SerializedBytes {
+            encoding: Some(serialized_bytes::Encoding::Msgpack(msgpack_payload(
+                &serde_json::json!({"data": "test"}),
+            ))),
+        }),
+        limits: vec![],
+        metadata: HashMap::new(),
+        task_group: "default".to_string(),
+    });
+    let result = svc.enqueue(req).await;
+    assert!(result.is_err(), "enqueue must fail on paused shard");
+    let status = result.err().unwrap();
+    assert_eq!(
+        status.code(),
+        tonic::Code::Unavailable,
+        "should return UNAVAILABLE, not silently succeed"
+    );
+    assert!(
+        status.message().contains("split in progress"),
+        "error message should mention split"
+    );
+
+    // Enqueue to the healthy shard — must succeed
+    let req = Request::new(EnqueueRequest {
+        shard: healthy_shard.to_string(),
+        tenant: None,
+        id: "job-healthy".to_string(),
+        priority: 0,
+        start_at_ms: 0,
+        retry_policy: None,
+        payload: Some(SerializedBytes {
+            encoding: Some(serialized_bytes::Encoding::Msgpack(msgpack_payload(
+                &serde_json::json!({"data": "test"}),
+            ))),
+        }),
+        limits: vec![],
+        metadata: HashMap::new(),
+        task_group: "default".to_string(),
+    });
+    let result = svc.enqueue(req).await;
+    assert!(
+        result.is_ok(),
+        "enqueue to non-paused shard must succeed even when k8s API is unreachable"
+    );
+}


### PR DESCRIPTION
## Summary
  - Add `paused_shards` local cache to `CoordinatorBase` so `is_shard_paused` is a lock-free read instead of a k8s/etcd API call
  - Update split execution, abandon, and completion paths to keep the cache in sync
  - On split resumption, re-hydrate the cache from persisted split state
  - Add `CoordinatorBase::new_with_shared` constructor for tests that share `shard_map`/`owned` Arcs
  - Add server-level test: enqueue returns UNAVAILABLE on a paused shard and succeeds on a healthy shard, even when the k8s API is completely unreachable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shard request routing behavior by making `Coordinator::is_shard_paused` rely on an in-memory cache that must stay consistent with persisted split records; bugs could cause shards to incorrectly accept or reject traffic during/after splits and restarts.
> 
> **Overview**
> **Avoids k8s/etcd reads on the hot path** by introducing a `CoordinatorBase` in-memory `paused_shards` cache and switching the default `Coordinator::is_shard_paused` implementation to consult it instead of loading split state.
> 
> **Keeps the cache in sync with split lifecycle**: split execution now marks shards paused/unpaused as phases change, clears paused state when abandoning or cleaning up splits, and adds `ShardSplitter::rehydrate_paused_shards` to repopulate paused state from persisted split records after restarts (called during startup in `main`).
> 
> **Tests updated/added** to validate restart rehydration, stale-split recovery clearing the cache, and server behavior when the coordination backend is unreachable (paused shard returns UNAVAILABLE while healthy shards still work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edab0bad14d109307178cd04f365ae18669b7552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->