### PR TITLE
Cache GetClusterInfo response behind a 5s coordinator timeout

### DIFF
--- a/example_configs/dev-node1.toml
+++ b/example_configs/dev-node1.toml
@@ -9,7 +9,7 @@ backend = "etcd"
 cluster_prefix = "silo-dev"
 lease_ttl_secs = 10
 num_shards = 8
-etcd_endpoints = ["http://127.0.0.1:2379"]
+etcd_endpoints = ["http://127.0.0.1:12379"]
 
 [tenancy]
 enabled = true

--- a/example_configs/dev-node2.toml
+++ b/example_configs/dev-node2.toml
@@ -9,7 +9,7 @@ backend = "etcd"
 cluster_prefix = "silo-dev"
 lease_ttl_secs = 10
 num_shards = 8
-etcd_endpoints = ["http://127.0.0.1:2379"]
+etcd_endpoints = ["http://127.0.0.1:12379"]
 
 [tenancy]
 enabled = true

--- a/nix/modules/devshell.nix
+++ b/nix/modules/devshell.nix
@@ -36,10 +36,13 @@
         };
       };
 
-      # Toxiproxy proxy definitions for dev (silo servers behind proxy ports)
+      # Toxiproxy proxy definitions for dev (silo servers behind proxy ports).
+      # The etcd proxy lets tests simulate a slow/unreachable coordination
+      # layer without stopping the etcd process outright.
       toxiproxyConfig = pkgs.writeText "toxiproxy-config.json" (builtins.toJSON [
         { name = "silo-1"; listen = "127.0.0.1:17450"; upstream = "127.0.0.1:7450"; enabled = true; }
         { name = "silo-2"; listen = "127.0.0.1:17451"; upstream = "127.0.0.1:7451"; enabled = true; }
+        { name = "etcd";   listen = "127.0.0.1:12379"; upstream = "127.0.0.1:2379"; enabled = true; }
       ]);
 
       # Script to run development services via process-compose

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,17 +1,18 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use rand::seq::SliceRandom;
 use tokio::net::TcpListener;
-use tokio::sync::broadcast;
+use tokio::sync::{Mutex, broadcast};
 use tokio::task::JoinHandle;
 use tokio_stream::Stream;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
 use tonic_health::server::health_reporter;
 use tonic_reflection::server::Builder as ReflectionBuilder;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::arrow_ipc::batch_to_ipc;
 use datafusion::common::{ParamValues, ScalarValue};
@@ -295,6 +296,12 @@ fn proto_metadata_to_domain(metadata: HashMap<String, String>) -> Option<Vec<(St
     }
 }
 
+/// Maximum time to wait on the coordination layer when servicing
+/// `GetClusterInfo`. If exceeded, we fall back to the last successfully
+/// cached response so transient control-plane outages (e.g. a slow k8s API
+/// server) don't take routing clients down with them.
+const CLUSTER_INFO_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// gRPC service implementation backed by a `ShardFactory`.
 #[derive(Clone)]
 pub struct SiloService {
@@ -302,6 +309,9 @@ pub struct SiloService {
     coordinator: Arc<dyn Coordinator>,
     cfg: AppConfig,
     metrics: Option<Metrics>,
+    /// Last successful `GetClusterInfo` response, served as a fallback when
+    /// the coordination layer is slow or unreachable.
+    cluster_info_cache: Arc<Mutex<Option<GetClusterInfoResponse>>>,
 }
 
 impl SiloService {
@@ -316,6 +326,7 @@ impl SiloService {
             coordinator,
             cfg,
             metrics,
+            cluster_info_cache: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -763,60 +774,91 @@ impl Silo for SiloService {
         &self,
         _req: Request<GetClusterInfoRequest>,
     ) -> Result<Response<GetClusterInfoResponse>, Status> {
-        let coord = &self.coordinator;
+        let coord = self.coordinator.clone();
 
-        let owner_map = coord
-            .get_shard_owner_map()
-            .await
-            .map_err(|e| Status::internal(format!("failed to get shard owner map: {}", e)))?;
+        // Build the response from the live coordination layer, bounded by a
+        // timeout so a hung k8s/etcd backend can't block routing clients
+        // indefinitely. On success we update the cache; on timeout/error we
+        // serve the last good response.
+        let build = async {
+            let owner_map = coord
+                .get_shard_owner_map()
+                .await
+                .map_err(|e| format!("failed to get shard owner map: {}", e))?;
 
-        let shard_owners: Vec<ShardOwner> = owner_map
-            .shard_map
-            .shards()
-            .iter()
-            .map(|shard_info| {
-                let grpc_addr = owner_map
-                    .shard_to_addr
-                    .get(&shard_info.id)
-                    .cloned()
-                    .unwrap_or_default();
-                let node_id = owner_map
-                    .shard_to_node
-                    .get(&shard_info.id)
-                    .cloned()
-                    .unwrap_or_default();
-                ShardOwner {
-                    shard_id: shard_info.id.to_string(),
-                    grpc_addr,
-                    node_id,
-                    range_start: shard_info.range.start.clone(),
-                    range_end: shard_info.range.end.clone(),
-                    placement_ring: shard_info.placement_ring.clone(),
-                }
+            let shard_owners: Vec<ShardOwner> = owner_map
+                .shard_map
+                .shards()
+                .iter()
+                .map(|shard_info| {
+                    let grpc_addr = owner_map
+                        .shard_to_addr
+                        .get(&shard_info.id)
+                        .cloned()
+                        .unwrap_or_default();
+                    let node_id = owner_map
+                        .shard_to_node
+                        .get(&shard_info.id)
+                        .cloned()
+                        .unwrap_or_default();
+                    ShardOwner {
+                        shard_id: shard_info.id.to_string(),
+                        grpc_addr,
+                        node_id,
+                        range_start: shard_info.range.start.clone(),
+                        range_end: shard_info.range.end.clone(),
+                        placement_ring: shard_info.placement_ring.clone(),
+                    }
+                })
+                .collect();
+
+            let member_infos = coord
+                .get_members()
+                .await
+                .map_err(|e| format!("failed to get cluster members: {}", e))?;
+            let members: Vec<ClusterMember> = member_infos
+                .iter()
+                .map(|m| ClusterMember {
+                    node_id: m.node_id.clone(),
+                    grpc_addr: m.grpc_addr.clone(),
+                    placement_rings: m.placement_rings.clone(),
+                })
+                .collect();
+
+            Ok::<GetClusterInfoResponse, String>(GetClusterInfoResponse {
+                num_shards: owner_map.num_shards() as u32,
+                shard_owners,
+                this_node_id: coord.node_id().to_string(),
+                this_grpc_addr: coord.grpc_addr().to_string(),
+                members,
             })
-            .collect();
+        };
 
-        // Get all cluster members with their ring participation
-        let member_infos = coord
-            .get_members()
-            .await
-            .map_err(|e| Status::internal(e.to_string()))?;
-        let members: Vec<ClusterMember> = member_infos
-            .iter()
-            .map(|m| ClusterMember {
-                node_id: m.node_id.clone(),
-                grpc_addr: m.grpc_addr.clone(),
-                placement_rings: m.placement_rings.clone(),
-            })
-            .collect();
+        let outcome = tokio::time::timeout(CLUSTER_INFO_TIMEOUT, build).await;
+        let fallback_reason = match outcome {
+            Ok(Ok(response)) => {
+                *self.cluster_info_cache.lock().await = Some(response.clone());
+                return Ok(Response::new(response));
+            }
+            Ok(Err(e)) => format!("coordinator error: {}", e),
+            Err(_) => format!(
+                "coordinator did not respond within {}s",
+                CLUSTER_INFO_TIMEOUT.as_secs()
+            ),
+        };
 
-        Ok(Response::new(GetClusterInfoResponse {
-            num_shards: owner_map.num_shards() as u32,
-            shard_owners,
-            this_node_id: coord.node_id().to_string(),
-            this_grpc_addr: coord.grpc_addr().to_string(),
-            members,
-        }))
+        if let Some(cached) = self.cluster_info_cache.lock().await.clone() {
+            warn!(
+                reason = %fallback_reason,
+                "GetClusterInfo serving cached response — coordination layer unhealthy"
+            );
+            return Ok(Response::new(cached));
+        }
+
+        Err(Status::unavailable(format!(
+            "GetClusterInfo unavailable: {} (no cached response yet)",
+            fallback_reason
+        )))
     }
 
     async fn enqueue(

--- a/tests/cluster_info_cache_tests.rs
+++ b/tests/cluster_info_cache_tests.rs
@@ -1,0 +1,293 @@
+//! Tests for the cached `GetClusterInfo` fallback in `SiloService`.
+//!
+//! When the coordination layer (k8s API server, etcd, ...) is slow or
+//! unreachable, `GetClusterInfo` should:
+//!  - return the last successfully observed response from an in-memory cache,
+//!  - within the configured timeout (so routing clients aren't blocked),
+//!  - and fall back to `Status::unavailable` only if no cached response exists.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use silo::coordination::{
+    CoordinationError, Coordinator, CoordinatorBase, MemberInfo, ShardOwnerMap, SplitStorageBackend,
+};
+use silo::factory::ShardFactory;
+use silo::gubernator::MockGubernatorClient;
+use silo::pb::silo_server::Silo;
+use silo::pb::*;
+use silo::server::SiloService;
+use silo::settings::{Backend, DatabaseTemplate};
+use silo::shard_range::{ShardId, ShardMap, SplitInProgress};
+use tonic::Request;
+
+/// Mock coordinator that can be told to hang on `get_shard_owner_map` /
+/// `get_members`, simulating a stuck k8s API server.
+struct HangingCoordinator {
+    base: CoordinatorBase,
+    hang: Arc<AtomicBool>,
+}
+
+impl HangingCoordinator {
+    async fn new(node_id: &str, grpc_addr: &str, num_shards: u32) -> Self {
+        let shard_map = ShardMap::create_initial(num_shards).expect("create shard map");
+        let owned: HashSet<ShardId> = shard_map.shard_ids().into_iter().collect();
+        let factory = Arc::new(ShardFactory::new_noop());
+        let base = CoordinatorBase::new(node_id, grpc_addr, shard_map, factory, Vec::new());
+        *base.owned.lock().await = owned;
+        Self {
+            base,
+            hang: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn set_hang(&self, hang: bool) {
+        self.hang.store(hang, Ordering::SeqCst);
+    }
+
+    async fn maybe_hang(&self) {
+        if self.hang.load(Ordering::SeqCst) {
+            // Sleep longer than the server's 5s GetClusterInfo timeout so the
+            // server is forced into the cache-fallback path.
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl Coordinator for HangingCoordinator {
+    fn base(&self) -> &CoordinatorBase {
+        &self.base
+    }
+
+    async fn get_members(&self) -> Result<Vec<MemberInfo>, CoordinationError> {
+        self.maybe_hang().await;
+        Ok(vec![MemberInfo {
+            node_id: self.base.node_id.clone(),
+            grpc_addr: self.base.grpc_addr.clone(),
+            hostname: Some("test-host".to_string()),
+            startup_time_ms: Some(0),
+            placement_rings: self.base.placement_rings.clone(),
+        }])
+    }
+
+    async fn get_shard_owner_map(&self) -> Result<ShardOwnerMap, CoordinationError> {
+        self.maybe_hang().await;
+        let shard_map = self.base.shard_map.lock().await;
+        let mut shard_to_node = HashMap::new();
+        let mut shard_to_addr = HashMap::new();
+        for shard in shard_map.shards() {
+            shard_to_node.insert(shard.id, self.base.node_id.clone());
+            shard_to_addr.insert(shard.id, self.base.grpc_addr.clone());
+        }
+        Ok(ShardOwnerMap {
+            shard_map: shard_map.clone(),
+            shard_to_node,
+            shard_to_addr,
+        })
+    }
+
+    async fn wait_converged(&self, _timeout: Duration) -> bool {
+        true
+    }
+
+    async fn shutdown(&self) -> Result<(), CoordinationError> {
+        Ok(())
+    }
+
+    async fn update_shard_placement_ring(
+        &self,
+        shard_id: &ShardId,
+        ring: Option<&str>,
+    ) -> Result<(Option<String>, Option<String>), CoordinationError> {
+        let mut shard_map = self.base.shard_map.lock().await;
+        let shard = shard_map
+            .get_shard_mut(shard_id)
+            .ok_or_else(|| CoordinationError::ShardNotFound(*shard_id))?;
+        let previous = shard.placement_ring.clone();
+        let current = ring.map(|s| s.to_string());
+        shard.placement_ring = current.clone();
+        Ok((previous, current))
+    }
+
+    async fn force_release_shard_lease(
+        &self,
+        _shard_id: &ShardId,
+    ) -> Result<(), CoordinationError> {
+        Ok(())
+    }
+
+    async fn reclaim_existing_leases(&self) -> Result<Vec<ShardId>, CoordinationError> {
+        Ok(vec![])
+    }
+}
+
+#[tonic::async_trait]
+impl SplitStorageBackend for HangingCoordinator {
+    async fn load_split(
+        &self,
+        _parent_shard_id: &ShardId,
+    ) -> Result<Option<SplitInProgress>, CoordinationError> {
+        Ok(None)
+    }
+
+    async fn store_split(&self, _split: &SplitInProgress) -> Result<(), CoordinationError> {
+        Err(CoordinationError::NotSupported)
+    }
+
+    async fn delete_split(&self, _parent_shard_id: &ShardId) -> Result<(), CoordinationError> {
+        Err(CoordinationError::NotSupported)
+    }
+
+    async fn update_shard_map_for_split(
+        &self,
+        _split: &SplitInProgress,
+    ) -> Result<(), CoordinationError> {
+        Err(CoordinationError::NotSupported)
+    }
+
+    async fn reload_shard_map(&self) -> Result<(), CoordinationError> {
+        Ok(())
+    }
+
+    async fn list_all_splits(&self) -> Result<Vec<SplitInProgress>, CoordinationError> {
+        Ok(vec![])
+    }
+}
+
+async fn create_test_service() -> (SiloService, Arc<HangingCoordinator>) {
+    let coord =
+        Arc::new(HangingCoordinator::new("cache-test-node", "http://localhost:7450", 4).await);
+
+    let tmpdir = std::env::temp_dir().join(format!(
+        "silo-cache-test-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+
+    let factory = Arc::new(ShardFactory::new(
+        DatabaseTemplate {
+            backend: Backend::Fs,
+            path: tmpdir.join("%shard%").to_string_lossy().to_string(),
+            wal: None,
+            apply_wal_on_close: true,
+            concurrency_reconcile_interval_ms: 5000,
+            slatedb: None,
+            memory_cache: None,
+        },
+        MockGubernatorClient::new_arc(),
+        None,
+    ));
+
+    let cfg = silo::settings::AppConfig::load(None).expect("load config");
+    let svc = SiloService::new(factory, coord.clone(), cfg, None);
+    (svc, coord)
+}
+
+/// Server returns the cached response within the timeout when the coordinator
+/// hangs, and the cached payload matches what the live call returned earlier.
+#[silo::test(flavor = "multi_thread")]
+async fn get_cluster_info_serves_cache_when_coordinator_hangs() {
+    let (svc, coord) = create_test_service().await;
+
+    let live = svc
+        .get_cluster_info(Request::new(GetClusterInfoRequest {}))
+        .await
+        .expect("baseline GetClusterInfo should succeed")
+        .into_inner();
+    assert_eq!(live.num_shards, 4);
+    assert_eq!(live.shard_owners.len(), 4);
+
+    // Now make the coordinator hang. The next call must not block forever and
+    // must return exactly what the cache holds from the baseline call.
+    coord.set_hang(true);
+
+    let started = Instant::now();
+    let cached = svc
+        .get_cluster_info(Request::new(GetClusterInfoRequest {}))
+        .await
+        .expect("cached GetClusterInfo should succeed")
+        .into_inner();
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(8),
+        "cached response should arrive within the server timeout window, took {:?}",
+        elapsed
+    );
+    assert!(
+        elapsed >= Duration::from_secs(5),
+        "cached response should only be returned after the timeout fires, took {:?}",
+        elapsed
+    );
+    assert_eq!(cached.num_shards, live.num_shards);
+    assert_eq!(cached.this_node_id, live.this_node_id);
+    assert_eq!(cached.this_grpc_addr, live.this_grpc_addr);
+    assert_eq!(cached.shard_owners.len(), live.shard_owners.len());
+    let mut cached_ids: Vec<_> = cached.shard_owners.iter().map(|s| &s.shard_id).collect();
+    let mut live_ids: Vec<_> = live.shard_owners.iter().map(|s| &s.shard_id).collect();
+    cached_ids.sort();
+    live_ids.sort();
+    assert_eq!(cached_ids, live_ids);
+}
+
+/// With no successful prior call to populate the cache, the server returns
+/// `Unavailable` rather than hanging or returning empty data.
+#[silo::test(flavor = "multi_thread")]
+async fn get_cluster_info_errors_when_no_cache_and_coordinator_hangs() {
+    let (svc, coord) = create_test_service().await;
+    coord.set_hang(true);
+
+    let started = Instant::now();
+    let err = svc
+        .get_cluster_info(Request::new(GetClusterInfoRequest {}))
+        .await
+        .expect_err("should fail when no cache and coordinator is unreachable");
+    let elapsed = started.elapsed();
+
+    assert_eq!(err.code(), tonic::Code::Unavailable);
+    assert!(
+        elapsed < Duration::from_secs(8),
+        "should fail within the timeout window, took {:?}",
+        elapsed
+    );
+}
+
+/// After the coordinator recovers, the next successful call refreshes the cache.
+#[silo::test(flavor = "multi_thread")]
+async fn get_cluster_info_refreshes_cache_after_recovery() {
+    let (svc, coord) = create_test_service().await;
+
+    let _ = svc
+        .get_cluster_info(Request::new(GetClusterInfoRequest {}))
+        .await
+        .expect("baseline call");
+
+    coord.set_hang(true);
+    let cached = svc
+        .get_cluster_info(Request::new(GetClusterInfoRequest {}))
+        .await
+        .expect("cached fallback")
+        .into_inner();
+
+    coord.set_hang(false);
+    let started = Instant::now();
+    let fresh = svc
+        .get_cluster_info(Request::new(GetClusterInfoRequest {}))
+        .await
+        .expect("call after recovery should succeed")
+        .into_inner();
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "post-recovery call should be fast, took {:?}",
+        elapsed
+    );
+    assert_eq!(fresh.num_shards, cached.num_shards);
+    assert_eq!(fresh.shard_owners.len(), cached.shard_owners.len());
+}

--- a/typescript_client/test/cluster-info-cache-integration.test.ts
+++ b/typescript_client/test/cluster-info-cache-integration.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { SiloGRPCClient } from "../src/client";
+import { Toxiproxy, Proxy, type Timeout } from "toxiproxy-node-client";
+
+const SILO_SERVERS = (
+  process.env.SILO_SERVERS ||
+  process.env.SILO_SERVER ||
+  "127.0.0.1:7450,127.0.0.1:7451"
+).split(",");
+
+const TOXIPROXY_API_URL = process.env.TOXIPROXY_API_URL || "http://127.0.0.1:8474";
+
+const RUN_INTEGRATION =
+  process.env.RUN_INTEGRATION === "true" || process.env.CI === "true";
+
+const ETCD_PROXY_NAME = "etcd";
+
+const toxiproxy = new Toxiproxy(TOXIPROXY_API_URL);
+
+async function isToxiproxyAvailable(): Promise<boolean> {
+  try {
+    await toxiproxy.getVersion();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getEtcdProxy(): Promise<Proxy | null> {
+  try {
+    return await toxiproxy.get(ETCD_PROXY_NAME);
+  } catch {
+    return null;
+  }
+}
+
+/** Drop the named toxic if present. `toxiproxy-node-client` has no
+ * removeToxic helper, so we look it up and call its own `.remove()`. */
+async function clearToxic(proxy: Proxy, name: string): Promise<void> {
+  try {
+    const toxic = await proxy.getToxic(name);
+    await toxic.remove();
+  } catch {
+    // toxic doesn't exist — nothing to do
+  }
+}
+
+async function enableProxy(proxy: Proxy): Promise<void> {
+  if (!proxy.enabled) {
+    await proxy.update({
+      enabled: true,
+      listen: proxy.listen,
+      upstream: proxy.upstream,
+    });
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForClusterConvergence(
+  client: SiloGRPCClient,
+  maxAttempts = 60,
+  delayMs = 500,
+): Promise<void> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await client.refreshTopology();
+      const topology = client.getTopology();
+      const hasShards = topology.shards.length > 0;
+      const allShardsHaveOwners = topology.shards.every(
+        (s) => s.serverAddr && s.serverAddr.length > 0,
+      );
+      if (hasShards && allShardsHaveOwners) {
+        await client.enqueue({
+          tenant: `convergence-check-${Date.now()}`,
+          taskGroup: "convergence-check",
+          payload: { check: true },
+        });
+        return;
+      }
+    } catch {
+      // ignore — cluster may still be acquiring shards
+    }
+    if (attempt === maxAttempts) {
+      throw new Error(`Cluster did not converge after ${maxAttempts} attempts`);
+    }
+    await sleep(delayMs);
+  }
+}
+
+describe.skipIf(!RUN_INTEGRATION)(
+  "GetClusterInfo cache fallback integration",
+  () => {
+    let etcdProxy: Proxy;
+    let client: SiloGRPCClient;
+
+    beforeAll(async () => {
+      if (!(await isToxiproxyAvailable())) {
+        throw new Error(
+          `toxiproxy API not reachable at ${TOXIPROXY_API_URL} — start the dev cluster before running this test`,
+        );
+      }
+
+      const proxy = await getEtcdProxy();
+      if (!proxy) {
+        throw new Error(
+          `toxiproxy proxy "${ETCD_PROXY_NAME}" is not configured — check nix/modules/devshell.nix and reload direnv`,
+        );
+      }
+      etcdProxy = proxy;
+
+      // Reset any leftover toxics before we start.
+      await clearToxic(etcdProxy, "etcd-timeout");
+      await enableProxy(etcdProxy);
+
+      client = new SiloGRPCClient({
+        servers: SILO_SERVERS,
+        useTls: false,
+        shardRouting: {
+          topologyRefreshIntervalMs: 0,
+          // Give topology refresh enough time to let the server's own 5s
+          // coordination-layer timeout elapse (plus a little slack).
+          topologyRefreshTimeoutMs: 15_000,
+        },
+        rpcOptions: { timeout: 15_000 },
+      });
+      await waitForClusterConvergence(client);
+    }, 90_000);
+
+    afterAll(async () => {
+      if (etcdProxy) {
+        await clearToxic(etcdProxy, "etcd-timeout");
+        await enableProxy(etcdProxy).catch(() => {});
+      }
+      client?.close();
+    });
+
+    afterEach(async () => {
+      if (etcdProxy) {
+        await clearToxic(etcdProxy, "etcd-timeout");
+        await enableProxy(etcdProxy).catch(() => {});
+      }
+    });
+
+    it(
+      "returns cached topology within the server's 5s timeout when etcd stops responding",
+      async () => {
+        // Capture the topology while etcd is healthy — this is what the
+        // server-side cache should contain after a successful call.
+        await client.refreshTopology();
+        const snapshot = client.getTopology();
+        expect(snapshot.shards.length).toBeGreaterThan(0);
+        const snapshotPairs = [...snapshot.shardToServer.entries()].sort();
+        expect(snapshotPairs.length).toBeGreaterThan(0);
+
+        // Block all etcd traffic from silo. The `timeout` toxic with
+        // timeout=0 holds the connection open and never delivers data, so
+        // silo's etcd client hangs — exactly the "k8s API unreachable"
+        // scenario we care about.
+        await etcdProxy.addToxic<Timeout>({
+          name: "etcd-timeout",
+          type: "timeout",
+          stream: "downstream",
+          toxicity: 1.0,
+          attributes: { timeout: 0 },
+        });
+
+        // Call GetClusterInfo and verify:
+        //  - it returns within the server's timeout window (≤8s is generous)
+        //  - the response matches the pre-outage snapshot (proving it came
+        //    from the server-side cache rather than a live etcd read)
+        const started = Date.now();
+        await client.refreshTopology();
+        const elapsed = Date.now() - started;
+
+        expect(
+          elapsed,
+          `expected cached refresh to return within 8s, took ${elapsed}ms`,
+        ).toBeLessThan(8_000);
+
+        const cached = client.getTopology();
+        const cachedPairs = [...cached.shardToServer.entries()].sort();
+        expect(cachedPairs).toEqual(snapshotPairs);
+        expect(cached.shards.map((s) => s.shardId).sort()).toEqual(
+          snapshot.shards.map((s) => s.shardId).sort(),
+        );
+      },
+      60_000,
+    );
+  },
+);


### PR DESCRIPTION
## Summary
- `src/server.rs` now races the coordination-layer calls in `GetClusterInfo` (`get_shard_owner_map` + `get_members`) against a 5s `tokio::time::timeout`. On success the response is stored in an `Arc<Mutex<Option<GetClusterInfoResponse>>>`; on timeout/error the last good response is returned so routing clients keep a usable topology view while the control plane (k8s API / etcd) is briefly unhealthy. Returns `Status::unavailable` only when nothing has ever been cached.
- Adds Rust integration tests (`tests/cluster_info_cache_tests.rs`) covering cache fallback on hang, the no-cache error path, and cache refresh after recovery.
- Adds a TS integration test (`typescript_client/test/cluster-info-cache-integration.test.ts`) that uses a toxiproxy `timeout` toxic on a new etcd proxy to hang silo's coord calls, then verifies `GetClusterInfo` returns the pre-outage topology within the 5s server-timeout window.
- Dev infra: adds an etcd proxy to `nix/modules/devshell.nix` (`127.0.0.1:12379` → `127.0.0.1:2379`) and points `example_configs/dev-node{1,2}.toml` at it so the TS test can simulate a slow/unreachable coordination layer without stopping etcd outright.

## Test plan
- [x] `cargo test --test cluster_info_cache_tests` — 3/3 (cache fallback on hang, no-cache error, refresh after recovery)
- [x] `cargo test --test server_split_paused_tests` — 5/5 (no regression)
- [x] `RUN_INTEGRATION=true pnpm exec vitest run test/cluster-info-cache-integration.test.ts` — passes against `dev` (runtime matches the 5s server timeout)
- [x] `pnpm exec vitest run test/shard-routing.test.ts` — 51/51 unit tests still pass
- [x] `cargo fmt` clean, `pnpm typecheck` clean

## Reviewer notes
- Pulling this branch requires `direnv reload` + `dev` restart to pick up the new `TOXIPROXY_CONFIG` and the updated `etcd_endpoints` in the dev configs.
- Follow-up: add a k8s-backed manual scenario to exercise the cache path against a real control-plane outage.