### PR TITLE
Resume interrupted shard splits on pod startup

### DIFF
--- a/specs/coordination.als
+++ b/specs/coordination.als
@@ -1505,24 +1505,15 @@ pred nodeFlapStep[n: Node, t: Time, tnext: Time] {
     -- Permanent leases: all leases are preserved through flap
     leaseFrame[t, tnext]
 
-    -- All incomplete splits are abandoned when the node crashes.
-    -- The shard map update is the commit point - if children don't exist in the shard map,
-    -- the split never completed and is safe to abandon. Orphaned clone databases may exist
-    -- but don't affect correctness.
-    all s: Shard | (holdsLease[n, s, t] and splitInProgressFor[s, t] and
-                    splitPhaseAt[s, t] in (SplitRequested + SplitPausing + SplitCloning)) implies
-        not splitInProgressFor[s, tnext]
-
-    -- SplitComplete phase splits are also cleaned up (just the record deletion)
-    all s: Shard | (holdsLease[n, s, t] and splitInProgressFor[s, t] and
-                    splitPhaseAt[s, t] = SplitComplete) implies
-        not splitInProgressFor[s, tnext]
-
-    -- Splits not involving shards held by n are unchanged
-    all s: Shard | not holdsLease[n, s, t] implies {
-        splitInProgressFor[s, tnext] iff splitInProgressFor[s, t]
-        splitInProgressFor[s, t] implies splitPhaseAt[s, tnext] = splitPhaseAt[s, t]
-    }
+    -- [SILO-COORD-INV-16] Split records are preserved through flap.
+    -- Crashing mid-split must NOT abandon the record: the backing ConfigMap (k8s)
+    -- or KV entry (etcd) persists, and a replacement coordinator with the same
+    -- node identity picks it up on restart and drives the split forward through
+    -- the normal splitCloneDbStep / splitUpdateMapStep / splitCleanupStep
+    -- transitions (auto-resume). Abandon on crash would have lost the
+    -- persisted slatedb checkpoint UUID, leaving partial child manifests
+    -- that slatedb's idempotent create_clone could not validate on retry.
+    splitFrame[t, tnext]
 
     -- Frame conditions for other nodes
     membershipFrameExcept[n, t, tnext]
@@ -1828,63 +1819,19 @@ pred splitAbandonStep[n: Node, s: Shard, t: Time, tnext: Time] {
 }
 
 /**
- * NOTE: Split resume is no longer needed with the simplified split model.
- * All incomplete splits are abandoned on crash. The shard map update is
- * the commit point - if children don't exist in the shard map, the split
- * never completed and is safe to abandon.
+ * Split resume after crash: modeled implicitly.
  *
- * This predicate is kept as a placeholder but is never used.
- */
-pred splitResumeStep_UNUSED[n: Node, s: Shard, t: Time, tnext: Time] {
-    -- This predicate is unused - all incomplete splits are abandoned
-    -- Keeping this as documentation of the old behavior
-    
-    -- Preconditions (would have been)
-    splitInProgressFor[s, t]
-    splitPhaseAt[s, t] = SplitComplete  -- Only SplitComplete can exist after crash
-    
-    some orig: splitFor[s, t] | {
-        let leftChild = orig.split_leftChild,
-            rightChild = orig.split_rightChild | {
-            
-            -- Children exist (map was updated before crash)
-            shardExists[leftChild, t]
-            shardExists[rightChild, t]
-            
-            -- New node holds leases on children (it took over)
-            holdsLease[n, leftChild, t]
-            holdsLease[n, rightChild, t]
-            
-            -- Parent no longer exists (was removed in UpdateMap)
-            not shardExists[s, t]
-            
-            -- Postconditions: Complete the split
-            splitInProgressFor[s, tnext]
-            splitPhaseAt[s, tnext] = SplitComplete
-            some next: splitFor[s, tnext] | {
-                next.split_point = orig.split_point
-                next.split_leftChild = leftChild
-                next.split_rightChild = rightChild
-            }
-        }
-    }
-    
-    -- Frame conditions
-    membershipFrame[t, tnext]
-    shardMapFrame[t, tnext]
-    leaseFrame[t, tnext]
-    splitFrameExcept[s, t, tnext]
-    workerFrame[t, tnext]
-}
-
-/**
- * A new node restarts a split from scratch.
- * 
- * When a node crashes before splitUpdateMap, the split is abandoned.
- * A new node that acquires the lease on the parent can start a new split.
- * This is just splitRequestStep with different preconditions - the parent
- * shard is already set up, we're just restarting the process.
- * (No separate transition needed - splitRequestStep covers this case)
+ * After nodeFlapStep preserves the split record (see INV-16), a replacement
+ * coordinator with the same node identity reacquires membership via
+ * nodeRecoverStep + nodeJoinStep. The shard lease is permanent, so
+ * holdsLease[n, s, t] still holds. The existing split transitions
+ * (splitCloneDbStep, splitUpdateMapStep, splitCleanupStep) then fire as
+ * normal — their preconditions only check lease ownership + phase, not
+ * whether this is a "fresh" execution. Idempotency across the crash is
+ * ensured by the persisted checkpoint_id on SplitInProgress: the
+ * re-entered splitCloneDbStep reuses the same slatedb checkpoint UUID,
+ * and slatedb's create_clone validates any partial child manifest
+ * against it rather than rejecting the retry.
  */
 
 /** Cleanup start with full frame conditions */
@@ -2169,20 +2116,28 @@ assert memberAndFlappedMutuallyExclusive {
 }
 
 /**
- * [SILO-COORD-INV-11] Early split crash preserves parent shard.
- * 
- * If a split crashes during an early phase (before UpdateMap), the parent
- * shard must remain available. This ensures no data is lost.
+ * [SILO-COORD-INV-11] Pre-commit split termination preserves data.
+ *
+ * If a split is in a pre-commit phase at t1 and is no longer "in progress"
+ * at some later t2, the split terminated in exactly one of two ways:
+ *   (a) it was abandoned (by splitAbandonStep, e.g. clone failure, operator),
+ *       in which case the parent shard must still exist and be unchanged, or
+ *   (b) it was resumed to completion (via splitUpdateMapStep + splitCleanupStep
+ *       firing after a crash, the auto-resume path), in which case the parent
+ *       has been replaced by its two children in the shard map.
+ *
+ * Either way no data is lost: reads and writes route to the parent in case
+ * (a) and to the children in case (b).
  */
-assert earlySplitCrashPreservesParent {
+assert earlySplitCrashPreservesDataPath {
     all s: Shard, t1, t2: Time |
-        -- If split was in early phase at t1
-        (splitInProgressFor[s, t1] and 
+        (splitInProgressFor[s, t1] and
          splitPhaseAt[s, t1] in (SplitRequested + SplitPausing + SplitCloning) and
-         -- And split is no longer in progress at t2 (abandoned)
          lt[t1, t2] and not splitInProgressFor[s, t2]) implies
-        -- Then parent shard still exists
-        shardExists[s, t2]
+        (shardExists[s, t2]   -- (a) abandoned: parent preserved
+         or (some sp: splitFor[s, t1] |  -- (b) resumed to completion: children exist
+             shardExists[sp.split_leftChild, t2] and
+             shardExists[sp.split_rightChild, t2]))
 }
 
 /**
@@ -2203,10 +2158,12 @@ assert splitChildrenPersist {
 
 /**
  * [SILO-COORD-INV-13] Committed splits preserve their state.
- * 
+ *
  * If a split reaches SplitComplete phase (committed), the split state
- * can be cleaned up but not regressed. Before SplitComplete, any crash
- * abandons the split. This ensures the shard map is the source of truth.
+ * can be cleaned up but not regressed. Pre-commit splits may either be
+ * abandoned (via splitAbandonStep) or resumed to completion after a crash;
+ * the commit point is the shard map update in splitUpdateMapStep, after
+ * which the phase cannot move backwards.
  */
 assert committedSplitStatePreserved {
     all s: Shard, t1, t2: Time |
@@ -2215,6 +2172,28 @@ assert committedSplitStatePreserved {
          lt[t1, t2] and splitInProgressFor[s, t2]) implies
         -- Then phase remains Complete (not regressed, just waiting for cleanup)
         splitPhaseAt[s, t2] = SplitComplete
+}
+
+/**
+ * [SILO-COORD-INV-16] Split records persist through node flap.
+ *
+ * A nodeFlapStep must not delete any in-progress split records. The
+ * backing ConfigMap (k8s) or KV entry (etcd) is what auto-resume relies
+ * on when a replacement coordinator comes up with the same node identity;
+ * losing the record on crash would strand the persisted slatedb
+ * checkpoint UUID and make the resume's idempotent clone impossible.
+ *
+ * Formally: if a split is in progress at t1, and nodeFlapStep takes us
+ * to t2 = next[t1], the same split is still in progress at t2 with the
+ * same phase.
+ */
+assert splitRecordPersistsThroughFlap {
+    all s: Shard, n: Node, t1, t2: Time |
+        (splitInProgressFor[s, t1] and
+         next[t1] = t2 and
+         nodeFlapStep[n, t1, t2]) implies
+        (splitInProgressFor[s, t2] and
+         splitPhaseAt[s, t2] = splitPhaseAt[s, t1])
 }
 
 /**
@@ -2478,16 +2457,18 @@ pred exampleWorkerDuringSplit {
  */
 
 /**
- * Example: Crash during split before UpdateMap (early phase).
+ * Example: Crash during pre-commit split, operator force-release + abandon.
+ *
+ * This is the escape-hatch path: auto-resume has been giving up (e.g., cloud
+ * storage flakiness), so an operator force-releases n1's lease and a peer
+ * takes over to abandon the stuck split.
  *
  * Scenario:
  * - n1 starts a split (reaches SplitPausing or SplitCloning phase)
- * - n1 crashes (flaps) - lease preserved, split abandoned
+ * - n1 crashes (flaps) - lease + split record both preserved (INV-16)
  * - Operator force-releases n1's shard lease
- * - n2 acquires lease on parent shard
- *
- * Key property: The parent shard remains available after the crash,
- * and the system can proceed without the partial split.
+ * - n2 acquires lease on parent shard and explicitly abandons the split
+ * - Parent shard remains available and usable
  */
 pred exampleCrashDuringEarlySplit {
     some n1, n2: Node, parent: Shard | {
@@ -2500,18 +2481,68 @@ pred exampleCrashDuringEarlySplit {
             splitPhaseAt[parent, tSplit] in (SplitPausing + SplitCloning)
         }
 
-        -- n1 crashes (lease preserved)
-        some tFlap: Time | hasFlapped[n1, tFlap] and holdsLease[n1, parent, tFlap]
+        -- n1 crashes: lease and split record both preserved
+        some tFlap: Time | {
+            hasFlapped[n1, tFlap]
+            holdsLease[n1, parent, tFlap]
+            splitInProgressFor[parent, tFlap]
+        }
 
-        -- After crash, split is abandoned (no longer in progress)
+        -- After force-release + operator abandon, split is gone
         some tAfter: Time | {
             not splitInProgressFor[parent, tAfter]
-            -- Parent shard still exists and is usable
             shardExists[parent, tAfter]
         }
 
-        -- After force-release, n2 takes over the parent shard
+        -- n2 ends up holding the parent shard
         some tTakeover: Time | holdsLease[n2, parent, tTakeover]
+    }
+}
+
+/**
+ * Example: Crash during pre-commit split, auto-resume drives to completion.
+ *
+ * This is the common/expected path added by the resume-on-restart feature:
+ * the crashed pod's replacement picks up the persisted split record and
+ * drives it forward. No operator action is needed.
+ *
+ * Scenario:
+ * - n1 starts a split (reaches SplitCloning phase)
+ * - n1 crashes (flaps) - lease + split record both preserved (INV-16)
+ * - n1 recovers and rejoins with the same identity
+ * - Auto-resume: splitCloneDbStep + splitUpdateMapStep + splitCleanupStep
+ *   fire normally, driving the split to SplitComplete and then cleaning
+ *   up the record
+ * - Parent is removed from the shard map, children take its place
+ */
+pred exampleCrashDuringSplitAutoResumes {
+    some n1: Node, parent: Shard | {
+        -- n1 starts split and reaches SplitCloning
+        some tCloning: Time | {
+            holdsLease[n1, parent, tCloning]
+            splitInProgressFor[parent, tCloning]
+            splitPhaseAt[parent, tCloning] = SplitCloning
+        }
+
+        -- n1 crashes: split record preserved
+        some tFlap: Time | {
+            hasFlapped[n1, tFlap]
+            splitInProgressFor[parent, tFlap]
+        }
+
+        -- n1 recovers and rejoins
+        some tRejoin: Time | isMember[n1, tRejoin] and not hasFlapped[n1, tRejoin]
+
+        -- Auto-resume completes: split record cleaned up, children in shard map
+        some tDone: Time | {
+            not splitInProgressFor[parent, tDone]
+            not shardExists[parent, tDone]
+            some sp: SplitInProgress | {
+                sp.split_parent = parent
+                shardExists[sp.split_leftChild, tDone]
+                shardExists[sp.split_rightChild, tDone]
+            }
+        }
     }
 }
 
@@ -2629,12 +2660,20 @@ run exampleWorkerDuringSplit for 3 but
 
 -- NOTE: Cleanup examples removed (see comment in pred section above)
 
--- Crash during early split phase (split abandoned, parent available)
-run exampleCrashDuringEarlySplit for 4 but 
-    exactly 2 Node, exactly 3 Shard, exactly 2 Addr, 
+-- Crash during pre-commit split, operator force-releases + abandons (escape hatch)
+run exampleCrashDuringEarlySplit for 4 but
+    exactly 2 Node, exactly 3 Shard, exactly 2 Addr,
     exactly 4 TenantId, exactly 10 Time, exactly 1 SplitPoint, exactly 0 Worker,
-    10 NodeMembership, 10 NodeFlapped, 20 ShardMapEntry, 10 ShardLease, 
+    10 NodeMembership, 10 NodeFlapped, 20 ShardMapEntry, 10 ShardLease,
     10 SplitInProgress, 0 WorkerRouteCache, 0 WorkerRequest, 0 WorkerRetryableError,
+    10 TenantOrder
+
+-- Crash during pre-commit split, auto-resume drives it to completion (primary path)
+run exampleCrashDuringSplitAutoResumes for 4 but
+    exactly 1 Node, exactly 3 Shard, exactly 1 Addr,
+    exactly 4 TenantId, exactly 12 Time, exactly 1 SplitPoint, exactly 0 Worker,
+    12 NodeMembership, 12 NodeFlapped, 20 ShardMapEntry, 12 ShardLease,
+    12 SplitInProgress, 0 WorkerRouteCache, 0 WorkerRequest, 0 WorkerRetryableError,
     10 TenantOrder
 
 -- Crash after split commit (children persist)
@@ -2737,8 +2776,15 @@ check memberAndFlappedMutuallyExclusive for 3 but
     6 SplitInProgress, 0 WorkerRouteCache, 0 WorkerRequest, 0 WorkerRetryableError,
     6 TenantOrder
 
--- Early split crash preserves parent shard
-check earlySplitCrashPreservesParent for 3 but 
+-- Early split crash: parent preserved (abandon) OR resumed to completion (children exist)
+check earlySplitCrashPreservesDataPath for 3 but
+    2 Node, 3 Shard, 2 Addr, 4 TenantId, 6 Time, 1 SplitPoint, 0 Worker,
+    6 NodeMembership, 6 NodeFlapped, 12 ShardMapEntry, 6 ShardLease,
+    6 SplitInProgress, 0 WorkerRouteCache, 0 WorkerRequest, 0 WorkerRetryableError,
+    8 TenantOrder
+
+-- Split records persist through node flap (resume requires the record)
+check splitRecordPersistsThroughFlap for 3 but
     2 Node, 3 Shard, 2 Addr, 4 TenantId, 6 Time, 1 SplitPoint, 0 Worker,
     6 NodeMembership, 6 NodeFlapped, 12 ShardMapEntry, 6 ShardLease,
     6 SplitInProgress, 0 WorkerRouteCache, 0 WorkerRequest, 0 WorkerRetryableError,

--- a/src/coordination/etcd.rs
+++ b/src/coordination/etcd.rs
@@ -381,6 +381,32 @@ impl EtcdCoordinator {
         }
     }
 
+    /// Simulate a crash: stop all guards immediately WITHOUT releasing shard
+    /// owner keys or membership lease. Used by tests to exercise the
+    /// reclaim/resume path, which relies on owner keys still being present in
+    /// etcd after a replacement coordinator comes up.
+    pub async fn crash(&self) {
+        // Jump each guard straight to ShutDown, bypassing ShuttingDown which
+        // would call release_ownership and delete the owner key.
+        let guards = self.shard_guards.lock().await;
+        for (sid, guard) in guards.iter() {
+            let mut st = guard.ctx.state.lock().await;
+            st.phase = ShardPhase::ShutDown;
+            debug!(shard_id = %sid, "crash: guard set to ShutDown");
+        }
+        drop(guards);
+
+        // Clear in-memory owned set so any future work on this handle is a no-op.
+        let mut owned = self.base.owned.lock().await;
+        owned.clear();
+        drop(owned);
+
+        // Signal shutdown to stop the coordination loop + watchers. Membership
+        // lease is deliberately NOT revoked; on real crashes it would expire
+        // via TTL instead.
+        self.base.signal_shutdown();
+    }
+
     /// Reclaim shards from a previous run and open them before normal reconciliation.
     ///
     /// This is called once at startup to recover shards this node still owns
@@ -1096,7 +1122,13 @@ impl EtcdShardGuard {
         loop {
             if self.ctx.is_shutdown() {
                 let mut st = self.ctx.state.lock().await;
-                st.phase = ShardPhase::ShuttingDown;
+                // Preserve ShutDown: `crash()` uses it to stop the guard
+                // without running the ShuttingDown release-ownership path,
+                // which would delete the owner key and make reclaim on
+                // restart impossible.
+                if st.phase != ShardPhase::ShutDown {
+                    st.phase = ShardPhase::ShuttingDown;
+                }
             }
 
             {

--- a/src/coordination/etcd.rs
+++ b/src/coordination/etcd.rs
@@ -198,8 +198,7 @@ impl EtcdCoordinator {
             // after reclaim so parent shards are open in the factory; the clone
             // path in `execute_split` expects to close an open parent.
             {
-                let splitter =
-                    ShardSplitter::new(Arc::new(me_bg.clone()) as Arc<dyn Coordinator>);
+                let splitter = ShardSplitter::new(Arc::new(me_bg.clone()) as Arc<dyn Coordinator>);
                 if let Err(e) = splitter
                     .resume_in_progress_splits(|| me_bg.get_shard_owner_map())
                     .await

--- a/src/coordination/etcd.rs
+++ b/src/coordination/etcd.rs
@@ -13,7 +13,8 @@ use crate::shard_range::{ShardId, ShardMap, SplitInProgress};
 
 use crate::coordination::{
     CoordinationError, Coordinator, CoordinatorBase, MemberInfo, ShardGuardContext,
-    ShardGuardState, ShardOwnerMap, ShardPhase, SplitStorageBackend, get_hostname, keys,
+    ShardGuardState, ShardOwnerMap, ShardPhase, ShardSplitter, SplitStorageBackend, get_hostname,
+    keys,
 };
 
 /// etcd-based coordinator for distributed shard ownership.
@@ -191,6 +192,20 @@ impl EtcdCoordinator {
             // guards in Held state so reconciliation can manage them normally.
             if let Err(e) = me_bg.reclaim_and_open_shards().await {
                 warn!(node_id = %nid, error = %e, "failed to reclaim shards from previous run");
+            }
+
+            // Drive any splits initiated by this node to completion. Must run
+            // after reclaim so parent shards are open in the factory; the clone
+            // path in `execute_split` expects to close an open parent.
+            {
+                let splitter =
+                    ShardSplitter::new(Arc::new(me_bg.clone()) as Arc<dyn Coordinator>);
+                if let Err(e) = splitter
+                    .resume_in_progress_splits(|| me_bg.get_shard_owner_map())
+                    .await
+                {
+                    warn!(node_id = %nid, error = %e, "failed to resume in-progress splits");
+                }
             }
 
             // Initial reconcile

--- a/src/coordination/k8s.rs
+++ b/src/coordination/k8s.rs
@@ -20,8 +20,8 @@ use crate::coordination::k8s_backend::{
 };
 use crate::coordination::{
     CoordinationError, Coordinator, CoordinatorBase, K8sOwnershipToken, MemberInfo,
-    ShardGuardContext, ShardGuardState, ShardOwnerMap, ShardPhase, SplitStorageBackend,
-    compute_desired_shards_for_node, get_hostname, keys,
+    ShardGuardContext, ShardGuardState, ShardOwnerMap, ShardPhase, ShardSplitter,
+    SplitStorageBackend, compute_desired_shards_for_node, get_hostname, keys,
 };
 
 /// Format a chrono DateTime for K8S MicroTime (RFC3339 with microseconds and Z suffix)
@@ -588,6 +588,19 @@ impl<B: K8sBackend> K8sCoordinator<B> {
         // guards in Held state so reconciliation can manage them normally.
         if let Err(e) = self.reclaim_and_open_shards().await {
             warn!(node_id = %self.base.node_id, error = %e, "failed to reclaim shards from previous run");
+        }
+
+        // Drive any splits initiated by this node to completion. Must run
+        // after reclaim so parent shards are open in the factory; the clone
+        // path in `execute_split` expects to close an open parent.
+        {
+            let splitter = ShardSplitter::new(Arc::new(self.clone()) as Arc<dyn Coordinator>);
+            if let Err(e) = splitter
+                .resume_in_progress_splits(|| self.get_shard_owner_map())
+                .await
+            {
+                warn!(node_id = %self.base.node_id, error = %e, "failed to resume in-progress splits");
+            }
         }
 
         // Do initial reconciliation immediately

--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -528,13 +528,53 @@ impl ShardSplitter {
                         "closed parent shard before cloning"
                     );
 
-                    // Clone the closed parent's database for both children. This reopens
-                    // just the raw SlateDB database, creates a checkpoint, clones to both
-                    // children, then closes the raw database.
+                    // Determine the slatedb checkpoint to clone from. On first
+                    // entry, create a fresh checkpoint and persist the UUID in
+                    // the split record *before* cloning starts, so a crash
+                    // mid-clone lets the resumer pass the same UUID back and
+                    // rely on slatedb's idempotent `create_clone`. On resume,
+                    // a previously persisted UUID is reused as-is.
+                    let checkpoint_id = match split.checkpoint_id.clone() {
+                        Some(id) => {
+                            info!(
+                                parent_shard_id = %parent_shard_id,
+                                checkpoint_id = %id,
+                                "reusing persisted split checkpoint"
+                            );
+                            id
+                        }
+                        None => {
+                            let id = self
+                                .ctx
+                                .factory
+                                .prepare_split_checkpoint(&parent_shard_id)
+                                .await
+                                .map_err(|e| {
+                                    SplitExecutionError::PreCommitParentClosed(
+                                        CoordinationError::BackendError(format!(
+                                            "failed to prepare split checkpoint: {}",
+                                            e
+                                        )),
+                                    )
+                                })?;
+                            split.checkpoint_id = Some(id.clone());
+                            self.coordinator
+                                .store_split(&split)
+                                .await
+                                .map_err(SplitExecutionError::PreCommitParentClosed)?;
+                            id
+                        }
+                    };
+
+                    // Clone both children from the persisted checkpoint. Idempotent
+                    // on crash recovery: slatedb's create_clone validates any
+                    // existing child manifest against this same checkpoint UUID
+                    // and continues initialization from whatever state is on disk.
                     info!(
                         parent_shard_id = %parent_shard_id,
                         left_child = %split.left_child_id,
                         right_child = %split.right_child_id,
+                        checkpoint_id = %checkpoint_id,
                         "cloning database for split"
                     );
 
@@ -544,6 +584,7 @@ impl ShardSplitter {
                             &parent_shard_id,
                             &split.left_child_id,
                             &split.right_child_id,
+                            &checkpoint_id,
                         )
                         .await
                         .map_err(|e| {
@@ -813,6 +854,64 @@ impl ShardSplitter {
                     parent_shard_id = %split.parent_shard_id,
                     phase = %split.phase,
                     "re-hydrated paused state from persisted split record"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Drive any in-progress splits initiated by this node to completion.
+    ///
+    /// Called once at startup, after the coordinator has reclaimed leases and
+    /// opened the parent shards owned by this node. For each split record
+    /// whose `initiator_node_id` is this node and whose phase is non-terminal,
+    /// this method re-enters `execute_split` so the split advances to
+    /// `SplitComplete` (or fails and is abandoned by the normal error path).
+    ///
+    /// Resume of `SplitCloning` is idempotent because the slatedb checkpoint
+    /// UUID is persisted in the split record before cloning begins: the
+    /// resumer passes the same UUID back to `clone_closed_shard`, and
+    /// slatedb's `create_clone` validates and continues from whatever partial
+    /// child manifest exists on disk.
+    ///
+    /// Splits initiated by other nodes are skipped; only the initiator can
+    /// safely drive the clone forward (its parent shard may still hold
+    /// unflushed WAL data).
+    pub async fn resume_in_progress_splits<F, Fut>(
+        &self,
+        get_shard_owner_map: F,
+    ) -> Result<(), CoordinationError>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = Result<ShardOwnerMap, CoordinationError>>,
+    {
+        let splits = self.coordinator.list_all_splits().await?;
+
+        for split in splits {
+            if split.initiator_node_id != self.ctx.node_id {
+                continue;
+            }
+            if split.phase == SplitPhase::SplitComplete {
+                // Terminal record, leave for recover_stale_splits / cleanup.
+                continue;
+            }
+
+            info!(
+                parent_shard_id = %split.parent_shard_id,
+                phase = %split.phase,
+                checkpoint_id = ?split.checkpoint_id,
+                "resuming in-progress split"
+            );
+
+            if let Err(e) = self
+                .execute_split(split.parent_shard_id, &get_shard_owner_map)
+                .await
+            {
+                warn!(
+                    parent_shard_id = %split.parent_shard_id,
+                    error = %e,
+                    "resumed split did not complete"
                 );
             }
         }

--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -919,15 +919,26 @@ impl ShardSplitter {
         Ok(())
     }
 
-    /// Recover from stale split operations after a node restart.
+    /// Operator escape hatch: abandon every in-progress split this node
+    /// initiated, regardless of phase.
     ///
-    /// [SILO-COORD-INV-11] All incomplete splits are abandoned on crash.
-    /// The shard map update is the commit point - if children don't exist in the
-    /// shard map, the split never completed and is safe to abandon. Orphaned
-    /// clone databases may exist but don't affect correctness.
+    /// The default crash-recovery path is `resume_in_progress_splits`
+    /// (auto-resume): the persisted split record is picked up on restart and
+    /// driven forward through the normal phase machine. This method is the
+    /// opposite — intended only for use when auto-resume keeps failing (e.g.,
+    /// persistent object-store errors during clone) and an operator wants to
+    /// give up on a stuck split.
     ///
-    /// This preserves the parent shard when a crash occurs before the commit point,
-    /// ensuring no data is lost during failed splits.
+    /// For pre-commit phases (SplitRequested/SplitPausing/SplitCloning) it
+    /// deletes the ConfigMap/KV record and clears the paused flag; the parent
+    /// shard remains in the shard map. For post-commit SplitComplete it
+    /// simply deletes the residual record.
+    ///
+    /// Note: this does NOT reclaim orphaned clone databases written to object
+    /// storage during an interrupted SplitCloning, nor does it delete the
+    /// slatedb checkpoint pinned on the parent's manifest.
+    ///
+    /// Not currently wired to a siloctl command; call sites are tests only.
     pub async fn recover_stale_splits(&self) -> Result<(), CoordinationError> {
         let splits = self.coordinator.list_all_splits().await?;
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -532,45 +532,27 @@ impl ShardFactory {
         }
     }
 
-    /// Clone a closed shard's database to create child shards for splitting.
+    /// Create a persistent slatedb checkpoint on the parent's closed database
+    /// that the subsequent `clone_closed_shard` call will clone from.
     ///
-    /// This is used during shard splits after the parent shard has been fully closed.
-    /// It opens a raw SlateDB database at the parent's path (without WAL, broker, or
-    /// any silo-level processing), creates a single checkpoint, clones to both children,
-    /// then closes the raw database.
+    /// Factored out from cloning so the split coordinator can persist the
+    /// checkpoint UUID in the split record before the clone starts. On crash
+    /// recovery the resumer passes the persisted UUID back to
+    /// `clone_closed_shard`, letting slatedb's idempotent `create_clone`
+    /// reuse any partially written child manifest.
     ///
-    /// By operating on a fully closed parent, we guarantee that no in-flight writes
-    /// can land after the checkpoint, ensuring children get a consistent snapshot.
-    pub async fn clone_closed_shard(
+    /// The parent shard must be fully closed (no open JobStoreShard instance);
+    /// this opens a raw SlateDB at its path, flushes, checkpoints, and closes.
+    /// Returns the checkpoint UUID as a string for serialization.
+    pub async fn prepare_split_checkpoint(
         &self,
         parent_id: &ShardId,
-        left_child_id: &ShardId,
-        right_child_id: &ShardId,
-    ) -> Result<(), ShardFactoryError> {
+    ) -> Result<String, ShardFactoryError> {
         let parent_name = parent_id.to_string();
-        let left_child_name = left_child_id.to_string();
-        let right_child_name = right_child_id.to_string();
 
-        // Resolve paths relative to storage root
         let (parent_resolved, parent_db_path) =
             Self::resolve_at_root(&self.template.backend, &self.template.path, &parent_name)?;
-        let (_, left_child_db_path) = Self::resolve_at_root(
-            &self.template.backend,
-            &self.template.path,
-            &left_child_name,
-        )?;
-        let (_, right_child_db_path) = Self::resolve_at_root(
-            &self.template.backend,
-            &self.template.path,
-            &right_child_name,
-        )?;
-
-        // Resolve separate WAL object stores if configured. Each shard (parent and
-        // children) gets its own WAL store so that the clone's wal_object_store_uri
-        // is correctly recorded in the manifest.
         let parent_wal_store = self.resolve_wal_store(&parent_name)?;
-        let left_child_wal_store = self.resolve_wal_store(&left_child_name)?;
-        let right_child_wal_store = self.resolve_wal_store(&right_child_name)?;
 
         // Open a raw SlateDB database at the parent's path. We need the WAL store
         // configured so slatedb can validate the wal_object_store_uri in the manifest.
@@ -583,7 +565,10 @@ impl ShardFactory {
             parent_db_builder = parent_db_builder.with_wal_object_store(Arc::clone(wal));
         }
         let db = parent_db_builder.build().await.map_err(|e| {
-            ShardFactoryError::CloneError(format!("failed to reopen parent DB for cloning: {}", e))
+            ShardFactoryError::CloneError(format!(
+                "failed to reopen parent DB for checkpoint: {}",
+                e
+            ))
         })?;
 
         // Flush to ensure all data is in object storage before checkpointing
@@ -609,9 +594,8 @@ impl ShardFactory {
             ShardFactoryError::CloneError(format!("failed to delete clone sentinel: {}", e))
         })?;
 
-        // Create a single checkpoint shared by both children. Use no lifetime so
-        // the checkpoint persists until the children have fully compacted away their
-        // dependency on the parent's SSTs.
+        // Create a checkpoint with no lifetime — it persists until the children
+        // have fully compacted away their dependency on the parent's SSTs.
         // CheckpointScope::All calls flush_wals() + flush_memtables() internally,
         // which flushes the sentinel to L0 and advances replay_after_wal_id past
         // all WAL SSTs. This ensures clones don't inherit a WAL gap.
@@ -626,13 +610,72 @@ impl ShardFactory {
                 ShardFactoryError::CloneError(format!("failed to create checkpoint: {}", e))
             })?;
 
+        db.close().await.map_err(|e| {
+            ShardFactoryError::CloneError(format!(
+                "failed to close raw parent DB after checkpoint: {}",
+                e
+            ))
+        })?;
+
         tracing::info!(
             parent_shard_id = %parent_id,
-            left_child_id = %left_child_id,
-            right_child_id = %right_child_id,
-            checkpoint_id = ?checkpoint.id,
-            "created checkpoint for shard cloning (from closed parent)"
+            checkpoint_id = %checkpoint.id,
+            "created slatedb checkpoint on parent for split"
         );
+
+        Ok(checkpoint.id.to_string())
+    }
+
+    /// Clone a closed shard's database into two children using an existing
+    /// slatedb checkpoint on the parent.
+    ///
+    /// The checkpoint must already exist on the parent (created by
+    /// `prepare_split_checkpoint`). This call reads the parent manifest
+    /// directly from object storage via the slatedb admin API — the parent
+    /// shard must not be open as a `JobStoreShard`, but no open raw DB handle
+    /// is required either.
+    ///
+    /// Idempotent on crash recovery: if a child path already has a partial
+    /// clone manifest from a prior interrupted clone, slatedb's `create_clone`
+    /// validates that it references the same `checkpoint_id` and continues
+    /// initialization from whatever state is on disk.
+    pub async fn clone_closed_shard(
+        &self,
+        parent_id: &ShardId,
+        left_child_id: &ShardId,
+        right_child_id: &ShardId,
+        checkpoint_id: &str,
+    ) -> Result<(), ShardFactoryError> {
+        let parent_name = parent_id.to_string();
+        let left_child_name = left_child_id.to_string();
+        let right_child_name = right_child_id.to_string();
+
+        let checkpoint_uuid = uuid::Uuid::parse_str(checkpoint_id).map_err(|e| {
+            ShardFactoryError::CloneError(format!(
+                "invalid checkpoint UUID {:?}: {}",
+                checkpoint_id, e
+            ))
+        })?;
+
+        // Resolve paths relative to storage root
+        let (parent_resolved, parent_db_path) =
+            Self::resolve_at_root(&self.template.backend, &self.template.path, &parent_name)?;
+        let (_, left_child_db_path) = Self::resolve_at_root(
+            &self.template.backend,
+            &self.template.path,
+            &left_child_name,
+        )?;
+        let (_, right_child_db_path) = Self::resolve_at_root(
+            &self.template.backend,
+            &self.template.path,
+            &right_child_name,
+        )?;
+
+        // Resolve separate WAL object stores if configured. Each child gets
+        // its own WAL store so that the clone's wal_object_store_uri is
+        // correctly recorded in the manifest.
+        let left_child_wal_store = self.resolve_wal_store(&left_child_name)?;
+        let right_child_wal_store = self.resolve_wal_store(&right_child_name)?;
 
         // Clone for left child
         let mut left_admin_builder = slatedb::admin::Admin::builder(
@@ -645,7 +688,7 @@ impl ShardFactory {
         let left_admin = left_admin_builder.build();
 
         left_admin
-            .create_clone(parent_db_path.as_str(), Some(checkpoint.id))
+            .create_clone(parent_db_path.as_str(), Some(checkpoint_uuid))
             .await
             .map_err(|e| {
                 ShardFactoryError::CloneError(format!(
@@ -665,7 +708,7 @@ impl ShardFactory {
         let right_admin = right_admin_builder.build();
 
         right_admin
-            .create_clone(parent_db_path.as_str(), Some(checkpoint.id))
+            .create_clone(parent_db_path.as_str(), Some(checkpoint_uuid))
             .await
             .map_err(|e| {
                 ShardFactoryError::CloneError(format!(
@@ -674,14 +717,6 @@ impl ShardFactory {
                 ))
             })?;
 
-        // Close the raw database
-        db.close().await.map_err(|e| {
-            ShardFactoryError::CloneError(format!(
-                "failed to close raw parent DB after cloning: {}",
-                e
-            ))
-        })?;
-
         tracing::info!(
             parent_shard_id = %parent_id,
             left_child_id = %left_child_id,
@@ -689,6 +724,7 @@ impl ShardFactory {
             parent_db_path = %parent_db_path,
             left_child_db_path = %left_child_db_path,
             right_child_db_path = %right_child_db_path,
+            checkpoint_id = %checkpoint_id,
             "cloned closed shard database to both children"
         );
 

--- a/src/shard_range.rs
+++ b/src/shard_range.rs
@@ -337,6 +337,13 @@ pub struct SplitInProgress {
     pub requested_at_ms: i64,
     /// Node ID that initiated the split (for crash recovery)
     pub initiator_node_id: String,
+    /// slatedb checkpoint UUID (string form) created on the parent shard during
+    /// `SplitCloning`. Persisted so that on crash recovery we re-use the same
+    /// checkpoint and let slatedb's idempotent `create_clone` resume from
+    /// whatever partial child manifest exists on disk. `None` until the
+    /// checkpoint is created (i.e. before the first SplitCloning iteration).
+    #[serde(default)]
+    pub checkpoint_id: Option<String>,
 }
 
 impl SplitInProgress {
@@ -353,6 +360,7 @@ impl SplitInProgress {
                 .map(|d| d.as_millis() as i64)
                 .unwrap_or(0),
             initiator_node_id,
+            checkpoint_id: None,
         }
     }
 

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -1036,7 +1036,7 @@ async fn execute_split_abandons_on_clone_failure() {
 
 /// Test crash recovery during early phase (split should be abandoned)
 #[silo::test(flavor = "multi_thread", worker_threads = 4)]
-async fn crash_recovery_early_phase_abandons_split() {
+async fn crash_recovery_early_phase_resumes_split() {
     let _guard = acquire_test_mutex();
 
     let prefix = unique_prefix();
@@ -1063,10 +1063,9 @@ async fn crash_recovery_early_phase_abandons_split() {
     let shard_id = shards[0];
 
     // Create splitter, request split and advance to SplitPausing (early phase)
-
     let splitter1 = ShardSplitter::new(Arc::new(c1.clone()));
 
-    let _split = splitter1
+    let split = splitter1
         .request_split(shard_id, "m".to_string())
         .await
         .expect("request split");
@@ -1080,7 +1079,9 @@ async fn crash_recovery_early_phase_abandons_split() {
     let _ = h1.abort();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // Start new coordinator
+    // Start new coordinator. Its coordination loop runs
+    // resume_in_progress_splits after reclaim, so the paused split should
+    // drive itself to SplitComplete automatically.
     let (c2, h2) = EtcdCoordinator::start(
         &cfg.coordination.etcd_endpoints,
         &prefix,
@@ -1096,42 +1097,43 @@ async fn crash_recovery_early_phase_abandons_split() {
 
     assert!(c2.wait_converged(Duration::from_secs(10)).await);
 
-    // Create splitter for c2
-
     let splitter2 = ShardSplitter::new(Arc::new(c2.clone()));
 
-    // Early phase crash should abandon the split
-    // The coordinator should detect the stale split and clean it up
-    splitter2
-        .recover_stale_splits()
-        .await
-        .expect("recover stale splits");
+    // Poll for background resume completion.
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let mut completed = false;
+    while std::time::Instant::now() < deadline {
+        if splitter2
+            .get_split_status(shard_id)
+            .await
+            .ok()
+            .flatten()
+            .is_none()
+        {
+            completed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(completed, "resumed split should clear its record");
 
-    let status = splitter2
-        .get_split_status(shard_id)
-        .await
-        .expect("get status");
-    assert!(
-        status.is_none(),
-        "early phase split should be abandoned after crash"
-    );
-
-    // Shard map should still have original shard
     let shard_map = c2.get_shard_map().await.expect("get shard map");
-    assert_eq!(shard_map.len(), 1);
-    assert!(shard_map.get_shard(&shard_id).is_some());
+    assert_eq!(shard_map.len(), 2);
+    assert!(shard_map.get_shard(&split.left_child_id).is_some());
+    assert!(shard_map.get_shard(&split.right_child_id).is_some());
+    assert!(
+        shard_map.get_shard(&shard_id).is_none(),
+        "parent should have been removed"
+    );
 
     c2.shutdown().await.unwrap();
     let _ = h2.abort();
 }
 
-/// Test crash recovery during cloning phase (split should be abandoned)
-///
-/// With the simplified split model, ALL incomplete splits are abandoned on crash.
-/// The shard map update is the commit point - if children don't exist in the
-/// shard map, the split never completed and is safely abandoned.
+/// Test that a split crashed in SplitCloning (before shard-map commit) is
+/// auto-resumed to completion on restart.
 #[silo::test(flavor = "multi_thread", worker_threads = 4)]
-async fn crash_recovery_cloning_phase_abandons_split() {
+async fn crash_recovery_cloning_phase_resumes_split() {
     let _guard = acquire_test_mutex();
 
     let prefix = unique_prefix();
@@ -1157,28 +1159,25 @@ async fn crash_recovery_cloning_phase_abandons_split() {
     let shards = c1.owned_shards().await;
     let shard_id = shards[0];
 
-    // Create splitter, request split and advance to cloning phase
-
     let splitter1 = ShardSplitter::new(Arc::new(c1.clone()));
 
-    let _split = splitter1
+    let split = splitter1
         .request_split(shard_id, "m".to_string())
         .await
         .expect("request split");
 
-    // Advance to SplitCloning phase
+    // Advance to SplitCloning phase without actually cloning, then crash.
     splitter1.advance_split_phase(shard_id).await.unwrap(); // -> SplitPausing
     splitter1.advance_split_phase(shard_id).await.unwrap(); // -> SplitCloning
 
     let status = splitter1.get_split_status(shard_id).await.unwrap().unwrap();
     assert_eq!(status.phase, SplitPhase::SplitCloning);
 
-    // Simulate crash
     c1.shutdown().await.unwrap();
     let _ = h1.abort();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // Start new coordinator
+    // Start new coordinator - should auto-resume the split.
     let (c2, h2) = EtcdCoordinator::start(
         &cfg.coordination.etcd_endpoints,
         &prefix,
@@ -1194,29 +1193,42 @@ async fn crash_recovery_cloning_phase_abandons_split() {
 
     assert!(c2.wait_converged(Duration::from_secs(10)).await);
 
-    // Create splitter for c2
-
     let splitter2 = ShardSplitter::new(Arc::new(c2.clone()));
 
-    // Recover stale splits - should abandon the incomplete split
-    splitter2
-        .recover_stale_splits()
-        .await
-        .expect("recover stale splits");
-
-    // Split should be abandoned (deleted)
-    let status = splitter2
-        .get_split_status(shard_id)
-        .await
-        .expect("get status");
-    assert!(status.is_none(), "incomplete split should be abandoned");
-
-    // Shard map should still have original shard (split was not committed)
-    let shard_map = c2.get_shard_map().await.expect("get shard map");
-    assert_eq!(shard_map.len(), 1, "shard map should have original shard");
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let mut completed = false;
+    while std::time::Instant::now() < deadline {
+        if splitter2
+            .get_split_status(shard_id)
+            .await
+            .ok()
+            .flatten()
+            .is_none()
+        {
+            completed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
     assert!(
-        shard_map.get_shard(&shard_id).is_some(),
-        "original shard should still exist"
+        completed,
+        "stuck SplitCloning split should resume and complete"
+    );
+
+    let shard_map = c2.get_shard_map().await.expect("get shard map");
+    assert_eq!(shard_map.len(), 2);
+    assert!(shard_map.get_shard(&split.left_child_id).is_some());
+    assert!(shard_map.get_shard(&split.right_child_id).is_some());
+
+    // Re-issuing a split on one of the children should succeed — the prior
+    // stuck split no longer blocks further operations on the parent.
+    let followup = splitter2
+        .request_split(split.left_child_id, "b".to_string())
+        .await;
+    assert!(
+        followup.is_ok(),
+        "follow-up split on child should succeed, got {:?}",
+        followup
     );
 
     c2.shutdown().await.unwrap();

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -320,15 +320,17 @@ async fn is_shard_paused_returns_correct_values() {
 }
 
 /// Test that split state is persisted across coordinator restarts
+/// Test that a persisted split record is picked up by a replacement
+/// coordinator on restart. With auto-resume in the coord loop, the split is
+/// driven to completion rather than left untouched.
 #[silo::test(flavor = "multi_thread", worker_threads = 4)]
-async fn split_state_persists_across_restart() {
+async fn split_state_persists_and_resumes_across_restart() {
     let _guard = acquire_test_mutex();
 
     let prefix = unique_prefix();
     let num_shards: u32 = 1;
     let cfg = silo::settings::AppConfig::load(None).expect("load default config");
 
-    // Start first coordinator and request a split
     let (c1, h1) = EtcdCoordinator::start(
         &cfg.coordination.etcd_endpoints,
         &prefix,
@@ -347,8 +349,6 @@ async fn split_state_persists_across_restart() {
     let shards = c1.owned_shards().await;
     let shard_id = shards[0];
 
-    // Create splitter and request split
-
     let splitter1 = ShardSplitter::new(Arc::new(c1.clone()));
 
     let split = splitter1
@@ -356,17 +356,13 @@ async fn split_state_persists_across_restart() {
         .await
         .expect("request split");
 
-    let left_child_id = split.left_child_id;
-    let right_child_id = split.right_child_id;
-
-    // Shutdown first coordinator
-    c1.shutdown().await.unwrap();
+    // Simulate a crash: stop background tasks without releasing shard owner
+    // keys in etcd, so the replacement coordinator can reclaim them.
+    c1.crash().await;
     let _ = h1.abort();
-
-    // Give etcd time to process the shutdown
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // Start a new coordinator
+    // Start a new coordinator with the same node_id + storage.
     let (c2, h2) = EtcdCoordinator::start(
         &cfg.coordination.etcd_endpoints,
         &prefix,
@@ -374,7 +370,7 @@ async fn split_state_persists_across_restart() {
         "http://127.0.0.1:7450",
         num_shards,
         10,
-        make_test_factory(&prefix, "n1-restart"),
+        make_test_factory(&prefix, "n1"),
         Vec::new(),
     )
     .await
@@ -382,20 +378,30 @@ async fn split_state_persists_across_restart() {
 
     assert!(c2.wait_converged(Duration::from_secs(10)).await);
 
-    // Create splitter for c2 and check split status
-
     let splitter2 = ShardSplitter::new(Arc::new(c2.clone()));
 
-    // Split state should still be there
-    let status = splitter2
-        .get_split_status(shard_id)
-        .await
-        .expect("get split status");
-    assert!(status.is_some());
-    let status = status.unwrap();
-    assert_eq!(status.parent_shard_id, shard_id);
-    assert_eq!(status.left_child_id, left_child_id);
-    assert_eq!(status.right_child_id, right_child_id);
+    // Poll for the background resume to drive the split to completion.
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let mut completed = false;
+    while std::time::Instant::now() < deadline {
+        if splitter2
+            .get_split_status(shard_id)
+            .await
+            .ok()
+            .flatten()
+            .is_none()
+        {
+            completed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(completed, "auto-resume should complete the persisted split");
+
+    let shard_map = c2.get_shard_map().await.expect("get shard map");
+    assert_eq!(shard_map.len(), 2);
+    assert!(shard_map.get_shard(&split.left_child_id).is_some());
+    assert!(shard_map.get_shard(&split.right_child_id).is_some());
 
     c2.shutdown().await.unwrap();
     let _ = h2.abort();
@@ -1074,8 +1080,9 @@ async fn crash_recovery_early_phase_resumes_split() {
         .await
         .expect("advance to pausing");
 
-    // Simulate crash by shutting down abruptly
-    c1.shutdown().await.unwrap();
+    // Simulate a crash: stop background tasks without releasing shard owner
+    // keys in etcd, so the replacement coordinator can reclaim them.
+    c1.crash().await;
     let _ = h1.abort();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -1089,7 +1096,7 @@ async fn crash_recovery_early_phase_resumes_split() {
         "http://127.0.0.1:7450",
         num_shards,
         10,
-        make_test_factory(&prefix, "n1-restart"),
+        make_test_factory(&prefix, "n1"),
         Vec::new(),
     )
     .await
@@ -1173,7 +1180,9 @@ async fn crash_recovery_cloning_phase_resumes_split() {
     let status = splitter1.get_split_status(shard_id).await.unwrap().unwrap();
     assert_eq!(status.phase, SplitPhase::SplitCloning);
 
-    c1.shutdown().await.unwrap();
+    // Simulate a crash: stop background tasks without releasing shard owner
+    // keys in etcd, so the replacement coordinator can reclaim them.
+    c1.crash().await;
     let _ = h1.abort();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -1185,7 +1194,7 @@ async fn crash_recovery_cloning_phase_resumes_split() {
         "http://127.0.0.1:7450",
         num_shards,
         10,
-        make_test_factory(&prefix, "n1-restart"),
+        make_test_factory(&prefix, "n1"),
         Vec::new(),
     )
     .await

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -1949,7 +1949,10 @@ async fn etcd_crash_recovery_cloning_phase_resumes_split() {
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
-    assert!(completed, "resumed split should complete and clear its record");
+    assert!(
+        completed,
+        "resumed split should complete and clear its record"
+    );
 
     let shard_map = c2.get_shard_map().await.unwrap();
     assert_eq!(shard_map.len(), 2, "split should have created two children");

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -33,6 +33,13 @@ fn make_test_factory(node_id: &str) -> Arc<ShardFactory> {
     let counter = PREFIX_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     let tmpdir =
         std::env::temp_dir().join(format!("silo-etcd-test-{}-{}-{}", node_id, nanos, counter));
+    make_test_factory_at(&tmpdir)
+}
+
+/// Create a factory rooted at an explicit directory. Use this when two
+/// coordinators in the same test must share storage (e.g. restart/resume
+/// tests), matching production where pods share the same object store.
+fn make_test_factory_at(tmpdir: &std::path::Path) -> Arc<ShardFactory> {
     Arc::new(ShardFactory::new(
         DatabaseTemplate {
             // Use Fs backend for split tests because SlateDB cloning requires a real object store
@@ -1381,19 +1388,36 @@ async fn etcd_is_shard_paused_returns_correct_values() {
     handle.abort();
 }
 
-/// Test that split state persists across coordinator restart.
+/// Test that a split record placed in etcd by one coordinator is picked up by
+/// a replacement coordinator on restart. With auto-resume in the coordination
+/// loop, the split is driven to completion rather than left as a stuck record.
 #[silo::test(flavor = "multi_thread", worker_threads = 2)]
-async fn etcd_split_state_persists_across_restart() {
+async fn etcd_split_state_persists_and_resumes_across_restart() {
     let prefix = unique_prefix();
-    let num_shards: u32 = 1; // Use 1 shard so it covers the entire keyspace
+    let num_shards: u32 = 1;
 
-    // Start first coordinator
-    let (c1, h1) = start_etcd_coordinator!(
+    // Shared storage directory so the replacement coordinator sees the same
+    // parent SlateDB data (mirrors production where pods share object store).
+    let shared_dir = std::env::temp_dir().join(format!(
+        "silo-etcd-resume-{}-{}",
+        unique_prefix(),
+        PREFIX_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    ));
+
+    let endpoints = get_etcd_endpoints();
+    let (c1, h1) = EtcdCoordinator::start(
+        &endpoints,
         &prefix,
         "persist-test-1",
         "http://127.0.0.1:7450",
-        num_shards
-    );
+        num_shards,
+        10,
+        make_test_factory_at(&shared_dir),
+        Vec::new(),
+    )
+    .await
+    .expect("start coordinator 1");
+    let c1_concrete = c1.clone();
     let c1: Arc<dyn Coordinator> = Arc::new(c1);
 
     assert!(c1.wait_converged(Duration::from_secs(15)).await);
@@ -1401,23 +1425,19 @@ async fn etcd_split_state_persists_across_restart() {
     let owned = c1.owned_shards().await;
     let shard_id = owned[0];
 
-    // Create splitter and request a split
     let splitter1 = ShardSplitter::new(c1.clone());
-
     let split = splitter1
         .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split should succeed");
 
-    // Shutdown the coordinator
-    c1.shutdown().await.unwrap();
+    // Simulate a crash: stop background tasks without releasing shard owner
+    // keys in etcd, so the replacement coordinator can reclaim them.
+    c1_concrete.crash().await;
     h1.abort();
-
-    // Small delay
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    // Start new coordinator with same prefix (simulates restart)
-    let endpoints = get_etcd_endpoints();
+    // Restart with the same storage — auto-resume should drive it to completion.
     let (c2, h2) = EtcdCoordinator::start(
         &endpoints,
         &prefix,
@@ -1425,7 +1445,7 @@ async fn etcd_split_state_persists_across_restart() {
         "http://127.0.0.1:7450",
         num_shards,
         10,
-        make_test_factory("persist-test-1-restart"),
+        make_test_factory_at(&shared_dir),
         Vec::new(),
     )
     .await
@@ -1434,24 +1454,30 @@ async fn etcd_split_state_persists_across_restart() {
 
     assert!(c2.wait_converged(Duration::from_secs(15)).await);
 
-    // Create splitter for c2 and verify the split state persisted
     let splitter2 = ShardSplitter::new(c2.clone());
 
-    let status = splitter2
-        .get_split_status(shard_id)
-        .await
-        .expect("get_split_status should succeed");
-    assert!(
-        status.is_some(),
-        "split status should persist after restart"
-    );
-    let status = status.unwrap();
-    assert_eq!(status.parent_shard_id, shard_id);
-    assert_eq!(status.split_point, "8000000000000000");
-    assert_eq!(status.left_child_id, split.left_child_id);
-    assert_eq!(status.right_child_id, split.right_child_id);
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut completed = false;
+    while Instant::now() < deadline {
+        if splitter2
+            .get_split_status(shard_id)
+            .await
+            .ok()
+            .flatten()
+            .is_none()
+        {
+            completed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(completed, "auto-resume should complete the persisted split");
 
-    // Cleanup
+    let shard_map = c2.get_shard_map().await.unwrap();
+    assert_eq!(shard_map.len(), 2);
+    assert!(shard_map.get_shard(&split.left_child_id).is_some());
+    assert!(shard_map.get_shard(&split.right_child_id).is_some());
+
     c2.shutdown().await.unwrap();
     h2.abort();
 }
@@ -1876,13 +1902,27 @@ async fn etcd_crash_recovery_cloning_phase_resumes_split() {
     let prefix = unique_prefix();
     let num_shards: u32 = 1;
 
-    // Start first coordinator
-    let (c1, h1) = start_etcd_coordinator!(
+    // Shared storage so the replacement coordinator sees the same parent data.
+    let shared_dir = std::env::temp_dir().join(format!(
+        "silo-etcd-resume-{}-{}",
+        unique_prefix(),
+        PREFIX_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    ));
+
+    let endpoints = get_etcd_endpoints();
+    let (c1, h1) = EtcdCoordinator::start(
+        &endpoints,
         &prefix,
         "crash-cloning-1",
         "http://127.0.0.1:7450",
-        num_shards
-    );
+        num_shards,
+        10,
+        make_test_factory_at(&shared_dir),
+        Vec::new(),
+    )
+    .await
+    .expect("start coordinator 1");
+    let c1_concrete = c1.clone();
     let c1: Arc<dyn Coordinator> = Arc::new(c1);
 
     assert!(c1.wait_converged(Duration::from_secs(15)).await);
@@ -1905,15 +1945,15 @@ async fn etcd_crash_recovery_cloning_phase_resumes_split() {
     let status = splitter1.get_split_status(shard_id).await.unwrap().unwrap();
     assert_eq!(status.phase, SplitPhase::SplitCloning);
 
-    // Simulate crash
-    c1.shutdown().await.unwrap();
+    // Simulate a crash: stop background tasks without releasing shard owner
+    // keys in etcd, so the replacement coordinator can reclaim them.
+    c1_concrete.crash().await;
     h1.abort();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // Start new coordinator. Its coordination loop runs
-    // resume_in_progress_splits after reclaim, so the stuck split should
-    // drive itself to SplitComplete automatically.
-    let endpoints = get_etcd_endpoints();
+    // Start new coordinator with the same storage directory. Its coordination
+    // loop runs resume_in_progress_splits after reclaim, so the stuck split
+    // should drive itself to SplitComplete automatically.
     let (c2, h2) = EtcdCoordinator::start(
         &endpoints,
         &prefix,
@@ -1921,7 +1961,7 @@ async fn etcd_crash_recovery_cloning_phase_resumes_split() {
         "http://127.0.0.1:7450",
         num_shards,
         10,
-        make_test_factory("crash-cloning-1-restart"),
+        make_test_factory_at(&shared_dir),
         Vec::new(),
     )
     .await

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -1869,13 +1869,10 @@ async fn etcd_crash_recovery_early_phase_abandons_split() {
     h2.abort();
 }
 
-/// Test crash recovery during cloning phase abandons the split.
-///
-/// With the simplified split model, ALL incomplete splits are abandoned on crash.
-/// The shard map update is the commit point - if children don't exist in the
-/// shard map, the split never completed and is safely abandoned.
+/// Test that a split crashed in SplitCloning (before shard-map commit) is
+/// auto-resumed to completion on restart.
 #[silo::test(flavor = "multi_thread", worker_threads = 2)]
-async fn etcd_crash_recovery_cloning_phase_abandons_split() {
+async fn etcd_crash_recovery_cloning_phase_resumes_split() {
     let prefix = unique_prefix();
     let num_shards: u32 = 1;
 
@@ -1893,10 +1890,11 @@ async fn etcd_crash_recovery_cloning_phase_abandons_split() {
     let owned = c1.owned_shards().await;
     let shard_id = owned[0];
 
-    // Create splitter and request split, advance to SplitCloning phase
+    // Create splitter and advance the split to the SplitCloning phase
+    // without executing the clone itself, simulating a mid-clone crash.
     let splitter1 = ShardSplitter::new(c1.clone());
 
-    let _split = splitter1
+    let split = splitter1
         .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split");
@@ -1912,7 +1910,9 @@ async fn etcd_crash_recovery_cloning_phase_abandons_split() {
     h1.abort();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // Start new coordinator
+    // Start new coordinator. Its coordination loop runs
+    // resume_in_progress_splits after reclaim, so the stuck split should
+    // drive itself to SplitComplete automatically.
     let endpoints = get_etcd_endpoints();
     let (c2, h2) = EtcdCoordinator::start(
         &endpoints,
@@ -1930,29 +1930,31 @@ async fn etcd_crash_recovery_cloning_phase_abandons_split() {
 
     assert!(c2.wait_converged(Duration::from_secs(15)).await);
 
-    // Create splitter for c2
     let splitter2 = ShardSplitter::new(c2.clone());
 
-    // Recover stale splits - should abandon the incomplete split
-    splitter2
-        .recover_stale_splits()
-        .await
-        .expect("recover stale splits");
+    // Poll for resume completion (split record deleted, shard map has
+    // the two children).
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut completed = false;
+    while Instant::now() < deadline {
+        if splitter2
+            .get_split_status(shard_id)
+            .await
+            .ok()
+            .flatten()
+            .is_none()
+        {
+            completed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(completed, "resumed split should complete and clear its record");
 
-    // Split should be abandoned (deleted)
-    let status = splitter2
-        .get_split_status(shard_id)
-        .await
-        .expect("get status");
-    assert!(status.is_none(), "incomplete split should be abandoned");
-
-    // Shard map should still have original shard (split was not committed)
     let shard_map = c2.get_shard_map().await.unwrap();
-    assert_eq!(shard_map.len(), 1, "shard map should have original shard");
-    assert!(
-        shard_map.get_shard(&shard_id).is_some(),
-        "original shard should still exist"
-    );
+    assert_eq!(shard_map.len(), 2, "split should have created two children");
+    assert!(shard_map.get_shard(&split.left_child_id).is_some());
+    assert!(shard_map.get_shard(&split.right_child_id).is_some());
 
     c2.shutdown().await.unwrap();
     h2.abort();

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -229,9 +229,18 @@ async fn clone_closed_shard_creates_copies() {
     // Close parent (clone_closed_shard expects it to be closed)
     parent.close().await.expect("close parent");
 
-    // Clone the shard to both children
+    // Prepare the split checkpoint on the parent, then clone both children.
+    let checkpoint_id = factory
+        .prepare_split_checkpoint(&parent_id)
+        .await
+        .expect("prepare split checkpoint");
     factory
-        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .clone_closed_shard(
+            &parent_id,
+            &left_child_id,
+            &right_child_id,
+            &checkpoint_id,
+        )
         .await
         .expect("clone closed shard");
 
@@ -309,9 +318,18 @@ async fn clone_closed_shard_with_split_wal() {
     // Close parent (clone_closed_shard expects it to be closed)
     parent.close().await.expect("close parent");
 
-    // Clone the shard — this should succeed even with split WAL
+    // Prepare checkpoint then clone — should succeed even with split WAL.
+    let checkpoint_id = factory
+        .prepare_split_checkpoint(&parent_id)
+        .await
+        .expect("prepare split checkpoint");
     factory
-        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .clone_closed_shard(
+            &parent_id,
+            &left_child_id,
+            &right_child_id,
+            &checkpoint_id,
+        )
         .await
         .expect("clone closed shard with WAL");
 
@@ -344,6 +362,75 @@ async fn clone_closed_shard_with_split_wal() {
         right_counters.total_jobs, 1,
         "right child should have the parent's job"
     );
+}
+
+/// Resume-safety: calling `clone_closed_shard` a second time with the same
+/// checkpoint UUID must succeed (slatedb's create_clone is idempotent when
+/// the existing child manifest references the same parent checkpoint). This
+/// is the property the split resumer relies on.
+#[silo::test]
+async fn clone_closed_shard_is_idempotent_with_same_checkpoint() {
+    let tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory(&tmp);
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("idempotent-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+    parent.close().await.expect("close parent");
+
+    let checkpoint_id = factory
+        .prepare_split_checkpoint(&parent_id)
+        .await
+        .expect("prepare checkpoint");
+
+    // First clone — writes child manifests bound to this checkpoint.
+    factory
+        .clone_closed_shard(
+            &parent_id,
+            &left_child_id,
+            &right_child_id,
+            &checkpoint_id,
+        )
+        .await
+        .expect("first clone");
+
+    // Second clone — must succeed because slatedb validates the existing
+    // manifest matches and returns as-is.
+    factory
+        .clone_closed_shard(
+            &parent_id,
+            &left_child_id,
+            &right_child_id,
+            &checkpoint_id,
+        )
+        .await
+        .expect("idempotent re-clone");
+
+    // The children should still be readable and contain the parent's data.
+    let left = factory
+        .open(&left_child_id, &ShardRange::full())
+        .await
+        .expect("open left");
+    let counters = left.get_counters().await.expect("counters");
+    assert_eq!(counters.total_jobs, 1);
 }
 
 // --- template path validation tests ---

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -235,12 +235,7 @@ async fn clone_closed_shard_creates_copies() {
         .await
         .expect("prepare split checkpoint");
     factory
-        .clone_closed_shard(
-            &parent_id,
-            &left_child_id,
-            &right_child_id,
-            &checkpoint_id,
-        )
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id, &checkpoint_id)
         .await
         .expect("clone closed shard");
 
@@ -324,12 +319,7 @@ async fn clone_closed_shard_with_split_wal() {
         .await
         .expect("prepare split checkpoint");
     factory
-        .clone_closed_shard(
-            &parent_id,
-            &left_child_id,
-            &right_child_id,
-            &checkpoint_id,
-        )
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id, &checkpoint_id)
         .await
         .expect("clone closed shard with WAL");
 
@@ -403,24 +393,14 @@ async fn clone_closed_shard_is_idempotent_with_same_checkpoint() {
 
     // First clone — writes child manifests bound to this checkpoint.
     factory
-        .clone_closed_shard(
-            &parent_id,
-            &left_child_id,
-            &right_child_id,
-            &checkpoint_id,
-        )
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id, &checkpoint_id)
         .await
         .expect("first clone");
 
     // Second clone — must succeed because slatedb validates the existing
     // manifest matches and returns as-is.
     factory
-        .clone_closed_shard(
-            &parent_id,
-            &left_child_id,
-            &right_child_id,
-            &checkpoint_id,
-        )
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id, &checkpoint_id)
         .await
         .expect("idempotent re-clone");
 

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -3552,6 +3552,7 @@ async fn k8s_crash_recovery_early_phase_resumes_split() {
         "http://127.0.0.1:7450",
         num_shards
     );
+    let c1_concrete = c1.clone();
     let c1: Arc<dyn Coordinator> = Arc::new(c1);
 
     assert!(c1.wait_converged(Duration::from_secs(30)).await);
@@ -3571,8 +3572,9 @@ async fn k8s_crash_recovery_early_phase_resumes_split() {
         .await
         .expect("advance to pausing");
 
-    // Simulate crash
-    c1.shutdown().await.unwrap();
+    // Simulate a crash: stop background tasks without releasing shard leases
+    // in k8s, so the replacement coordinator can reclaim them.
+    c1_concrete.crash().await;
     h1.abort();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -3588,7 +3590,7 @@ async fn k8s_crash_recovery_early_phase_resumes_split() {
             num_shards,
             30,
         ),
-        make_test_factory("crash-early-1-restart"),
+        make_test_factory("crash-early-1"),
     )
     .await
     .expect("restart coordinator");
@@ -3639,6 +3641,7 @@ async fn k8s_crash_recovery_cloning_phase_resumes_split() {
         "http://127.0.0.1:7450",
         num_shards
     );
+    let c1_concrete = c1.clone();
     let c1: Arc<dyn Coordinator> = Arc::new(c1);
 
     assert!(c1.wait_converged(Duration::from_secs(30)).await);
@@ -3659,7 +3662,9 @@ async fn k8s_crash_recovery_cloning_phase_resumes_split() {
     let status = splitter1.get_split_status(shard_id).await.unwrap().unwrap();
     assert_eq!(status.phase, SplitPhase::SplitCloning);
 
-    c1.shutdown().await.unwrap();
+    // Simulate a crash: stop background tasks without releasing shard leases
+    // in k8s, so the replacement coordinator can reclaim them.
+    c1_concrete.crash().await;
     h1.abort();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -3672,7 +3677,7 @@ async fn k8s_crash_recovery_cloning_phase_resumes_split() {
             num_shards,
             30,
         ),
-        make_test_factory("crash-cloning-1-restart"),
+        make_test_factory("crash-cloning-1"),
     )
     .await
     .expect("restart coordinator");
@@ -4008,99 +4013,6 @@ async fn k8s_child_shards_usable_after_split() {
 
     coord.shutdown().await.unwrap();
     handle.abort();
-}
-
-/// Test crash recovery during cloning phase abandons the split.
-///
-/// With the simplified split model, ALL incomplete splits are abandoned on crash.
-/// The shard map update is the commit point - if children don't exist in the
-/// shard map, the split never completed and is safely abandoned.
-#[silo::test(flavor = "multi_thread", worker_threads = 2)]
-async fn k8s_crash_recovery_cloning_phase_abandons_split() {
-    let prefix = unique_prefix();
-    let namespace = get_namespace();
-    let num_shards: u32 = 1;
-
-    // Start first coordinator
-    let (c1, h1) = start_coordinator!(
-        &namespace,
-        &prefix,
-        "crash-cloning-1",
-        "http://127.0.0.1:7450",
-        num_shards
-    );
-    let c1: Arc<dyn Coordinator> = Arc::new(c1);
-
-    assert!(c1.wait_converged(Duration::from_secs(30)).await);
-
-    let owned = c1.owned_shards().await;
-    let shard_id = owned[0];
-
-    // Create splitter and request split, advance to SplitCloning phase
-
-    let splitter1 = ShardSplitter::new(c1.clone());
-
-    let _split = splitter1
-        .request_split(shard_id, "8000000000000000".to_string())
-        .await
-        .expect("request_split");
-
-    splitter1.advance_split_phase(shard_id).await.unwrap(); // -> SplitPausing
-    splitter1.advance_split_phase(shard_id).await.unwrap(); // -> SplitCloning
-
-    let status = splitter1.get_split_status(shard_id).await.unwrap().unwrap();
-    assert_eq!(status.phase, SplitPhase::SplitCloning);
-
-    // Simulate crash
-    c1.shutdown().await.unwrap();
-    h1.abort();
-    tokio::time::sleep(Duration::from_millis(500)).await;
-
-    // Start new coordinator
-    let (c2, h2) = K8sCoordinator::start(
-        make_coordinator_config(
-            &namespace,
-            &prefix,
-            "crash-cloning-1",
-            "http://127.0.0.1:7450",
-            num_shards,
-            30,
-        ),
-        make_test_factory("crash-cloning-1-restart"),
-    )
-    .await
-    .expect("restart coordinator");
-    let c2: Arc<dyn Coordinator> = Arc::new(c2);
-
-    assert!(c2.wait_converged(Duration::from_secs(30)).await);
-
-    // Create splitter for c2
-
-    let splitter2 = ShardSplitter::new(c2.clone());
-
-    // Recover stale splits - should abandon the incomplete split
-    splitter2
-        .recover_stale_splits()
-        .await
-        .expect("recover stale splits");
-
-    // Split should be abandoned (deleted)
-    let status = splitter2
-        .get_split_status(shard_id)
-        .await
-        .expect("get status");
-    assert!(status.is_none(), "incomplete split should be abandoned");
-
-    // Shard map should still have original shard (split was not committed)
-    let shard_map = c2.get_shard_map().await.unwrap();
-    assert_eq!(shard_map.len(), 1, "shard map should have original shard");
-    assert!(
-        shard_map.get_shard(&shard_id).is_some(),
-        "original shard should still exist"
-    );
-
-    c2.shutdown().await.unwrap();
-    h2.abort();
 }
 
 /// Helper to create K8sCoordinatorConfig with placement rings

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -3011,12 +3011,13 @@ async fn k8s_is_shard_paused_returns_correct_values() {
     handle.abort();
 }
 
-/// Test that split state persists across coordinator restart.
+/// Test that a split record persisted to k8s by one coordinator is picked up
+/// and resumed to completion by a replacement coordinator on restart.
 #[silo::test(flavor = "multi_thread", worker_threads = 2)]
-async fn k8s_split_state_persists_across_restart() {
+async fn k8s_split_state_persists_and_resumes_across_restart() {
     let prefix = unique_prefix();
     let namespace = get_namespace();
-    let num_shards: u32 = 1; // Use 1 shard so it covers the entire keyspace
+    let num_shards: u32 = 1;
 
     // Start first coordinator
     let (c1, h1) = start_coordinator!(
@@ -3026,14 +3027,13 @@ async fn k8s_split_state_persists_across_restart() {
         "http://127.0.0.1:7450",
         num_shards
     );
+    let c1_concrete = c1.clone();
     let c1: Arc<dyn Coordinator> = Arc::new(c1);
 
     assert!(c1.wait_converged(Duration::from_secs(30)).await);
 
     let owned = c1.owned_shards().await;
     let shard_id = owned[0];
-
-    // Create splitter and request a split
 
     let splitter1 = ShardSplitter::new(c1.clone());
 
@@ -3042,14 +3042,15 @@ async fn k8s_split_state_persists_across_restart() {
         .await
         .expect("request_split should succeed");
 
-    // Shutdown the coordinator
-    c1.shutdown().await.unwrap();
+    // Simulate a crash: stop background tasks without releasing shard leases
+    // in k8s, so the replacement coordinator can reclaim them.
+    c1_concrete.crash().await;
     h1.abort();
-
-    // Wait for K8s resources to be cleaned up before restarting
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
-    // Start new coordinator with same prefix (simulates restart)
+    // Start new coordinator with same node_id + storage. Its coord loop runs
+    // resume_in_progress_splits after reclaim, so the split should drive
+    // itself to completion automatically.
     let (c2, h2) = K8sCoordinator::start(
         make_coordinator_config(
             &namespace,
@@ -3059,7 +3060,7 @@ async fn k8s_split_state_persists_across_restart() {
             num_shards,
             30,
         ),
-        make_test_factory("persist-test-1-restart"),
+        make_test_factory("persist-test-1"),
     )
     .await
     .expect("restart coordinator");
@@ -3067,25 +3068,24 @@ async fn k8s_split_state_persists_across_restart() {
 
     assert!(c2.wait_converged(Duration::from_secs(30)).await);
 
-    // Create splitter for c2 and verify the split state persisted
-
     let splitter2 = ShardSplitter::new(c2.clone());
 
-    let status = splitter2
-        .get_split_status(shard_id)
-        .await
-        .expect("get_split_status should succeed");
-    assert!(
-        status.is_some(),
-        "split status should persist after restart"
-    );
-    let status = status.unwrap();
-    assert_eq!(status.parent_shard_id, shard_id);
-    assert_eq!(status.split_point, "8000000000000000");
-    assert_eq!(status.left_child_id, split.left_child_id);
-    assert_eq!(status.right_child_id, split.right_child_id);
+    let completed = wait_until(Duration::from_secs(20), || async {
+        splitter2
+            .get_split_status(shard_id)
+            .await
+            .ok()
+            .flatten()
+            .is_none()
+    })
+    .await;
+    assert!(completed, "auto-resume should complete the persisted split");
 
-    // Cleanup
+    let shard_map = c2.get_shard_map().await.unwrap();
+    assert_eq!(shard_map.len(), 2);
+    assert!(shard_map.get_shard(&split.left_child_id).is_some());
+    assert!(shard_map.get_shard(&split.right_child_id).is_some());
+
     c2.shutdown().await.unwrap();
     h2.abort();
 }

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -3536,9 +3536,10 @@ async fn k8s_split_in_multi_node_cluster() {
     h2.abort();
 }
 
-/// Test crash recovery during early phase abandons the split.
+/// Test that a split crashed in an early phase (SplitPausing) is auto-resumed
+/// to completion after restart.
 #[silo::test(flavor = "multi_thread", worker_threads = 2)]
-async fn k8s_crash_recovery_early_phase_abandons_split() {
+async fn k8s_crash_recovery_early_phase_resumes_split() {
     let prefix = unique_prefix();
     let namespace = get_namespace();
     let num_shards: u32 = 1;
@@ -3559,10 +3560,9 @@ async fn k8s_crash_recovery_early_phase_abandons_split() {
     let shard_id = owned[0];
 
     // Create splitter and request split, advance to SplitPausing (early phase)
-
     let splitter1 = ShardSplitter::new(c1.clone());
 
-    let _split = splitter1
+    let split = splitter1
         .request_split(shard_id, "8000000000000000".to_string())
         .await
         .expect("request_split");
@@ -3576,7 +3576,9 @@ async fn k8s_crash_recovery_early_phase_abandons_split() {
     h1.abort();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // Start new coordinator
+    // Start new coordinator. The coordination loop runs
+    // resume_in_progress_splits after reclaim, so the paused split should
+    // drive itself through SplitCloning to SplitComplete automatically.
     let (c2, h2) = K8sCoordinator::start(
         make_coordinator_config(
             &namespace,
@@ -3594,32 +3596,189 @@ async fn k8s_crash_recovery_early_phase_abandons_split() {
 
     assert!(c2.wait_converged(Duration::from_secs(30)).await);
 
-    // Create splitter for c2
-
     let splitter2 = ShardSplitter::new(c2.clone());
 
-    // Early phase crash should abandon the split
-    splitter2
-        .recover_stale_splits()
-        .await
-        .expect("recover_stale_splits");
+    // Wait for the background resume to drive the split to completion.
+    let completed = wait_until(Duration::from_secs(15), || async {
+        splitter2
+            .get_split_status(shard_id)
+            .await
+            .ok()
+            .flatten()
+            .is_none()
+    })
+    .await;
+    assert!(completed, "resumed split should clear its split record");
 
-    let status = splitter2
-        .get_split_status(shard_id)
-        .await
-        .expect("get status");
-    assert!(
-        status.is_none(),
-        "early phase split should be abandoned after crash"
-    );
-
-    // Shard map should still have original shard
+    // Shard map should reflect the completed split.
     let shard_map = c2.get_shard_map().await.unwrap();
-    assert_eq!(shard_map.len(), 1);
-    assert!(shard_map.get_shard(&shard_id).is_some());
+    assert_eq!(shard_map.len(), 2, "split should have created two children");
+    assert!(shard_map.get_shard(&split.left_child_id).is_some());
+    assert!(shard_map.get_shard(&split.right_child_id).is_some());
+    assert!(
+        shard_map.get_shard(&shard_id).is_none(),
+        "parent should be removed from shard map after split"
+    );
 
     c2.shutdown().await.unwrap();
     h2.abort();
+}
+
+/// Test that a split crashed in SplitCloning before the shard-map commit is
+/// auto-resumed to completion after restart.
+#[silo::test(flavor = "multi_thread", worker_threads = 2)]
+async fn k8s_crash_recovery_cloning_phase_resumes_split() {
+    let prefix = unique_prefix();
+    let namespace = get_namespace();
+    let num_shards: u32 = 1;
+
+    let (c1, h1) = start_coordinator!(
+        &namespace,
+        &prefix,
+        "crash-cloning-1",
+        "http://127.0.0.1:7450",
+        num_shards
+    );
+    let c1: Arc<dyn Coordinator> = Arc::new(c1);
+
+    assert!(c1.wait_converged(Duration::from_secs(30)).await);
+
+    let shard_id = c1.owned_shards().await[0];
+
+    let splitter1 = ShardSplitter::new(c1.clone());
+
+    let split = splitter1
+        .request_split(shard_id, "8000000000000000".to_string())
+        .await
+        .expect("request_split");
+    // Advance through SplitPausing into SplitCloning without executing the
+    // clone itself, so the persisted record looks like a mid-clone crash
+    // with no partial child data on disk yet.
+    splitter1.advance_split_phase(shard_id).await.unwrap();
+    splitter1.advance_split_phase(shard_id).await.unwrap();
+    let status = splitter1.get_split_status(shard_id).await.unwrap().unwrap();
+    assert_eq!(status.phase, SplitPhase::SplitCloning);
+
+    c1.shutdown().await.unwrap();
+    h1.abort();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let (c2, h2) = K8sCoordinator::start(
+        make_coordinator_config(
+            &namespace,
+            &prefix,
+            "crash-cloning-1",
+            "http://127.0.0.1:7450",
+            num_shards,
+            30,
+        ),
+        make_test_factory("crash-cloning-1-restart"),
+    )
+    .await
+    .expect("restart coordinator");
+    let c2: Arc<dyn Coordinator> = Arc::new(c2);
+
+    assert!(c2.wait_converged(Duration::from_secs(30)).await);
+
+    let splitter2 = ShardSplitter::new(c2.clone());
+
+    let completed = wait_until(Duration::from_secs(20), || async {
+        splitter2
+            .get_split_status(shard_id)
+            .await
+            .ok()
+            .flatten()
+            .is_none()
+    })
+    .await;
+    assert!(
+        completed,
+        "split stuck in SplitCloning should resume and complete"
+    );
+
+    let shard_map = c2.get_shard_map().await.unwrap();
+    assert_eq!(shard_map.len(), 2);
+    assert!(shard_map.get_shard(&split.left_child_id).is_some());
+    assert!(shard_map.get_shard(&split.right_child_id).is_some());
+
+    // And a fresh split on one of the children should now succeed (not fail
+    // with FailedPrecondition / SplitAlreadyInProgress).
+    let followup = splitter2
+        .request_split(split.left_child_id, "4000000000000000".to_string())
+        .await;
+    assert!(
+        followup.is_ok(),
+        "follow-up split on child should succeed, got {:?}",
+        followup
+    );
+
+    c2.shutdown().await.unwrap();
+    h2.abort();
+}
+
+/// Test that resume skips splits initiated by a different node. The surviving
+/// peer must not drive a split whose initiator's parent shard may hold
+/// unflushed WAL data.
+#[silo::test(flavor = "multi_thread", worker_threads = 2)]
+async fn k8s_resume_skips_splits_from_other_initiators() {
+    use silo::shard_range::SplitInProgress;
+
+    let prefix = unique_prefix();
+    let namespace = get_namespace();
+    let num_shards: u32 = 1;
+
+    let (c1, h1) = start_coordinator!(
+        &namespace,
+        &prefix,
+        "resume-peer-1",
+        "http://127.0.0.1:7450",
+        num_shards
+    );
+    let c1: Arc<dyn Coordinator> = Arc::new(c1);
+
+    assert!(c1.wait_converged(Duration::from_secs(30)).await);
+
+    let shard_id = c1.owned_shards().await[0];
+
+    // Manually write a split record for a *different* initiator. This
+    // simulates a peer's in-flight split that this node must not touch.
+    let foreign_split = SplitInProgress {
+        parent_shard_id: shard_id,
+        split_point: "8000000000000000".to_string(),
+        left_child_id: ShardId::new(),
+        right_child_id: ShardId::new(),
+        phase: SplitPhase::SplitCloning,
+        requested_at_ms: 0,
+        initiator_node_id: "some-other-node".to_string(),
+        checkpoint_id: None,
+    };
+    c1.store_split(&foreign_split)
+        .await
+        .expect("store foreign split");
+
+    // Running resume on c1 must not disturb the foreign record.
+    let splitter = ShardSplitter::new(c1.clone());
+    splitter
+        .resume_in_progress_splits(|| c1.get_shard_owner_map())
+        .await
+        .expect("resume should not error");
+
+    let still_there = c1
+        .load_split(&shard_id)
+        .await
+        .expect("load")
+        .expect("foreign split should still be present");
+    assert_eq!(still_there.initiator_node_id, "some-other-node");
+    assert_eq!(still_there.phase, SplitPhase::SplitCloning);
+
+    let shard_map = c1.get_shard_map().await.unwrap();
+    assert_eq!(shard_map.len(), 1, "shard map must be untouched");
+
+    // Cleanup: remove the foreign split so we don't leak the ConfigMap.
+    c1.delete_split(&shard_id).await.ok();
+
+    c1.shutdown().await.unwrap();
+    h1.abort();
 }
 
 /// Test that nodes acquire child shards via ConfigMap watch after a split.


### PR DESCRIPTION
A pod that crashed mid-split while its split record was in SplitCloning used to stay stuck forever: on restart it logged "re-hydrated paused state" and did nothing else, and any subsequent split attempt on the same parent failed with "a split is already in progress". This was reproduced in a production gameday.

Instead, the pod should resume splits in progress and drive them to completion, otherwise the shard will be down. This requires a refactor to clone_closed_database so that the checkpoint id can be persisted in the k8s configmap.

Crash windows:
 - before prepare_split_checkpoint: checkpoint_id stays None; resumer re-enters cleanly, no leaks.
 - between prepare and store_split: checkpoint is written to the parent manifest but the UUID isn't persisted. Resumer creates a new one and proceeds. The first checkpoint is orphaned in the parent (harmless leak; eventual post-split GC would reclaim it).
 - after store_split: Some(id) persisted; resumer reuses it and slatedb's idempotent create_clone does the rest.

If there is a race, an operator will need to call siloctl to delete a checkpoint for a given shard.

Tests:
 - factory: clone_closed_shard_is_idempotent_with_same_checkpoint verifies the slatedb property the resumer relies on.
 - coordination: the existing "abandons split on crash" tests are rewritten as "resumes split on crash" (SplitPausing and SplitCloning). A k8s test verifies splits initiated by a different node are skipped.