### PR TITLE
Default embedded SlateDB compactor off in silo TOML configs

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,14 @@ use std::time::Duration;
 /// values with defaults. This is necessary because slatedb's Settings struct
 /// doesn't use #[serde(default)] on its fields, so serde requires all non-Option
 /// fields to be present when any field is specified.
+///
+/// Silo's default diverges from slatedb's in one place: the embedded compactor
+/// is off unless the user explicitly configures it. If the user's TOML has no
+/// `compactor_options` key, we strip it from the default base so the merged
+/// result has `compactor_options: None` → no in-process compactor. If the user
+/// does provide `compactor_options`, we seed the base with
+/// `Some(CompactorOptions::default())` so their partial overrides merge onto a
+/// complete set of fields (CompactorOptions lacks per-field serde defaults).
 fn deserialize_slatedb_settings<'de, D>(
     deserializer: D,
 ) -> Result<Option<slatedb::config::Settings>, D::Error>
@@ -20,8 +28,16 @@ where
     match user_config {
         None => Ok(None),
         Some(user_table) => {
-            // Serialize defaults to TOML
-            let defaults = slatedb::config::Settings::default();
+            // Silo default: embedded compactor off unless the user asks for it.
+            let user_has_compactor_options = user_table.contains_key("compactor_options");
+            let defaults = slatedb::config::Settings {
+                compactor_options: if user_has_compactor_options {
+                    Some(slatedb::config::CompactorOptions::default())
+                } else {
+                    None
+                },
+                ..slatedb::config::Settings::default()
+            };
             let default_str = toml::to_string(&defaults).map_err(serde::de::Error::custom)?;
             let mut merged: toml::Table =
                 toml::from_str(&default_str).map_err(serde::de::Error::custom)?;

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -732,6 +732,40 @@ flush_interval = "1ms"
 }
 
 #[silo::test]
+fn parse_toml_slatedb_compactor_enabled_via_nested_scheduler_options() {
+    // Regression: the common "only override scheduler_options" shape must still
+    // enable the compactor and fill in the rest of CompactorOptions from defaults.
+    let toml_str = r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+
+[database.slatedb.compactor_options.scheduler_options]
+min_compaction_sources = "2"
+max_compaction_sources = "16"
+"#;
+    let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
+    let slatedb_settings = cfg.database.slatedb.expect("slatedb settings present");
+    let compactor = slatedb_settings
+        .compactor_options
+        .expect("compactor_options should be Some when [compactor_options.*] is present");
+    assert_eq!(
+        compactor.scheduler_options.get("min_compaction_sources"),
+        Some(&"2".to_string())
+    );
+    assert_eq!(
+        compactor.scheduler_options.get("max_compaction_sources"),
+        Some(&"16".to_string())
+    );
+    let defaults = slatedb::config::CompactorOptions::default();
+    assert_eq!(compactor.poll_interval, defaults.poll_interval);
+    assert_eq!(
+        compactor.max_concurrent_compactions,
+        defaults.max_concurrent_compactions
+    );
+}
+
+#[silo::test]
 fn parse_toml_slatedb_compactor_enabled_when_section_present() {
     // When the user explicitly provides [compactor_options], the compactor is enabled and
     // partial overrides merge onto CompactorOptions::default().

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -546,6 +546,10 @@ scan_interval = "3600s"
     );
     assert_eq!(slatedb_settings.l0_sst_size_bytes, 33554432);
     assert_eq!(slatedb_settings.l0_max_ssts, 4);
+    assert!(
+        slatedb_settings.compactor_options.is_some(),
+        "[compactor_options] in TOML should enable the embedded compactor"
+    );
 }
 
 #[silo::test]
@@ -700,6 +704,55 @@ cache_puts = true
         slatedb_settings.object_store_cache_options.part_size_bytes,
         defaults.object_store_cache_options.part_size_bytes,
         "part_size_bytes should use default"
+    );
+
+    // Silo default: embedded compactor is off unless the user explicitly configures it.
+    assert!(
+        slatedb_settings.compactor_options.is_none(),
+        "compactor_options should default to None when user omits [compactor_options]"
+    );
+}
+
+#[silo::test]
+fn parse_toml_slatedb_compactor_disabled_when_omitted() {
+    let toml_str = r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+
+[database.slatedb]
+flush_interval = "1ms"
+"#;
+    let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
+    let slatedb_settings = cfg.database.slatedb.expect("slatedb settings present");
+    assert!(
+        slatedb_settings.compactor_options.is_none(),
+        "omitting [compactor_options] must disable the embedded compactor"
+    );
+}
+
+#[silo::test]
+fn parse_toml_slatedb_compactor_enabled_when_section_present() {
+    // When the user explicitly provides [compactor_options], the compactor is enabled and
+    // partial overrides merge onto CompactorOptions::default().
+    let toml_str = r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+
+[database.slatedb.compactor_options]
+poll_interval = "7s"
+"#;
+    let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
+    let slatedb_settings = cfg.database.slatedb.expect("slatedb settings present");
+    let compactor = slatedb_settings
+        .compactor_options
+        .expect("compactor_options should be Some when [compactor_options] is present");
+    assert_eq!(compactor.poll_interval, std::time::Duration::from_secs(7));
+    let defaults = slatedb::config::CompactorOptions::default();
+    assert_eq!(
+        compactor.max_concurrent_compactions, defaults.max_concurrent_compactions,
+        "unspecified compactor fields should use CompactorOptions defaults"
     );
 }
 


### PR DESCRIPTION
## Summary
- Silo's `deserialize_slatedb_settings` now defaults the embedded SlateDB compactor **off** when the user's TOML has `[database.slatedb]` but does not include `[compactor_options]`.
- If the user provides `[compactor_options]`, the embedded compactor runs and any partial fields merge onto `CompactorOptions::default()` (consistent with the pre-existing partial-merge behavior).
- No new config field: this reuses SlateDB's own `compactor_options: Option<CompactorOptions>` knob, overcoming TOML's lack of `null` by conditionally omitting the key from the merge base.

## Why
A standalone compactor process (to be added) will own compaction. Dev nodes and future silo deployments can switch off the embedded compactor simply by not providing `[compactor_options]`.

## Scope note
Rust struct-literal uses of `DatabaseTemplate` / `DatabaseConfig` (tests, benches) that set `slatedb: None` are unaffected — they bypass the deserializer and continue to use SlateDB's native defaults with the compactor on. The `CompactShard` gRPC endpoint submits specs via the Admin API independent of the embedded compactor, so it keeps working either way.

## Test plan
- [x] New tests:
  - `parse_toml_slatedb_compactor_disabled_when_omitted` — asserts `compactor_options = None` when `[compactor_options]` is absent.
  - `parse_toml_slatedb_compactor_enabled_when_section_present` — asserts `compactor_options = Some(...)` with partial overrides merged onto `CompactorOptions::default()`.
- [x] Updated `parse_toml_with_full_slatedb_settings` to assert `compactor_options.is_some()`.
- [x] Updated `parse_toml_with_partial_slatedb_settings_merges_with_defaults` to assert `compactor_options.is_none()`.
- [x] Full `config_and_db_tests` (30/30), `compact_shard_tests` (6/6, including the tombstone-removal test), `shard_cleanup_tests`, `factory_tests` all pass.
- [x] `cargo check --all-targets` clean.