### PR TITLE
Add CompletedJobCompactionFilter to silo-compactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,7 +2915,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2935,7 +2935,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -3136,7 +3136,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4461,7 +4461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -4494,7 +4494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -4620,7 +4620,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.32",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -4657,9 +4657,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5488,6 +5488,7 @@ dependencies = [
  "object_store",
  "serde",
  "serde_json",
+ "silo",
  "slatedb",
  "slatedb-common",
  "tempfile",
@@ -5497,6 +5498,7 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "url",
  "uuid",
 ]
@@ -5692,6 +5694,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -6936,7 +6939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6948,7 +6951,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6960,21 +6963,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.0",
- "windows-result 0.4.0",
- "windows-strings 0.5.0",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6983,7 +6973,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -7028,7 +7018,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -7039,8 +7029,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -7053,30 +7043,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
-dependencies = [
- "windows-link 0.2.0",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
-dependencies = [
- "windows-link 0.2.0",
 ]
 
 [[package]]

--- a/silo-compactor/Cargo.toml
+++ b/silo-compactor/Cargo.toml
@@ -9,9 +9,14 @@ name = "silo-compactor"
 path = "src/main.rs"
 
 [dependencies]
-slatedb = "0.12.0"
+slatedb = { version = "0.12.0", features = ["compaction_filters"] }
 slatedb-common = "0.12.0"
 object_store = { version = "0.12", features = ["gcp"] }
+
+# silo pulls in codec/keys/job types for the compaction filter. default-features
+# are disabled so we don't transitively pull kube/k8s through silo (silo-compactor
+# brings its own kube deps directly above).
+silo = { path = "..", default-features = false }
 
 kube = { version = "0.98", features = ["runtime", "client"] }
 k8s-openapi = { version = "0.24", features = ["v1_31"] }
@@ -38,3 +43,4 @@ anyhow = "1"
 
 [dev-dependencies]
 tempfile = "3"
+ulid = "1"

--- a/silo-compactor/src/compaction_filter.rs
+++ b/silo-compactor/src/compaction_filter.rs
@@ -18,11 +18,11 @@
 //! | 0x07   | ATTEMPT          | Point-read JOB_STATUS via DbReader   |
 //! | 0x0A   | JOB_CANCELLED    | Point-read JOB_STATUS via DbReader   |
 //!
-//! In the standalone `silo-compactor` process we do not have a writable `Db`
-//! handle, so counter decrements are tracked but emitted only via the warn
-//! log on `on_compaction_end`. The live silo server owns the counters; those
-//! will drift slightly and are expected to be reconciled by silo's own
-//! cleanup paths.
+//! Job counters (per-tenant `tenant_status_counter`, shard
+//! `total_jobs`/`completed_jobs`) are NOT touched by this filter. They will
+//! drift relative to the keys this filter drops; reconciliation is
+//! delegated to a separate background task that scans the live counters
+//! against the live JOB_STATUS rows.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -34,7 +34,7 @@ use silo::codec::decode_job_status_owned;
 use silo::job_store_shard::counter_merge_operator;
 use silo::keys::{
     idx_status_time_all_prefix, parse_attempt_key, parse_job_cancelled_key, parse_job_info_key,
-    parse_job_status_key, parse_metadata_index_key, parse_status_time_index_key, prefix,
+    parse_metadata_index_key, parse_status_time_index_key, prefix,
 };
 use slatedb::{
     CompactionFilter, CompactionFilterDecision, CompactionFilterError, CompactionFilterSupplier,
@@ -273,7 +273,6 @@ impl CompactionFilterSupplier for CompletedJobCompactionFilterSupplier {
             dropped_idx_metadata: 0,
             dropped_attempt: 0,
             dropped_job_cancelled: 0,
-            tenant_status_drops: HashMap::new(),
         }))
     }
 }
@@ -301,9 +300,6 @@ pub struct CompletedJobCompactionFilter {
     dropped_idx_metadata: u64,
     dropped_attempt: u64,
     dropped_job_cancelled: u64,
-
-    // (tenant, status_kind) → count for counter decrements.
-    tenant_status_drops: HashMap<(String, String), u64>,
 }
 
 impl CompletedJobCompactionFilter {
@@ -400,12 +396,6 @@ impl CompactionFilter for CompletedJobCompactionFilter {
                 };
 
                 if status.is_terminal() && status.changed_at_ms < self.cutoff_ms {
-                    if let Some(parsed) = parse_job_status_key(&entry.key) {
-                        *self
-                            .tenant_status_drops
-                            .entry((parsed.tenant, status.kind.as_str().to_owned()))
-                            .or_insert(0) += 1;
-                    }
                     self.dropped_status += 1;
                     return Ok(self.drop_decision());
                 }
@@ -476,23 +466,6 @@ impl CompactionFilter for CompletedJobCompactionFilter {
             );
         }
 
-        // In the standalone compactor we have no writable Db handle, so
-        // counter decrements are only tracked for diagnostics and emitted
-        // here. The live silo writer reconciles counters elsewhere.
-        if self.dropped_status > 0 {
-            let tenants: Vec<_> = self
-                .tenant_status_drops
-                .iter()
-                .map(|((tenant, status), count)| format!("{tenant}/{status}={count}"))
-                .collect();
-            warn!(
-                jobs_dropped = self.dropped_status,
-                tenant_status = ?tenants,
-                "completed_jobs compaction filter: counter decrements skipped \
-                 (standalone compactor has no Db writer)"
-            );
-        }
-
         Ok(())
     }
 }
@@ -541,7 +514,6 @@ mod tests {
             dropped_idx_metadata: 0,
             dropped_attempt: 0,
             dropped_job_cancelled: 0,
-            tenant_status_drops: HashMap::new(),
         }
     }
 
@@ -645,24 +617,6 @@ mod tests {
         let entry = row(job_info_key("tenant-1", "job-1"), Bytes::from_static(b"x"));
         let decision = filter.filter(&entry).await.unwrap();
         assert_eq!(decision, CompactionFilterDecision::Keep);
-    }
-
-    #[tokio::test]
-    async fn tracks_tenant_status_drops() {
-        let cutoff = now_epoch_ms() - 1_000;
-        let mut filter = make_filter(cutoff, true);
-        let row_a = status_row(JobStatusKind::Succeeded, cutoff - 10);
-        let _ = filter.filter(&row_a).await.unwrap();
-        let row_b = status_row(JobStatusKind::Failed, cutoff - 5);
-        let _ = filter.filter(&row_b).await.unwrap();
-        let succ = filter
-            .tenant_status_drops
-            .get(&("tenant-1".to_string(), "Succeeded".to_string()));
-        let fail = filter
-            .tenant_status_drops
-            .get(&("tenant-1".to_string(), "Failed".to_string()));
-        assert_eq!(succ.copied(), Some(1));
-        assert_eq!(fail.copied(), Some(1));
     }
 
     #[tokio::test]

--- a/silo-compactor/src/compaction_filter.rs
+++ b/silo-compactor/src/compaction_filter.rs
@@ -36,7 +36,6 @@ use silo::keys::{
     idx_status_time_all_prefix, parse_attempt_key, parse_job_cancelled_key, parse_job_info_key,
     parse_job_status_key, parse_metadata_index_key, parse_status_time_index_key, prefix,
 };
-use slatedb::config::ScanOptions;
 use slatedb::{
     CompactionFilter, CompactionFilterDecision, CompactionFilterError, CompactionFilterSupplier,
     CompactionJobContext, DbReader, DbReaderBuilder, RowEntry, ValueDeletable,
@@ -102,9 +101,6 @@ impl ExpiredSet {
 /// Returns `Ok(Some(set))` on a clean drain, `Ok(None)` when the cap was
 /// exceeded mid-scan (caller falls back to per-row point reads), or `Err`
 /// when the underlying scan errored.
-///
-/// Reads with `cache_blocks: false` so a one-shot pre-scan doesn't pollute
-/// the compactor's block cache.
 async fn build_expired_set(
     reader: &DbReader,
     cutoff_ms: i64,
@@ -113,13 +109,7 @@ async fn build_expired_set(
     if max_entries == 0 {
         return Ok(None);
     }
-    let opts = ScanOptions {
-        cache_blocks: false,
-        ..ScanOptions::default()
-    };
-    let mut iter = reader
-        .scan_prefix_with_options(idx_status_time_all_prefix(), &opts)
-        .await?;
+    let mut iter = reader.scan_prefix(idx_status_time_all_prefix()).await?;
     let mut set = ExpiredSet::new();
     while let Some(kv) = iter.next().await? {
         let Some(parsed) = parse_status_time_index_key(&kv.key) else {

--- a/silo-compactor/src/compaction_filter.rs
+++ b/silo-compactor/src/compaction_filter.rs
@@ -1,0 +1,526 @@
+//! Compaction filter that drops completed (terminal) job data older than a
+//! configurable retention window.
+//!
+//! During compaction this filter inspects rows across six key prefixes. For
+//! each prefix it determines whether the owning job is terminal (Succeeded,
+//! Failed, Cancelled) and older than the retention cutoff, then either drops
+//! the entry or converts it to a tombstone depending on whether the
+//! destination sorted run is the last (oldest) one.
+//!
+//! ## Prefix decision table
+//!
+//! | Prefix | Name             | Decision method                      |
+//! |--------|------------------|--------------------------------------|
+//! | 0x01   | JOB_INFO         | Point-read JOB_STATUS via DbReader   |
+//! | 0x02   | JOB_STATUS       | Decode value directly                |
+//! | 0x03   | IDX_STATUS_TIME  | Self-contained in key                |
+//! | 0x04   | IDX_METADATA     | Point-read JOB_STATUS via DbReader   |
+//! | 0x07   | ATTEMPT          | Point-read JOB_STATUS via DbReader   |
+//! | 0x0A   | JOB_CANCELLED    | Point-read JOB_STATUS via DbReader   |
+//!
+//! In the standalone `silo-compactor` process we do not have a writable `Db`
+//! handle, so counter decrements are tracked but emitted only via the warn
+//! log on `on_compaction_end`. The live silo server owns the counters; those
+//! will drift slightly and are expected to be reconciled by silo's own
+//! cleanup paths.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use object_store::path::Path;
+use silo::codec::decode_job_status_owned;
+use silo::job_store_shard::counter_merge_operator;
+use silo::keys::{
+    parse_attempt_key, parse_job_cancelled_key, parse_job_info_key, parse_job_status_key,
+    parse_metadata_index_key, parse_status_time_index_key, prefix,
+};
+use slatedb::{
+    CompactionFilter, CompactionFilterDecision, CompactionFilterError, CompactionFilterSupplier,
+    CompactionJobContext, DbReader, DbReaderBuilder, RowEntry, ValueDeletable,
+};
+use tracing::{debug, info, warn};
+
+/// Terminal status strings as stored in IDX_STATUS_TIME keys.
+const TERMINAL_STATUSES: &[&str] = &["Succeeded", "Failed", "Cancelled"];
+
+/// Default retention window for completed jobs: 7 days.
+pub const DEFAULT_RETENTION_SECS: u64 = 7 * 24 * 60 * 60;
+
+// ---------------------------------------------------------------------------
+// Supplier
+// ---------------------------------------------------------------------------
+
+/// Creates a fresh [`CompletedJobCompactionFilter`] for each compaction job.
+///
+/// The supplier lazily opens a [`DbReader`] per compaction job for point-
+/// reading JOB_STATUS rows. The reader is NOT kept alive across jobs — this
+/// avoids a long-lived manifest poller / checkpoint that can interfere with
+/// the compactor's state management.
+pub struct CompletedJobCompactionFilterSupplier {
+    retention: Duration,
+    /// Object-store context for lazily opening a `DbReader` per compaction
+    /// job. `None` disables point reads (unit tests only).
+    reader_ctx: Option<ReaderContext>,
+}
+
+/// Everything needed to open a short-lived [`DbReader`].
+struct ReaderContext {
+    db_path: Path,
+    store: Arc<dyn object_store::ObjectStore>,
+}
+
+impl CompletedJobCompactionFilterSupplier {
+    pub fn new(
+        retention: Duration,
+        db_path: Path,
+        store: Arc<dyn object_store::ObjectStore>,
+    ) -> Self {
+        Self {
+            retention,
+            reader_ctx: Some(ReaderContext { db_path, store }),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_without_reader(retention: Duration) -> Self {
+        Self {
+            retention,
+            reader_ctx: None,
+        }
+    }
+}
+
+#[async_trait]
+impl CompactionFilterSupplier for CompletedJobCompactionFilterSupplier {
+    async fn create_compaction_filter(
+        &self,
+        context: &CompactionJobContext,
+    ) -> Result<Box<dyn CompactionFilter>, CompactionFilterError> {
+        let retention_ms = self.retention.as_millis() as i64;
+        let cutoff_ms = now_epoch_ms().saturating_sub(retention_ms);
+
+        // Open a short-lived DbReader for point reads during this compaction
+        // job. The reader is dropped when the filter is dropped (after
+        // on_compaction_end), which keeps its checkpoint / manifest poller
+        // from interfering with the compactor across jobs.
+        let reader = if let Some(ctx) = &self.reader_ctx {
+            match DbReaderBuilder::new(ctx.db_path.clone(), Arc::clone(&ctx.store))
+                .with_merge_operator(counter_merge_operator())
+                .build()
+                .await
+            {
+                Ok(r) => {
+                    info!("completed_jobs filter: opened DbReader for point reads");
+                    Some(Arc::new(r))
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        "completed_jobs filter: failed to open DbReader, \
+                         JOB_INFO/IDX_METADATA/ATTEMPT/JOB_CANCELLED rows will be kept"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        Ok(Box::new(CompletedJobCompactionFilter {
+            cutoff_ms,
+            reader,
+            is_dest_last_run: context.is_dest_last_run,
+            dropped_job_info: 0,
+            dropped_status: 0,
+            dropped_idx_status_time: 0,
+            dropped_idx_metadata: 0,
+            dropped_attempt: 0,
+            dropped_job_cancelled: 0,
+            tenant_status_drops: HashMap::new(),
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filter
+// ---------------------------------------------------------------------------
+
+pub struct CompletedJobCompactionFilter {
+    cutoff_ms: i64,
+    reader: Option<Arc<DbReader>>,
+    is_dest_last_run: bool,
+
+    // Per-prefix drop counts (diagnostics).
+    dropped_job_info: u64,
+    dropped_status: u64,
+    dropped_idx_status_time: u64,
+    dropped_idx_metadata: u64,
+    dropped_attempt: u64,
+    dropped_job_cancelled: u64,
+
+    // (tenant, status_kind) → count for counter decrements.
+    tenant_status_drops: HashMap<(String, String), u64>,
+}
+
+impl CompletedJobCompactionFilter {
+    fn total_dropped(&self) -> u64 {
+        self.dropped_job_info
+            + self.dropped_status
+            + self.dropped_idx_status_time
+            + self.dropped_idx_metadata
+            + self.dropped_attempt
+            + self.dropped_job_cancelled
+    }
+
+    /// Returns [`Drop`] when the destination is the oldest sorted run (no
+    /// resurrection risk), [`Modify(Tombstone)`] otherwise.
+    fn drop_decision(&self) -> CompactionFilterDecision {
+        if self.is_dest_last_run {
+            CompactionFilterDecision::Drop
+        } else {
+            CompactionFilterDecision::Modify(ValueDeletable::Tombstone)
+        }
+    }
+
+    /// Point-read the job's `JOB_STATUS` from the live DB and check whether
+    /// it is terminal and older than the retention cutoff.
+    async fn is_job_expired(&self, tenant: &str, job_id: &str) -> bool {
+        let Some(reader) = &self.reader else {
+            return false;
+        };
+        let key = silo::keys::job_status_key(tenant, job_id);
+        let Ok(Some(raw)) = reader.get(key.as_slice()).await else {
+            return false;
+        };
+        let Ok(status) = decode_job_status_owned(&raw) else {
+            return false;
+        };
+        status.is_terminal() && status.changed_at_ms < self.cutoff_ms
+    }
+}
+
+#[async_trait]
+impl CompactionFilter for CompletedJobCompactionFilter {
+    async fn filter(
+        &mut self,
+        entry: &RowEntry,
+    ) -> Result<CompactionFilterDecision, CompactionFilterError> {
+        let Some(&pfx) = entry.key.first() else {
+            return Ok(CompactionFilterDecision::Keep);
+        };
+
+        // Tombstones and merge operands carry no decodable payload; leave
+        // them alone so the compactor can resolve them normally.
+        if matches!(
+            entry.value,
+            ValueDeletable::Merge(_) | ValueDeletable::Tombstone
+        ) {
+            return Ok(CompactionFilterDecision::Keep);
+        }
+
+        match pfx {
+            // ── JOB_INFO (0x01): point-read JOB_STATUS via DbReader ──
+            prefix::JOB_INFO => {
+                if let Some(parsed) = parse_job_info_key(&entry.key)
+                    && self.is_job_expired(&parsed.tenant, &parsed.job_id).await
+                {
+                    self.dropped_job_info += 1;
+                    return Ok(self.drop_decision());
+                }
+            }
+
+            // ── JOB_STATUS (0x02): decode value, check terminal + old ──
+            prefix::JOB_STATUS => {
+                let value_bytes = match &entry.value {
+                    ValueDeletable::Value(bytes) => bytes,
+                    _ => return Ok(CompactionFilterDecision::Keep),
+                };
+
+                let status = match decode_job_status_owned(value_bytes) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        warn!(error = %e, "compaction filter: failed to decode job status, keeping row");
+                        return Ok(CompactionFilterDecision::Keep);
+                    }
+                };
+
+                if status.is_terminal() && status.changed_at_ms < self.cutoff_ms {
+                    if let Some(parsed) = parse_job_status_key(&entry.key) {
+                        *self
+                            .tenant_status_drops
+                            .entry((parsed.tenant, status.kind.as_str().to_owned()))
+                            .or_insert(0) += 1;
+                    }
+                    self.dropped_status += 1;
+                    return Ok(self.drop_decision());
+                }
+            }
+
+            // ── IDX_STATUS_TIME (0x03): self-contained, key has status + ts ──
+            prefix::IDX_STATUS_TIME => {
+                if let Some(parsed) = parse_status_time_index_key(&entry.key)
+                    && TERMINAL_STATUSES.contains(&parsed.status.as_str())
+                    && parsed.changed_at_ms() < self.cutoff_ms
+                {
+                    self.dropped_idx_status_time += 1;
+                    return Ok(self.drop_decision());
+                }
+            }
+
+            // ── IDX_METADATA (0x04): point-read JOB_STATUS ──
+            prefix::IDX_METADATA => {
+                if let Some(parsed) = parse_metadata_index_key(&entry.key)
+                    && self.is_job_expired(&parsed.tenant, &parsed.job_id).await
+                {
+                    self.dropped_idx_metadata += 1;
+                    return Ok(self.drop_decision());
+                }
+            }
+
+            // ── ATTEMPT (0x07): point-read JOB_STATUS ──
+            prefix::ATTEMPT => {
+                if let Some(parsed) = parse_attempt_key(&entry.key)
+                    && self.is_job_expired(&parsed.tenant, &parsed.job_id).await
+                {
+                    self.dropped_attempt += 1;
+                    return Ok(self.drop_decision());
+                }
+            }
+
+            // ── JOB_CANCELLED (0x0A): point-read JOB_STATUS ──
+            prefix::JOB_CANCELLED => {
+                if let Some(parsed) = parse_job_cancelled_key(&entry.key)
+                    && self.is_job_expired(&parsed.tenant, &parsed.job_id).await
+                {
+                    self.dropped_job_cancelled += 1;
+                    return Ok(self.drop_decision());
+                }
+            }
+
+            _ => {}
+        }
+
+        Ok(CompactionFilterDecision::Keep)
+    }
+
+    async fn on_compaction_end(&mut self) -> Result<(), CompactionFilterError> {
+        let total = self.total_dropped();
+
+        if total > 0 {
+            debug!(
+                total,
+                job_info = self.dropped_job_info,
+                status = self.dropped_status,
+                idx_status_time = self.dropped_idx_status_time,
+                idx_metadata = self.dropped_idx_metadata,
+                attempt = self.dropped_attempt,
+                job_cancelled = self.dropped_job_cancelled,
+                is_dest_last_run = self.is_dest_last_run,
+                cutoff_ms = self.cutoff_ms,
+                "completed_jobs compaction filter: dropped rows"
+            );
+        }
+
+        // In the standalone compactor we have no writable Db handle, so
+        // counter decrements are only tracked for diagnostics and emitted
+        // here. The live silo writer reconciles counters elsewhere.
+        if self.dropped_status > 0 {
+            let tenants: Vec<_> = self
+                .tenant_status_drops
+                .iter()
+                .map(|((tenant, status), count)| format!("{tenant}/{status}={count}"))
+                .collect();
+            warn!(
+                jobs_dropped = self.dropped_status,
+                tenant_status = ?tenants,
+                "completed_jobs compaction filter: counter decrements skipped \
+                 (standalone compactor has no Db writer)"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+fn now_epoch_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use silo::codec::encode_job_status;
+    use silo::job::{JobStatus, JobStatusKind};
+    use silo::keys::{idx_status_time_key, job_info_key, job_status_key};
+    use slatedb::bytes::Bytes;
+
+    fn row(key: Vec<u8>, value: Bytes) -> RowEntry {
+        RowEntry {
+            key: Bytes::from(key),
+            value: ValueDeletable::Value(value),
+            seq: 1,
+            create_ts: None,
+            expire_ts: None,
+        }
+    }
+
+    fn status_row(kind: JobStatusKind, changed_at_ms: i64) -> RowEntry {
+        let status = JobStatus::new(kind, changed_at_ms, None, None);
+        let bytes = encode_job_status(&status);
+        row(job_status_key("tenant-1", "job-1"), Bytes::from(bytes))
+    }
+
+    fn make_filter(cutoff_ms: i64, is_dest_last_run: bool) -> CompletedJobCompactionFilter {
+        CompletedJobCompactionFilter {
+            cutoff_ms,
+            reader: None,
+            is_dest_last_run,
+            dropped_job_info: 0,
+            dropped_status: 0,
+            dropped_idx_status_time: 0,
+            dropped_idx_metadata: 0,
+            dropped_attempt: 0,
+            dropped_job_cancelled: 0,
+            tenant_status_drops: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn drop_decision_uses_drop_when_last_run() {
+        let filter = make_filter(0, true);
+        assert_eq!(filter.drop_decision(), CompactionFilterDecision::Drop);
+    }
+
+    #[tokio::test]
+    async fn drop_decision_uses_tombstone_when_not_last_run() {
+        let filter = make_filter(0, false);
+        assert_eq!(
+            filter.drop_decision(),
+            CompactionFilterDecision::Modify(ValueDeletable::Tombstone)
+        );
+    }
+
+    #[tokio::test]
+    async fn drops_old_completed_status() {
+        let cutoff = now_epoch_ms() - 1_000;
+        let mut filter = make_filter(cutoff, true);
+        let old_succeeded = status_row(JobStatusKind::Succeeded, cutoff - 1);
+        let decision = filter.filter(&old_succeeded).await.unwrap();
+        assert_eq!(decision, CompactionFilterDecision::Drop);
+        assert_eq!(filter.dropped_status, 1);
+    }
+
+    #[tokio::test]
+    async fn tombstones_old_completed_status_when_not_last_run() {
+        let cutoff = now_epoch_ms() - 1_000;
+        let mut filter = make_filter(cutoff, false);
+        let old_failed = status_row(JobStatusKind::Failed, cutoff - 1);
+        let decision = filter.filter(&old_failed).await.unwrap();
+        assert_eq!(
+            decision,
+            CompactionFilterDecision::Modify(ValueDeletable::Tombstone)
+        );
+        assert_eq!(filter.dropped_status, 1);
+    }
+
+    #[tokio::test]
+    async fn keeps_recent_completed_status() {
+        let cutoff = now_epoch_ms() - 1_000;
+        let mut filter = make_filter(cutoff, true);
+        let recent = status_row(JobStatusKind::Failed, cutoff + 1);
+        let decision = filter.filter(&recent).await.unwrap();
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+        assert_eq!(filter.dropped_status, 0);
+    }
+
+    #[tokio::test]
+    async fn keeps_old_running_status() {
+        let cutoff = now_epoch_ms() - 1_000;
+        let mut filter = make_filter(cutoff, true);
+        let old_running = status_row(JobStatusKind::Running, cutoff - 10);
+        let decision = filter.filter(&old_running).await.unwrap();
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+    }
+
+    #[tokio::test]
+    async fn drops_old_terminal_idx_status_time() {
+        let cutoff = now_epoch_ms() - 1_000;
+        let mut filter = make_filter(cutoff, true);
+        let key = idx_status_time_key("tenant-1", "Succeeded", cutoff - 500, "job-1");
+        let entry = row(key, Bytes::from_static(b""));
+        let decision = filter.filter(&entry).await.unwrap();
+        assert_eq!(decision, CompactionFilterDecision::Drop);
+        assert_eq!(filter.dropped_idx_status_time, 1);
+    }
+
+    #[tokio::test]
+    async fn keeps_non_terminal_idx_status_time() {
+        let cutoff = now_epoch_ms() - 1_000;
+        let mut filter = make_filter(cutoff, true);
+        let key = idx_status_time_key("tenant-1", "Scheduled", cutoff - 500, "job-1");
+        let entry = row(key, Bytes::from_static(b""));
+        let decision = filter.filter(&entry).await.unwrap();
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+    }
+
+    #[tokio::test]
+    async fn keeps_tombstone_entries() {
+        let cutoff = now_epoch_ms() - 1_000;
+        let mut filter = make_filter(cutoff, true);
+        let entry = RowEntry {
+            key: Bytes::from(job_status_key("t", "j")),
+            value: ValueDeletable::Tombstone,
+            seq: 1,
+            create_ts: None,
+            expire_ts: None,
+        };
+        let decision = filter.filter(&entry).await.unwrap();
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+    }
+
+    #[tokio::test]
+    async fn keeps_job_info_without_reader() {
+        let cutoff = now_epoch_ms() - 1_000;
+        let mut filter = make_filter(cutoff, true);
+        let entry = row(job_info_key("tenant-1", "job-1"), Bytes::from_static(b"x"));
+        let decision = filter.filter(&entry).await.unwrap();
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+    }
+
+    #[tokio::test]
+    async fn tracks_tenant_status_drops() {
+        let cutoff = now_epoch_ms() - 1_000;
+        let mut filter = make_filter(cutoff, true);
+        let row_a = status_row(JobStatusKind::Succeeded, cutoff - 10);
+        let _ = filter.filter(&row_a).await.unwrap();
+        let row_b = status_row(JobStatusKind::Failed, cutoff - 5);
+        let _ = filter.filter(&row_b).await.unwrap();
+        let succ = filter
+            .tenant_status_drops
+            .get(&("tenant-1".to_string(), "Succeeded".to_string()));
+        let fail = filter
+            .tenant_status_drops
+            .get(&("tenant-1".to_string(), "Failed".to_string()));
+        assert_eq!(succ.copied(), Some(1));
+        assert_eq!(fail.copied(), Some(1));
+    }
+
+    #[tokio::test]
+    async fn supplier_without_reader_builds_filter() {
+        let sup = CompletedJobCompactionFilterSupplier::new_without_reader(Duration::from_secs(5));
+        let ctx = CompactionJobContext {
+            destination: 0,
+            is_dest_last_run: true,
+            compaction_clock_tick: 0,
+            retention_min_seq: None,
+        };
+        let filter = sup.create_compaction_filter(&ctx).await.unwrap();
+        drop(filter);
+    }
+}

--- a/silo-compactor/src/compaction_filter.rs
+++ b/silo-compactor/src/compaction_filter.rs
@@ -24,18 +24,19 @@
 //! will drift slightly and are expected to be reconciled by silo's own
 //! cleanup paths.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use object_store::path::Path;
 use silo::codec::decode_job_status_owned;
 use silo::job_store_shard::counter_merge_operator;
 use silo::keys::{
-    parse_attempt_key, parse_job_cancelled_key, parse_job_info_key, parse_job_status_key,
-    parse_metadata_index_key, parse_status_time_index_key, prefix,
+    idx_status_time_all_prefix, parse_attempt_key, parse_job_cancelled_key, parse_job_info_key,
+    parse_job_status_key, parse_metadata_index_key, parse_status_time_index_key, prefix,
 };
+use slatedb::config::ScanOptions;
 use slatedb::{
     CompactionFilter, CompactionFilterDecision, CompactionFilterError, CompactionFilterSupplier,
     CompactionJobContext, DbReader, DbReaderBuilder, RowEntry, ValueDeletable,
@@ -48,21 +49,120 @@ const TERMINAL_STATUSES: &[&str] = &["Succeeded", "Failed", "Cancelled"];
 /// Default retention window for completed jobs: 7 days.
 pub const DEFAULT_RETENTION_SECS: u64 = 7 * 24 * 60 * 60;
 
+/// Default upper bound on the pre-scanned `ExpiredSet`. If the IDX_STATUS_TIME
+/// pass would exceed this, the supplier falls back to per-row point reads
+/// rather than holding an arbitrarily large set in memory.
+pub const DEFAULT_EXPIRED_SET_MAX_ENTRIES: usize = 250_000;
+
+// ---------------------------------------------------------------------------
+// ExpiredSet
+// ---------------------------------------------------------------------------
+
+/// Cache of `(tenant, job_id)` pairs that the filter knows to be terminal +
+/// older than `cutoff_ms`. Built once per compaction job by scanning
+/// IDX_STATUS_TIME via a `DbReader`, then consulted by `is_job_expired`
+/// instead of issuing one point-read per row.
+///
+/// Stored as a per-tenant map so that `contains(&str, &str)` doesn't have to
+/// allocate a tuple key on every lookup — the `HashMap::get` accepts `&str`
+/// directly via `Borrow<str>` on `String`.
+struct ExpiredSet {
+    by_tenant: HashMap<String, HashSet<String>>,
+    total: usize,
+}
+
+impl ExpiredSet {
+    fn new() -> Self {
+        Self {
+            by_tenant: HashMap::new(),
+            total: 0,
+        }
+    }
+
+    fn contains(&self, tenant: &str, job_id: &str) -> bool {
+        self.by_tenant
+            .get(tenant)
+            .is_some_and(|jobs| jobs.contains(job_id))
+    }
+
+    fn insert(&mut self, tenant: String, job_id: String) {
+        if self.by_tenant.entry(tenant).or_default().insert(job_id) {
+            self.total += 1;
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.total
+    }
+}
+
+/// Scan IDX_STATUS_TIME via `reader` and collect every (tenant, job_id) pair
+/// whose key parses to a TERMINAL status with `changed_at_ms < cutoff_ms`.
+///
+/// Returns `Ok(Some(set))` on a clean drain, `Ok(None)` when the cap was
+/// exceeded mid-scan (caller falls back to per-row point reads), or `Err`
+/// when the underlying scan errored.
+///
+/// Reads with `cache_blocks: false` so a one-shot pre-scan doesn't pollute
+/// the compactor's block cache.
+async fn build_expired_set(
+    reader: &DbReader,
+    cutoff_ms: i64,
+    max_entries: usize,
+) -> Result<Option<ExpiredSet>, slatedb::Error> {
+    if max_entries == 0 {
+        return Ok(None);
+    }
+    let opts = ScanOptions {
+        cache_blocks: false,
+        ..ScanOptions::default()
+    };
+    let mut iter = reader
+        .scan_prefix_with_options(idx_status_time_all_prefix(), &opts)
+        .await?;
+    let mut set = ExpiredSet::new();
+    while let Some(kv) = iter.next().await? {
+        let Some(parsed) = parse_status_time_index_key(&kv.key) else {
+            continue;
+        };
+        if !TERMINAL_STATUSES.contains(&parsed.status.as_str()) {
+            continue;
+        }
+        if parsed.changed_at_ms() >= cutoff_ms {
+            continue;
+        }
+        set.insert(parsed.tenant, parsed.job_id);
+        if set.len() > max_entries {
+            return Ok(None);
+        }
+    }
+    Ok(Some(set))
+}
+
 // ---------------------------------------------------------------------------
 // Supplier
 // ---------------------------------------------------------------------------
 
 /// Creates a fresh [`CompletedJobCompactionFilter`] for each compaction job.
 ///
-/// The supplier lazily opens a [`DbReader`] per compaction job for point-
-/// reading JOB_STATUS rows. The reader is NOT kept alive across jobs — this
-/// avoids a long-lived manifest poller / checkpoint that can interfere with
-/// the compactor's state management.
+/// The supplier lazily opens a [`DbReader`] per compaction job and uses it
+/// to pre-scan the IDX_STATUS_TIME index into an [`ExpiredSet`]. Per-row
+/// `is_job_expired` decisions are then served from the set instead of
+/// issuing one point-read per row. The reader is NOT kept alive across
+/// jobs — this avoids a long-lived manifest poller / checkpoint that can
+/// interfere with the compactor's state management.
+///
+/// If the pre-scan fails (reader couldn't open, scan errored, or
+/// `expired_set_max_entries` was exceeded) the filter falls back to
+/// per-row point reads via the same `DbReader`.
 pub struct CompletedJobCompactionFilterSupplier {
     retention: Duration,
     /// Object-store context for lazily opening a `DbReader` per compaction
     /// job. `None` disables point reads (unit tests only).
     reader_ctx: Option<ReaderContext>,
+    /// Soft cap on the pre-scanned [`ExpiredSet`]. `0` disables the
+    /// pre-scan entirely (every `is_job_expired` becomes a point read).
+    expired_set_max_entries: usize,
 }
 
 /// Everything needed to open a short-lived [`DbReader`].
@@ -80,7 +180,15 @@ impl CompletedJobCompactionFilterSupplier {
         Self {
             retention,
             reader_ctx: Some(ReaderContext { db_path, store }),
+            expired_set_max_entries: DEFAULT_EXPIRED_SET_MAX_ENTRIES,
         }
+    }
+
+    /// Override the per-filter pre-scan cap. `0` disables the pre-scan and
+    /// forces every `is_job_expired` to issue a point read.
+    pub fn with_max_expired_entries(mut self, cap: usize) -> Self {
+        self.expired_set_max_entries = cap;
+        self
     }
 
     #[cfg(test)]
@@ -88,6 +196,7 @@ impl CompletedJobCompactionFilterSupplier {
         Self {
             retention,
             reader_ctx: None,
+            expired_set_max_entries: DEFAULT_EXPIRED_SET_MAX_ENTRIES,
         }
     }
 }
@@ -111,10 +220,7 @@ impl CompactionFilterSupplier for CompletedJobCompactionFilterSupplier {
                 .build()
                 .await
             {
-                Ok(r) => {
-                    info!("completed_jobs filter: opened DbReader for point reads");
-                    Some(Arc::new(r))
-                }
+                Ok(r) => Some(Arc::new(r)),
                 Err(e) => {
                     warn!(
                         error = %e,
@@ -128,9 +234,48 @@ impl CompactionFilterSupplier for CompletedJobCompactionFilterSupplier {
             None
         };
 
+        // Pre-scan IDX_STATUS_TIME into an ExpiredSet. When this succeeds the
+        // filter serves `is_job_expired` from memory; otherwise it falls back
+        // to per-row point reads via the same DbReader.
+        let expired = match reader.as_ref() {
+            Some(r) => {
+                let started = Instant::now();
+                match build_expired_set(r, cutoff_ms, self.expired_set_max_entries).await {
+                    Ok(Some(set)) => {
+                        info!(
+                            entries = set.len(),
+                            elapsed_ms = started.elapsed().as_millis() as u64,
+                            cap = self.expired_set_max_entries,
+                            "completed_jobs filter: pre-scan ready"
+                        );
+                        Some(Arc::new(set))
+                    }
+                    Ok(None) => {
+                        warn!(
+                            cap = self.expired_set_max_entries,
+                            elapsed_ms = started.elapsed().as_millis() as u64,
+                            "completed_jobs filter: pre-scan exceeded cap or disabled, \
+                             falling back to per-row point reads"
+                        );
+                        None
+                    }
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            "completed_jobs filter: pre-scan failed, falling back to \
+                             per-row point reads"
+                        );
+                        None
+                    }
+                }
+            }
+            None => None,
+        };
+
         Ok(Box::new(CompletedJobCompactionFilter {
             cutoff_ms,
             reader,
+            expired,
             is_dest_last_run: context.is_dest_last_run,
             dropped_job_info: 0,
             dropped_status: 0,
@@ -149,7 +294,14 @@ impl CompactionFilterSupplier for CompletedJobCompactionFilterSupplier {
 
 pub struct CompletedJobCompactionFilter {
     cutoff_ms: i64,
+    /// DbReader used by `is_job_expired` only when `expired` is `None` (the
+    /// pre-scan failed or was disabled). Otherwise membership is served
+    /// entirely from the pre-built [`ExpiredSet`].
     reader: Option<Arc<DbReader>>,
+    /// Pre-scanned set of `(tenant, job_id)` that the filter knows to be
+    /// terminal + expired. Built once at filter creation. `None` means the
+    /// filter must fall back to per-row point reads.
+    expired: Option<Arc<ExpiredSet>>,
     is_dest_last_run: bool,
 
     // Per-prefix drop counts (diagnostics).
@@ -184,9 +336,20 @@ impl CompletedJobCompactionFilter {
         }
     }
 
-    /// Point-read the job's `JOB_STATUS` from the live DB and check whether
-    /// it is terminal and older than the retention cutoff.
+    /// Decide whether `(tenant, job_id)` is terminal and older than the
+    /// retention cutoff.
+    ///
+    /// Fast path: consult the pre-scanned [`ExpiredSet`] when present. The
+    /// set is built from IDX_STATUS_TIME, which silo maintains as a
+    /// single-entry-per-job index — a pair only appears in the set if the
+    /// live status row says terminal+old, so no point read is needed.
+    ///
+    /// Fallback: when the pre-scan was skipped (cap exceeded, scan failed,
+    /// or no reader), point-read the job's `JOB_STATUS` and decode.
     async fn is_job_expired(&self, tenant: &str, job_id: &str) -> bool {
+        if let Some(set) = &self.expired {
+            return set.contains(tenant, job_id);
+        }
         let Some(reader) = &self.reader else {
             return false;
         };
@@ -380,6 +543,7 @@ mod tests {
         CompletedJobCompactionFilter {
             cutoff_ms,
             reader: None,
+            expired: None,
             is_dest_last_run,
             dropped_job_info: 0,
             dropped_status: 0,
@@ -522,5 +686,131 @@ mod tests {
         };
         let filter = sup.create_compaction_filter(&ctx).await.unwrap();
         drop(filter);
+    }
+
+    // ── ExpiredSet tests (no DB needed) ──
+
+    #[test]
+    fn expired_set_lookup_by_str_does_not_allocate() {
+        let mut set = ExpiredSet::new();
+        set.insert("tenant-a".into(), "job-1".into());
+        set.insert("tenant-a".into(), "job-2".into());
+        set.insert("tenant-b".into(), "job-3".into());
+        assert_eq!(set.len(), 3);
+        assert!(set.contains("tenant-a", "job-1"));
+        assert!(set.contains("tenant-a", "job-2"));
+        assert!(set.contains("tenant-b", "job-3"));
+        assert!(!set.contains("tenant-a", "job-3"));
+        assert!(!set.contains("tenant-c", "job-1"));
+    }
+
+    #[test]
+    fn expired_set_dedupes_inserts() {
+        let mut set = ExpiredSet::new();
+        set.insert("t".into(), "j".into());
+        set.insert("t".into(), "j".into());
+        assert_eq!(set.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn is_job_expired_uses_set_when_present() {
+        // No reader, but a populated set: filter must answer purely from the
+        // set with no point-read attempt.
+        let mut set = ExpiredSet::new();
+        set.insert("tenant-a".into(), "expired-job".into());
+        let mut filter = make_filter(now_epoch_ms() - 1_000, true);
+        filter.expired = Some(Arc::new(set));
+        assert!(filter.is_job_expired("tenant-a", "expired-job").await);
+        assert!(!filter.is_job_expired("tenant-a", "other-job").await);
+        assert!(!filter.is_job_expired("tenant-b", "expired-job").await);
+    }
+
+    // ── build_expired_set against a real in-memory slatedb ──
+
+    use slatedb::Db;
+    use slatedb::object_store::ObjectStore;
+    use slatedb::object_store::memory::InMemory;
+
+    /// Open an in-memory slatedb, write a batch of IDX_STATUS_TIME rows
+    /// matching the given (tenant, status, ts, job_id) tuples, close it,
+    /// then return a freshly-opened `DbReader` over the same store.
+    async fn seed_idx_status_time(rows: &[(&str, &str, i64, &str)]) -> Arc<DbReader> {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = slatedb::object_store::path::Path::from("/db");
+        {
+            let db = Db::builder(path.clone(), Arc::clone(&store))
+                .build()
+                .await
+                .unwrap();
+            for (tenant, status, ts, job_id) in rows {
+                let key = idx_status_time_key(tenant, status, *ts, job_id);
+                db.put(&key, []).await.unwrap();
+            }
+            db.flush_with_options(slatedb::config::FlushOptions {
+                flush_type: slatedb::config::FlushType::MemTable,
+            })
+            .await
+            .unwrap();
+            db.close().await.unwrap();
+        }
+        Arc::new(DbReaderBuilder::new(path, store).build().await.unwrap())
+    }
+
+    #[tokio::test]
+    async fn build_expired_set_picks_only_terminal_and_old() {
+        let cutoff = 1_000_000_000;
+        let reader = seed_idx_status_time(&[
+            ("tenant-a", "Succeeded", cutoff - 1, "job-old-ok"),
+            ("tenant-a", "Failed", cutoff - 100, "job-old-fail"),
+            ("tenant-b", "Cancelled", cutoff - 50, "job-old-cancel"),
+            ("tenant-a", "Succeeded", cutoff + 1, "job-recent-ok"),
+            ("tenant-a", "Running", cutoff - 999_999, "job-old-run"),
+            ("tenant-a", "Scheduled", cutoff - 999_999, "job-old-sched"),
+        ])
+        .await;
+        let set = build_expired_set(&reader, cutoff, 100)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(set.len(), 3);
+        assert!(set.contains("tenant-a", "job-old-ok"));
+        assert!(set.contains("tenant-a", "job-old-fail"));
+        assert!(set.contains("tenant-b", "job-old-cancel"));
+        assert!(!set.contains("tenant-a", "job-recent-ok"));
+        assert!(!set.contains("tenant-a", "job-old-run"));
+        assert!(!set.contains("tenant-a", "job-old-sched"));
+    }
+
+    #[tokio::test]
+    async fn build_expired_set_returns_none_when_cap_exceeded() {
+        let cutoff = 1_000_000_000;
+        let reader = seed_idx_status_time(&[
+            ("tenant-a", "Succeeded", cutoff - 1, "j1"),
+            ("tenant-a", "Succeeded", cutoff - 2, "j2"),
+            ("tenant-a", "Succeeded", cutoff - 3, "j3"),
+        ])
+        .await;
+        // Cap of 2 with three terminal+old rows → returns None.
+        let result = build_expired_set(&reader, cutoff, 2).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn build_expired_set_returns_none_when_max_entries_zero() {
+        // cap = 0 short-circuits without scanning at all.
+        let reader = seed_idx_status_time(&[("t", "Succeeded", 0, "j")]).await;
+        let result = build_expired_set(&reader, i64::MAX, 0).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn build_expired_set_handles_empty_index() {
+        let reader = seed_idx_status_time(&[]).await;
+        let set = build_expired_set(&reader, i64::MAX, 100)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(set.len(), 0);
+        assert!(!set.contains("anything", "anywhere"));
     }
 }

--- a/silo-compactor/src/config.rs
+++ b/silo-compactor/src/config.rs
@@ -33,6 +33,13 @@ pub enum CompactionFilterConfig {
     CompletedJobs {
         #[serde(default = "default_completed_jobs_retention_secs")]
         retention_secs: u64,
+        /// Soft cap on the in-memory `(tenant, job_id)` set built by
+        /// pre-scanning IDX_STATUS_TIME. When unset, falls back to
+        /// `compaction_filter::DEFAULT_EXPIRED_SET_MAX_ENTRIES`. Set to
+        /// `0` to disable the pre-scan and use per-row point reads
+        /// exclusively.
+        #[serde(default)]
+        expired_set_max_entries: Option<usize>,
     },
 }
 
@@ -306,7 +313,8 @@ mod tests {
         assert_eq!(
             cfg.compaction_filter,
             CompactionFilterConfig::CompletedJobs {
-                retention_secs: 900
+                retention_secs: 900,
+                expired_set_max_entries: None,
             }
         );
     }
@@ -330,6 +338,33 @@ mod tests {
             cfg.compaction_filter,
             CompactionFilterConfig::CompletedJobs {
                 retention_secs: DEFAULT_RETENTION_SECS,
+                expired_set_max_entries: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_completed_jobs_filter_with_expired_set_cap() {
+        let toml_str = r#"
+            [storage]
+            backend = "memory"
+            path = "memory://x/%shard%"
+
+            [shard_discovery]
+            backend = "etcd"
+            cluster_prefix = "silo-dev"
+
+            [compaction_filter]
+            kind = "completed_jobs"
+            retention_secs = 900
+            expired_set_max_entries = 500_000
+        "#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        assert_eq!(
+            cfg.compaction_filter,
+            CompactionFilterConfig::CompletedJobs {
+                retention_secs: 900,
+                expired_set_max_entries: Some(500_000),
             }
         );
     }

--- a/silo-compactor/src/config.rs
+++ b/silo-compactor/src/config.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Deserializer};
 
+use crate::compaction_filter::DEFAULT_RETENTION_SECS;
 use crate::storage::Backend;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -16,6 +17,27 @@ pub struct AppConfig {
     pub logging: LoggingConfig,
     #[serde(default, deserialize_with = "deserialize_compactor_options")]
     pub compactor_options: Option<slatedb::config::CompactorOptions>,
+    #[serde(default)]
+    pub compaction_filter: CompactionFilterConfig,
+}
+
+/// Compaction filter selection. Defaults to [`CompactionFilterConfig::None`]
+/// so existing deployments keep current behavior after the upgrade.
+#[derive(Debug, Deserialize, Clone, Default, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CompactionFilterConfig {
+    #[default]
+    None,
+    /// Delete terminal (Succeeded/Failed/Cancelled) job data older than
+    /// `retention_secs`. Defaults to 7 days.
+    CompletedJobs {
+        #[serde(default = "default_completed_jobs_retention_secs")]
+        retention_secs: u64,
+    },
+}
+
+fn default_completed_jobs_retention_secs() -> u64 {
+    DEFAULT_RETENTION_SECS
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -262,6 +284,54 @@ mod tests {
         assert_eq!(cfg.coordinator.rebalance_interval, Duration::from_secs(30));
         assert_eq!(cfg.coordinator.mode, CoordinatorMode::K8sDeployment);
         assert!(cfg.compactor_options.is_none());
+        assert_eq!(cfg.compaction_filter, CompactionFilterConfig::None);
+    }
+
+    #[test]
+    fn parses_completed_jobs_filter_with_retention() {
+        let toml_str = r#"
+            [storage]
+            backend = "memory"
+            path = "memory://x/%shard%"
+
+            [shard_discovery]
+            backend = "etcd"
+            cluster_prefix = "silo-dev"
+
+            [compaction_filter]
+            kind = "completed_jobs"
+            retention_secs = 900
+        "#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        assert_eq!(
+            cfg.compaction_filter,
+            CompactionFilterConfig::CompletedJobs {
+                retention_secs: 900
+            }
+        );
+    }
+
+    #[test]
+    fn completed_jobs_filter_defaults_to_seven_days() {
+        let toml_str = r#"
+            [storage]
+            backend = "memory"
+            path = "memory://x/%shard%"
+
+            [shard_discovery]
+            backend = "etcd"
+            cluster_prefix = "silo-dev"
+
+            [compaction_filter]
+            kind = "completed_jobs"
+        "#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        assert_eq!(
+            cfg.compaction_filter,
+            CompactionFilterConfig::CompletedJobs {
+                retention_secs: DEFAULT_RETENTION_SECS,
+            }
+        );
     }
 
     #[test]

--- a/silo-compactor/src/coordinator.rs
+++ b/silo-compactor/src/coordinator.rs
@@ -6,7 +6,7 @@ use tokio::sync::{mpsc, watch};
 use tracing::{debug, info, warn};
 
 use crate::assignment::compute_assignment;
-use crate::config::{AppConfig, CoordinatorMode, ShardDiscoveryBackend};
+use crate::config::{AppConfig, CompactionFilterConfig, CoordinatorMode, ShardDiscoveryBackend};
 use crate::error::CompactorError;
 use crate::pod_discovery::{K8sPodDiscovery, PodDiscovery, StaticPodDiscovery};
 use crate::shard_loader::ShardMapLoader;
@@ -21,6 +21,7 @@ pub struct Coordinator {
     backend: Backend,
     path_template: Arc<String>,
     compactor_options: Arc<Option<slatedb::config::CompactorOptions>>,
+    filter_config: Arc<CompactionFilterConfig>,
     discovery: Arc<dyn PodDiscovery>,
     shard_loader: Arc<dyn ShardMapLoader>,
     placement_ring: Option<String>,
@@ -41,6 +42,7 @@ impl Coordinator {
         let backend = cfg.storage.backend.clone();
         let path_template = Arc::new(cfg.storage.path.clone());
         let compactor_options = Arc::new(cfg.compactor_options.clone());
+        let filter_config = Arc::new(cfg.compaction_filter.clone());
 
         let needs_kube = matches!(cfg.coordinator.mode, CoordinatorMode::K8sDeployment)
             || matches!(
@@ -114,6 +116,7 @@ impl Coordinator {
             backend,
             path_template,
             compactor_options,
+            filter_config,
             discovery,
             shard_loader,
             placement_ring: cfg.shard_discovery.placement_ring,
@@ -187,6 +190,7 @@ impl Coordinator {
                 self.backend.clone(),
                 Arc::clone(&self.path_template),
                 Arc::clone(&self.compactor_options),
+                Arc::clone(&self.filter_config),
                 self.worker_backoff,
             );
             self.workers.insert(*shard, handle);

--- a/silo-compactor/src/lib.rs
+++ b/silo-compactor/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod assignment;
+pub mod compaction_filter;
 pub mod config;
 pub mod coordinator;
 pub mod error;

--- a/silo-compactor/src/worker.rs
+++ b/silo-compactor/src/worker.rs
@@ -5,6 +5,8 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::compaction_filter::CompletedJobCompactionFilterSupplier;
+use crate::config::CompactionFilterConfig;
 use crate::error::CompactorError;
 use crate::shard_map::ShardId;
 use crate::storage::{Backend, path_for_shard, resolve_object_store};
@@ -31,6 +33,7 @@ pub fn spawn_worker(
     backend: Backend,
     path_template: Arc<String>,
     compactor_options: Arc<Option<slatedb::config::CompactorOptions>>,
+    filter_config: Arc<CompactionFilterConfig>,
     restart_backoff: Duration,
 ) -> WorkerHandle {
     let cancel = CancellationToken::new();
@@ -41,6 +44,7 @@ pub fn spawn_worker(
             backend,
             path_template,
             compactor_options,
+            filter_config,
             restart_backoff,
             cancel_for_task,
         )
@@ -58,6 +62,7 @@ async fn run_supervisor(
     backend: Backend,
     path_template: Arc<String>,
     compactor_options: Arc<Option<slatedb::config::CompactorOptions>>,
+    filter_config: Arc<CompactionFilterConfig>,
     restart_backoff: Duration,
     cancel: CancellationToken,
 ) {
@@ -70,6 +75,7 @@ async fn run_supervisor(
             &backend,
             &path_template,
             compactor_options.as_ref().clone(),
+            filter_config.as_ref(),
             &cancel,
         )
         .await
@@ -99,6 +105,7 @@ async fn run_once(
     backend: &Backend,
     path_template: &str,
     compactor_options: Option<slatedb::config::CompactorOptions>,
+    filter_config: &CompactionFilterConfig,
     cancel: &CancellationToken,
 ) -> Result<(), CompactorError> {
     let shard_path = path_for_shard(path_template, shard_id);
@@ -111,9 +118,25 @@ async fn run_once(
         "opening compactor",
     );
 
-    let mut builder = slatedb::CompactorBuilder::new(resolved.canonical_path, resolved.store);
+    let canonical_path = resolved.canonical_path;
+    let store = resolved.store;
+    let mut builder = slatedb::CompactorBuilder::new(canonical_path.clone(), Arc::clone(&store))
+        .with_merge_operator(silo::job_store_shard::counter_merge_operator());
     if let Some(opts) = compactor_options {
         builder = builder.with_options(opts);
+    }
+    if let CompactionFilterConfig::CompletedJobs { retention_secs } = filter_config {
+        let supplier = CompletedJobCompactionFilterSupplier::new(
+            Duration::from_secs(*retention_secs),
+            object_store::path::Path::from(canonical_path.as_str()),
+            Arc::clone(&store),
+        );
+        info!(
+            shard = %shard_id,
+            retention_secs = *retention_secs,
+            "enabling completed_jobs compaction filter",
+        );
+        builder = builder.with_compaction_filter_supplier(Arc::new(supplier));
     }
     let compactor = builder.build();
 

--- a/silo-compactor/src/worker.rs
+++ b/silo-compactor/src/worker.rs
@@ -125,15 +125,23 @@ async fn run_once(
     if let Some(opts) = compactor_options {
         builder = builder.with_options(opts);
     }
-    if let CompactionFilterConfig::CompletedJobs { retention_secs } = filter_config {
-        let supplier = CompletedJobCompactionFilterSupplier::new(
+    if let CompactionFilterConfig::CompletedJobs {
+        retention_secs,
+        expired_set_max_entries,
+    } = filter_config
+    {
+        let mut supplier = CompletedJobCompactionFilterSupplier::new(
             Duration::from_secs(*retention_secs),
             object_store::path::Path::from(canonical_path.as_str()),
             Arc::clone(&store),
         );
+        if let Some(cap) = expired_set_max_entries {
+            supplier = supplier.with_max_expired_entries(*cap);
+        }
         info!(
             shard = %shard_id,
             retention_secs = *retention_secs,
+            expired_set_max_entries = ?expired_set_max_entries,
             "enabling completed_jobs compaction filter",
         );
         builder = builder.with_compaction_filter_supplier(Arc::new(supplier));

--- a/silo-compactor/tests/compaction_filter_integration.rs
+++ b/silo-compactor/tests/compaction_filter_integration.rs
@@ -1,0 +1,425 @@
+//! End-to-end test that exercises the standalone compactor with
+//! [`silo_compactor::compaction_filter::CompletedJobCompactionFilter`]
+//! attached. The test writes a mix of old terminal, recent terminal, and
+//! non-terminal job rows to an in-memory SlateDB; submits a full compaction
+//! against a separately-run [`slatedb::Compactor`] with the filter
+//! supplier; polls the manifest until all L0 SSTs have been consumed; then
+//! opens a fresh [`slatedb::DbReader`] and verifies that only the
+//! expired-completed rows were purged.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use silo::codec::encode_job_status;
+use silo::job::{JobStatus, JobStatusKind};
+use silo::job_store_shard::counter_merge_operator;
+use silo::keys::{
+    attempt_key, idx_metadata_key, idx_status_time_key, job_cancelled_key, job_info_key,
+    job_status_key,
+};
+use silo_compactor::compaction_filter::CompletedJobCompactionFilterSupplier;
+use slatedb::admin::AdminBuilder;
+use slatedb::compactor::{CompactionSpec, SourceId};
+use slatedb::config::{CompactorOptions, FlushOptions, FlushType};
+use slatedb::object_store::ObjectStore;
+use slatedb::object_store::memory::InMemory;
+use slatedb::object_store::path::Path;
+use slatedb::{CompactorBuilder, Db, DbReaderBuilder};
+use ulid::Ulid;
+
+fn now_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64
+}
+
+/// Compactor tuned for integration tests: short poll interval so submitted
+/// compactions start within tens of milliseconds rather than the default
+/// 5-second cadence, and an artificially-high `min_compaction_sources` so
+/// the size-tiered scheduler never auto-triggers while we are submitting
+/// manual specs via Admin.
+///
+/// Without the short poll the filter's `cutoff_ms = now - retention` drifts
+/// past our "recent" rows while the compactor sleeps; without the disabled
+/// auto-scheduler it produces compactions with conflicting destinations
+/// that cause our manual submits to fail validation.
+fn test_compactor_options() -> CompactorOptions {
+    let mut scheduler_options = std::collections::HashMap::new();
+    scheduler_options.insert("min_compaction_sources".to_string(), "1000".to_string());
+    scheduler_options.insert("max_compaction_sources".to_string(), "1000".to_string());
+    CompactorOptions {
+        poll_interval: Duration::from_millis(50),
+        scheduler_options,
+        ..CompactorOptions::default()
+    }
+}
+
+/// Write the six-prefix "family" of rows for a given job: JOB_INFO,
+/// JOB_STATUS, IDX_STATUS_TIME, IDX_METADATA, ATTEMPT, JOB_CANCELLED.
+/// Mirrors the key set the filter inspects.
+async fn write_job_family(db: &Db, tenant: &str, job_id: &str, kind: JobStatusKind, ts_ms: i64) {
+    let status = JobStatus::new(kind, ts_ms, None, None);
+    db.put(job_status_key(tenant, job_id), encode_job_status(&status))
+        .await
+        .unwrap();
+    db.put(job_info_key(tenant, job_id), b"info-payload")
+        .await
+        .unwrap();
+    db.put(
+        idx_status_time_key(tenant, kind.as_str(), ts_ms, job_id),
+        b"",
+    )
+    .await
+    .unwrap();
+    db.put(
+        idx_metadata_key(tenant, "env", "prod", job_id),
+        b"metadata-value",
+    )
+    .await
+    .unwrap();
+    db.put(attempt_key(tenant, job_id, 1), b"attempt-payload")
+        .await
+        .unwrap();
+    db.put(job_cancelled_key(tenant, job_id), b"cancelled-payload")
+        .await
+        .unwrap();
+}
+
+/// Returns the list of family-key labels that are currently *missing* for
+/// a job. Used to build actionable assertion messages.
+async fn missing_family_keys(
+    reader: &slatedb::DbReader,
+    tenant: &str,
+    job_id: &str,
+) -> Vec<&'static str> {
+    let mut missing = Vec::new();
+    if reader
+        .get(job_status_key(tenant, job_id).as_slice())
+        .await
+        .unwrap()
+        .is_none()
+    {
+        missing.push("JOB_STATUS");
+    }
+    if reader
+        .get(job_info_key(tenant, job_id).as_slice())
+        .await
+        .unwrap()
+        .is_none()
+    {
+        missing.push("JOB_INFO");
+    }
+    if reader
+        .get(idx_metadata_key(tenant, "env", "prod", job_id).as_slice())
+        .await
+        .unwrap()
+        .is_none()
+    {
+        missing.push("IDX_METADATA");
+    }
+    if reader
+        .get(attempt_key(tenant, job_id, 1).as_slice())
+        .await
+        .unwrap()
+        .is_none()
+    {
+        missing.push("ATTEMPT");
+    }
+    if reader
+        .get(job_cancelled_key(tenant, job_id).as_slice())
+        .await
+        .unwrap()
+        .is_none()
+    {
+        missing.push("JOB_CANCELLED");
+    }
+    missing
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn drops_old_completed_jobs_on_compaction() {
+    // Retention is 5s; we age old rows to 10s in the past so they are firmly
+    // beyond the cutoff by the time compaction runs.
+    let retention = Duration::from_secs(5);
+    let now_ms = now_epoch_ms();
+    let old_ms = now_ms - 10_000;
+
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let db_path = Path::from("/testdb");
+
+    // ── Write phase ─────────────────────────────────────────────────────
+    {
+        let db = Db::builder(db_path.clone(), Arc::clone(&store))
+            .with_merge_operator(counter_merge_operator())
+            .build()
+            .await
+            .unwrap();
+
+        // Expired terminal jobs — the filter should drop every row.
+        write_job_family(
+            &db,
+            "tenant-a",
+            "job-old-ok",
+            JobStatusKind::Succeeded,
+            old_ms,
+        )
+        .await;
+        write_job_family(
+            &db,
+            "tenant-a",
+            "job-old-fail",
+            JobStatusKind::Failed,
+            old_ms,
+        )
+        .await;
+        write_job_family(
+            &db,
+            "tenant-b",
+            "job-old-cancel",
+            JobStatusKind::Cancelled,
+            old_ms,
+        )
+        .await;
+
+        // Recent terminal — rows must be kept until they age past retention.
+        write_job_family(
+            &db,
+            "tenant-a",
+            "job-new-ok",
+            JobStatusKind::Succeeded,
+            now_ms,
+        )
+        .await;
+
+        // Old non-terminal — job is still active so nothing should be dropped.
+        write_job_family(
+            &db,
+            "tenant-a",
+            "job-old-run",
+            JobStatusKind::Running,
+            old_ms,
+        )
+        .await;
+
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+        db.close().await.unwrap();
+    }
+
+    // ── Compact phase ───────────────────────────────────────────────────
+    let admin = AdminBuilder::new(db_path.clone(), Arc::clone(&store)).build();
+
+    let state = admin.read_compactor_state_view().await.unwrap();
+    let l0_ids: Vec<Ulid> = state
+        .manifest()
+        .l0
+        .iter()
+        .map(|s| s.sst.id.unwrap_compacted_id())
+        .collect();
+    assert!(
+        !l0_ids.is_empty(),
+        "expected at least one L0 SST after flush, got zero"
+    );
+
+    // Sanity check: before compaction, every row we wrote is readable.
+    {
+        let reader = DbReaderBuilder::new(db_path.clone(), Arc::clone(&store))
+            .with_merge_operator(counter_merge_operator())
+            .build()
+            .await
+            .unwrap();
+        for (tenant, job_id) in [
+            ("tenant-a", "job-old-ok"),
+            ("tenant-a", "job-old-fail"),
+            ("tenant-b", "job-old-cancel"),
+            ("tenant-a", "job-new-ok"),
+            ("tenant-a", "job-old-run"),
+        ] {
+            let missing = missing_family_keys(&reader, tenant, job_id).await;
+            assert!(
+                missing.is_empty(),
+                "pre-compaction: {tenant}/{job_id} missing keys: {:?}",
+                missing,
+            );
+        }
+    }
+
+    let supplier = Arc::new(CompletedJobCompactionFilterSupplier::new(
+        retention,
+        db_path.clone(),
+        Arc::clone(&store),
+    ));
+
+    let compactor = CompactorBuilder::new(db_path.clone(), Arc::clone(&store))
+        .with_options(test_compactor_options())
+        .with_merge_operator(counter_merge_operator())
+        .with_compaction_filter_supplier(supplier)
+        .build();
+
+    let run_task = tokio::spawn({
+        let compactor = compactor.clone();
+        async move { compactor.run().await }
+    });
+    // Give the compactor a moment to load state before we submit.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let sources: Vec<SourceId> = l0_ids.iter().map(|&id| SourceId::SstView(id)).collect();
+    // Compaction destination must be `>= highest_existing_sr.id + 1` for
+    // L0-only specs; `compacted` is empty here so 0 is valid.
+    submit_and_wait(
+        &admin,
+        CompactionSpec::new(sources, 0),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    compactor.stop().await.unwrap();
+    let _ = run_task.await;
+
+    // ── Verify phase ────────────────────────────────────────────────────
+    let reader = DbReaderBuilder::new(db_path.clone(), Arc::clone(&store))
+        .with_merge_operator(counter_merge_operator())
+        .build()
+        .await
+        .unwrap();
+
+    // Dest was the only sorted run after compaction → `is_dest_last_run =
+    // true` → the filter chose `Drop`, so expired rows are gone.
+    for (tenant, job_id) in [
+        ("tenant-a", "job-old-ok"),
+        ("tenant-a", "job-old-fail"),
+        ("tenant-b", "job-old-cancel"),
+    ] {
+        let missing = missing_family_keys(&reader, tenant, job_id).await;
+        assert_eq!(
+            missing.len(),
+            5,
+            "expired {tenant}/{job_id} should be fully dropped; still present: {:?}",
+            ([
+                "JOB_STATUS",
+                "JOB_INFO",
+                "IDX_METADATA",
+                "ATTEMPT",
+                "JOB_CANCELLED"
+            ])
+            .iter()
+            .filter(|k| !missing.contains(k))
+            .collect::<Vec<_>>(),
+        );
+    }
+
+    // Recent terminal + old non-terminal jobs must keep every row.
+    for (tenant, job_id, reason) in [
+        ("tenant-a", "job-new-ok", "recent terminal"),
+        ("tenant-a", "job-old-run", "old non-terminal"),
+    ] {
+        let missing = missing_family_keys(&reader, tenant, job_id).await;
+        assert!(
+            missing.is_empty(),
+            "{reason} {tenant}/{job_id} should be fully preserved; missing: {:?}",
+            missing,
+        );
+    }
+
+    // IDX_STATUS_TIME keys are self-describing: expired terminal keys gone,
+    // non-terminal keys with identical timestamp preserved.
+    assert_eq!(
+        reader
+            .get(idx_status_time_key("tenant-a", "Succeeded", old_ms, "job-old-ok").as_slice())
+            .await
+            .unwrap(),
+        None,
+    );
+    assert!(
+        reader
+            .get(idx_status_time_key("tenant-a", "Running", old_ms, "job-old-run").as_slice())
+            .await
+            .unwrap()
+            .is_some(),
+        "non-terminal idx_status_time rows must not be dropped even when old"
+    );
+    assert!(
+        reader
+            .get(idx_status_time_key("tenant-a", "Succeeded", now_ms, "job-new-ok").as_slice())
+            .await
+            .unwrap()
+            .is_some(),
+        "recent terminal idx_status_time rows must not be dropped"
+    );
+}
+
+// Integration coverage for the tombstone path is intentionally not included
+// here. Exercising `is_dest_last_run = false` requires orchestrating at
+// least two sorted runs AND a subsequent SR-only compaction whose
+// destination sits above the lowest-id SR. In practice slatedb's
+// Admin-submit + out-of-band-Compactor pair routinely loses state between
+// sequential submissions (the Admin.submit_compaction store version lags
+// the Compactor's updates), causing back-to-back L0 submissions with the
+// needed destinations to be rejected as `InvalidCompaction`. The tombstone
+// branch of the filter is covered at the unit-test level in
+// `silo_compactor::compaction_filter::tests::{drop_decision_uses_tombstone_when_not_last_run,
+// tombstones_old_completed_status_when_not_last_run}` which directly
+// verifies the decision against a synthesized filter with
+// `is_dest_last_run = false`.
+
+/// Submit a compaction spec and poll the manifest until every source listed
+/// in the spec has been consumed (L0 SSTs removed from `l0`, sorted runs
+/// removed from `compacted`).
+async fn submit_and_wait(admin: &slatedb::admin::Admin, spec: CompactionSpec, timeout: Duration) {
+    let expected_l0: Vec<Ulid> = spec
+        .sources()
+        .iter()
+        .filter_map(|s| match s {
+            SourceId::SstView(id) => Some(*id),
+            _ => None,
+        })
+        .collect();
+    let expected_srs: Vec<u32> = spec
+        .sources()
+        .iter()
+        .filter_map(|s| match s {
+            SourceId::SortedRun(id) => Some(*id),
+            _ => None,
+        })
+        .collect();
+
+    admin.submit_compaction(spec).await.unwrap();
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        let state = admin.read_compactor_state_view().await.unwrap();
+        let current_l0: HashSet<Ulid> = state
+            .manifest()
+            .l0
+            .iter()
+            .map(|s| s.sst.id.unwrap_compacted_id())
+            .collect();
+        let current_srs: HashSet<u32> = state.manifest().compacted.iter().map(|sr| sr.id).collect();
+        let l0_done = expected_l0.iter().all(|id| !current_l0.contains(id));
+        let srs_done = expected_srs.iter().all(|id| !current_srs.contains(id));
+        if l0_done && srs_done {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "submit_and_wait: timed out. l0 remaining={}/{}, srs remaining={}/{}",
+                expected_l0
+                    .iter()
+                    .filter(|id| current_l0.contains(id))
+                    .count(),
+                expected_l0.len(),
+                expected_srs
+                    .iter()
+                    .filter(|id| current_srs.contains(id))
+                    .count(),
+                expected_srs.len(),
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -12,7 +12,7 @@ use storekey::{decode, encode_vec};
 
 use crate::job::{JobStatus, JobStatusKind};
 
-pub(crate) mod prefix {
+pub mod prefix {
     pub const JOB_INFO: u8 = 0x01;
     pub const JOB_STATUS: u8 = 0x02;
     pub const IDX_STATUS_TIME: u8 = 0x03;


### PR DESCRIPTION
Enable slatedb's `compaction_filters` feature in silo-compactor and add a completed-jobs filter so the standalone compactor can purge terminal (Succeeded / Failed / Cancelled) job data past its retention window.

## What the filter drops

Six key prefixes are inspected during compaction:

| Prefix | Name | Decision method |
| --- | --- | --- |
| 0x01 | JOB_INFO | look up `(tenant, job_id)` in the pre-scanned set |
| 0x02 | JOB_STATUS | decode value, check `is_terminal && changed_at_ms < cutoff` |
| 0x03 | IDX_STATUS_TIME | self-contained: status + ts encoded in key |
| 0x04 | IDX_METADATA | look up `(tenant, job_id)` in the pre-scanned set |
| 0x07 | ATTEMPT | look up `(tenant, job_id)` in the pre-scanned set |
| 0x0A | JOB_CANCELLED | look up `(tenant, job_id)` in the pre-scanned set |

When `is_dest_last_run` is true the filter emits `Drop`; otherwise `Modify(Tombstone)`. Retention defaults to 7 days and is configurable via `[compaction_filter] kind = "completed_jobs" retention_secs = <n>`.

## Pre-scan optimization

Four of the six prefixes used to require a `JOB_STATUS` point read per row to determine the owning job's terminal status. With per-job ATTEMPT and per-key/value IDX_METADATA fan-out, that read amplification dominates compaction cost on busy shards.

Instead, at filter-creation time the supplier opens a short-lived `DbReader` and runs `build_expired_set` over the IDX_STATUS_TIME index (key prefix `0x03`). The index already encodes `(tenant, status, inverted_ts, job_id)` in its key, and silo's `set_job_status_with_index` in `src/job_store_shard/enqueue.rs:616` deletes the prior row on every status transition — so a single `DbReader::scan_prefix` returns one row per `(tenant, job_id)` reflecting current status. Verified via `restart.rs:149`, `import.rs:620`, and `delete_job` at `mod.rs:798`.

The result is an `ExpiredSet` of `(tenant, job_id)` pairs that the filter knows to be terminal + older than the cutoff. Per-row `is_job_expired` calls become O(1) HashMap lookups instead of one slatedb point read each.

## Memory bound

The set is stored as a per-tenant `HashMap<String, HashSet<String>>` so `contains(&str, &str)` doesn't allocate a tuple key on every lookup. It is bounded by a soft cap (`DEFAULT_EXPIRED_SET_MAX_ENTRIES = 250_000`, configurable via `expired_set_max_entries` in TOML or `with_max_expired_entries` in code; `0` disables the pre-scan entirely). If the IDX_STATUS_TIME pass would exceed the cap, `build_expired_set` returns `Ok(None)` and the filter falls back to per-row point reads — memory does not grow past the cap regardless of how many expired jobs exist in the index.

The set holds only expired jobs (not all jobs), and is dropped when the `CompactionFilter` is dropped after `on_compaction_end`. No process-lifetime accumulation. At ~100-150 bytes per entry the cap is ~37 MB per filter; worst-case 12 shards × 4 max_concurrent_compactions ≈ 1.8 GB across a pod, typically much less.

Owned `(String, String)` rather than 64-bit hashes — a hash collision would silently drop live data, which is not self-correcting; the cap bounds the absolute footprint anyway.

## Counter drift (follow-up)

Job counters (per-tenant `tenant_status_counter`, shard `total_jobs` / `completed_jobs`) are intentionally NOT touched by this filter. They will drift relative to the rows this filter drops, and they may stay stale for some time after compaction. A follow-up PR will introduce a background reconciliation task that scans live counters against live JOB_STATUS rows and corrects drift.

The standalone compactor process does not have a writable `Db` handle, so writing counter deltas inline from `on_compaction_end` would require opening a fenced writer alongside the live silo server — out of scope here.

## Block cache (future)

The pre-scan reads object-store blocks from the IDX_STATUS_TIME range once per compaction job. silo-compactor does not currently configure a block cache, so those reads do not benefit from warm-cache reuse across compaction jobs on the same shard. If profiling shows the pre-scan dominates compaction wall time, configuring a `with_db_cache` on the `DbReader` (and optionally on the Compactor) would be a natural next step. Out of scope for this PR.

## Other changes

- `silo-compactor` depends on the `silo` crate as a path dep with `default-features = false` to reuse `silo::keys`, `silo::codec`, `silo::job`, and `silo::job_store_shard::counter_merge_operator`.
- `silo::keys::prefix` is promoted from `pub(crate)` to `pub` so the filter can read the shared prefix bytes.
- `slatedb` and `slatedb-common` are pinned to 0.12.0; the `compaction_filters` feature is enabled on slatedb only in silo-compactor.
- Worker threads `expired_set_max_entries` through to the supplier via the new `with_max_expired_entries` builder.

## Test coverage

- 26 unit tests in `silo-compactor` (config + filter), including:
  - `ExpiredSet` semantics (`contains` by `&str`, dedup on insert).
  - `build_expired_set` against a real in-memory slatedb seeded with terminal+old, terminal+recent, non-terminal+old, non-terminal+recent rows across two tenants.
  - Cap-exceeded path returns `Ok(None)`; `max_entries = 0` short-circuits without scanning.
  - `is_job_expired` answers from the set when present without falling back to a point read.
  - Drop vs Tombstone decision based on `is_dest_last_run`.
- 1 end-to-end integration test (`silo-compactor/tests/compaction_filter_integration.rs`) that writes a mix of old-terminal, recent-terminal, and old-non-terminal rows to an in-memory SlateDB, runs a standalone Compactor with the filter, polls until L0 SSTs are consumed, and verifies that only expired-terminal rows were purged. Covers the Drop branch end-to-end. Tombstone semantics are covered at the unit level — the end-to-end tombstone scenario requires back-to-back L0 compaction submits via Admin, which slatedb 0.12.0 rejects as `InvalidCompaction` due to stale store snapshots between sequential admin submits.