### PR TITLE
Add periodic counter reconciliation background task

### DIFF
--- a/src/job_store_shard/counters.rs
+++ b/src/job_store_shard/counters.rs
@@ -14,18 +14,21 @@
 //! counter keys from conflict detection, since these global shard-level keys would otherwise
 //! cause excessive transaction conflicts under concurrent load.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use slatedb::bytes::Bytes;
 use slatedb::{MergeOperator, MergeOperatorError};
 
+use crate::codec::decode_job_status_owned;
 use crate::job_store_shard::helpers::WriteBatcher;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
     concurrency_requester_counter_key, concurrency_requester_counter_tenant_prefix, end_bound,
-    parse_concurrency_requester_counter_key, shard_completed_jobs_counter_key,
-    shard_total_jobs_counter_key,
+    parse_concurrency_requester_counter_key, parse_job_info_key, parse_job_status_key, prefix,
+    shard_completed_jobs_counter_key, shard_total_jobs_counter_key, tenant_status_counter_key,
 };
+use crate::shard_range::ShardRange;
 
 /// Shard job counters returned by get_counters.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -323,4 +326,209 @@ impl JobStoreShard {
         }
         Ok(results)
     }
+
+    /// Re-derive shard-level and per-tenant counter truth by scanning the
+    /// `JOB_INFO` and `JOB_STATUS` source-of-truth keys, then write a single
+    /// signed merge operand per counter to correct any drift.
+    ///
+    /// Drift is expected because the standalone `silo-compactor` drops terminal
+    /// job rows during compaction without a writable `Db` handle and therefore
+    /// cannot decrement counters at drop time. This method is the sole owner of
+    /// counter truth in steady state.
+    ///
+    /// The pass is best-effort: if any individual counter fails to scan or
+    /// merge, a `warn!` is logged for that counter and the rest of the pass
+    /// continues. Concurrent writes during the scan can leave the corrected
+    /// value slightly off; the next pass corrects that drift.
+    pub async fn reconcile_counters(
+        &self,
+        range: &ShardRange,
+    ) -> ReconcileSummary {
+        let mut summary = ReconcileSummary::default();
+
+        match self.reconcile_shard_counters(range).await {
+            Ok((scanned, corrected)) => {
+                summary.scanned_jobs = scanned;
+                summary.corrected += corrected;
+            }
+            Err(e) => {
+                summary.failed += 1;
+                tracing::warn!(
+                    shard = %self.name,
+                    error = %e,
+                    "counter reconcile failed (shard counters); shard counters will remain stale until next pass"
+                );
+            }
+        }
+
+        match self.reconcile_tenant_status_counters(range).await {
+            Ok(corrected) => summary.corrected += corrected,
+            Err(e) => {
+                summary.failed += 1;
+                tracing::warn!(
+                    shard = %self.name,
+                    error = %e,
+                    "counter reconcile failed (tenant status counters); per-tenant counters will remain stale until next pass"
+                );
+            }
+        }
+
+        summary
+    }
+
+    /// Reconcile the two shard-level counters (`total_jobs`, `completed_jobs`).
+    /// Returns `(jobs_scanned, counters_corrected)`.
+    async fn reconcile_shard_counters(
+        &self,
+        range: &ShardRange,
+    ) -> Result<(u64, u64), JobStoreShardError> {
+        // Truth scan: count JOB_INFO rows for total_jobs.
+        let mut total_jobs_truth: i64 = 0;
+        let info_prefix = vec![prefix::JOB_INFO];
+        let info_end = end_bound(&info_prefix);
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(info_prefix..info_end, &crate::scan_options())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            if let Some(parsed) = parse_job_info_key(&kv.key)
+                && range.contains_tenant(&parsed.tenant)
+            {
+                total_jobs_truth += 1;
+            }
+        }
+
+        // Truth scan: count terminal JOB_STATUS rows for completed_jobs.
+        let mut completed_jobs_truth: i64 = 0;
+        let mut scanned: u64 = 0;
+        let status_prefix = vec![prefix::JOB_STATUS];
+        let status_end = end_bound(&status_prefix);
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(status_prefix..status_end, &crate::scan_options())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let Some(parsed) = parse_job_status_key(&kv.key) else {
+                continue;
+            };
+            if !range.contains_tenant(&parsed.tenant) {
+                continue;
+            }
+            scanned += 1;
+            match decode_job_status_owned(&kv.value) {
+                Ok(status) if status.is_terminal() => completed_jobs_truth += 1,
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        shard = %self.name,
+                        tenant = %parsed.tenant,
+                        job_id = %parsed.job_id,
+                        error = %e,
+                        "counter reconcile: failed to decode job status, skipping row"
+                    );
+                }
+            }
+        }
+
+        let mut corrected: u64 = 0;
+        corrected += self
+            .apply_counter_correction(shard_total_jobs_counter_key(), total_jobs_truth)
+            .await?;
+        corrected += self
+            .apply_counter_correction(shard_completed_jobs_counter_key(), completed_jobs_truth)
+            .await?;
+
+        Ok((scanned, corrected))
+    }
+
+    /// Reconcile per-tenant per-status counters by re-scanning JOB_STATUS and
+    /// computing truth, then driving any stale stored counters to that truth.
+    /// Returns the number of counters that received a non-zero correction.
+    async fn reconcile_tenant_status_counters(
+        &self,
+        range: &ShardRange,
+    ) -> Result<u64, JobStoreShardError> {
+        // Build truth from JOB_STATUS scan.
+        let mut truth: HashMap<(String, String), i64> = HashMap::new();
+        let status_prefix = vec![prefix::JOB_STATUS];
+        let status_end = end_bound(&status_prefix);
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(status_prefix..status_end, &crate::scan_options())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let Some(parsed) = parse_job_status_key(&kv.key) else {
+                continue;
+            };
+            if !range.contains_tenant(&parsed.tenant) {
+                continue;
+            }
+            let Ok(status) = decode_job_status_owned(&kv.value) else {
+                continue;
+            };
+            *truth
+                .entry((parsed.tenant, status.kind.as_str().to_owned()))
+                .or_insert(0) += 1;
+        }
+
+        // Collect existing stored counters in this shard's range so we can
+        // explicitly drive zombies (counter > 0 but no matching JOB_STATUS) to
+        // zero. Reuses `scan_tenant_status_counters` which already filters by
+        // shard range, but only returns count > 0 rows — that's exactly the
+        // set we might need to zero out.
+        let existing = self.scan_tenant_status_counters(None).await?;
+
+        let mut corrected: u64 = 0;
+        let mut truth_remaining = truth;
+
+        for (tenant, kind, _current) in existing {
+            let want = truth_remaining
+                .remove(&(tenant.clone(), kind.clone()))
+                .unwrap_or(0);
+            let key = tenant_status_counter_key(&tenant, &kind);
+            corrected += self.apply_counter_correction(key, want).await?;
+        }
+
+        // Anything remaining in truth_remaining has no existing stored counter
+        // (or the existing stored counter was already <= 0 and was filtered
+        // out by scan_tenant_status_counters). Issue a fresh delta from 0.
+        for ((tenant, kind), want) in truth_remaining {
+            if want != 0 {
+                let key = tenant_status_counter_key(&tenant, &kind);
+                corrected += self.apply_counter_correction(key, want).await?;
+            }
+        }
+
+        Ok(corrected)
+    }
+
+    /// Read `key`, compute `delta = truth - current`, and merge the delta if
+    /// non-zero. Returns 1 if a merge was issued, 0 otherwise.
+    async fn apply_counter_correction(
+        &self,
+        key: Vec<u8>,
+        truth: i64,
+    ) -> Result<u64, JobStoreShardError> {
+        let current = match self.db.get(&key).await? {
+            Some(b) => decode_counter(&b),
+            None => 0,
+        };
+        let delta = truth.saturating_sub(current);
+        if delta == 0 {
+            return Ok(0);
+        }
+        self.db.merge(&key, &encode_counter(delta)).await?;
+        Ok(1)
+    }
+}
+
+/// Result of a single `reconcile_counters` pass.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ReconcileSummary {
+    /// Number of `JOB_STATUS` rows scanned.
+    pub scanned_jobs: u64,
+    /// Number of counters that received a non-zero correction merge.
+    pub corrected: u64,
+    /// Number of sub-tasks that failed (each has been logged at warn).
+    pub failed: u64,
 }

--- a/src/job_store_shard/counters.rs
+++ b/src/job_store_shard/counters.rs
@@ -336,21 +336,35 @@ impl JobStoreShard {
     /// cannot decrement counters at drop time. This method is the sole owner of
     /// counter truth in steady state.
     ///
-    /// The pass is best-effort: if any individual counter fails to scan or
-    /// merge, a `warn!` is logged for that counter and the rest of the pass
-    /// continues. Concurrent writes during the scan can leave the corrected
-    /// value slightly off; the next pass corrects that drift.
-    pub async fn reconcile_counters(
-        &self,
-        range: &ShardRange,
-    ) -> ReconcileSummary {
+    /// The pass is best-effort: if any individual scan or merge fails, a
+    /// `warn!` is logged and the rest of the pass continues. Concurrent writes
+    /// during the scan can leave the corrected value slightly off; the next
+    /// pass corrects that drift.
+    pub async fn reconcile_counters(&self, range: &ShardRange) -> ReconcileSummary {
         let mut summary = ReconcileSummary::default();
 
-        match self.reconcile_shard_counters(range).await {
-            Ok((scanned, corrected)) => {
-                summary.scanned_jobs = scanned;
-                summary.corrected += corrected;
+        // Single shared walk of the JOB_STATUS prefix feeds both the
+        // shard-level `completed_jobs` correction and every per-tenant
+        // `tenant_status_counter` correction.
+        let truth = match self.scan_job_status_truth(range).await {
+            Ok(t) => {
+                summary.scanned_jobs = t.scanned_jobs;
+                Some(t)
             }
+            Err(e) => {
+                summary.failed += 1;
+                tracing::warn!(
+                    shard = %self.name,
+                    error = %e,
+                    "counter reconcile: JOB_STATUS scan failed; \
+                     completed_jobs and tenant_status counters will remain stale until next pass"
+                );
+                None
+            }
+        };
+
+        match self.reconcile_shard_counters(range, truth.as_ref()).await {
+            Ok(corrected) => summary.corrected += corrected,
             Err(e) => {
                 summary.failed += 1;
                 tracing::warn!(
@@ -361,28 +375,82 @@ impl JobStoreShard {
             }
         }
 
-        match self.reconcile_tenant_status_counters(range).await {
-            Ok(corrected) => summary.corrected += corrected,
-            Err(e) => {
-                summary.failed += 1;
-                tracing::warn!(
-                    shard = %self.name,
-                    error = %e,
-                    "counter reconcile failed (tenant status counters); per-tenant counters will remain stale until next pass"
-                );
+        if let Some(t) = truth.as_ref() {
+            match self.reconcile_tenant_status_counters(range, t).await {
+                Ok(corrected) => summary.corrected += corrected,
+                Err(e) => {
+                    summary.failed += 1;
+                    tracing::warn!(
+                        shard = %self.name,
+                        error = %e,
+                        "counter reconcile failed (tenant status counters); per-tenant counters will remain stale until next pass"
+                    );
+                }
             }
         }
 
         summary
     }
 
+    /// Walk the `JOB_STATUS` prefix once and aggregate everything either
+    /// downstream reconciler needs into a single [`JobStatusTruth`].
+    ///
+    /// Range-filtered. Decode failures are logged at warn (not silently
+    /// skipped) and the row is dropped from both aggregations.
+    pub async fn scan_job_status_truth(
+        &self,
+        range: &ShardRange,
+    ) -> Result<JobStatusTruth, JobStoreShardError> {
+        let mut truth = JobStatusTruth::default();
+        let status_prefix = vec![prefix::JOB_STATUS];
+        let status_end = end_bound(&status_prefix);
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(status_prefix..status_end, &crate::scan_options())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let Some(parsed) = parse_job_status_key(&kv.key) else {
+                continue;
+            };
+            if !range.contains_tenant(&parsed.tenant) {
+                continue;
+            }
+            truth.scanned_jobs += 1;
+            match decode_job_status_owned(&kv.value) {
+                Ok(status) => {
+                    if status.is_terminal() {
+                        truth.completed_jobs += 1;
+                    }
+                    *truth
+                        .per_tenant_status
+                        .entry((parsed.tenant, status.kind.as_str().to_owned()))
+                        .or_insert(0) += 1;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        shard = %self.name,
+                        tenant = %parsed.tenant,
+                        job_id = %parsed.job_id,
+                        error = %e,
+                        "counter reconcile: failed to decode job status, skipping row"
+                    );
+                }
+            }
+        }
+        Ok(truth)
+    }
+
     /// Reconcile the two shard-level counters (`total_jobs`, `completed_jobs`).
-    /// Returns `(jobs_scanned, counters_corrected)`.
+    ///
+    /// `total_jobs` is derived from a fresh `JOB_INFO` scan (canonical source
+    /// of truth, different prefix). `completed_jobs` is read from the
+    /// precomputed `truth`. When `truth` is `None` (the upstream JOB_STATUS
+    /// scan failed) we still correct `total_jobs` and skip `completed_jobs`.
     async fn reconcile_shard_counters(
         &self,
         range: &ShardRange,
-    ) -> Result<(u64, u64), JobStoreShardError> {
-        // Truth scan: count JOB_INFO rows for total_jobs.
+        truth: Option<&JobStatusTruth>,
+    ) -> Result<u64, JobStoreShardError> {
         let mut total_jobs_truth: i64 = 0;
         let info_prefix = vec![prefix::JOB_INFO];
         let info_end = end_bound(&info_prefix);
@@ -398,88 +466,37 @@ impl JobStoreShard {
             }
         }
 
-        // Truth scan: count terminal JOB_STATUS rows for completed_jobs.
-        let mut completed_jobs_truth: i64 = 0;
-        let mut scanned: u64 = 0;
-        let status_prefix = vec![prefix::JOB_STATUS];
-        let status_end = end_bound(&status_prefix);
-        let mut iter = self
-            .db
-            .scan_with_options::<Vec<u8>, _>(status_prefix..status_end, &crate::scan_options())
-            .await?;
-        while let Some(kv) = iter.next().await? {
-            let Some(parsed) = parse_job_status_key(&kv.key) else {
-                continue;
-            };
-            if !range.contains_tenant(&parsed.tenant) {
-                continue;
-            }
-            scanned += 1;
-            match decode_job_status_owned(&kv.value) {
-                Ok(status) if status.is_terminal() => completed_jobs_truth += 1,
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        shard = %self.name,
-                        tenant = %parsed.tenant,
-                        job_id = %parsed.job_id,
-                        error = %e,
-                        "counter reconcile: failed to decode job status, skipping row"
-                    );
-                }
-            }
-        }
-
         let mut corrected: u64 = 0;
         corrected += self
             .apply_counter_correction(shard_total_jobs_counter_key(), total_jobs_truth)
             .await?;
-        corrected += self
-            .apply_counter_correction(shard_completed_jobs_counter_key(), completed_jobs_truth)
-            .await?;
+        if let Some(t) = truth {
+            corrected += self
+                .apply_counter_correction(shard_completed_jobs_counter_key(), t.completed_jobs)
+                .await?;
+        }
 
-        Ok((scanned, corrected))
+        Ok(corrected)
     }
 
-    /// Reconcile per-tenant per-status counters by re-scanning JOB_STATUS and
-    /// computing truth, then driving any stale stored counters to that truth.
+    /// Reconcile per-tenant per-status counters using a precomputed truth
+    /// from [`scan_job_status_truth`]. Drives stale stored counters (including
+    /// zombies that should be 0) to match `truth.per_tenant_status`.
     /// Returns the number of counters that received a non-zero correction.
     async fn reconcile_tenant_status_counters(
         &self,
-        range: &ShardRange,
+        _range: &ShardRange,
+        truth: &JobStatusTruth,
     ) -> Result<u64, JobStoreShardError> {
-        // Build truth from JOB_STATUS scan.
-        let mut truth: HashMap<(String, String), i64> = HashMap::new();
-        let status_prefix = vec![prefix::JOB_STATUS];
-        let status_end = end_bound(&status_prefix);
-        let mut iter = self
-            .db
-            .scan_with_options::<Vec<u8>, _>(status_prefix..status_end, &crate::scan_options())
-            .await?;
-        while let Some(kv) = iter.next().await? {
-            let Some(parsed) = parse_job_status_key(&kv.key) else {
-                continue;
-            };
-            if !range.contains_tenant(&parsed.tenant) {
-                continue;
-            }
-            let Ok(status) = decode_job_status_owned(&kv.value) else {
-                continue;
-            };
-            *truth
-                .entry((parsed.tenant, status.kind.as_str().to_owned()))
-                .or_insert(0) += 1;
-        }
-
-        // Collect existing stored counters in this shard's range so we can
+        // Enumerate existing stored counters in this shard's range so we can
         // explicitly drive zombies (counter > 0 but no matching JOB_STATUS) to
-        // zero. Reuses `scan_tenant_status_counters` which already filters by
-        // shard range, but only returns count > 0 rows — that's exactly the
-        // set we might need to zero out.
+        // zero. `scan_tenant_status_counters` already filters by shard range
+        // and only returns count > 0 rows — exactly the set we might need to
+        // zero out.
         let existing = self.scan_tenant_status_counters(None).await?;
 
         let mut corrected: u64 = 0;
-        let mut truth_remaining = truth;
+        let mut truth_remaining = truth.per_tenant_status.clone();
 
         for (tenant, kind, _current) in existing {
             let want = truth_remaining
@@ -489,9 +506,9 @@ impl JobStoreShard {
             corrected += self.apply_counter_correction(key, want).await?;
         }
 
-        // Anything remaining in truth_remaining has no existing stored counter
-        // (or the existing stored counter was already <= 0 and was filtered
-        // out by scan_tenant_status_counters). Issue a fresh delta from 0.
+        // Anything remaining in `truth_remaining` has no existing stored
+        // counter (or its existing value was filtered out as <= 0). Issue a
+        // fresh delta from 0.
         for ((tenant, kind), want) in truth_remaining {
             if want != 0 {
                 let key = tenant_status_counter_key(&tenant, &kind);
@@ -520,6 +537,28 @@ impl JobStoreShard {
         self.db.merge(&key, &encode_counter(delta)).await?;
         Ok(1)
     }
+}
+
+/// Aggregated truth from one walk of the `JOB_STATUS` prefix in a shard's
+/// range. Built once per [`JobStoreShard::reconcile_counters`] pass and
+/// consumed by both the shard-level and per-tenant reconcilers so we don't
+/// scan `JOB_STATUS` twice.
+///
+/// Memory bound: `per_tenant_status` holds at most `N_tenants × N_status_kinds`
+/// entries (status_kind is a small fixed-size enum). For a shard with 100k
+/// tenants this is ~500k entries × ~100 bytes ≈ 50 MB — bounded by tenant
+/// count, not by job count. Unchanged from the pre-fusion code, which already
+/// built the same map inside `reconcile_tenant_status_counters`.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct JobStatusTruth {
+    /// Total terminal rows seen — feeds shard `completed_jobs`.
+    pub completed_jobs: i64,
+    /// Per-(tenant, status_kind) row counts — feeds `tenant_status_counter`.
+    /// See struct-level note for the bound.
+    pub per_tenant_status: HashMap<(String, String), i64>,
+    /// Total in-range rows examined (terminal and non-terminal).
+    /// Drives the [`ReconcileSummary::scanned_jobs`] field.
+    pub scanned_jobs: u64,
 }
 
 /// Result of a single `reconcile_counters` pass.

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -16,7 +16,9 @@ mod scan;
 
 pub use cleanup::{CleanupProgress, CleanupResult};
 
-pub use counters::{ShardCounters, TenantStatusCounterScanRange, counter_merge_operator};
+pub use counters::{
+    ReconcileSummary, ShardCounters, TenantStatusCounterScanRange, counter_merge_operator,
+};
 pub use expedite::JobNotExpediteableError;
 pub use import::JobNotReimportableError;
 pub use lease_task::JobNotLeaseableError;
@@ -390,7 +392,13 @@ impl JobStoreShard {
 
         // Periodically reconcile pending concurrency requests to self-heal from
         // missed in-memory notifications or transient scanner failures.
-        shard.spawn_concurrency_reconcile_task(range);
+        shard.spawn_concurrency_reconcile_task(range.clone());
+
+        // Periodically reconcile job counters from JOB_INFO/JOB_STATUS truth.
+        // Required because the standalone compactor drops terminal job rows
+        // without a writable Db handle and therefore cannot decrement counters
+        // at drop time.
+        shard.spawn_counter_reconcile_task(range);
 
         // Set the shard creation timestamp if this is the first time opening
         shard.set_created_at_ms_if_unset().await?;
@@ -518,6 +526,91 @@ impl JobStoreShard {
                         tracing::debug!(
                             shard = %shard_name,
                             "stopping periodic concurrency reconciliation (shard closing)"
+                        );
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    /// Spawn a background task that periodically calls `reconcile_counters`.
+    ///
+    /// Unlike the concurrency reconciler (small scan, fast cadence), this task
+    /// scans all `JOB_INFO` + `JOB_STATUS` rows in the shard and so runs at
+    /// hourly cadence by default. To avoid all shards spiking object-store
+    /// reads at the same wall-clock minute on process boot, we sleep a
+    /// shard-deterministic jitter `[0, interval)` before the first tick. The
+    /// jitter is derived from the shard name's hash so that deterministic
+    /// simulation tests remain reproducible.
+    fn spawn_counter_reconcile_task(self: &Arc<Self>, range: ShardRange) {
+        let shard = Arc::clone(self);
+        let cancellation = self.cancellation.clone();
+        let shard_name = self.name.clone();
+        // Hardcoded: this counter is eventually-consistent observability with
+        // no operational SLA, so there's no reason to tune it per-shard or
+        // per-deployment. Plumbing a knob here would force every test/bench
+        // that constructs OpenShardOptions/DatabaseTemplate to set a value.
+        let reconcile_interval = Duration::from_millis(
+            crate::settings::DEFAULT_COUNTER_RECONCILE_INTERVAL_MS.max(1),
+        );
+
+        tokio::spawn(async move {
+            // Deterministic jitter based on shard name so we don't stampede
+            // object storage when many shards open simultaneously.
+            let interval_ms = reconcile_interval.as_millis() as u64;
+            let jitter_ms = if interval_ms > 0 {
+                let mut h: u64 = 1469598103934665603;
+                for b in shard_name.as_bytes() {
+                    h ^= *b as u64;
+                    h = h.wrapping_mul(1099511628211);
+                }
+                h % interval_ms
+            } else {
+                0
+            };
+
+            tokio::select! {
+                biased;
+                _ = tokio::time::sleep(Duration::from_millis(jitter_ms)) => {}
+                _ = cancellation.cancelled() => {
+                    tracing::debug!(
+                        shard = %shard_name,
+                        "stopping periodic counter reconciliation before first tick (shard closing)"
+                    );
+                    return;
+                }
+            }
+
+            let mut interval = tokio::time::interval(reconcile_interval);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = interval.tick() => {
+                        let summary = shard.reconcile_counters(&range).await;
+                        if summary.failed > 0 {
+                            tracing::warn!(
+                                shard = %shard_name,
+                                scanned_jobs = summary.scanned_jobs,
+                                corrected = summary.corrected,
+                                failed = summary.failed,
+                                "counter reconcile pass had failures; counters may remain stale until next pass"
+                            );
+                        } else {
+                            tracing::debug!(
+                                shard = %shard_name,
+                                scanned_jobs = summary.scanned_jobs,
+                                corrected = summary.corrected,
+                                "counter reconcile pass complete"
+                            );
+                        }
+                    }
+                    _ = cancellation.cancelled() => {
+                        tracing::debug!(
+                            shard = %shard_name,
+                            "stopping periodic counter reconciliation (shard closing)"
                         );
                         break;
                     }

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -17,7 +17,8 @@ mod scan;
 pub use cleanup::{CleanupProgress, CleanupResult};
 
 pub use counters::{
-    ReconcileSummary, ShardCounters, TenantStatusCounterScanRange, counter_merge_operator,
+    JobStatusTruth, ReconcileSummary, ShardCounters, TenantStatusCounterScanRange,
+    counter_merge_operator,
 };
 pub use expedite::JobNotExpediteableError;
 pub use import::JobNotReimportableError;
@@ -551,9 +552,8 @@ impl JobStoreShard {
         // no operational SLA, so there's no reason to tune it per-shard or
         // per-deployment. Plumbing a knob here would force every test/bench
         // that constructs OpenShardOptions/DatabaseTemplate to set a value.
-        let reconcile_interval = Duration::from_millis(
-            crate::settings::DEFAULT_COUNTER_RECONCILE_INTERVAL_MS.max(1),
-        );
+        let reconcile_interval =
+            Duration::from_millis(crate::settings::DEFAULT_COUNTER_RECONCILE_INTERVAL_MS.max(1));
 
         tokio::spawn(async move {
             // Deterministic jitter based on shard name so we don't stampede

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -182,6 +182,13 @@ fn default_concurrency_reconcile_interval_ms() -> u64 {
     DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS
 }
 
+/// Hardcoded interval for the per-shard counter reconciliation background
+/// task. The reconciler corrects counter drift caused by the standalone
+/// compactor dropping terminal job rows without a writable `Db` handle. There
+/// is no operational reason to tune it per-shard or per-deployment, so it is
+/// not exposed as a config field.
+pub const DEFAULT_COUNTER_RECONCILE_INTERVAL_MS: u64 = 60 * 60 * 1000;
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseTemplate {
     pub backend: Backend,

--- a/tests/counter_reconcile_tests.rs
+++ b/tests/counter_reconcile_tests.rs
@@ -1,0 +1,197 @@
+//! Tests for `JobStoreShard::reconcile_counters`.
+//!
+//! The reconciler is the sole owner of counter correctness in steady state —
+//! the standalone compactor drops terminal job rows but cannot decrement
+//! counters (no writable Db handle), so this background task closes the loop
+//! by re-deriving counter truth from `JOB_INFO`/`JOB_STATUS` and writing a
+//! signed merge operand to correct any drift.
+
+mod test_helpers;
+
+use silo::job_attempt::AttemptOutcome;
+use silo::keys::{
+    shard_completed_jobs_counter_key, shard_total_jobs_counter_key, tenant_status_counter_key,
+};
+use silo::shard_range::ShardRange;
+use test_helpers::*;
+
+/// Inject a signed delta directly against a counter key, bypassing the normal
+/// transactional bookkeeping. Used to seed drift for tests.
+async fn drift_counter(shard: &silo::job_store_shard::JobStoreShard, key: &[u8], delta: i64) {
+    shard
+        .db()
+        .merge(key, delta.to_le_bytes())
+        .await
+        .expect("seed drift via merge");
+}
+
+async fn enqueue_one(
+    shard: &silo::job_store_shard::JobStoreShard,
+    tenant: &str,
+    suffix: &str,
+) -> String {
+    shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now_ms(),
+            None,
+            msgpack_payload(&serde_json::json!({"reconcile": suffix})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue")
+}
+
+async fn dequeue_and_succeed(shard: &silo::job_store_shard::JobStoreShard) {
+    let tasks = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 1, "expected one task");
+    let task_id = tasks[0].attempt().task_id().to_string();
+    shard
+        .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report success");
+}
+
+#[silo::test]
+async fn reconcile_corrects_total_jobs_drift() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    enqueue_one(&shard, "-", "a").await;
+    enqueue_one(&shard, "-", "b").await;
+
+    // Inject +5 drift into total_jobs.
+    drift_counter(&shard, &shard_total_jobs_counter_key(), 5).await;
+
+    let pre = shard.get_counters().await.expect("get_counters");
+    assert_eq!(pre.total_jobs, 7, "drifted total should be 2 + 5");
+
+    let summary = shard.reconcile_counters(&ShardRange::full()).await;
+    assert_eq!(summary.failed, 0, "no failures expected");
+    assert!(summary.corrected >= 1, "should issue at least one correction");
+
+    let post = shard.get_counters().await.expect("get_counters");
+    assert_eq!(post.total_jobs, 2, "reconcile should restore truth");
+    assert_eq!(post.completed_jobs, 0);
+}
+
+#[silo::test]
+async fn reconcile_corrects_completed_jobs_drift() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    enqueue_one(&shard, "-", "a").await;
+    enqueue_one(&shard, "-", "b").await;
+    dequeue_and_succeed(&shard).await;
+    dequeue_and_succeed(&shard).await;
+
+    // Inject -3 drift into completed_jobs (under-report).
+    drift_counter(&shard, &shard_completed_jobs_counter_key(), -3).await;
+
+    let pre = shard.get_counters().await.expect("get_counters");
+    assert_eq!(pre.completed_jobs, -1, "drifted completed should be 2 - 3");
+
+    let summary = shard.reconcile_counters(&ShardRange::full()).await;
+    assert_eq!(summary.failed, 0);
+
+    let post = shard.get_counters().await.expect("get_counters");
+    assert_eq!(post.total_jobs, 2);
+    assert_eq!(post.completed_jobs, 2, "reconcile should restore truth");
+}
+
+#[silo::test]
+async fn reconcile_is_idempotent() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    enqueue_one(&shard, "-", "a").await;
+    dequeue_and_succeed(&shard).await;
+
+    let first = shard.reconcile_counters(&ShardRange::full()).await;
+    assert_eq!(first.failed, 0);
+
+    let second = shard.reconcile_counters(&ShardRange::full()).await;
+    assert_eq!(second.failed, 0);
+    assert_eq!(
+        second.corrected, 0,
+        "second pass should issue zero corrections when truth already matches"
+    );
+
+    let counters = shard.get_counters().await.expect("get_counters");
+    assert_eq!(counters.total_jobs, 1);
+    assert_eq!(counters.completed_jobs, 1);
+}
+
+#[silo::test]
+async fn reconcile_zeroes_zombie_tenant_status_counter() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    // Seed a tenant_status_counter for a tenant/kind with no matching JOB_STATUS.
+    drift_counter(
+        &shard,
+        &tenant_status_counter_key("ghost-tenant", "Succeeded"),
+        7,
+    )
+    .await;
+
+    let summary = shard.reconcile_counters(&ShardRange::full()).await;
+    assert_eq!(summary.failed, 0);
+
+    let entries = shard
+        .scan_tenant_status_counters(None)
+        .await
+        .expect("scan tenant_status");
+    assert!(
+        !entries
+            .iter()
+            .any(|(t, k, _)| t == "ghost-tenant" && k == "Succeeded"),
+        "zombie counter should have been driven to 0 (filtered out by scan): {entries:?}"
+    );
+}
+
+#[silo::test]
+async fn reconcile_corrects_tenant_status_counter_drift() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    enqueue_one(&shard, "-", "a").await;
+    dequeue_and_succeed(&shard).await;
+
+    // Drift the per-tenant Succeeded counter upward.
+    drift_counter(&shard, &tenant_status_counter_key("-", "Succeeded"), 4).await;
+
+    let summary = shard.reconcile_counters(&ShardRange::full()).await;
+    assert_eq!(summary.failed, 0);
+    assert!(summary.corrected >= 1);
+
+    let entries = shard
+        .scan_tenant_status_counters(None)
+        .await
+        .expect("scan tenant_status");
+    let succeeded = entries
+        .iter()
+        .find(|(t, k, _)| t == "-" && k == "Succeeded")
+        .map(|(_, _, c)| *c);
+    assert_eq!(
+        succeeded,
+        Some(1),
+        "tenant_status Succeeded should be exactly 1 after reconcile, got entries {entries:?}"
+    );
+}
+
+#[silo::test]
+async fn reconcile_summary_reports_scanned_jobs() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    enqueue_one(&shard, "-", "a").await;
+    enqueue_one(&shard, "-", "b").await;
+    enqueue_one(&shard, "-", "c").await;
+
+    let summary = shard.reconcile_counters(&ShardRange::full()).await;
+    assert_eq!(summary.failed, 0);
+    assert_eq!(summary.scanned_jobs, 3, "should have scanned 3 JOB_STATUS rows");
+}

--- a/tests/counter_reconcile_tests.rs
+++ b/tests/counter_reconcile_tests.rs
@@ -75,7 +75,10 @@ async fn reconcile_corrects_total_jobs_drift() {
 
     let summary = shard.reconcile_counters(&ShardRange::full()).await;
     assert_eq!(summary.failed, 0, "no failures expected");
-    assert!(summary.corrected >= 1, "should issue at least one correction");
+    assert!(
+        summary.corrected >= 1,
+        "should issue at least one correction"
+    );
 
     let post = shard.get_counters().await.expect("get_counters");
     assert_eq!(post.total_jobs, 2, "reconcile should restore truth");
@@ -184,6 +187,63 @@ async fn reconcile_corrects_tenant_status_counter_drift() {
 }
 
 #[silo::test]
+async fn scan_job_status_truth_reflects_jobs() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    enqueue_one(&shard, "-", "open-a").await;
+    enqueue_one(&shard, "-", "open-b").await;
+    enqueue_one(&shard, "-", "to-succeed").await;
+    dequeue_and_succeed(&shard).await;
+
+    let truth = shard
+        .scan_job_status_truth(&ShardRange::full())
+        .await
+        .expect("scan_job_status_truth");
+
+    assert_eq!(truth.scanned_jobs, 3, "all 3 JOB_STATUS rows scanned");
+    assert_eq!(truth.completed_jobs, 1, "exactly one terminal");
+    let succeeded = truth
+        .per_tenant_status
+        .get(&("-".to_string(), "Succeeded".to_string()))
+        .copied();
+    assert_eq!(succeeded, Some(1));
+    let scheduled = truth
+        .per_tenant_status
+        .get(&("-".to_string(), "Scheduled".to_string()))
+        .copied();
+    assert_eq!(scheduled, Some(2), "two jobs still scheduled");
+}
+
+#[silo::test]
+async fn scan_job_status_truth_filters_by_range() {
+    // Open a shard whose range covers everything *except* tenant "out".
+    let inside_range = ShardRange::full();
+    let (_tmp, shard) = open_temp_shard().await;
+
+    // Both inside-range and out-of-range tenants get jobs. Then we call
+    // scan_job_status_truth twice — once with the full range, once with an
+    // explicitly empty range — and assert the empty range produces no rows.
+    enqueue_one(&shard, "tenant-x", "a").await;
+    enqueue_one(&shard, "tenant-y", "b").await;
+
+    let full = shard
+        .scan_job_status_truth(&inside_range)
+        .await
+        .expect("scan with full range");
+    assert_eq!(full.scanned_jobs, 2);
+
+    // Empty range — start == end so contains_tenant returns false.
+    let empty = ShardRange::new("zzzzz".to_string(), "zzzzz".to_string());
+    let none = shard
+        .scan_job_status_truth(&empty)
+        .await
+        .expect("scan with empty range");
+    assert_eq!(none.scanned_jobs, 0, "no rows in an empty range");
+    assert_eq!(none.completed_jobs, 0);
+    assert!(none.per_tenant_status.is_empty());
+}
+
+#[silo::test]
 async fn reconcile_summary_reports_scanned_jobs() {
     let (_tmp, shard) = open_temp_shard().await;
 
@@ -193,5 +253,8 @@ async fn reconcile_summary_reports_scanned_jobs() {
 
     let summary = shard.reconcile_counters(&ShardRange::full()).await;
     assert_eq!(summary.failed, 0);
-    assert_eq!(summary.scanned_jobs, 3, "should have scanned 3 JOB_STATUS rows");
+    assert_eq!(
+        summary.scanned_jobs, 3,
+        "should have scanned 3 JOB_STATUS rows"
+    );
 }


### PR DESCRIPTION
## Summary
- Adds `JobStoreShard::reconcile_counters` that re-derives `total_jobs`, `completed_jobs`, and per-tenant `tenant_status_counter` truth from `JOB_INFO`/`JOB_STATUS` scans and corrects drift via a single signed merge operand per counter.
- Spawns a per-shard background task (`spawn_counter_reconcile_task` in `JobStoreShard::open`) that runs hourly with shard-deterministic FNV-hash jitter to avoid object-store stampedes on cluster boot. Mirrors the shape of `spawn_concurrency_reconcile_task` (interval + cancellation + `MissedTickBehavior::Skip`).
- The reconciler is the sole owner of counter correctness in steady state — it patches the drift caused by the standalone compactor dropping terminal rows without a writable `Db` handle (slatedb is single-writer; the silo server owns the writer).
- Per-counter `warn!` on failure with the message that counters will remain stale until the next pass; one bad scan/merge does not abort the rest of the pass. End-of-pass `debug!` summary, or `warn!` summary when any sub-task failed.
- Interval is hardcoded (`DEFAULT_COUNTER_RECONCILE_INTERVAL_MS = 1h`) rather than threaded through `OpenShardOptions`/`DatabaseTemplate` — these are eventually-consistent observability counters with no SLA, so there's no operational reason to tune per-shard or per-deployment, and a knob would force every test/bench to set a value.

## Test plan
- [x] `cargo test --test counter_reconcile_tests` — drift correction for all three counter classes, idempotency (zero corrections on a clean second pass), zombie zero-out (counter > 0 with no matching JOB_STATUS), summary `scanned_jobs` accuracy
- [x] Regression sweep across `shard_counters_tests`, `tenant_status_counter_tests`, `concurrency_requester_counter_tests`, `factory_tests`, `config_and_db_tests`, `cluster_info_cache_tests`, `concurrency_tests` — 100 tests pass
- [x] `cargo check --all-targets` clean
- [ ] Manual smoke: enqueue + complete jobs locally, run the standalone compactor with a short retention window so it drops terminal rows, observe `tenant_counts` SQL view and `GetNodeInfo` proto output stabilize after the configured interval