### PR TITLE
When a shard is unavailable the `queue` and `tenant` pages throw an error.

### DIFF
--- a/src/webui.rs
+++ b/src/webui.rs
@@ -16,6 +16,7 @@ use axum::{
     routing::{get, post},
 };
 use datafusion::arrow::array::Array;
+use futures::future::join_all;
 use tokio::sync::broadcast;
 use tracing::warn;
 
@@ -23,6 +24,7 @@ use crate::cluster_client::ClusterClient;
 use crate::cluster_query::ClusterQueryEngine;
 use crate::coordination::{Coordinator, SplitCleanupStatus};
 use crate::factory::ShardFactory;
+use crate::pb::{SerializedBytes, serialized_bytes};
 use crate::settings::AppConfig;
 
 #[derive(Clone)]
@@ -95,6 +97,8 @@ pub struct ShardRow {
     pub name: String,
     pub owner: String,
     pub job_count: usize,
+    /// Shard exists in the owner map but did not report node info
+    pub is_unavailable: bool,
     /// If this shard has a split in progress, the current phase
     pub split_phase: Option<String>,
     /// Cleanup status if not CompactionDone
@@ -151,6 +155,7 @@ struct QueuesTemplate {
     nav_active: &'static str,
     tenancy_enabled: bool,
     queues: Vec<QueueRow>,
+    unavailable_shards: Vec<String>,
     error: Option<String>,
 }
 
@@ -299,6 +304,7 @@ struct TenantsTemplate {
     page: usize,
     per_page: usize,
     total_pages: usize,
+    unavailable_shards: Vec<String>,
     error: Option<String>,
 }
 
@@ -481,6 +487,115 @@ struct TenantStatusCounts {
     scheduled: usize,
     running: usize,
     terminal: usize,
+}
+
+struct PartialShardQueryRows<T> {
+    rows: Vec<T>,
+    unavailable_shards: Vec<String>,
+    errors: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct QueueCountQueryRow {
+    queue_name: Option<String>,
+    entry_type: Option<String>,
+    cnt: Option<i64>,
+}
+
+#[derive(serde::Deserialize)]
+struct TenantCountQueryRow {
+    tenant: Option<String>,
+    status_kind: Option<String>,
+    cnt: Option<i64>,
+}
+
+fn decode_query_row<T: serde::de::DeserializeOwned>(row: &SerializedBytes) -> Result<T, String> {
+    let Some(serialized_bytes::Encoding::Msgpack(data)) = &row.encoding else {
+        return Err("unsupported row encoding".to_string());
+    };
+
+    rmp_serde::from_slice(data).map_err(|e| format!("failed to decode query row: {}", e))
+}
+
+async fn query_shards_partial<T>(state: &AppState, sql: &str) -> PartialShardQueryRows<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let owner_map = match state.cluster_client.get_shard_owner_map().await {
+        Ok(owner_map) => Some(owner_map),
+        Err(e) => {
+            warn!(error = %e, "failed to get shard owner map for partial query");
+            None
+        }
+    };
+
+    let mut shard_ids = owner_map
+        .as_ref()
+        .map(|owner_map| owner_map.shard_ids())
+        .unwrap_or_else(|| {
+            state
+                .factory
+                .instances()
+                .keys()
+                .copied()
+                .collect::<Vec<_>>()
+        });
+
+    shard_ids.sort();
+
+    let local_node_id = state.coordinator.node_id().to_string();
+    let query_futures = shard_ids.into_iter().map(|shard_id| {
+        let owner_map = owner_map.clone();
+        let local_node_id = local_node_id.clone();
+        async move {
+            let shard_is_locally_unavailable = owner_map
+                .as_ref()
+                .and_then(|owner_map| owner_map.shard_to_node.get(&shard_id))
+                .map(|owner| owner == &local_node_id)
+                .unwrap_or(false)
+                && state.factory.get(&shard_id).is_none();
+
+            if shard_is_locally_unavailable {
+                return (shard_id, None, Some("local shard is not open".to_string()));
+            }
+
+            match state.cluster_client.query_shard(&shard_id, sql).await {
+                Ok(result) => (shard_id, Some(result), None),
+                Err(e) => (shard_id, None, Some(e.to_string())),
+            }
+        }
+    });
+
+    let mut rows = Vec::new();
+    let mut unavailable_shards = Vec::new();
+    let mut errors = Vec::new();
+
+    for (shard_id, result, query_error) in join_all(query_futures).await {
+        match result {
+            Some(result) => {
+                for row in result.rows {
+                    match decode_query_row::<T>(&row) {
+                        Ok(decoded) => rows.push(decoded),
+                        Err(e) => errors.push(format!("{}: {}", shard_id, e)),
+                    }
+                }
+            }
+            None => {
+                unavailable_shards.push(shard_id.to_string());
+                if let Some(error) = query_error {
+                    warn!(shard_id = %shard_id, error = %error, "skipping unavailable shard in web UI");
+                }
+            }
+        }
+    }
+
+    unavailable_shards.sort();
+
+    PartialShardQueryRows {
+        rows,
+        unavailable_shards,
+        errors,
+    }
 }
 
 async fn index_handler(State(state): State<AppState>) -> impl IntoResponse {
@@ -803,55 +918,23 @@ async fn cancel_job_handler(
 async fn queues_handler(State(state): State<AppState>) -> impl IntoResponse {
     // Key: queue_name -> (holders, waiters)
     let mut all_queues: HashMap<String, (usize, usize)> = HashMap::new();
-    let mut error: Option<String> = None;
-
-    // Use cluster query engine for proper aggregation across all shards
     let sql = "SELECT queue_name, entry_type, COUNT(*) as cnt FROM queues GROUP BY queue_name, entry_type";
+    let partial_rows = query_shards_partial::<QueueCountQueryRow>(&state, sql).await;
 
-    match state.query_engine.sql(sql).await {
-        Ok(df) => match df.collect().await {
-            Ok(batches) => {
-                for batch in batches {
-                    let name_col = batch.column_by_name("queue_name").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::StringArray>()
-                    });
-                    let type_col = batch.column_by_name("entry_type").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::StringArray>()
-                    });
-                    let cnt_col = batch.column_by_name("cnt").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::Int64Array>()
-                    });
+    for row in partial_rows.rows {
+        let Some(queue_name) = row.queue_name else {
+            continue;
+        };
+        if queue_name.is_empty() {
+            continue;
+        }
 
-                    if let (Some(names), Some(types), Some(counts)) = (name_col, type_col, cnt_col)
-                    {
-                        for i in 0..batch.num_rows() {
-                            let queue_name = names.value(i).to_string();
-                            let entry_type = types.value(i);
-                            let count = counts.value(i) as usize;
-
-                            if !queue_name.is_empty() {
-                                let entry = all_queues.entry(queue_name).or_insert((0, 0));
-                                match entry_type {
-                                    "holder" => entry.0 += count,
-                                    "requester" => entry.1 += count,
-                                    _ => {}
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                warn!(error = %e, "failed to collect query results");
-                error = Some(format!("Query execution error: {}", e));
-            }
-        },
-        Err(e) => {
-            warn!(error = %e, "failed to query queues from cluster");
-            error = Some(format!("Query error: {}", e));
+        let count = row.cnt.unwrap_or(0).max(0) as usize;
+        let entry = all_queues.entry(queue_name).or_insert((0, 0));
+        match row.entry_type.as_deref() {
+            Some("holder") => entry.0 += count,
+            Some("requester") => entry.1 += count,
+            _ => {}
         }
     }
 
@@ -867,10 +950,17 @@ async fn queues_handler(State(state): State<AppState>) -> impl IntoResponse {
         .collect();
     queues.sort_by(|a, b| b.holders.cmp(&a.holders));
 
+    let error = if partial_rows.errors.is_empty() {
+        None
+    } else {
+        Some(partial_rows.errors.join("\n"))
+    };
+
     let template = QueuesTemplate {
         nav_active: "queues",
         tenancy_enabled: state.config.tenancy.enabled,
         queues,
+        unavailable_shards: partial_rows.unavailable_shards,
         error,
     };
 
@@ -1057,62 +1147,28 @@ async fn tenants_handler(
 
     let mut status_by_tenant: HashMap<String, TenantStatusCounts> = HashMap::new();
     let mut errors: Vec<String> = Vec::new();
-
     let jobs_sql = "SELECT tenant, status_kind, cnt FROM tenant_counts";
-    match state.query_engine.sql(jobs_sql).await {
-        Ok(df) => match df.collect().await {
-            Ok(batches) => {
-                for batch in batches {
-                    let tenant_col = batch.column_by_name("tenant").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::StringArray>()
-                    });
-                    let status_col = batch.column_by_name("status_kind").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::StringArray>()
-                    });
-                    let count_col = batch.column_by_name("cnt").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::Int64Array>()
-                    });
+    let partial_rows = query_shards_partial::<TenantCountQueryRow>(&state, jobs_sql).await;
 
-                    if let (Some(tenants), Some(statuses), Some(counts)) =
-                        (tenant_col, status_col, count_col)
-                    {
-                        for i in 0..batch.num_rows() {
-                            if tenants.is_null(i) {
-                                continue;
-                            }
-                            let tenant = tenants.value(i).to_string();
-                            let status = if statuses.is_null(i) {
-                                ""
-                            } else {
-                                statuses.value(i)
-                            };
-                            let count = counts.value(i).max(0) as usize;
+    for row in partial_rows.rows {
+        let Some(tenant) = row.tenant else {
+            continue;
+        };
 
-                            let entry = status_by_tenant.entry(tenant).or_default();
-                            entry.total += count;
-                            match status {
-                                "Scheduled" | "Waiting" => entry.scheduled += count,
-                                "Running" => entry.running += count,
-                                "Succeeded" | "Failed" | "Cancelled" => entry.terminal += count,
-                                _ => {}
-                            }
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                warn!(error = %e, "failed to collect tenant status query results");
-                errors.push(format!("Jobs aggregation failed: {}", e));
-            }
-        },
-        Err(e) => {
-            warn!(error = %e, "failed to query tenant status aggregates");
-            errors.push(format!("Jobs query failed: {}", e));
+        let status = row.status_kind.unwrap_or_default();
+        let count = row.cnt.unwrap_or(0).max(0) as usize;
+
+        let entry = status_by_tenant.entry(tenant).or_default();
+        entry.total += count;
+        match status.as_str() {
+            "Scheduled" | "Waiting" => entry.scheduled += count,
+            "Running" => entry.running += count,
+            "Succeeded" | "Failed" | "Cancelled" => entry.terminal += count,
+            _ => {}
         }
     }
+
+    errors.extend(partial_rows.errors);
 
     let mut tenant_names = std::collections::BTreeSet::new();
     for tenant in status_by_tenant.keys() {
@@ -1172,6 +1228,7 @@ async fn tenants_handler(
         page,
         per_page,
         total_pages,
+        unavailable_shards: partial_rows.unavailable_shards,
         error,
     };
 
@@ -1482,6 +1539,8 @@ async fn render_cluster_page(state: &AppState) -> Html<String> {
             "local".to_string()
         };
 
+        let is_unavailable = shard_info.is_none();
+
         // Check if this shard has a split in progress
         let split_phase = active_split_map
             .get(&shard_id.to_string())
@@ -1511,6 +1570,7 @@ async fn render_cluster_page(state: &AppState) -> Html<String> {
             name: shard_id.to_string(),
             owner,
             job_count,
+            is_unavailable,
             split_phase,
             cleanup_status,
             parent_shard_id,

--- a/templates/cluster.html
+++ b/templates/cluster.html
@@ -88,8 +88,8 @@
         <div class="p-4">
             <div class="flex flex-wrap gap-2 justify-center py-4">
                 {% for shard in shards %}
-                <a href="/shard?id={{ shard.name }}" class="w-16 h-16 {% if shard.split_phase.is_some() %}bg-amber-900/30 border-amber-700{% else if shard.cleanup_status.is_some() %}bg-blue-900/30 border-blue-700{% else %}bg-emerald-900/30 border-emerald-700{% endif %} border flex flex-col items-center justify-center text-xs hover:opacity-80">
-                    <span class="{% if shard.split_phase.is_some() %}text-amber-400{% else if shard.cleanup_status.is_some() %}text-blue-400{% else %}text-emerald-400{% endif %} font-bold w-full truncate text-center">{{ shard.name }}</span>
+                <a href="/shard?id={{ shard.name }}" class="w-16 h-16 {% if shard.is_unavailable %}bg-red-900/30 border-red-700{% else if shard.split_phase.is_some() %}bg-amber-900/30 border-amber-700{% else if shard.cleanup_status.is_some() %}bg-blue-900/30 border-blue-700{% else %}bg-emerald-900/30 border-emerald-700{% endif %} border flex flex-col items-center justify-center text-xs hover:opacity-80">
+                    <span class="{% if shard.is_unavailable %}text-red-400{% else if shard.split_phase.is_some() %}text-amber-400{% else if shard.cleanup_status.is_some() %}text-blue-400{% else %}text-emerald-400{% endif %} font-bold w-full truncate text-center">{{ shard.name }}</span>
                     <span class="text-zinc-500">{{ shard.job_count }} jobs</span>
                 </a>
                 {% endfor %}
@@ -139,7 +139,9 @@
                             </td>
                             <td class="px-3 py-2 text-sm text-zinc-300 whitespace-nowrap">{{ shard.job_count }}</td>
                             <td class="px-3 py-2 text-sm whitespace-nowrap">
-                                {% if let Some(phase) = shard.split_phase %}
+                                {% if shard.is_unavailable %}
+                                <span class="px-2 py-0.5 text-xs font-medium border bg-amber-900/40 border-amber-700 text-amber-300">Active (Unavailable)</span>
+                                {% else if let Some(phase) = shard.split_phase %}
                                 <span class="px-2 py-0.5 text-xs font-medium border bg-amber-900/50 border-amber-600 text-amber-300">Splitting: {{ phase }}</span>
                                 {% else if let Some(cleanup) = shard.cleanup_status %}
                                 <span class="px-2 py-0.5 text-xs font-medium border bg-blue-900/50 border-blue-700 text-blue-400">{{ cleanup }}</span>

--- a/templates/queues.html
+++ b/templates/queues.html
@@ -15,6 +15,18 @@
         <pre class="text-red-300 text-xs mt-2 whitespace-pre-wrap">{{ error.as_ref().unwrap() }}</pre>
     </div>
     {% endif %}
+
+    {% if !unavailable_shards.is_empty() %}
+    <div class="bg-amber-900/20 border border-amber-700 p-4">
+        <div class="text-amber-300 text-sm font-medium">Partial results</div>
+        <div class="text-amber-200 text-sm mt-2">
+            Unavailable shards:
+            {% for shard in unavailable_shards %}
+            <code class="text-amber-100">{{ shard }}</code>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
     
     <div class="bg-zinc-800 border border-zinc-700  overflow-hidden">
         <div class="bg-zinc-850 border-b border-zinc-700 px-4 py-2">
@@ -55,4 +67,3 @@
     </div>
 </div>
 {% endblock %}
-

--- a/templates/tenants.html
+++ b/templates/tenants.html
@@ -16,6 +16,18 @@
     </div>
     {% endif %}
 
+    {% if !unavailable_shards.is_empty() %}
+    <div class="bg-amber-900/20 border border-amber-700 p-4">
+        <div class="text-amber-300 text-sm font-medium">Partial results</div>
+        <div class="text-amber-200 text-sm mt-2">
+            Unavailable shards:
+            {% for shard in unavailable_shards %}
+            <code class="text-amber-100">{{ shard }}</code>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
     <div class="bg-zinc-800 border border-zinc-700 overflow-hidden">
         <div class="bg-zinc-850 border-b border-zinc-700 px-4 py-2">
             <h2 class="text-sm font-semibold text-zinc-300">Tenant Overview</h2>

--- a/tests/webui_tests.rs
+++ b/tests/webui_tests.rs
@@ -601,6 +601,57 @@ async fn test_queues_page_shows_queues_from_all_shards() {
 }
 
 #[silo::test]
+async fn test_queues_page_shows_unavailable_shards_and_partial_results() {
+    use silo::job::{ConcurrencyLimit, Limit};
+
+    let (_tmp, state, shard_map) = setup_multi_shard_state(2).await;
+
+    let live_shard_id = shard_map.shards()[0].id;
+    let unavailable_shard_id = shard_map.shards()[1].id;
+    let live_shard = state.factory.get(&live_shard_id).expect("live shard");
+    let _ = live_shard
+        .enqueue(
+            "-",
+            Some("queue-live-job".to_string()),
+            50,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: "queue-live".to_string(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue live queue job");
+    let _ = live_shard.dequeue("worker-live", "default", 1).await;
+
+    state
+        .factory
+        .close(&unavailable_shard_id)
+        .await
+        .expect("close unavailable shard");
+
+    let (status, body) = make_request(state, "GET", "/queues").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.contains("queue-live"),
+        "live shard data should still render"
+    );
+    assert!(
+        body.contains("Unavailable shards"),
+        "page should explain partial results"
+    );
+    assert!(
+        body.contains(&unavailable_shard_id.to_string()),
+        "page should list the unavailable shard"
+    );
+}
+
+#[silo::test]
 async fn test_job_view_with_correct_shard_and_tenant_hint() {
     // Test that providing correct shard and tenant makes job lookup work efficiently
     let (_tmp, state, shard_map) = setup_multi_shard_state(3).await;
@@ -1146,6 +1197,60 @@ async fn test_tenants_index_shows_tenant_data() {
 }
 
 #[silo::test]
+async fn test_tenants_page_shows_unavailable_shards_and_partial_results() {
+    let (_tmp, state, shard_map) = setup_multi_shard_state_with_tenancy(2, true).await;
+
+    let live_shard_id = shard_map.shards()[0].id;
+    let unavailable_shard_id = shard_map.shards()[1].id;
+    let live_tenant = (0..1024)
+        .map(|i| format!("tenant-live-{}", i))
+        .find(|tenant| {
+            shard_map
+                .shard_for_tenant(tenant)
+                .map(|shard| shard.id == live_shard_id)
+                .unwrap_or(false)
+        })
+        .expect("find tenant routed to live shard");
+    let live_shard = state.factory.get(&live_shard_id).expect("live shard");
+    let _ = live_shard
+        .enqueue(
+            &live_tenant,
+            Some("tenant-live-job".to_string()),
+            50,
+            test_helpers::now_ms() + 60_000,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"tenant":"live"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue tenant job");
+
+    state
+        .factory
+        .close(&unavailable_shard_id)
+        .await
+        .expect("close unavailable shard");
+
+    let (status, body) = make_request(state, "GET", "/tenants").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.contains(&live_tenant),
+        "live tenant data should still render"
+    );
+    assert!(
+        body.contains("Unavailable shards"),
+        "page should explain partial results"
+    );
+    assert!(
+        body.contains(&unavailable_shard_id.to_string()),
+        "page should list the unavailable shard"
+    );
+}
+
+#[silo::test]
 async fn test_tenant_detail_shows_queues_and_waiting_jobs() {
     use silo::job::{ConcurrencyLimit, Limit};
 
@@ -1223,4 +1328,22 @@ async fn test_tenant_detail_shows_queues_and_waiting_jobs() {
         !body.contains("Tenant counts query failed"),
         "tenant detail should render tenant status counts via tenant_counts"
     );
+}
+
+#[silo::test]
+async fn test_cluster_page_marks_active_unavailable_shard() {
+    let (_tmp, state, shard_map) = setup_multi_shard_state(2).await;
+
+    let unavailable_shard_id = shard_map.shards()[1].id;
+    state
+        .factory
+        .close(&unavailable_shard_id)
+        .await
+        .expect("close unavailable shard");
+
+    let (status, body) = make_request(state, "GET", "/cluster").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("Active (Unavailable)"));
+    assert!(body.contains(&unavailable_shard_id.to_string()));
 }


### PR DESCRIPTION
This change makes it so that we show the tenant and queue information we can and don't throw an error when a shard is unavailable. Also we indicate which shards are active but unavailable now as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the web UI queries shard data by fanning out per-shard RPCs and merging partial results, which could affect correctness/visibility of queue and tenant aggregates under failure scenarios.
> 
> **Overview**
> Web UI `queues` and `tenants` pages now return **partial results** instead of failing when one or more shards can’t be queried.
> 
> This replaces cluster-wide aggregation for these pages with a new per-shard query fan-out (`query_shards_partial`) that merges decoded msgpack rows, tracks per-shard failures, and surfaces both *decode/query errors* and a list of `unavailable_shards` in the templates.
> 
> The cluster overview UI now marks shards as `Active (Unavailable)` (and colors them red) when a shard appears in the owner map but has no node info, and tests were added to cover the new partial-results/unavailable-shard behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e65e33efffce11d4c5799eeb620541ec3ffea208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->