### PR TITLE
Enable heap profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5428,6 +5428,8 @@ dependencies = [
  "storekey",
  "tempfile",
  "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5953,6 +5955,37 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,8 @@ rand = "0.9"
 datafusion-sql = "50"
 hostname = "0.4"
 pprof = { version = "0.15", features = ["prost-codec", "frame-pointer"] }
+tikv-jemallocator = { version = "0.6", features = ["profiling"] }
+tikv-jemalloc-ctl = { version = "0.6", features = ["profiling"] }
 flate2 = "1"
 urlencoding = "2"
 storekey = { version = "0.11", features = ["storekey-derive"] }

--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -323,3 +323,40 @@ siloctl profile --output after-change.pb.gz
 # Compare using pprof's diff mode
 pprof -http=:8080 -diff_base=baseline.pb.gz after-change.pb.gz
 ```
+
+## Heap Profiling
+
+Silo also supports on-demand heap profiling using jemalloc's built-in sampling profiler. A heap profile activates jemalloc profiling for a short window, then dumps the currently-live sampled allocations in `jeprof` format.
+
+### Capturing a Heap Profile
+
+Use `siloctl` to capture a heap profile from a running node:
+
+```bash
+siloctl -a http://silo-node:7450 heap-profile --duration 30
+```
+
+Options:
+- `--duration`, `-d`: How long to keep heap profiling active before dumping (1-300, default 30)
+- `--output`, `-o`: Output file path (default: `heap-profile-{timestamp}.heap`)
+
+### Analyzing Heap Profiles
+
+Heap profiles are saved in jemalloc's `jeprof` format. Analysis requires the exact `silo` binary that produced the dump:
+
+```bash
+# Text summary
+jeprof --text /path/to/silo heap-profile-1706123456.heap
+
+# SVG graph
+jeprof --svg /path/to/silo heap-profile-1706123456.heap > heap.svg
+```
+
+To compare two dumps, use `jeprof --base=<baseline.heap> /path/to/silo <after.heap>`.
+
+### Production Considerations
+
+- Heap profiling is sampling-based rather than a full heap walk, which keeps overhead manageable.
+- The default runtime configuration enables profiling support but keeps sampling inactive until a profile is requested.
+- Profiles show sampled live allocations at dump time; they are most useful for investigating growth during a controlled window.
+- On macOS, the dump only covers allocations that flow through the process allocator; external system allocations may not appear.

--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -337,7 +337,7 @@ siloctl -a http://silo-node:7450 heap-profile --duration 30
 ```
 
 Options:
-- `--duration`, `-d`: How long to keep heap profiling active before dumping (1-300, default 30)
+- `--duration`, `-d`: How long to wait before dumping the current live heap profile (1-300, default 30)
 - `--output`, `-o`: Output file path (default: `heap-profile-{timestamp}.heap`)
 
 ### Analyzing Heap Profiles
@@ -358,5 +358,7 @@ To compare two dumps, use `jeprof --base=<baseline.heap> /path/to/silo <after.he
 
 - Heap profiling is sampling-based rather than a full heap walk, which keeps overhead manageable.
 - The default runtime configuration enables profiling support but keeps sampling inactive until a profile is requested.
-- Profiles show sampled live allocations at dump time; they are most useful for investigating growth during a controlled window.
+- Profiles show sampled live allocations at dump time; the duration delays the dump and increases sample density during that window, but it does not restrict the dump to allocations created during the wait.
+- For a quick current snapshot, use `--duration 1`. For leak investigation or growth analysis, leave profiling active for several minutes before dumping.
+- Analysts need the exact matching binary for symbolization; in production, match it by image SHA rather than by version tag alone.
 - On macOS, the dump only covers allocations that flow through the process allocator; external system allocations may not appear.

--- a/docs/src/content/docs/introduction.md
+++ b/docs/src/content/docs/introduction.md
@@ -22,7 +22,7 @@ Silo sits in between. It has the simplicity and speed of a traditional job queue
 - **Concurrency limits**: built-in concurrency and rate limiting with high cardinality keys and dynamic floating limits.
 - **Job lifecycle management**: retries with exponential backoff, future scheduling, expediting, cancellation, restart, and deletion.
 - **Job results**: workers can return results that are stored and retrievable by the enqueuing process.
-- **Observability**: Prometheus metrics, OpenTelemetry tracing, structured logging, and on-demand CPU profiling.
+- **Observability**: Prometheus metrics, OpenTelemetry tracing, structured logging, and on-demand CPU and heap profiling.
 - **SQL queries**: inspect jobs with SQL via the built-in query engine.
 - **Web UI**: operator-facing dashboard for cluster health, queue inspection, and debugging.
 

--- a/docs/src/content/docs/reference/siloctl.mdx
+++ b/docs/src/content/docs/reference/siloctl.mdx
@@ -401,6 +401,57 @@ Profiling uses sampling and has low overhead (~1-2%). The default 100Hz frequenc
 
 ---
 
+### heap-profile
+
+Capture a jemalloc heap profile from the connected Silo node. This activates heap profiling for the requested duration, then dumps currently-live sampled allocations in `jeprof` format.
+
+```bash
+siloctl heap-profile [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-d`, `--duration <SECONDS>` | How long to keep heap profiling active before dumping (1-300, default: 30) |
+| `-o`, `--output <FILE>` | Output file path (default: `heap-profile-{timestamp}.heap`) |
+
+**Example:**
+
+```bash
+siloctl -a http://silo-node:7450 heap-profile --duration 30
+```
+
+```
+Starting heap profile for 30 seconds...
+
+Heap profile saved to: heap-profile-1706123456.heap
+Duration: 30s, Size: 18342 bytes
+
+Analyze with:
+  jeprof --text /path/to/silo heap-profile-1706123456.heap
+  jeprof --svg /path/to/silo heap-profile-1706123456.heap > heap.svg
+```
+
+**JSON output:**
+
+```bash
+siloctl --json heap-profile --duration 10
+```
+
+```json
+{
+  "status": "completed",
+  "output_file": "heap-profile-1706123456.heap",
+  "duration_seconds": 10,
+  "profile_bytes": 18342
+}
+```
+
+<Aside type="note">
+Heap profiles require the `silo` binary used to produce the dump when analyzing with `jeprof`. On macOS, only Rust allocations that go through the process allocator are guaranteed to appear in the dump.
+</Aside>
+
+---
+
 ### validate-config
 
 Validate a Silo configuration file without starting the server. This is useful for checking configuration syntax and semantics before deployment.

--- a/docs/src/content/docs/reference/siloctl.mdx
+++ b/docs/src/content/docs/reference/siloctl.mdx
@@ -411,7 +411,7 @@ siloctl heap-profile [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `-d`, `--duration <SECONDS>` | How long to keep heap profiling active before dumping (1-300, default: 30) |
+| `-d`, `--duration <SECONDS>` | How long to wait before dumping the current live heap profile (1-300, default: 30) |
 | `-o`, `--output <FILE>` | Output file path (default: `heap-profile-{timestamp}.heap`) |
 
 **Example:**
@@ -447,7 +447,7 @@ siloctl --json heap-profile --duration 10
 ```
 
 <Aside type="note">
-Heap profiles require the `silo` binary used to produce the dump when analyzing with `jeprof`. On macOS, only Rust allocations that go through the process allocator are guaranteed to appear in the dump.
+Heap profiles require the exact `silo` binary used to produce the dump when analyzing with `jeprof`; in production, match by image SHA. The duration delays the dump and increases sample density, but the dump still reflects all sampled live allocations at capture time. For a quick snapshot, use `--duration 1`; for leak investigation, leave profiling active longer. On macOS, only allocations that go through the process allocator are guaranteed to appear in the dump.
 </Aside>
 
 ---

--- a/nix/modules/devshell.nix
+++ b/nix/modules/devshell.nix
@@ -61,6 +61,11 @@
     {
       devShells.default = pkgs.mkShell {
         name = "silo-shell";
+        # Disable fortify hardening so jemalloc's configure script can build
+        # its strerror_r feature test. Nix's default _FORTIFY_SOURCE=2 + cargo's
+        # debug -O0 + jemalloc's -Werror combine into a hard error in glibc's
+        # features.h ("_FORTIFY_SOURCE requires compiling with optimization").
+        hardeningDisable = [ "fortify" ];
         packages = [
           rustToolchain
         ] ++ (with pkgs; [

--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -455,6 +455,20 @@ message CpuProfileResponse {
   uint64 samples = 3;           // Number of samples collected.
 }
 
+// Request to capture a heap profile from this node.
+// The profiler is activated for the requested duration, then a jemalloc heap
+// dump of currently-live sampled allocations is returned.
+message HeapProfileRequest {
+  uint32 duration_seconds = 1;  // How long to profile before dumping (1-300 seconds). Default 30.
+}
+
+// Heap profile data in jemalloc/jeprof format.
+// Analyze with `jeprof <path-to-silo-binary> <profile-file>`.
+message HeapProfileResponse {
+  bytes profile_data = 1;       // jemalloc heap profile bytes.
+  uint32 duration_seconds = 2;  // Actual duration profiled.
+}
+
 // Request to initiate a shard split operation.
 message RequestSplitRequest {
   string shard_id = 1;     // Shard ID (UUID) of the shard to split.
@@ -685,6 +699,11 @@ service Silo {
   // Returns pprof protobuf data that can be analyzed with pprof or go tool pprof.
   // The profile captures CPU usage for the specified duration.
   rpc CpuProfile(CpuProfileRequest) returns (CpuProfileResponse);
+
+  // Capture a jemalloc heap profile from this node.
+  // The profiler is activated for the specified duration and then dumps
+  // currently-live sampled allocations in jeprof-compatible format.
+  rpc HeapProfile(HeapProfileRequest) returns (HeapProfileResponse);
   
   // Request a shard split operation.
   // Initiates splitting a shard into two child shards at the specified split point.

--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -459,7 +459,7 @@ message CpuProfileResponse {
 // The profiler is activated for the requested duration, then a jemalloc heap
 // dump of currently-live sampled allocations is returned.
 message HeapProfileRequest {
-  uint32 duration_seconds = 1;  // How long to profile before dumping (1-300 seconds). Default 30.
+  uint32 duration_seconds = 1;  // How long to wait before dumping the current live heap profile (1-300 seconds). Default 30.
 }
 
 // Heap profile data in jemalloc/jeprof format.

--- a/src/bin/siloctl.rs
+++ b/src/bin/siloctl.rs
@@ -93,6 +93,15 @@ enum Command {
         #[arg(long, short = 'o')]
         output: Option<String>,
     },
+    /// Capture a jemalloc heap profile from a Silo node
+    HeapProfile {
+        /// Duration in seconds to keep heap profiling active before dumping (1-300)
+        #[arg(long, short = 'd', default_value = "30")]
+        duration: u32,
+        /// Output file path (default: heap-profile-{timestamp}.heap)
+        #[arg(long, short = 'o')]
+        output: Option<String>,
+    },
     /// Validate a config file and exit
     ValidateConfig {
         /// Path to the TOML config file to validate
@@ -303,6 +312,9 @@ async fn run(args: Args) -> anyhow::Result<()> {
             frequency,
             output,
         } => siloctl::profile(&opts, &mut stdout, *duration, *frequency, output.clone()).await,
+        Command::HeapProfile { duration, output } => {
+            siloctl::heap_profile(&opts, &mut stdout, *duration, output.clone()).await
+        }
         Command::ValidateConfig { config } => {
             siloctl::validate_config(&opts, &mut stdout, config).await
         }

--- a/src/bin/siloctl.rs
+++ b/src/bin/siloctl.rs
@@ -95,7 +95,7 @@ enum Command {
     },
     /// Capture a jemalloc heap profile from a Silo node
     HeapProfile {
-        /// Duration in seconds to keep heap profiling active before dumping (1-300)
+        /// Seconds to wait before dumping the current live heap profile (1-300)
         #[arg(long, short = 'd', default_value = "30")]
         duration: u32,
         /// Output file path (default: heap-profile-{timestamp}.heap)

--- a/src/heap_profile.rs
+++ b/src/heap_profile.rs
@@ -1,0 +1,71 @@
+use std::ffi::{CString, c_char};
+use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+
+#[cfg(unix)]
+const OPT_PROF: &[u8] = b"opt.prof\0";
+#[cfg(unix)]
+const PROF_ACTIVE: &[u8] = b"prof.active\0";
+#[cfg(unix)]
+const PROF_DUMP: &[u8] = b"prof.dump\0";
+
+#[cfg(unix)]
+pub fn profiling_enabled() -> anyhow::Result<bool> {
+    // SAFETY: The mallctl key and expected return type match jemalloc's
+    // `opt.prof` boolean runtime option.
+    unsafe { tikv_jemalloc_ctl::raw::read(OPT_PROF) }
+        .map_err(|e| anyhow::anyhow!("mallctl opt.prof failed: {e}"))
+}
+
+#[cfg(not(unix))]
+pub fn profiling_enabled() -> anyhow::Result<bool> {
+    Ok(false)
+}
+
+#[cfg(unix)]
+pub fn profiling_active() -> anyhow::Result<bool> {
+    // SAFETY: The mallctl key and expected return type match jemalloc's
+    // `prof.active` boolean runtime option.
+    unsafe { tikv_jemalloc_ctl::raw::read(PROF_ACTIVE) }
+        .map_err(|e| anyhow::anyhow!("mallctl prof.active read failed: {e}"))
+}
+
+#[cfg(not(unix))]
+pub fn profiling_active() -> anyhow::Result<bool> {
+    Ok(false)
+}
+
+#[cfg(unix)]
+pub fn set_profiling_active(active: bool) -> anyhow::Result<()> {
+    // SAFETY: The mallctl key and written value type match jemalloc's
+    // `prof.active` boolean runtime option.
+    unsafe { tikv_jemalloc_ctl::raw::update(PROF_ACTIVE, active) }
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("mallctl prof.active write failed: {e}"))
+}
+
+#[cfg(not(unix))]
+pub fn set_profiling_active(_active: bool) -> anyhow::Result<()> {
+    anyhow::bail!("heap profiling is only supported on unix targets")
+}
+
+#[cfg(unix)]
+pub fn dump_profile(path: &Path) -> anyhow::Result<()> {
+    let mut path_bytes = CString::new(path.as_os_str().as_bytes())
+        .map_err(|e| anyhow::anyhow!("invalid heap profile path: {e}"))?
+        .into_bytes_with_nul();
+    let path_ptr = path_bytes.as_mut_ptr().cast::<c_char>();
+
+    // SAFETY: `prof.dump` expects a mutable pointer to a NUL-terminated path.
+    // `path_bytes` is kept alive for the duration of the call.
+    unsafe { tikv_jemalloc_ctl::raw::write(PROF_DUMP, path_ptr) }
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("mallctl prof.dump failed: {e}"))
+}
+
+#[cfg(not(unix))]
+pub fn dump_profile(_path: &Path) -> anyhow::Result<()> {
+    anyhow::bail!("heap profiling is only supported on unix targets")
+}

--- a/src/heap_profile.rs
+++ b/src/heap_profile.rs
@@ -1,5 +1,7 @@
 use std::ffi::{CString, c_char};
 use std::path::Path;
+#[cfg(test)]
+use std::sync::Mutex;
 
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
@@ -51,6 +53,35 @@ pub fn set_profiling_active(_active: bool) -> anyhow::Result<()> {
     anyhow::bail!("heap profiling is only supported on unix targets")
 }
 
+pub struct ProfilingActivationGuard {
+    deactivate_on_drop: bool,
+}
+
+impl ProfilingActivationGuard {
+    pub fn activate_if_needed() -> anyhow::Result<Self> {
+        let was_active = profiling_active()?;
+        if !was_active {
+            set_profiling_active(true)?;
+        }
+
+        Ok(Self {
+            deactivate_on_drop: !was_active,
+        })
+    }
+
+    pub fn activated_profiling(&self) -> bool {
+        self.deactivate_on_drop
+    }
+}
+
+impl Drop for ProfilingActivationGuard {
+    fn drop(&mut self) {
+        if self.deactivate_on_drop {
+            let _ = set_profiling_active(false);
+        }
+    }
+}
+
 #[cfg(unix)]
 pub fn dump_profile(path: &Path) -> anyhow::Result<()> {
     let mut path_bytes = CString::new(path.as_os_str().as_bytes())
@@ -68,4 +99,29 @@ pub fn dump_profile(path: &Path) -> anyhow::Result<()> {
 #[cfg(not(unix))]
 pub fn dump_profile(_path: &Path) -> anyhow::Result<()> {
     anyhow::bail!("heap profiling is only supported on unix targets")
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    static HEAP_PROFILE_TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn profiling_guard_deactivates_on_drop() -> anyhow::Result<()> {
+        let _lock = HEAP_PROFILE_TEST_MUTEX.lock().unwrap();
+
+        if !profiling_enabled()? {
+            anyhow::bail!("heap profiling is not enabled in the allocator")
+        }
+
+        set_profiling_active(false)?;
+        {
+            let guard = ProfilingActivationGuard::activate_if_needed()?;
+            assert!(guard.activated_profiling());
+            assert!(profiling_active()?);
+        }
+        assert!(!profiling_active()?);
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,25 +53,19 @@ union MallocConfPtr {
     as_c_char: &'static std::ffi::c_char,
 }
 
-// Enable jemalloc heap profiling support in-process without requiring MALLOC_CONF
-// to be injected externally at startup.
 #[cfg(unix)]
-#[used]
-#[unsafe(no_mangle)]
-pub static malloc_conf: Option<&'static std::ffi::c_char> = Some(unsafe {
-    MallocConfPtr {
-        as_u8: &b"prof:true,prof_active:false,lg_prof_sample:19\0"[0],
-    }
-    .as_c_char
-});
+const MALLOC_CONF_STR: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
 
+// This build keeps jemalloc's default `_rjem_` prefixing. If we switch to
+// `unprefixed_malloc_on_supported_platforms` later, this export should change
+// to the unprefixed `malloc_conf` symbol in the same patch.
 #[cfg(unix)]
 #[used]
 #[allow(non_upper_case_globals)]
 #[unsafe(export_name = "_rjem_malloc_conf")]
 pub static rjem_malloc_conf: Option<&'static std::ffi::c_char> = Some(unsafe {
     MallocConfPtr {
-        as_u8: &b"prof:true,prof_active:false,lg_prof_sample:19\0"[0],
+        as_u8: &MALLOC_CONF_STR[0],
     }
     .as_c_char
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod coordination;
 pub mod dst_events;
 pub mod factory;
 pub mod gubernator;
+pub mod heap_profile;
 pub mod job;
 pub mod job_attempt;
 pub mod job_store_shard;
@@ -41,6 +42,39 @@ pub mod pb {
 }
 pub mod server;
 pub mod siloctl;
+
+#[cfg(unix)]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[cfg(unix)]
+union MallocConfPtr {
+    as_u8: &'static u8,
+    as_c_char: &'static std::ffi::c_char,
+}
+
+// Enable jemalloc heap profiling support in-process without requiring MALLOC_CONF
+// to be injected externally at startup.
+#[cfg(unix)]
+#[used]
+#[unsafe(no_mangle)]
+pub static malloc_conf: Option<&'static std::ffi::c_char> = Some(unsafe {
+    MallocConfPtr {
+        as_u8: &b"prof:true,prof_active:false,lg_prof_sample:19\0"[0],
+    }
+    .as_c_char
+});
+
+#[cfg(unix)]
+#[used]
+#[allow(non_upper_case_globals)]
+#[unsafe(export_name = "_rjem_malloc_conf")]
+pub static rjem_malloc_conf: Option<&'static std::ffi::c_char> = Some(unsafe {
+    MallocConfPtr {
+        as_u8: &b"prof:true,prof_active:false,lg_prof_sample:19\0"[0],
+    }
+    .as_c_char
+});
 
 /// Default scan options for all silo scans.
 ///

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use rand::seq::SliceRandom;
@@ -30,6 +31,9 @@ use crate::pb::silo_server::{Silo, SiloServer};
 use crate::pb::*;
 use crate::settings::AppConfig;
 use crate::task::DEFAULT_LEASE_MS;
+
+static HEAP_PROFILE_MUTEX: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
 
 /// Convert a job::JobStatusKind to a proto JobStatus enum value
 fn job_status_kind_to_proto(kind: JobStatusKind) -> JobStatus {
@@ -1720,6 +1724,71 @@ impl Silo for SiloService {
             profile_data,
             duration_seconds: duration,
             samples,
+        }))
+    }
+
+    async fn heap_profile(
+        &self,
+        req: Request<HeapProfileRequest>,
+    ) -> Result<Response<HeapProfileResponse>, Status> {
+        let r = req.into_inner();
+
+        let duration = if r.duration_seconds == 0 {
+            30
+        } else {
+            r.duration_seconds.clamp(1, 300)
+        };
+
+        let _profile_lock = HEAP_PROFILE_MUTEX.lock().await;
+
+        if !crate::heap_profile::profiling_enabled()
+            .map_err(|e| Status::internal(format!("failed to inspect heap profiler: {e}")))?
+        {
+            return Err(Status::failed_precondition(
+                "heap profiling is not enabled in the allocator",
+            ));
+        }
+
+        let was_active = crate::heap_profile::profiling_active()
+            .map_err(|e| Status::internal(format!("failed to inspect heap profiler: {e}")))?;
+
+        if !was_active {
+            crate::heap_profile::set_profiling_active(true)
+                .map_err(|e| Status::internal(format!("failed to activate heap profiler: {e}")))?;
+        }
+
+        tracing::info!(duration_seconds = duration, "starting heap profile");
+
+        tokio::time::sleep(std::time::Duration::from_secs(duration as u64)).await;
+
+        let tmp_dir = tempfile::tempdir()
+            .map_err(|e| Status::internal(format!("failed to create tempdir: {e}")))?;
+        let dump_path = tmp_dir.path().join("silo.heap");
+
+        let profile_data = (|| -> Result<Vec<u8>, Status> {
+            crate::heap_profile::dump_profile(&dump_path)
+                .map_err(|e| Status::internal(format!("failed to dump heap profile: {e}")))?;
+            std::fs::read(&dump_path)
+                .map_err(|e| Status::internal(format!("failed to read heap profile: {e}")))
+        })();
+
+        if !was_active {
+            crate::heap_profile::set_profiling_active(false).map_err(|e| {
+                Status::internal(format!("failed to deactivate heap profiler: {e}"))
+            })?;
+        }
+
+        let profile_data = profile_data?;
+
+        tracing::info!(
+            duration_seconds = duration,
+            profile_bytes = profile_data.len(),
+            "heap profile completed"
+        );
+
+        Ok(Response::new(HeapProfileResponse {
+            profile_data,
+            duration_seconds: duration,
         }))
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -32,7 +32,7 @@ use crate::pb::*;
 use crate::settings::AppConfig;
 use crate::task::DEFAULT_LEASE_MS;
 
-static HEAP_PROFILE_MUTEX: LazyLock<tokio::sync::Mutex<()>> =
+static PROFILE_MUTEX: LazyLock<tokio::sync::Mutex<()>> =
     LazyLock::new(|| tokio::sync::Mutex::new(()));
 
 /// Convert a job::JobStatusKind to a proto JobStatus enum value
@@ -1662,6 +1662,7 @@ impl Silo for SiloService {
         &self,
         req: Request<CpuProfileRequest>,
     ) -> Result<Response<CpuProfileResponse>, Status> {
+        let _profile_lock = PROFILE_MUTEX.lock().await;
         let r = req.into_inner();
 
         // Validate and clamp duration (1-300 seconds, default 30)
@@ -1731,6 +1732,7 @@ impl Silo for SiloService {
         &self,
         req: Request<HeapProfileRequest>,
     ) -> Result<Response<HeapProfileResponse>, Status> {
+        let _profile_lock = PROFILE_MUTEX.lock().await;
         let r = req.into_inner();
 
         let duration = if r.duration_seconds == 0 {
@@ -1738,8 +1740,6 @@ impl Silo for SiloService {
         } else {
             r.duration_seconds.clamp(1, 300)
         };
-
-        let _profile_lock = HEAP_PROFILE_MUTEX.lock().await;
 
         if !crate::heap_profile::profiling_enabled()
             .map_err(|e| Status::internal(format!("failed to inspect heap profiler: {e}")))?
@@ -1749,15 +1749,14 @@ impl Silo for SiloService {
             ));
         }
 
-        let was_active = crate::heap_profile::profiling_active()
-            .map_err(|e| Status::internal(format!("failed to inspect heap profiler: {e}")))?;
+        let activation_guard = crate::heap_profile::ProfilingActivationGuard::activate_if_needed()
+            .map_err(|e| Status::internal(format!("failed to activate heap profiler: {e}")))?;
 
-        if !was_active {
-            crate::heap_profile::set_profiling_active(true)
-                .map_err(|e| Status::internal(format!("failed to activate heap profiler: {e}")))?;
-        }
-
-        tracing::info!(duration_seconds = duration, "starting heap profile");
+        tracing::warn!(
+            duration_seconds = duration,
+            activated_profiling = activation_guard.activated_profiling(),
+            "starting heap profile; dump may contain sampled live payload bytes"
+        );
 
         tokio::time::sleep(std::time::Duration::from_secs(duration as u64)).await;
 
@@ -1771,12 +1770,6 @@ impl Silo for SiloService {
             std::fs::read(&dump_path)
                 .map_err(|e| Status::internal(format!("failed to read heap profile: {e}")))
         })();
-
-        if !was_active {
-            crate::heap_profile::set_profiling_active(false).map_err(|e| {
-                Status::internal(format!("failed to deactivate heap profiler: {e}"))
-            })?;
-        }
 
         let profile_data = profile_data?;
 

--- a/src/siloctl.rs
+++ b/src/siloctl.rs
@@ -738,11 +738,7 @@ pub async fn heap_profile<W: Write>(
     let mut client = connect(&opts.address, opts.auth_token.as_deref()).await?;
 
     if !opts.json {
-        writeln!(
-            out,
-            "Starting heap profile for {} seconds...",
-            duration
-        )?;
+        writeln!(out, "Starting heap profile for {} seconds...", duration)?;
         out.flush()?;
     }
 
@@ -794,7 +790,11 @@ pub async fn heap_profile<W: Write>(
             .map(|s| s.to_string_lossy().to_string())
             .unwrap_or(output_file.clone());
         writeln!(out, "  jeprof --text /path/to/silo {}", display_path)?;
-        writeln!(out, "  jeprof --svg /path/to/silo {} > heap.svg", display_path)?;
+        writeln!(
+            out,
+            "  jeprof --svg /path/to/silo {} > heap.svg",
+            display_path
+        )?;
     }
 
     Ok(())

--- a/src/siloctl.rs
+++ b/src/siloctl.rs
@@ -12,8 +12,8 @@ use crate::pb::silo_client::SiloClient;
 use crate::pb::{
     CancelJobRequest, CompactShardRequest, ConfigureShardRequest, CpuProfileRequest,
     DeleteJobRequest, ExpediteJobRequest, ForceReleaseShardRequest, GetClusterInfoRequest,
-    GetJobRequest, GetJobResultRequest, GetSplitStatusRequest, QueryRequest, RequestSplitRequest,
-    RestartJobRequest,
+    GetJobRequest, GetJobResultRequest, GetSplitStatusRequest, HeapProfileRequest, QueryRequest,
+    RequestSplitRequest, RestartJobRequest,
 };
 use flate2::Compression;
 use flate2::write::GzEncoder;
@@ -723,6 +723,78 @@ pub async fn profile<W: Write>(
             .unwrap_or(output_file.clone());
         writeln!(out, "  pprof -http=:8080 {}", display_path)?;
         writeln!(out, "  go tool pprof -http=:8080 {}", display_path)?;
+    }
+
+    Ok(())
+}
+
+/// Capture a heap profile from the connected Silo node
+pub async fn heap_profile<W: Write>(
+    opts: &GlobalOptions,
+    out: &mut W,
+    duration: u32,
+    output_path: Option<String>,
+) -> anyhow::Result<()> {
+    let mut client = connect(&opts.address, opts.auth_token.as_deref()).await?;
+
+    if !opts.json {
+        writeln!(
+            out,
+            "Starting heap profile for {} seconds...",
+            duration
+        )?;
+        out.flush()?;
+    }
+
+    let response = client
+        .heap_profile(HeapProfileRequest {
+            duration_seconds: duration,
+        })
+        .await?
+        .into_inner();
+
+    let output_file = output_path.unwrap_or_else(|| {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        format!("heap-profile-{}.heap", timestamp)
+    });
+
+    let output_file = if output_file.ends_with(".heap") {
+        output_file
+    } else {
+        format!("{}.heap", output_file)
+    };
+
+    std::fs::write(&output_file, &response.profile_data)?;
+
+    if opts.json {
+        let json_output = serde_json::json!({
+            "status": "completed",
+            "output_file": output_file,
+            "duration_seconds": response.duration_seconds,
+            "profile_bytes": response.profile_data.len(),
+        });
+        writeln!(out, "{}", serde_json::to_string_pretty(&json_output)?)?;
+    } else {
+        writeln!(out)?;
+        writeln!(out, "Heap profile saved to: {}", output_file)?;
+        writeln!(
+            out,
+            "Duration: {}s, Size: {} bytes",
+            response.duration_seconds,
+            response.profile_data.len()
+        )?;
+        writeln!(out)?;
+        writeln!(out, "Analyze with:")?;
+
+        let display_path = Path::new(&output_file)
+            .file_name()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or(output_file.clone());
+        writeln!(out, "  jeprof --text /path/to/silo {}", display_path)?;
+        writeln!(out, "  jeprof --svg /path/to/silo {} > heap.svg", display_path)?;
     }
 
     Ok(())

--- a/tests/routing_client_tests.rs
+++ b/tests/routing_client_tests.rs
@@ -167,6 +167,13 @@ impl Silo for CountingClusterInfoService {
         Self::unimplemented("cpu_profile")
     }
 
+    async fn heap_profile(
+        &self,
+        _request: Request<HeapProfileRequest>,
+    ) -> Result<Response<HeapProfileResponse>, Status> {
+        Self::unimplemented("heap_profile")
+    }
+
     async fn request_split(
         &self,
         _request: Request<RequestSplitRequest>,

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -880,8 +880,13 @@ async fn siloctl_heap_profile() -> anyhow::Result<()> {
         );
         assert!(output_path.exists(), "heap profile file should exist");
 
-        let metadata = std::fs::metadata(&output_path)?;
-        assert!(metadata.len() > 0, "heap profile should not be empty");
+        let profile_bytes = std::fs::read(&output_path)?;
+        assert!(!profile_bytes.is_empty(), "heap profile should not be empty");
+        assert!(
+            profile_bytes.starts_with(b"heap_v2/"),
+            "heap profile should start with jeprof header, got {:?}",
+            &profile_bytes[..profile_bytes.len().min(16)]
+        );
 
         shutdown_server(shutdown_tx, server).await?;
         Ok::<(), anyhow::Error>(())

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -881,7 +881,10 @@ async fn siloctl_heap_profile() -> anyhow::Result<()> {
         assert!(output_path.exists(), "heap profile file should exist");
 
         let profile_bytes = std::fs::read(&output_path)?;
-        assert!(!profile_bytes.is_empty(), "heap profile should not be empty");
+        assert!(
+            !profile_bytes.is_empty(),
+            "heap profile should not be empty"
+        );
         assert!(
             profile_bytes.starts_with(b"heap_v2/"),
             "heap profile should start with jeprof header, got {:?}",

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -15,7 +15,7 @@ use silo::pb::*;
 use silo::settings::AppConfig;
 use silo::siloctl::{self, BytesOutputFormat, GlobalOptions};
 
-// Global mutex to serialize profile tests - only one CPU profiler can run at a time system-wide
+// Global mutex to serialize profiler tests - both profilers use process-global state.
 static PROFILE_TEST_MUTEX: Mutex<()> = Mutex::new(());
 
 fn opts_for_addr(addr: &std::net::SocketAddr) -> GlobalOptions {
@@ -840,6 +840,48 @@ async fn siloctl_profile_json_output() -> anyhow::Result<()> {
             parsed.get("profile_bytes").is_some(),
             "JSON should have profile_bytes"
         );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn siloctl_heap_profile() -> anyhow::Result<()> {
+    let _profile_lock = PROFILE_TEST_MUTEX.lock().unwrap();
+
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(60000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (_client, shutdown_tx, server, addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let opts = opts_for_addr(&addr);
+        let mut output = Vec::new();
+
+        let tmp_dir = tempfile::tempdir()?;
+        let output_path = tmp_dir.path().join("test-heap-profile.heap");
+
+        siloctl::heap_profile(
+            &opts,
+            &mut output,
+            1,
+            Some(output_path.to_string_lossy().to_string()),
+        )
+        .await?;
+
+        let stdout = String::from_utf8(output)?;
+        assert!(
+            stdout.contains("Heap profile saved to:"),
+            "should confirm save: {}",
+            stdout
+        );
+        assert!(output_path.exists(), "heap profile file should exist");
+
+        let metadata = std::fs::metadata(&output_path)?;
+        assert!(metadata.len() > 0, "heap profile should not be empty");
 
         shutdown_server(shutdown_tx, server).await?;
         Ok::<(), anyhow::Error>(())

--- a/typescript_client/src/pb/silo.client.ts
+++ b/typescript_client/src/pb/silo.client.ts
@@ -20,6 +20,8 @@ import type { GetSplitStatusResponse } from "./silo";
 import type { GetSplitStatusRequest } from "./silo";
 import type { RequestSplitResponse } from "./silo";
 import type { RequestSplitRequest } from "./silo";
+import type { HeapProfileResponse } from "./silo";
+import type { HeapProfileRequest } from "./silo";
 import type { CpuProfileResponse } from "./silo";
 import type { CpuProfileRequest } from "./silo";
 import type { ArrowIpcMessage } from "./silo";
@@ -192,6 +194,14 @@ export interface ISiloClient {
      * @generated from protobuf rpc: CpuProfile
      */
     cpuProfile(input: CpuProfileRequest, options?: RpcOptions): UnaryCall<CpuProfileRequest, CpuProfileResponse>;
+    /**
+     * Capture a jemalloc heap profile from this node.
+     * The profiler is activated for the specified duration and then dumps
+     * currently-live sampled allocations in jeprof-compatible format.
+     *
+     * @generated from protobuf rpc: HeapProfile
+     */
+    heapProfile(input: HeapProfileRequest, options?: RpcOptions): UnaryCall<HeapProfileRequest, HeapProfileResponse>;
     /**
      * Request a shard split operation.
      * Initiates splitting a shard into two child shards at the specified split point.
@@ -452,6 +462,17 @@ export class SiloClient implements ISiloClient, ServiceInfo {
         return stackIntercept<CpuProfileRequest, CpuProfileResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * Capture a jemalloc heap profile from this node.
+     * The profiler is activated for the specified duration and then dumps
+     * currently-live sampled allocations in jeprof-compatible format.
+     *
+     * @generated from protobuf rpc: HeapProfile
+     */
+    heapProfile(input: HeapProfileRequest, options?: RpcOptions): UnaryCall<HeapProfileRequest, HeapProfileResponse> {
+        const method = this.methods[17], opt = this._transport.mergeOptions(options);
+        return stackIntercept<HeapProfileRequest, HeapProfileResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
      * Request a shard split operation.
      * Initiates splitting a shard into two child shards at the specified split point.
      * Returns FAILED_PRECONDITION if a split is already in progress.
@@ -461,7 +482,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: RequestSplit
      */
     requestSplit(input: RequestSplitRequest, options?: RpcOptions): UnaryCall<RequestSplitRequest, RequestSplitResponse> {
-        const method = this.methods[17], opt = this._transport.mergeOptions(options);
+        const method = this.methods[18], opt = this._transport.mergeOptions(options);
         return stackIntercept<RequestSplitRequest, RequestSplitResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -472,7 +493,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: GetSplitStatus
      */
     getSplitStatus(input: GetSplitStatusRequest, options?: RpcOptions): UnaryCall<GetSplitStatusRequest, GetSplitStatusResponse> {
-        const method = this.methods[18], opt = this._transport.mergeOptions(options);
+        const method = this.methods[19], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetSplitStatusRequest, GetSplitStatusResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -484,7 +505,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ConfigureShard
      */
     configureShard(input: ConfigureShardRequest, options?: RpcOptions): UnaryCall<ConfigureShardRequest, ConfigureShardResponse> {
-        const method = this.methods[19], opt = this._transport.mergeOptions(options);
+        const method = this.methods[20], opt = this._transport.mergeOptions(options);
         return stackIntercept<ConfigureShardRequest, ConfigureShardResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -496,7 +517,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ImportJobs
      */
     importJobs(input: ImportJobsRequest, options?: RpcOptions): UnaryCall<ImportJobsRequest, ImportJobsResponse> {
-        const method = this.methods[20], opt = this._transport.mergeOptions(options);
+        const method = this.methods[21], opt = this._transport.mergeOptions(options);
         return stackIntercept<ImportJobsRequest, ImportJobsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -507,7 +528,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ResetShards
      */
     resetShards(input: ResetShardsRequest, options?: RpcOptions): UnaryCall<ResetShardsRequest, ResetShardsResponse> {
-        const method = this.methods[21], opt = this._transport.mergeOptions(options);
+        const method = this.methods[22], opt = this._transport.mergeOptions(options);
         return stackIntercept<ResetShardsRequest, ResetShardsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -518,7 +539,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ForceReleaseShard
      */
     forceReleaseShard(input: ForceReleaseShardRequest, options?: RpcOptions): UnaryCall<ForceReleaseShardRequest, ForceReleaseShardResponse> {
-        const method = this.methods[22], opt = this._transport.mergeOptions(options);
+        const method = this.methods[23], opt = this._transport.mergeOptions(options);
         return stackIntercept<ForceReleaseShardRequest, ForceReleaseShardResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -529,7 +550,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: CompactShard
      */
     compactShard(input: CompactShardRequest, options?: RpcOptions): UnaryCall<CompactShardRequest, CompactShardResponse> {
-        const method = this.methods[23], opt = this._transport.mergeOptions(options);
+        const method = this.methods[24], opt = this._transport.mergeOptions(options);
         return stackIntercept<CompactShardRequest, CompactShardResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -540,7 +561,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: GetShardStorageInfo
      */
     getShardStorageInfo(input: GetShardStorageInfoRequest, options?: RpcOptions): UnaryCall<GetShardStorageInfoRequest, GetShardStorageInfoResponse> {
-        const method = this.methods[24], opt = this._transport.mergeOptions(options);
+        const method = this.methods[25], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetShardStorageInfoRequest, GetShardStorageInfoResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -1248,7 +1248,7 @@ export interface HeapProfileRequest {
     /**
      * @generated from protobuf field: uint32 duration_seconds = 1
      */
-    durationSeconds: number; // How long to profile before dumping (1-300 seconds). Default 30.
+    durationSeconds: number; // How long to wait before dumping the current live heap profile (1-300 seconds). Default 30.
 }
 /**
  * Heap profile data in jemalloc/jeprof format.

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -1238,6 +1238,35 @@ export interface CpuProfileResponse {
     samples: bigint; // Number of samples collected.
 }
 /**
+ * Request to capture a heap profile from this node.
+ * The profiler is activated for the requested duration, then a jemalloc heap
+ * dump of currently-live sampled allocations is returned.
+ *
+ * @generated from protobuf message silo.v1.HeapProfileRequest
+ */
+export interface HeapProfileRequest {
+    /**
+     * @generated from protobuf field: uint32 duration_seconds = 1
+     */
+    durationSeconds: number; // How long to profile before dumping (1-300 seconds). Default 30.
+}
+/**
+ * Heap profile data in jemalloc/jeprof format.
+ * Analyze with `jeprof <path-to-silo-binary> <profile-file>`.
+ *
+ * @generated from protobuf message silo.v1.HeapProfileResponse
+ */
+export interface HeapProfileResponse {
+    /**
+     * @generated from protobuf field: bytes profile_data = 1
+     */
+    profileData: Uint8Array; // jemalloc heap profile bytes.
+    /**
+     * @generated from protobuf field: uint32 duration_seconds = 2
+     */
+    durationSeconds: number; // Actual duration profiled.
+}
+/**
  * Request to initiate a shard split operation.
  *
  * @generated from protobuf message silo.v1.RequestSplitRequest
@@ -5476,6 +5505,108 @@ class CpuProfileResponse$Type extends MessageType<CpuProfileResponse> {
  */
 export const CpuProfileResponse = new CpuProfileResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class HeapProfileRequest$Type extends MessageType<HeapProfileRequest> {
+    constructor() {
+        super("silo.v1.HeapProfileRequest", [
+            { no: 1, name: "duration_seconds", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+        ]);
+    }
+    create(value?: PartialMessage<HeapProfileRequest>): HeapProfileRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.durationSeconds = 0;
+        if (value !== undefined)
+            reflectionMergePartial<HeapProfileRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: HeapProfileRequest): HeapProfileRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* uint32 duration_seconds */ 1:
+                    message.durationSeconds = reader.uint32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: HeapProfileRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* uint32 duration_seconds = 1; */
+        if (message.durationSeconds !== 0)
+            writer.tag(1, WireType.Varint).uint32(message.durationSeconds);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.HeapProfileRequest
+ */
+export const HeapProfileRequest = new HeapProfileRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class HeapProfileResponse$Type extends MessageType<HeapProfileResponse> {
+    constructor() {
+        super("silo.v1.HeapProfileResponse", [
+            { no: 1, name: "profile_data", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "duration_seconds", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+        ]);
+    }
+    create(value?: PartialMessage<HeapProfileResponse>): HeapProfileResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.profileData = new Uint8Array(0);
+        message.durationSeconds = 0;
+        if (value !== undefined)
+            reflectionMergePartial<HeapProfileResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: HeapProfileResponse): HeapProfileResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* bytes profile_data */ 1:
+                    message.profileData = reader.bytes();
+                    break;
+                case /* uint32 duration_seconds */ 2:
+                    message.durationSeconds = reader.uint32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: HeapProfileResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* bytes profile_data = 1; */
+        if (message.profileData.length)
+            writer.tag(1, WireType.LengthDelimited).bytes(message.profileData);
+        /* uint32 duration_seconds = 2; */
+        if (message.durationSeconds !== 0)
+            writer.tag(2, WireType.Varint).uint32(message.durationSeconds);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.HeapProfileResponse
+ */
+export const HeapProfileResponse = new HeapProfileResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class RequestSplitRequest$Type extends MessageType<RequestSplitRequest> {
     constructor() {
         super("silo.v1.RequestSplitRequest", [
@@ -6833,6 +6964,7 @@ export const Silo = new ServiceType("silo.v1.Silo", [
     { name: "Query", options: {}, I: QueryRequest, O: QueryResponse },
     { name: "QueryArrow", serverStreaming: true, options: {}, I: QueryArrowRequest, O: ArrowIpcMessage },
     { name: "CpuProfile", options: {}, I: CpuProfileRequest, O: CpuProfileResponse },
+    { name: "HeapProfile", options: {}, I: HeapProfileRequest, O: HeapProfileResponse },
     { name: "RequestSplit", options: {}, I: RequestSplitRequest, O: RequestSplitResponse },
     { name: "GetSplitStatus", options: {}, I: GetSplitStatusRequest, O: GetSplitStatusResponse },
     { name: "ConfigureShard", options: {}, I: ConfigureShardRequest, O: ConfigureShardResponse },


### PR DESCRIPTION
Enable jemalloc heap profiling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the process-wide allocator configuration on Unix and adds a new profiling RPC that manipulates jemalloc global state, which could impact memory behavior and production debugging endpoints if misused.
> 
> **Overview**
> Adds **on-demand heap profiling** to Silo using jemalloc sampling, exposed as a new `HeapProfile` gRPC RPC and a `siloctl heap-profile` command that writes `jeprof`-compatible `.heap` dumps.
> 
> Switches Unix builds to the `tikv-jemallocator` global allocator and exports a jemalloc `malloc_conf` to enable profiling support by default (inactive until requested). Introduces `src/heap_profile.rs` to manage `mallctl` interactions (enable/disable, dump) and serializes CPU+heap profiling requests with a shared mutex to avoid concurrent profiler operations.
> 
> Updates docs and TypeScript generated protobuf client/types to document and consume the new heap profiling API, and extends tests to cover the new CLI command and RPC behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ea2acaf4ecd926ea9c46c2c4cade01559499489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->