### PR TITLE
Fix silo-dev docker build by disabling fortify hardening

### DIFF
--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -62,6 +62,11 @@
         strictDeps = true;
         nativeBuildInputs = [ pkgs.protobuf pkgs.flatbuffers ];
         CARGO_PROFILE = "dev";
+        # Disable fortify hardening so jemalloc's configure script can build
+        # its strerror_r feature test. Nix's default _FORTIFY_SOURCE=2 + cargo's
+        # debug -O0 + jemalloc's -Werror combine into a hard error in glibc's
+        # features.h ("_FORTIFY_SOURCE requires compiling with optimization").
+        hardeningDisable = [ "fortify" ];
       };
       cargoArtifactsDebug = craneLib.buildDepsOnly debugArgs;
       silo-debug = craneLib.buildPackage (debugArgs // {


### PR DESCRIPTION
## Summary
- Apply the same `hardeningDisable = [ "fortify" ]` fix
- `silo-debug` builds with `CARGO_PROFILE = "dev"` (`-O0`), so it hits the same `_FORTIFY_SOURCE=2` + jemalloc `-Werror` collision in glibc's `features.h` that broke CI

## Test plan
- [ ] `nix build .#silo-docker-dev` succeeds
- [ ] Built image still runs via `scripts/deploy-local-orbstack.mts`