### PR TITLE
Bound grant scanner status-lookup fan-out and per-call batch size

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -40,6 +40,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
+use futures::StreamExt;
+
 use slatedb::config::WriteOptions;
 use slatedb::{Db, DbIterator, WriteBatch};
 
@@ -83,6 +85,13 @@ impl From<crate::codec::CodecError> for ConcurrencyError {
         ConcurrencyError::Encoding(e.to_string())
     }
 }
+
+/// Max in-flight `db.get(job_status_key)` lookups during a single
+/// `process_grants` pass. Caps slatedb-side block-fetch fan-out so the
+/// scanner can't pin unbounded `Bytes` while validating a large pending
+/// backlog. Mirrors the `CONCURRENCY = 64` pattern used in
+/// `job_store_shard::get_jobs_status_batch` for the same reason.
+const STATUS_LOOKUP_CONCURRENCY: usize = 64;
 
 /// Result of attempting to enqueue a job with concurrency limits
 #[derive(Debug)]
@@ -917,14 +926,25 @@ impl ConcurrencyManager {
             }
 
             // --- Batch validate status ---
-            let status_futures: Vec<_> = scanned
+            // Use `buffered` (order-preserving) rather than `join_all` so that
+            // we cap in-flight slatedb reads at STATUS_LOOKUP_CONCURRENCY. Each
+            // db.get() can fan out to many SST block fetches; with thousands of
+            // pending requests, an unbounded join_all pinned multi-GB of Bytes.
+            // `buffered` (not `buffer_unordered`) keeps results in scanned-order
+            // for the zip below. Keys are materialized owned to avoid borrowing
+            // `scanned` across await points (needed for HRTB on the async closure).
+            let status_keys: Vec<_> = scanned
                 .iter()
-                .map(|c| {
-                    let key = job_status_key(tenant, &c.job_id);
-                    async move { db.get(&key).await }
-                })
+                .map(|c| job_status_key(tenant, &c.job_id))
                 .collect();
-            let status_results = futures::future::join_all(status_futures).await;
+            let status_results: Vec<_> = futures::stream::iter(
+                status_keys
+                    .into_iter()
+                    .map(|key| async move { db.get(&key).await }),
+            )
+            .buffered(STATUS_LOOKUP_CONCURRENCY)
+            .collect()
+            .await;
 
             let mut valid_requests: Vec<ScannedRequest> = Vec::new();
             for (req, status_result) in scanned.into_iter().zip(status_results.into_iter()) {

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -1834,3 +1834,104 @@ async fn grant_scanner_interleaved_stale_and_valid_requests() {
     );
     assert_eq!(count_concurrency_holders(shard.db()).await, 5);
 }
+
+/// Regression test for the unbounded `join_all` fan-out in `process_grants`
+/// that drove production OOMs (heap profile showed ~5.5 GB pinned in
+/// `CachedObjectStore::read_part` from concurrent slatedb reads).
+///
+/// Exercises the bounded `buffered(STATUS_LOOKUP_CONCURRENCY)` path with a
+/// pending backlog larger than the in-flight cap (currently 64). Verifies
+/// correctness — order-preserving validation must still pair each result
+/// with the right request — across more than one buffered batch.
+#[silo::test]
+async fn grant_scanner_handles_backlog_larger_than_status_lookup_concurrency() {
+    // Sized to be a multiple of STATUS_LOOKUP_CONCURRENCY (64) plus extras
+    // so we cross at least two buffered windows. Kept modest to keep the
+    // test fast while still beating the in-flight cap meaningfully.
+    const N: usize = 200;
+
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "backlog-q";
+    let tenant = "backlog-tenant";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: N as u32,
+    });
+
+    shard.stop_grant_scanner();
+
+    // Fill all N concurrency slots with holders.
+    for i in 0..N {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("holder-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+    let mut holder_tasks = Vec::with_capacity(N);
+    while holder_tasks.len() < N {
+        let tasks = shard.dequeue("w", "tg", N).await.unwrap().tasks;
+        assert!(!tasks.is_empty(), "dequeue should return holders");
+        for t in tasks {
+            holder_tasks.push(t.attempt().task_id().to_string());
+        }
+    }
+
+    // Enqueue N more — capacity is full, so each becomes a request record.
+    for i in 0..N {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("waiter-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(count_concurrency_requests(shard.db()).await, N);
+
+    // Release all holders to free capacity for the waiters.
+    for task_id in &holder_tasks {
+        shard
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .unwrap();
+    }
+
+    // One process_grants call should drain all N waiters. Internally this
+    // runs the buffered status-lookup pipeline across multiple batches of
+    // up to STATUS_LOOKUP_CONCURRENCY (64) in-flight db.gets.
+    let granted = shard
+        .process_concurrency_grants(tenant, queue, N as u32)
+        .await;
+    assert_eq!(
+        granted.len(),
+        N,
+        "all {} valid waiters should be granted via the bounded buffered pipeline",
+        N
+    );
+
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "all request records should be consumed"
+    );
+    assert_eq!(count_concurrency_holders(shard.db()).await, N);
+}


### PR DESCRIPTION
This join_all was introduced in https://github.com/gadget-inc/silo/pull/233 but when there are many outstanding grants to process this causes OOMs, so we need to chunk it.

Heap profiles from production showed `process_grants` pinning multi-GB of `Bytes` in `CachedObjectStore::read_part` via an unbounded `futures::future::join_all` over `db.get(job_status_key)` lookups. With large pending-request backlogs, each `db.get` fans out to many slatedb SST block fetches, and thousands in flight at once exceeds container memory before a single pass can complete (19 OOMKills on silo-1, similar on silo-5/6).

- Replace `join_all` with `stream::iter(...).buffered(64)` — order-preserving so the `scanned.zip(status_results)` pairing still holds, while capping concurrent slatedb reads.
-  ~In `start_grant_scanner`, chunk each queue's `count` into batches of at most 1024 per `process_grants` call. Bounds WriteBatch growth and releases memory between durable writes; short-circuits when a chunk grants fewer than asked (iterator/capacity exhausted).~ removed because it was causing GRPC timeouts / client cancellations
- Add a regression test that drains a 200-waiter backlog through the buffered pipeline across multiple in-flight windows.

---

process_grants benchmark results


process_grants benchmark — branch vs main

```  ┌───────────────────────┬───────────────────────────┬───────────────────────┬────────────────┐
  │ Case (grants/waiters) │ main (join_all unbounded) │ branch (buffered(64)) │       Δ        │
  ├───────────────────────┼───────────────────────────┼───────────────────────┼────────────────┤
  │ small (5 / 20)        │ 1.5 ms                    │ 2.2 ms                │ +0.7 ms (+47%) │
  ├───────────────────────┼───────────────────────────┼───────────────────────┼────────────────┤
  │ medium (50 / 200)     │ 1.9 ms                    │ 1.8 ms                │ −0.1 ms (−5%)  │
  ├───────────────────────┼───────────────────────────┼───────────────────────┼────────────────┤
  │ large (500 / 1000)    │ 8.9 ms                    │ 6.6 ms                │ −2.3 ms (−26%) │
  └───────────────────────┴───────────────────────────┴───────────────────────┴────────────────┘
```

  Interpretation

  - Large case (500 grants): branch is ~26% faster. This is the case where bounded concurrency could matter: with join_all unbounded, 500 simultaneous db.get(job_status_key) calls fan out to many in-flight slatedb
  block fetches, increasing cache/memory pressure. Capping at 64 in-flight reads appears to actually help throughput here, in addition to bounding heap residency.
  - Medium case (50): essentially identical — 50 < 64 cap, so buffered and join_all schedule the same number of futures.
  - Small case (5): branch shows +0.7 ms, but this is a single-iteration measurement (bench_op is called with 0 warmup + 1 measured for process_grants), so a sub-ms delta on a 1.5 ms run is well within run-to-run
  noise. Each invocation also uses a freshly cloned shard, so there's no shared cache state between branches.


---

another benchmark with process_grants called 10x for the 500 case

 process_grants(500) — 10 iterations each

```
  Per-iteration timings (ms)

  ┌──────┬─────────────────┬───────────────────────┐
  │ iter │ main (join_all) │ branch (buffered(64)) │
  ├──────┼─────────────────┼───────────────────────┤
  │    0 │            8.40 │                  6.09 │
  ├──────┼─────────────────┼───────────────────────┤
  │    1 │           11.59 │                  6.81 │
  ├──────┼─────────────────┼───────────────────────┤
  │    2 │            7.29 │                  7.50 │
  ├──────┼─────────────────┼───────────────────────┤
  │    3 │            6.23 │                  5.44 │
  ├──────┼─────────────────┼───────────────────────┤
  │    4 │           10.27 │                  6.67 │
  ├──────┼─────────────────┼───────────────────────┤
  │    5 │            6.66 │                  6.30 │
  ├──────┼─────────────────┼───────────────────────┤
  │    6 │            7.45 │                  6.11 │
  ├──────┼─────────────────┼───────────────────────┤
  │    7 │            6.59 │                  6.48 │
  ├──────┼─────────────────┼───────────────────────┤
  │    8 │            9.81 │                  6.20 │
  ├──────┼─────────────────┼───────────────────────┤
  │    9 │           10.37 │                  8.54 │
  └──────┴─────────────────┴───────────────────────┘

  Aggregated

  ┌────────┬─────────┬────────┬──────┐
  │ metric │  main   │ branch │  Δ   │
  ├────────┼─────────┼────────┼──────┤
  │ min    │  6.2 ms │ 5.4 ms │ −13% │
  ├────────┼─────────┼────────┼──────┤
  │ p50    │  8.4 ms │ 6.5 ms │ −23% │
  ├────────┼─────────┼────────┼──────┤
  │ mean   │  8.5 ms │ 6.6 ms │ −22% │
  ├────────┼─────────┼────────┼──────┤
  │ p99    │ 11.6 ms │ 8.5 ms │ −27% │
  ├────────┼─────────┼────────┼──────┤
  │ max    │ 11.6 ms │ 8.5 ms │ −27% │
  └────────┴─────────┴────────┴──────┘

```
 
 Throughput (grants/sec, mean)

  - main: 500 / 0.0085 ≈ 58.8 K grants/sec
  - branch: 500 / 0.0066 ≈ 75.8 K grants/sec
  - +29% on the bounded-concurrency branch