### PR TITLE
Add jemalloc and object cache stats to heap-profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,8 @@ rand = "0.9"
 datafusion-sql = "50"
 hostname = "0.4"
 pprof = { version = "0.15", features = ["prost-codec", "frame-pointer"] }
-tikv-jemallocator = { version = "0.6", features = ["profiling"] }
-tikv-jemalloc-ctl = { version = "0.6", features = ["profiling"] }
+tikv-jemallocator = { version = "0.6", features = ["profiling", "stats"] }
+tikv-jemalloc-ctl = { version = "0.6", features = ["profiling", "stats"] }
 flate2 = "1"
 urlencoding = "2"
 storekey = { version = "0.11", features = ["storekey-derive"] }

--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -462,11 +462,33 @@ message HeapProfileRequest {
   uint32 duration_seconds = 1;  // How long to wait before dumping the current live heap profile (1-300 seconds). Default 30.
 }
 
+// Snapshot of jemalloc memory stats at the time the heap profile was captured.
+// All values are bytes. See jemalloc's `stats.*` mallctl namespace for definitions.
+message JemallocStats {
+  uint64 allocated = 1;  // Bytes allocated by the application (live objects).
+  uint64 active = 2;     // Bytes in pages allocated by the application.
+  uint64 resident = 3;   // Bytes in physically resident pages (RSS-equivalent).
+  uint64 mapped = 4;     // Bytes in extents mapped from the OS.
+  uint64 metadata = 5;   // Bytes used by jemalloc internal metadata.
+  uint64 retained = 6;   // Bytes retained from the OS but not in active use.
+}
+
+// Per-cache record describing a SlateDB block/meta cache configured on this node.
+// `capacity_bytes` is the foyer cache's max capacity (an upper bound on the
+// in-RAM footprint of cached object-storage blocks for this shard).
+message ObjectCacheStat {
+  string shard = 1;           // Shard name/UUID that owns the cache.
+  string kind = 2;            // "block" or "meta".
+  uint64 capacity_bytes = 3;  // Configured max capacity in bytes.
+}
+
 // Heap profile data in jemalloc/jeprof format.
 // Analyze with `jeprof <path-to-silo-binary> <profile-file>`.
 message HeapProfileResponse {
   bytes profile_data = 1;       // jemalloc heap profile bytes.
   uint32 duration_seconds = 2;  // Actual duration profiled.
+  JemallocStats jemalloc_stats = 3;             // Allocator stats at capture time.
+  repeated ObjectCacheStat object_caches = 4;   // Per-shard SlateDB cache configurations.
 }
 
 // Request to initiate a shard split operation.

--- a/src/heap_profile.rs
+++ b/src/heap_profile.rs
@@ -1,6 +1,5 @@
 use std::ffi::{CString, c_char};
 use std::path::Path;
-#[cfg(test)]
 use std::sync::Mutex;
 
 #[cfg(unix)]
@@ -12,6 +11,121 @@ const OPT_PROF: &[u8] = b"opt.prof\0";
 const PROF_ACTIVE: &[u8] = b"prof.active\0";
 #[cfg(unix)]
 const PROF_DUMP: &[u8] = b"prof.dump\0";
+
+#[cfg(unix)]
+const STATS_ALLOCATED: &[u8] = b"stats.allocated\0";
+#[cfg(unix)]
+const STATS_ACTIVE: &[u8] = b"stats.active\0";
+#[cfg(unix)]
+const STATS_RESIDENT: &[u8] = b"stats.resident\0";
+#[cfg(unix)]
+const STATS_MAPPED: &[u8] = b"stats.mapped\0";
+#[cfg(unix)]
+const STATS_METADATA: &[u8] = b"stats.metadata\0";
+#[cfg(unix)]
+const STATS_RETAINED: &[u8] = b"stats.retained\0";
+
+/// Snapshot of jemalloc-reported memory stats.
+///
+/// All values are bytes. `allocated` is application-requested live bytes;
+/// `resident` is the RSS-relevant total (active + metadata + retained pages
+/// the kernel has not reclaimed).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct JemallocStats {
+    pub allocated: u64,
+    pub active: u64,
+    pub resident: u64,
+    pub mapped: u64,
+    pub metadata: u64,
+    pub retained: u64,
+}
+
+#[cfg(unix)]
+pub fn read_stats() -> anyhow::Result<JemallocStats> {
+    // jemalloc requires advancing the epoch before reading stats so that the
+    // per-thread caches flush into the global counters.
+    let epoch: u64 = 1;
+    // SAFETY: `epoch` is the documented mallctl key and `u64` is the
+    // expected value type.
+    unsafe { tikv_jemalloc_ctl::raw::write(b"epoch\0", epoch) }
+        .map_err(|e| anyhow::anyhow!("mallctl epoch advance failed: {e}"))?;
+
+    // SAFETY: each `stats.*` mallctl key returns a `usize`. We read each
+    // independently and widen to `u64` for transport.
+    Ok(JemallocStats {
+        allocated: unsafe { tikv_jemalloc_ctl::raw::read::<usize>(STATS_ALLOCATED) }
+            .map_err(|e| anyhow::anyhow!("mallctl stats.allocated failed: {e}"))?
+            as u64,
+        active: unsafe { tikv_jemalloc_ctl::raw::read::<usize>(STATS_ACTIVE) }
+            .map_err(|e| anyhow::anyhow!("mallctl stats.active failed: {e}"))?
+            as u64,
+        resident: unsafe { tikv_jemalloc_ctl::raw::read::<usize>(STATS_RESIDENT) }
+            .map_err(|e| anyhow::anyhow!("mallctl stats.resident failed: {e}"))?
+            as u64,
+        mapped: unsafe { tikv_jemalloc_ctl::raw::read::<usize>(STATS_MAPPED) }
+            .map_err(|e| anyhow::anyhow!("mallctl stats.mapped failed: {e}"))?
+            as u64,
+        metadata: unsafe { tikv_jemalloc_ctl::raw::read::<usize>(STATS_METADATA) }
+            .map_err(|e| anyhow::anyhow!("mallctl stats.metadata failed: {e}"))?
+            as u64,
+        retained: unsafe { tikv_jemalloc_ctl::raw::read::<usize>(STATS_RETAINED) }
+            .map_err(|e| anyhow::anyhow!("mallctl stats.retained failed: {e}"))?
+            as u64,
+    })
+}
+
+#[cfg(not(unix))]
+pub fn read_stats() -> anyhow::Result<JemallocStats> {
+    Ok(JemallocStats::default())
+}
+
+/// Registered object-storage (SlateDB block/meta) cache capacity record.
+///
+/// SlateDB's `FoyerCache` wrapper does not expose live byte usage, so we
+/// register the configured capacities at construction. The configured
+/// capacity is the upper bound; the actual RAM footprint of cache contents
+/// is reflected in `JemallocStats::allocated`.
+#[derive(Debug, Clone)]
+pub struct ObjectCacheStat {
+    pub shard: String,
+    pub kind: ObjectCacheKind,
+    pub capacity_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectCacheKind {
+    Block,
+    Meta,
+}
+
+impl ObjectCacheKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ObjectCacheKind::Block => "block",
+            ObjectCacheKind::Meta => "meta",
+        }
+    }
+}
+
+static OBJECT_CACHES: Mutex<Vec<ObjectCacheStat>> = Mutex::new(Vec::new());
+
+pub fn register_object_cache(shard: String, kind: ObjectCacheKind, capacity_bytes: u64) {
+    let mut guard = OBJECT_CACHES
+        .lock()
+        .expect("object cache registry poisoned");
+    guard.push(ObjectCacheStat {
+        shard,
+        kind,
+        capacity_bytes,
+    });
+}
+
+pub fn read_object_cache_stats() -> Vec<ObjectCacheStat> {
+    OBJECT_CACHES
+        .lock()
+        .expect("object cache registry poisoned")
+        .clone()
+}
 
 #[cfg(unix)]
 pub fn profiling_enabled() -> anyhow::Result<bool> {
@@ -106,6 +220,14 @@ mod tests {
     use super::*;
 
     static HEAP_PROFILE_TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn read_stats_returns_nonzero_allocated() -> anyhow::Result<()> {
+        let stats = read_stats()?;
+        assert!(stats.allocated > 0, "allocated should be > 0");
+        assert!(stats.resident >= stats.allocated, "resident >= allocated");
+        Ok(())
+    }
 
     #[test]
     fn profiling_guard_deactivates_on_drop() -> anyhow::Result<()> {

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -333,18 +333,32 @@ impl JobStoreShard {
                 foyer::{FoyerCache, FoyerCacheOptions},
             };
 
+            let block_capacity = cache_cfg
+                .block_cache_bytes
+                .unwrap_or(DEFAULT_BLOCK_CACHE_CAPACITY);
+            let meta_capacity = cache_cfg
+                .meta_cache_bytes
+                .unwrap_or(DEFAULT_META_CACHE_CAPACITY);
+
             let block_cache = Arc::new(FoyerCache::new_with_opts(FoyerCacheOptions {
-                max_capacity: cache_cfg
-                    .block_cache_bytes
-                    .unwrap_or(DEFAULT_BLOCK_CACHE_CAPACITY),
+                max_capacity: block_capacity,
                 ..Default::default()
             }));
             let meta_cache = Arc::new(FoyerCache::new_with_opts(FoyerCacheOptions {
-                max_capacity: cache_cfg
-                    .meta_cache_bytes
-                    .unwrap_or(DEFAULT_META_CACHE_CAPACITY),
+                max_capacity: meta_capacity,
                 ..Default::default()
             }));
+
+            crate::heap_profile::register_object_cache(
+                name.clone(),
+                crate::heap_profile::ObjectCacheKind::Block,
+                block_capacity,
+            );
+            crate::heap_profile::register_object_cache(
+                name.clone(),
+                crate::heap_profile::ObjectCacheKind::Meta,
+                meta_capacity,
+            );
 
             let cache = SplitCache::new()
                 .with_block_cache(Some(block_cache))

--- a/src/server.rs
+++ b/src/server.rs
@@ -1773,15 +1773,62 @@ impl Silo for SiloService {
 
         let profile_data = profile_data?;
 
-        tracing::info!(
-            duration_seconds = duration,
-            profile_bytes = profile_data.len(),
-            "heap profile completed"
-        );
+        let jemalloc_stats = match crate::heap_profile::read_stats() {
+            Ok(s) => Some(s),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to read jemalloc stats for heap profile");
+                None
+            }
+        };
+
+        let object_caches = crate::heap_profile::read_object_cache_stats();
+
+        let object_cache_total: u64 = object_caches.iter().map(|c| c.capacity_bytes).sum();
+        if let Some(s) = jemalloc_stats.as_ref() {
+            tracing::info!(
+                duration_seconds = duration,
+                profile_bytes = profile_data.len(),
+                jemalloc_allocated = s.allocated,
+                jemalloc_active = s.active,
+                jemalloc_resident = s.resident,
+                jemalloc_mapped = s.mapped,
+                jemalloc_metadata = s.metadata,
+                jemalloc_retained = s.retained,
+                object_cache_capacity_total = object_cache_total,
+                object_cache_count = object_caches.len(),
+                "heap profile completed"
+            );
+        } else {
+            tracing::info!(
+                duration_seconds = duration,
+                profile_bytes = profile_data.len(),
+                object_cache_capacity_total = object_cache_total,
+                object_cache_count = object_caches.len(),
+                "heap profile completed"
+            );
+        }
+
+        let object_caches_pb = object_caches
+            .into_iter()
+            .map(|c| ObjectCacheStat {
+                shard: c.shard,
+                kind: c.kind.as_str().to_string(),
+                capacity_bytes: c.capacity_bytes,
+            })
+            .collect();
 
         Ok(Response::new(HeapProfileResponse {
             profile_data,
             duration_seconds: duration,
+            jemalloc_stats: jemalloc_stats.map(|s| JemallocStats {
+                allocated: s.allocated,
+                active: s.active,
+                resident: s.resident,
+                mapped: s.mapped,
+                metadata: s.metadata,
+                retained: s.retained,
+            }),
+            object_caches: object_caches_pb,
         }))
     }
 

--- a/src/siloctl.rs
+++ b/src/siloctl.rs
@@ -765,12 +765,32 @@ pub async fn heap_profile<W: Write>(
 
     std::fs::write(&output_file, &response.profile_data)?;
 
+    let object_cache_total: u64 = response
+        .object_caches
+        .iter()
+        .map(|c| c.capacity_bytes)
+        .sum();
+
     if opts.json {
         let json_output = serde_json::json!({
             "status": "completed",
             "output_file": output_file,
             "duration_seconds": response.duration_seconds,
             "profile_bytes": response.profile_data.len(),
+            "jemalloc_stats": response.jemalloc_stats.as_ref().map(|s| serde_json::json!({
+                "allocated": s.allocated,
+                "active": s.active,
+                "resident": s.resident,
+                "mapped": s.mapped,
+                "metadata": s.metadata,
+                "retained": s.retained,
+            })),
+            "object_caches": response.object_caches.iter().map(|c| serde_json::json!({
+                "shard": c.shard,
+                "kind": c.kind,
+                "capacity_bytes": c.capacity_bytes,
+            })).collect::<Vec<_>>(),
+            "object_cache_capacity_total": object_cache_total,
         });
         writeln!(out, "{}", serde_json::to_string_pretty(&json_output)?)?;
     } else {
@@ -782,6 +802,73 @@ pub async fn heap_profile<W: Write>(
             response.duration_seconds,
             response.profile_data.len()
         )?;
+
+        if let Some(s) = response.jemalloc_stats.as_ref() {
+            writeln!(out)?;
+            writeln!(out, "Jemalloc stats:")?;
+            writeln!(
+                out,
+                "  allocated: {:>14}  ({})",
+                s.allocated,
+                format_byte_size(s.allocated)
+            )?;
+            writeln!(
+                out,
+                "  active:    {:>14}  ({})",
+                s.active,
+                format_byte_size(s.active)
+            )?;
+            writeln!(
+                out,
+                "  resident:  {:>14}  ({})",
+                s.resident,
+                format_byte_size(s.resident)
+            )?;
+            writeln!(
+                out,
+                "  mapped:    {:>14}  ({})",
+                s.mapped,
+                format_byte_size(s.mapped)
+            )?;
+            writeln!(
+                out,
+                "  metadata:  {:>14}  ({})",
+                s.metadata,
+                format_byte_size(s.metadata)
+            )?;
+            writeln!(
+                out,
+                "  retained:  {:>14}  ({})",
+                s.retained,
+                format_byte_size(s.retained)
+            )?;
+        }
+
+        if !response.object_caches.is_empty() {
+            writeln!(out)?;
+            writeln!(
+                out,
+                "Object-storage caches ({} entries, configured capacity — actual RAM use is bounded by allocated above):",
+                response.object_caches.len()
+            )?;
+            for c in &response.object_caches {
+                writeln!(
+                    out,
+                    "  shard={} kind={:<5} capacity={} ({})",
+                    c.shard,
+                    c.kind,
+                    c.capacity_bytes,
+                    format_byte_size(c.capacity_bytes)
+                )?;
+            }
+            writeln!(
+                out,
+                "  total configured capacity: {} ({})",
+                object_cache_total,
+                format_byte_size(object_cache_total)
+            )?;
+        }
+
         writeln!(out)?;
         writeln!(out, "Analyze with:")?;
 
@@ -798,6 +885,22 @@ pub async fn heap_profile<W: Write>(
     }
 
     Ok(())
+}
+
+fn format_byte_size(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let b = bytes as f64;
+    if b >= GIB {
+        format!("{:.2} GiB", b / GIB)
+    } else if b >= MIB {
+        format!("{:.2} MiB", b / MIB)
+    } else if b >= KIB {
+        format!("{:.2} KiB", b / KIB)
+    } else {
+        format!("{} B", bytes)
+    }
 }
 
 /// Request a shard split operation


### PR DESCRIPTION
Surfaces jemalloc stats.{allocated,active,resident,mapped,metadata,retained} and per-shard SlateDB block/meta cache capacities through the heap_profile gRPC response and siloctl output, so we can attribute RSS growth between live allocations, retained pages, and configured object-storage caches.

Enables the `stats` cargo feature on tikv-jemallocator/-ctl, which is required for the stats.* mallctl namespace.