### PR TITLE
When workers crash and their leases expire we leak holders

### DIFF
--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -11,7 +11,9 @@ use crate::job::{JobStatus, JobView};
 use crate::job_attempt::{AttemptStatus, JobAttempt, JobAttemptView};
 use crate::job_store_shard::helpers::{DbWriteBatcher, now_epoch_ms};
 use crate::job_store_shard::{DequeueResult, JobStoreShard, JobStoreShardError, LimitTaskParams};
-use crate::keys::{attempt_key, job_info_key, leased_task_key, parse_task_key};
+use crate::keys::{
+    attempt_key, concurrency_holder_key, job_info_key, leased_task_key, parse_task_key,
+};
 use crate::shard_range::ShardRange;
 use crate::task::{DEFAULT_LEASE_MS, LeaseRecord, LeasedRefreshTask, LeasedTask, Task};
 use crate::task_broker::BrokerTask;
@@ -26,6 +28,10 @@ struct DequeueIterationState {
     grants_to_rollback: Vec<(String, String, String)>,
     leased_tasks_for_dst: Vec<(String, String, String)>,
     pending_attempts: Vec<(String, JobView, Vec<u8>)>,
+    /// Holders that were deleted in this iteration's batch and need their
+    /// in-memory slot released + the grant scanner notified after commit.
+    /// Format: (tenant, queue, task_id).
+    holder_releases: Vec<(String, String, String)>,
     processed_internal: bool,
 }
 
@@ -38,6 +44,7 @@ impl DequeueIterationState {
             grants_to_rollback: Vec::new(),
             leased_tasks_for_dst: Vec::new(),
             pending_attempts: Vec::new(),
+            holder_releases: Vec::new(),
             processed_internal: false,
         }
     }
@@ -84,6 +91,9 @@ impl JobStoreShard {
         // Track leased tasks for DST event emission after commit
         // Format: (tenant, job_id, task_id)
         let mut leased_tasks_for_dst: Vec<(String, String, String)> = Vec::new();
+        // Track holders deleted in the batch that need post-commit in-memory
+        // release + grant-scanner wakeup. Format: (tenant, queue, task_id).
+        let mut holder_releases: Vec<(String, String, String)> = Vec::new();
 
         // Loop to process internal tasks until we have tasks that are destined for the worker, or no more ready tasks at all.
         const MAX_INTERNAL_ITERATIONS: usize = 10;
@@ -173,6 +183,7 @@ impl JobStoreShard {
 
             // Merge iteration state into outer accumulators
             grants_to_rollback.append(&mut state.grants_to_rollback);
+            holder_releases.append(&mut state.holder_releases);
 
             // Two-phase DST events: emit before write for correct causal ordering,
             // confirm after write succeeds, cancel if write fails.
@@ -226,6 +237,17 @@ impl JobStoreShard {
 
             // DB write succeeded - clear rollback lists for next iteration
             grants_to_rollback.clear();
+
+            // Post-commit: drop in-memory slots for any holders we removed in
+            // this batch (e.g. a RunAttempt task we dropped because its job_info
+            // was missing) and wake the grant scanner so a queued requester
+            // can take the freed slot.
+            for (tenant, queue, task_id) in holder_releases.drain(..) {
+                self.concurrency
+                    .counts()
+                    .atomic_release(&tenant, &queue, &task_id);
+                self.concurrency.request_grant(&tenant, &queue);
+            }
 
             // Collect pending attempts from this iteration
             pending_attempts.append(&mut state.pending_attempts);
@@ -655,9 +677,28 @@ impl JobStoreShard {
         let job_key = job_info_key(tenant, job_id);
         let maybe_job = self.db.get(&job_key).await?;
         let Some(job_bytes) = maybe_job else {
-            // If job missing, delete task key to clean up
+            // Job missing — drop the task and release any concurrency holders
+            // it acquired at enqueue time. Without this, a stranded holder
+            // permanently consumes a slot for the queue.
             state.batch.delete(task_key);
             state.ack_deleted(task_key);
+            if let Some(held) = ra.held_queues() {
+                for q in held.iter() {
+                    let queue = q.to_string();
+                    state
+                        .batch
+                        .delete(concurrency_holder_key(tenant, &queue, task_id));
+                    state
+                        .holder_releases
+                        .push((tenant.to_string(), queue, task_id.to_string()));
+                }
+            }
+            tracing::warn!(
+                tenant = %tenant,
+                job_id = %job_id,
+                task_id = %task_id,
+                "dropped RunAttempt for missing job_info; released held concurrency queues",
+            );
             return Ok(());
         };
 

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -14,7 +14,8 @@ use crate::job_attempt::{AttemptOutcome, AttemptStatus, JobAttempt};
 use crate::job_store_shard::helpers::{DbWriteBatcher, now_epoch_ms};
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
-    attempt_key, concurrency_holder_key, floating_limit_state_key, job_info_key, leased_task_key,
+    attempt_key, concurrency_holder_key, concurrency_holders_tenant_prefix, end_bound,
+    floating_limit_state_key, job_info_key, leased_task_key, parse_concurrency_holder_key,
 };
 use crate::task::{DEFAULT_LEASE_MS, HeartbeatResult};
 use tracing::{debug, info_span};
@@ -527,5 +528,71 @@ impl JobStoreShard {
         );
 
         Ok(())
+    }
+
+    /// Defensive cleanup: scan tenant-scoped concurrency holders and delete any
+    /// rows attributed to the given `task_id`, releasing the in-memory slot for
+    /// each. Used as a self-healing path when a worker reports outcome for a
+    /// task whose lease has already been reaped — if the reaper somehow failed
+    /// to release the holder atomically, this brings the system back to a
+    /// consistent state.
+    ///
+    /// Returns the number of holder rows deleted. Idempotent: zero deletions on
+    /// repeated calls.
+    pub async fn purge_orphaned_holders_for_task(
+        &self,
+        tenant: &str,
+        task_id: &str,
+    ) -> Result<usize, JobStoreShardError> {
+        let start = concurrency_holders_tenant_prefix(tenant);
+        let end = end_bound(&start);
+        let mut iter: DbIterator = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
+
+        let mut to_delete: Vec<(Vec<u8>, String)> = Vec::new();
+        while let Some(kv) = iter.next().await? {
+            let Some(parsed) = parse_concurrency_holder_key(&kv.key) else {
+                continue;
+            };
+            if parsed.task_id == task_id {
+                to_delete.push((kv.key.to_vec(), parsed.queue));
+            }
+        }
+
+        if to_delete.is_empty() {
+            return Ok(0);
+        }
+
+        let mut batch = WriteBatch::new();
+        for (key, _) in &to_delete {
+            batch.delete(key);
+        }
+        self.db
+            .write_with_options(
+                batch,
+                &WriteOptions {
+                    await_durable: true,
+                },
+            )
+            .await?;
+
+        // Post-commit: drop the in-memory reservation and wake the grant scanner
+        // so a queued requester can be admitted in place of the orphan.
+        for (_, queue) in &to_delete {
+            self.concurrency
+                .counts()
+                .atomic_release(tenant, queue, task_id);
+            self.concurrency.request_grant(tenant, queue);
+            tracing::warn!(
+                tenant = %tenant,
+                queue = %queue,
+                task_id = %task_id,
+                "purged orphaned concurrency holder during late report_outcome cleanup"
+            );
+        }
+
+        Ok(to_delete.len())
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1339,10 +1339,29 @@ impl Silo for SiloService {
                 (AttemptOutcome::Cancelled, "cancelled")
             }
         };
-        shard
-            .report_attempt_outcome(&r.task_id, outcome)
-            .await
-            .map_err(map_err)?;
+        match shard.report_attempt_outcome(&r.task_id, outcome).await {
+            Ok(()) => {}
+            Err(e @ crate::job_store_shard::JobStoreShardError::LeaseNotFound(_)) => {
+                // The lease was already reaped server-side (worker SIGTERM,
+                // crashed mid-task, etc.). Self-heal any stranded concurrency
+                // holders attributed to this task_id so a leaked holder can be
+                // recovered by the worker simply retrying its ack.
+                if let Some(tenant) = r.tenant_id.as_deref().filter(|t| !t.is_empty())
+                    && let Err(purge_err) = shard
+                        .purge_orphaned_holders_for_task(tenant, &r.task_id)
+                        .await
+                {
+                    tracing::warn!(
+                        tenant = %tenant,
+                        task_id = %r.task_id,
+                        error = %purge_err,
+                        "best-effort orphan-holder purge failed during late report_outcome"
+                    );
+                }
+                return Err(map_err(e));
+            }
+            Err(e) => return Err(map_err(e)),
+        }
 
         // Record completion metrics
         if let Some(ref m) = self.metrics {

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -1,0 +1,431 @@
+//! Reproduction tests for `floatingConcurrency` holder leaks.
+//!
+//! These cover code paths where holders ought to be released atomically with the
+//! task transition that ends a lease, but currently may not be.
+
+mod test_helpers;
+
+use silo::codec::{decode_lease, encode_holder, encode_lease};
+use silo::job::{FloatingConcurrencyLimit, Limit};
+use silo::job_attempt::AttemptOutcome;
+use silo::job_store_shard::JobStoreShardError;
+use silo::keys::{concurrency_holder_key, job_info_key};
+use silo::task::{HolderRecord, LeaseRecord};
+
+use test_helpers::*;
+
+fn fc_limit(queue: &str, default_max: u32) -> Limit {
+    Limit::FloatingConcurrency(FloatingConcurrencyLimit {
+        key: queue.to_string(),
+        default_max_concurrency: default_max,
+        refresh_interval_ms: 60_000,
+        metadata: vec![],
+    })
+}
+
+/// Force the worker's lease for `task_id` to be already expired by rewriting the
+/// stored lease record. Mirrors the pattern in
+/// `tests/concurrency_tests.rs::concurrency_reap_expired_lease_releases_holder`.
+async fn expire_first_lease(shard: &silo::job_store_shard::JobStoreShard) {
+    let (lease_key, lease_value) = first_lease_kv(shard.db()).await.expect("lease present");
+    let decoded = decode_lease(lease_value).expect("decode lease");
+    let expired = LeaseRecord {
+        worker_id: decoded.worker_id().to_string(),
+        task: decoded.to_task().unwrap(),
+        expiry_ms: now_ms() - 1,
+        started_at_ms: decoded.started_at_ms(),
+    };
+    shard
+        .db()
+        .put(&lease_key, &encode_lease(&expired))
+        .await
+        .expect("put expired lease");
+    shard.db().flush().await.expect("flush");
+}
+
+/// Headline scenario: a job with a `FloatingConcurrency` limit gets its lease
+/// reaped (worker SIGTERM). The holder must be released so the next requester
+/// can be admitted, and `count_concurrency_holders` must be zero in steady state.
+#[silo::test]
+async fn floating_concurrency_holder_released_on_lease_expiry() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "fl-leak-q".to_string();
+
+    let _job1 = shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![fc_limit(&queue, 1)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue1");
+
+    let leased = shard.dequeue("w1", "default", 1).await.expect("deq1").tasks;
+    assert_eq!(leased.len(), 1, "first job should lease immediately");
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "holder should exist while task is leased"
+    );
+
+    // Worker disappears (SIGTERM) — lease expires, server reaps.
+    expire_first_lease(&shard).await;
+    let reaped = shard.reap_expired_leases("-").await.expect("reap");
+    assert_eq!(reaped, 1);
+
+    // Steady-state invariant: holder must be gone.
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "holder leaked: reaper failed to release it for FloatingConcurrency"
+    );
+    assert_eq!(
+        count_concurrency_holders_for_tenant(shard.db(), "-").await,
+        0,
+        "tenant-scoped holder count should also be zero"
+    );
+}
+
+/// After a lease has been reaped server-side, the worker may still call
+/// `report_attempt_outcome` with the same task_id (race against reap). That call
+/// must return `LeaseNotFound` AND must not leave any orphaned holder behind.
+#[silo::test]
+async fn floating_concurrency_holder_released_when_report_outcome_after_reap() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "fl-late-ack-q".to_string();
+
+    shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![fc_limit(&queue, 1)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+
+    let leased = shard.dequeue("w1", "default", 1).await.expect("deq").tasks;
+    assert_eq!(leased.len(), 1);
+    let task_id = leased[0].attempt().task_id().to_string();
+
+    expire_first_lease(&shard).await;
+    let reaped = shard.reap_expired_leases("-").await.expect("reap");
+    assert_eq!(reaped, 1);
+
+    // Late ack from the worker that just came back: server should signal not-found,
+    // and the steady state must still have zero holders.
+    let result = shard
+        .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+        .await;
+    assert!(
+        matches!(result, Err(JobStoreShardError::LeaseNotFound(_))),
+        "report_attempt_outcome on a reaped task should return LeaseNotFound, got {:?}",
+        result
+    );
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "holder must remain released after a late report_attempt_outcome"
+    );
+}
+
+/// Direct reproduction of a real holder-leak path: a `RunAttempt` task is
+/// dequeued (the concurrency grant already wrote a holder at enqueue time), but
+/// `handle_run_attempt` finds no `job_info` for the task. Today
+/// (`dequeue.rs:657-662`) it deletes the task and returns Ok without releasing
+/// the held queues — the holder is stranded.
+///
+/// Job-info-missing-while-task-exists shows up at least via:
+///   - mid-flight tenant migration (new shard has the row, old shard's task
+///     still references the now-missing job_info)
+///   - background cleanup that deletes job_info ahead of derived data
+///   - an import/restore that wrote a partial state
+#[silo::test]
+async fn holder_leaked_when_run_attempt_finds_missing_job_info() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "fl-missing-job-q".to_string();
+
+    let job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![fc_limit(&queue, 1)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+
+    // FloatingConcurrency granted at enqueue time → holder + RunAttempt task.
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+
+    // Simulate the job_info disappearing before the worker dequeues.
+    let mut delete_batch = slatedb::WriteBatch::new();
+    delete_batch.delete(&job_info_key(tenant, &job_id));
+    shard
+        .db()
+        .write(delete_batch)
+        .await
+        .expect("delete job_info");
+    shard.db().flush().await.expect("flush");
+
+    // Worker dequeues. handle_run_attempt at dequeue.rs:657-662 deletes the
+    // task and returns Ok without releasing held_queues.
+    let result = shard.dequeue("w1", "default", 1).await.expect("dequeue");
+    assert_eq!(
+        result.tasks.len(),
+        0,
+        "task is dropped because job_info is missing"
+    );
+
+    // BUG: the holder is now stranded — no task, no lease, no job, but the
+    // FloatingConcurrency cap is still consumed by this dead grant.
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "holder must be released when handle_run_attempt drops a task with held_queues",
+    );
+}
+
+// NOTE: there is a separate dormant holder-leak bug at `dequeue.rs:534-541`
+// (handle_check_rate_limit's max-retries early return drops the task without
+// releasing `held_queues`). It cannot be exercised today because
+// `record_grant_outcome` at `src/job_store_shard/enqueue.rs:67-80` swaps the
+// None/Some arms relative to what `concurrency::handle_enqueue` returns, so
+// chained limits never advance past the first grant — `held_queues` therefore
+// never accumulate inside a CheckRateLimit task. The two should be fixed
+// together; flagging here so a follow-up PR can do both.
+
+/// Defensive idempotency: a stranded holder (no corresponding lease and no
+/// task) must be removable by an explicit purge call. This is the recovery hook
+/// the gRPC handler invokes when a worker reports outcome for a task whose
+/// lease has already been reaped, so workers can self-heal a leaked holder by
+/// retrying their ack.
+#[silo::test]
+async fn purge_orphaned_holders_for_task_removes_stranded_holders() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue_a = "purge-q-a";
+    let queue_b = "purge-q-b";
+    let task_id = "orphan-task-id";
+    let other_task_id = "other-task-id";
+
+    // Manually plant orphaned holders (no lease, no task).
+    let holder_val = encode_holder(&HolderRecord {
+        granted_at_ms: now_ms(),
+    });
+    shard
+        .db()
+        .put(
+            &concurrency_holder_key(tenant, queue_a, task_id),
+            &holder_val,
+        )
+        .await
+        .expect("put holder a");
+    shard
+        .db()
+        .put(
+            &concurrency_holder_key(tenant, queue_b, task_id),
+            &holder_val,
+        )
+        .await
+        .expect("put holder b");
+    // A holder for an unrelated task — must be left alone.
+    shard
+        .db()
+        .put(
+            &concurrency_holder_key(tenant, queue_a, other_task_id),
+            &holder_val,
+        )
+        .await
+        .expect("put unrelated holder");
+    shard.db().flush().await.expect("flush");
+    assert_eq!(count_concurrency_holders(shard.db()).await, 3);
+
+    let purged = shard
+        .purge_orphaned_holders_for_task(tenant, task_id)
+        .await
+        .expect("purge");
+    assert_eq!(purged, 2, "should report two holders deleted");
+
+    // Only the unrelated holder remains.
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+
+    // Idempotent: calling again is a no-op.
+    let purged_again = shard
+        .purge_orphaned_holders_for_task(tenant, task_id)
+        .await
+        .expect("purge again");
+    assert_eq!(purged_again, 0);
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+}
+
+/// End-to-end variant: a worker calls `report_attempt_outcome` for a task_id
+/// whose lease was already reaped. The server returns LeaseNotFound. The worker
+/// (or the gRPC layer) then invokes `purge_orphaned_holders_for_task` and the
+/// stranded holder is gone.
+#[silo::test]
+async fn late_report_outcome_followed_by_purge_clears_holder() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "fl-late-purge-q".to_string();
+
+    shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![fc_limit(&queue, 1)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+
+    let leased = shard.dequeue("w1", "default", 1).await.expect("deq").tasks;
+    let task_id = leased[0].attempt().task_id().to_string();
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+
+    // Plant an extra stale holder under the same task_id to simulate an
+    // orphan that escaped a prior release path. (We can't reproduce the
+    // production failure mode here, but we can prove purge cleans it up.)
+    let stale_queue = "stale-extra-q";
+    shard
+        .db()
+        .put(
+            &concurrency_holder_key(tenant, stale_queue, &task_id),
+            &encode_holder(&HolderRecord {
+                granted_at_ms: now_ms(),
+            }),
+        )
+        .await
+        .expect("plant stale");
+    shard.db().flush().await.expect("flush");
+    assert_eq!(count_concurrency_holders(shard.db()).await, 2);
+
+    expire_first_lease(&shard).await;
+    shard.reap_expired_leases(tenant).await.expect("reap");
+    // Reaper handled the legitimate held queue; the planted orphan remains.
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+
+    // Worker comes back with a late ack — server signals not-found.
+    let res = shard
+        .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+        .await;
+    assert!(matches!(res, Err(JobStoreShardError::LeaseNotFound(_))));
+
+    // gRPC handler should call purge in this case → stale holder is gone.
+    shard
+        .purge_orphaned_holders_for_task(tenant, &task_id)
+        .await
+        .expect("purge");
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "purge after late ack should remove the planted orphan"
+    );
+}
+
+/// Drive several jobs through enqueue → lease → mixture of (success, reap) and
+/// assert that the per-tenant holder count is zero in steady state. Guards
+/// against double-release and accounting drift across concurrent grants.
+#[silo::test]
+async fn floating_concurrency_steady_state_zero_holders_after_full_cycle() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "fl-cycle-q".to_string();
+
+    // Cap = 3 with 3 jobs, all leased concurrently.
+    for i in 0..3 {
+        shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now,
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({"i": i})),
+                vec![fc_limit(&queue, 3)],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+    }
+
+    let leased = shard.dequeue("w1", "default", 3).await.expect("deq").tasks;
+    assert_eq!(leased.len(), 3);
+    assert_eq!(count_concurrency_holders(shard.db()).await, 3);
+
+    // Succeed one explicitly.
+    shard
+        .report_attempt_outcome(
+            leased[0].attempt().task_id(),
+            AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("report success");
+
+    // Reap the rest by expiring all remaining leases.
+    let now_minus_1 = now_ms() - 1;
+    let leases_prefix = silo::keys::leases_prefix();
+    let leases_end = silo::keys::end_bound(&leases_prefix);
+    let mut iter = shard
+        .db()
+        .scan::<Vec<u8>, _>(leases_prefix..leases_end)
+        .await
+        .expect("scan leases");
+    let mut to_expire: Vec<(Vec<u8>, bytes::Bytes)> = Vec::new();
+    while let Some(kv) = iter.next().await.expect("iter") {
+        to_expire.push((kv.key.to_vec(), kv.value));
+    }
+    for (lease_key, lease_value) in to_expire {
+        let decoded = decode_lease(lease_value).expect("decode lease");
+        let expired = LeaseRecord {
+            worker_id: decoded.worker_id().to_string(),
+            task: decoded.to_task().unwrap(),
+            expiry_ms: now_minus_1,
+            started_at_ms: decoded.started_at_ms(),
+        };
+        shard
+            .db()
+            .put(&lease_key, &encode_lease(&expired))
+            .await
+            .expect("put expired");
+    }
+    shard.db().flush().await.expect("flush");
+    shard.reap_expired_leases("-").await.expect("reap");
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "holders must be zero after every job has reached a terminal state"
+    );
+    assert_eq!(
+        count_concurrency_holders_for_tenant(shard.db(), "-").await,
+        0,
+        "per-tenant holder count must be zero too"
+    );
+}


### PR DESCRIPTION
Problem

  In production, floatingConcurrency holder rows accumulate to exactly defaultMaxConcurrency per (tenant, queue), with job_id = NULL (the corresponding job is gone). Once the cap is hit, no new requesters are admitted — the limit is permanently
  saturated. One observed tenant: 540 stranded holders spanning a ~7.5h window, with 588k requesters piled up waiting.

  Root cause (one path proven)

  JobStoreShard::handle_run_attempt in src/job_store_shard/dequeue.rs looks up job_info for the task it's about to lease. If job_info is missing it deletes the task and returns Ok — without releasing the concurrency holders the task acquired at
  enqueue time. The holder was created atomically with the task at enqueue, but the cleanup only handled the task half:

  let Some(job_bytes) = maybe_job else {
      state.batch.delete(task_key);  // task: gone
      state.ack_deleted(task_key);
      return Ok(());                  // holder: still there, forever
  };

  Once we land in this branch, the holder is unreachable to every other release path: the reaper only walks lease records (no lease was ever created), report_attempt_outcome only releases holders attached to a lease (none), and the grant scanner
   only creates holders. Repeat per affected job until the cap is saturated.

  I have not nailed down what causes job_info to go missing on the owning shard in production. The leak path itself is reproduced deterministically in a unit test by manually deleting job_info_key after enqueue and before dequeue. The fix is
  defensible regardless of the upstream cause, since the dequeue path shouldn't strand a holder under any precondition failure.

  Fix

  src/job_store_shard/dequeue.rs — handle_run_attempt's missing-job branch now deletes each concurrency_holder_key(tenant, queue, task_id) for every entry in the RunAttempt's held_queues in the same batch as the task delete. A new
  holder_releases accumulator on DequeueIterationState carries these to a post-commit step that runs atomic_release + request_grant for each, dropping the in-memory cap and waking the grant scanner so a queued requester takes the freed slot
  immediately. Includes a tracing::warn! so this path is observable if it fires.

  src/job_store_shard/lease.rs — added JobStoreShard::purge_orphaned_holders_for_task(tenant, task_id). Tenant-scoped scan (bounded by the cap) that deletes any holder rows attributed to task_id and post-commit calls atomic_release +
  request_grant. Idempotent.

  src/server.rs — when the gRPC report_outcome returns LeaseNotFound, the handler now invokes purge_orphaned_holders_for_task (when tenant_id is on the request) before returning the error. This is the "defensive idempotent cleanup" hook so that
  a worker hitting TaskNotFoundError on a retry causes any matching stranded holder to be cleaned up. Belt-and-suspenders for any leak path I haven't found.

  Tests (tests/holder_leak_tests.rs, all passing)

  - holder_leaked_when_run_attempt_finds_missing_job_info — the direct reproduction. Fails before the fix, passes after.
  - floating_concurrency_holder_released_on_lease_expiry — invariant: the simple reaper path releases the holder.
  - floating_concurrency_holder_released_when_report_outcome_after_reap — invariant: a late ack after reap returns LeaseNotFound and leaves no holder.
  - purge_orphaned_holders_for_task_removes_stranded_holders — the purge primitive: removes target holders, leaves unrelated ones, idempotent.
  - late_report_outcome_followed_by_purge_clears_holder — end-to-end: late ack + purge clears a planted orphan.
  - floating_concurrency_steady_state_zero_holders_after_full_cycle — drives multiple jobs through enqueue → lease → mixed (success, reap) and asserts zero holders remain.

  Each test ends with count_concurrency_holders == 0 as a steady-state invariant so future regressions in any release path will fire here.

  Out of scope (flagged for follow-up)

  I found two pre-existing bugs while investigating. Neither matches the production fingerprint (gadget uses a single FloatingConcurrency limit, not a chain), so I did not fix them in this PR:

  - Chained-limit advancement is broken at src/job_store_shard/enqueue.rs:67-80. record_grant_outcome swaps the None/Some arms relative to what concurrency::handle_enqueue returns, so any job with multiple limits stops at the first grant. Easy
  reproduction: [Concurrency, Concurrency] produces 1 holder instead of 2.
  - CheckRateLimit max-retries silently drops held_queues at src/job_store_shard/dequeue.rs:534-541. Dormant today (chains never advance, so CheckRateLimit tasks never accumulate held_queues), but will leak as soon as the chain bug is fixed.

  These should be fixed together in a follow-up.

  Verification

  - cargo test --test holder_leak_tests — 6/6 pass.
  - cargo test --test concurrency_tests --test floating_concurrency_tests — 22/22 and 21/21 still pass.
  - cargo test --tests — all pass except cluster_query_integration_tests which require a local etcd; unrelated to these changes.

  After merge, query production for entry_type = 'holder' AND job_id IS NULL. The leak rate on new traffic should be zero. Existing leaked holders for affected tenants need a one-time cleanup (not done here — out of scope).

  Risk

  - The new dequeue post-commit step adds an atomic_release + request_grant call per holder released in the missing-job branch. Hot path is unchanged for the normal case (the loop is empty when no holders were dropped).
  - purge_orphaned_holders_for_task is only called from the LeaseNotFound error path on report_outcome. Tenant-scoped scan, bounded by the cap (hundreds of holders typical), so cost is acceptable for an exception path.
  - No protocol changes. No client changes required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency holder lifecycle across dequeue and outcome reporting; mistakes could cause incorrect capacity accounting or extra DB work on error paths, but changes are mostly defensive and isolated to cleanup branches.
> 
> **Overview**
> Fixes a holder-leak where `RunAttempt` tasks dropped during dequeue (missing `job_info`) could strand `FloatingConcurrency` holder rows and permanently consume queue capacity.
> 
> `dequeue` now deletes any `concurrency_holder_key`s associated with a dropped task and performs a post-commit in-memory `atomic_release` + `request_grant` wakeup to immediately free capacity. Adds a new `purge_orphaned_holders_for_task` API that tenant-scans and deletes holder rows for a `task_id`, and the gRPC `report_outcome` handler invokes it on `LeaseNotFound` as best-effort self-healing.
> 
> Adds `tests/holder_leak_tests.rs` covering lease-reap, missing-job-info drop, late outcome reporting, purge idempotency, and steady-state “zero holders” invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b6381e71c6fcee820710feb661ac9412fcda42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->