### PR TITLE
Record silo_concurrency_tickets_granted_total from grant scanner

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -61,6 +61,7 @@ use crate::keys::{
     concurrency_requests_prefix, end_bound, floating_limit_state_key, job_status_key,
     parse_concurrency_holder_key, parse_concurrency_request_key, task_key,
 };
+use crate::metrics::Metrics;
 use crate::shard_range::ShardRange;
 use crate::task::{ConcurrencyAction, HolderRecord, Task};
 use crate::task_broker::TaskBrokerRegistry;
@@ -377,22 +378,24 @@ pub struct ConcurrencyManager {
     /// In-memory cache of resolved concurrency limits per queue.
     /// Key: concurrency_counts_key(tenant, queue). Populated during enqueue and grant_next.
     limit_cache: Mutex<HashMap<Vec<u8>, CachedQueueLimit>>,
+    metrics: Option<Metrics>,
 }
 
 impl Default for ConcurrencyManager {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
 impl ConcurrencyManager {
-    pub fn new() -> Self {
+    pub fn new(metrics: Option<Metrics>) -> Self {
         Self {
             counts: ConcurrencyCounts::new(),
             pending_grants: Mutex::new(BTreeMap::new()),
             grant_notify: tokio::sync::Notify::new(),
             grant_running: AtomicBool::new(false),
             limit_cache: Mutex::new(HashMap::new()),
+            metrics,
         }
     }
 
@@ -1099,6 +1102,12 @@ impl ConcurrencyManager {
                 task_group = %task_group,
                 "grant scanner: granted concurrency ticket"
             );
+        }
+
+        if let Some(ref m) = self.metrics {
+            for _ in 0..grants.len() {
+                m.record_concurrency_ticket_granted();
+            }
         }
 
         grants.into_iter().map(|(_, tg)| tg).collect()

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -356,7 +356,7 @@ impl JobStoreShard {
 
         let db = db_builder.build().await?;
         let db = Arc::new(db);
-        let concurrency = Arc::new(ConcurrencyManager::new());
+        let concurrency = Arc::new(ConcurrencyManager::new(metrics.clone()));
 
         // Note: concurrency counts are hydrated lazily on first access to each queue.
         // This avoids blocking shard startup while scanning potentially large holder sets.

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -1728,6 +1728,105 @@ async fn grant_scanner_handles_all_stale_requests() {
     );
 }
 
+/// Tests that the grant scanner increments the `silo_concurrency_tickets_granted_total`
+/// counter once per ticket it grants. Without this, the metric only reflects the
+/// synchronous dequeue path (handle_request_ticket) and goes silent the moment a
+/// queue first hits its concurrency limit, since all subsequent grants flow through
+/// the async grant scanner as holders are released.
+#[silo::test]
+async fn grant_scanner_records_concurrency_ticket_granted_metric() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let queue = "metric-q";
+    let tenant = "metric-tenant";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: 2,
+    });
+
+    shard.stop_grant_scanner();
+
+    // Fill the 2 concurrency slots
+    let mut holder_tasks = Vec::new();
+    for i in 0..2 {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("holder-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+    for _ in 0..2 {
+        let tasks = shard.dequeue("w", "tg", 1).await.unwrap().tasks;
+        holder_tasks.push(tasks[0].attempt().task_id().to_string());
+    }
+
+    let baseline = read_concurrency_tickets_granted(&metrics);
+
+    // Enqueue 3 more jobs that will queue as concurrency requests (queue is full).
+    for i in 0..3 {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("waiter-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+
+    // Free both slots so the grant scanner has capacity to grant the waiters.
+    for task_id in &holder_tasks {
+        shard
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .unwrap();
+    }
+
+    // Drive the async grant-scanner path directly.
+    let granted = shard.process_concurrency_grants(tenant, queue, 2).await;
+    assert_eq!(granted.len(), 2, "should grant 2 of the 3 waiters");
+
+    let after = read_concurrency_tickets_granted(&metrics);
+    assert_eq!(
+        after - baseline,
+        2.0,
+        "process_grants must increment the counter once per granted ticket"
+    );
+}
+
+/// Read the current value of the `silo_concurrency_tickets_granted_total` counter
+/// out of the Prometheus registry. The counter is unlabelled, so we just sum the
+/// single sample.
+fn read_concurrency_tickets_granted(metrics: &silo::metrics::Metrics) -> f64 {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|f| f.get_name() == "silo_concurrency_tickets_granted_total")
+        .map(|f| {
+            f.get_metric()
+                .iter()
+                .map(|m| m.get_counter().get_value())
+                .sum()
+        })
+        .unwrap_or(0.0)
+}
+
 /// Tests that stale requests interleaved with valid ones are handled correctly:
 /// the grant scanner should skip stale ones and keep scanning to find valid ones.
 #[silo::test]

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -54,6 +54,36 @@ pub async fn open_temp_shard() -> (tempfile::TempDir, std::sync::Arc<JobStoreSha
     open_temp_shard_with_rate_limiter(rate_limiter).await
 }
 
+/// Open a temp shard wired to a fresh Metrics registry, returning both so tests
+/// can read counter values directly without going through the Prometheus endpoint.
+pub async fn open_temp_shard_with_metrics() -> (
+    tempfile::TempDir,
+    std::sync::Arc<JobStoreShard>,
+    silo::metrics::Metrics,
+) {
+    let rate_limiter = MockGubernatorClient::new_arc();
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = DatabaseConfig {
+        name: "test".to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        wal: None,
+        apply_wal_on_close: true,
+        slatedb: Some(fast_flush_slatedb_settings()),
+        memory_cache: None,
+    };
+    let metrics = silo::metrics::init().expect("init metrics");
+    let shard = JobStoreShard::open(
+        &cfg,
+        rate_limiter,
+        Some(metrics.clone()),
+        ShardRange::full(),
+    )
+    .await
+    .expect("open shard");
+    (tmp, shard, metrics)
+}
+
 /// Open a temp shard with a custom periodic concurrency reconciliation interval.
 pub async fn open_temp_shard_with_reconcile_interval_ms(
     interval_ms: u64,


### PR DESCRIPTION
## Summary
- `silo_concurrency_tickets_granted_total` was only incremented on the synchronous `RequestTicket` dequeue path (`handle_request_ticket`), so it went silent the moment a queue first hit its concurrency limit — every subsequent grant flows through the async grant scanner as holders release, which never touched the counter.
- Wire `Metrics` into `ConcurrencyManager` and increment the counter once per granted ticket in `process_grants`, after the durable batch write succeeds (so failed writes that roll back reservations don't get counted).
- Adds an `open_temp_shard_with_metrics` test helper and a regression test that drives `process_grants` directly and asserts the counter increments by exactly the number of grants.

## Test plan
- [x] `cargo test --test job_store_shard_concurrency_tests` (21 passed)
- [x] New `grant_scanner_records_concurrency_ticket_granted_metric` test passes