### PR TITLE
Build dev image on pushes to main

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -1,6 +1,9 @@
 name: Build Dev Image
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       push:
@@ -41,7 +44,7 @@ jobs:
           docker load < result
 
       - name: Authenticate gcloud
-        if: ${{ inputs.push }}
+        if: ${{ github.event_name == 'push' || inputs.push }}
         id: auth
         uses: google-github-actions/auth@v2
         with:
@@ -50,7 +53,7 @@ jobs:
           service_account: ${{ vars.GCLOUD_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Login to Google Artifact Registry
-        if: ${{ inputs.push }}
+        if: ${{ github.event_name == 'push' || inputs.push }}
         uses: docker/login-action@v3
         with:
           registry: us-central1-docker.pkg.dev
@@ -58,7 +61,7 @@ jobs:
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Tag and push image
-        if: ${{ inputs.push }}
+        if: ${{ github.event_name == 'push' || inputs.push }}
         run: |
           sha=$(git rev-parse --short HEAD)
           registry="us-central1-docker.pkg.dev/gadget-core-production/core-production/silo"
@@ -72,7 +75,7 @@ jobs:
   merge-docker-dev-manifests:
     name: Merge Docker dev manifests
     needs: build-docker-dev
-    if: ${{ inputs.push }}
+    if: ${{ github.event_name == 'push' || inputs.push }}
     runs-on: ubuntu-latest
     permissions:
       contents: "read"


### PR DESCRIPTION
## Summary
- Adds a `push` trigger to `.github/workflows/build-dev-image.yml` for the `main` branch so the dev image builds and pushes whenever PRs merge.
- Updates the four `if: ${{ inputs.push }}` gates (auth, registry login, tag/push, manifest merge job) to also fire on push events, where `inputs.push` is empty.

## Test plan
- [ ] Merge to main triggers the workflow and successfully pushes `silo-dev:sha-<sha>` and `silo-dev:latest` multi-arch manifests.
- [ ] `workflow_dispatch` still works with the `push` input toggle.