### PR TITLE
Parallelize Docker builds and push to Cachix on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,28 +322,23 @@ jobs:
         with:
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Build silo Docker image with Nix
+      - name: Build Docker images with Nix
         run: |
-          nix build .#packages.${{ matrix.nix_system }}.silo-docker -L
-          docker load < result
-
-      - name: Build silo-autoscaler Docker image with Nix
-        run: |
-          nix build .#packages.${{ matrix.nix_system }}.silo-autoscaler-docker -L
-          docker load < result
-
-      - name: Build silo-compactor Docker image with Nix
-        run: |
-          nix build .#packages.${{ matrix.nix_system }}.silo-compactor-docker -L
-          docker load < result
+          nix build -L \
+            .#packages.${{ matrix.nix_system }}.silo-docker \
+            .#packages.${{ matrix.nix_system }}.silo-autoscaler-docker \
+            .#packages.${{ matrix.nix_system }}.silo-compactor-docker \
+            -o result-silo -o result-autoscaler -o result-compactor
+          docker load < result-silo
+          docker load < result-autoscaler
+          docker load < result-compactor
 
       - name: Push to Cachix
-        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
-          # Push the silo binary and its dependencies to Cachix for future builds
-          cachix push silo result
+          # Push the silo binaries and their dependencies to Cachix for future builds
+          cachix push silo result-silo result-autoscaler result-compactor
 
       - name: Authenticate gcloud
         if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,18 +327,18 @@ jobs:
           nix build -L \
             .#packages.${{ matrix.nix_system }}.silo-docker \
             .#packages.${{ matrix.nix_system }}.silo-autoscaler-docker \
-            .#packages.${{ matrix.nix_system }}.silo-compactor-docker \
-            -o result-silo -o result-autoscaler -o result-compactor
-          docker load < result-silo
-          docker load < result-autoscaler
-          docker load < result-compactor
+            .#packages.${{ matrix.nix_system }}.silo-compactor-docker
+          # nix build creates result, result-1, result-2 for multiple installables
+          docker load < result
+          docker load < result-1
+          docker load < result-2
 
       - name: Push to Cachix
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
           # Push the silo binaries and their dependencies to Cachix for future builds
-          cachix push silo result-silo result-autoscaler result-compactor
+          cachix push silo result result-1 result-2
 
       - name: Authenticate gcloud
         if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary
- Build `silo`, `silo-autoscaler`, and `silo-compactor` Docker images in a single `nix build` invocation so the shared Rust workspace artifacts are realized once instead of three times per arch.
- Run the Cachix push step on PR builds (not just `main`/`workflow_dispatch`) so cold builds populate the cache for subsequent runs — especially useful for arm64 wall-clock.
- The dev image workflow (`build-dev-image.yml`) is intentionally left alone.

## Test plan
- [ ] CI on this PR completes successfully on both amd64 and arm64.
- [ ] Confirm the `Push to Cachix` step uploads the closure on this PR run.
- [ ] Confirm a follow-up run (e.g. push another commit) sees Cachix cache hits and finishes faster on arm64.