### PR TITLE
Add Prometheus metrics endpoint to silo-compactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5486,6 +5486,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "object_store",
+ "prometheus",
  "serde",
  "serde_json",
  "silo",

--- a/deploy/local-test/compactor-config.toml
+++ b/deploy/local-test/compactor-config.toml
@@ -29,6 +29,10 @@ worker_restart_backoff = "2s"
 [logging]
 format = "json"
 
+[metrics]
+enabled = true
+addr = "0.0.0.0:9090"
+
 [compactor_options]
 poll_interval = "5s"
 max_sst_size = 67108864

--- a/deploy/local-test/compactor-deployment.yaml
+++ b/deploy/local-test/compactor-deployment.yaml
@@ -26,6 +26,10 @@ data:
     [logging]
     format = "json"
 
+    [metrics]
+    enabled = true
+    addr = "0.0.0.0:9090"
+
     [compactor_options]
     poll_interval = "5s"
     max_sst_size = 67108864

--- a/example_configs/compactor-dev.toml
+++ b/example_configs/compactor-dev.toml
@@ -23,6 +23,11 @@ worker_restart_backoff = "5s"
 [logging]
 format = "text"
 
+[metrics]
+enabled = true
+# silo-1/silo-2 already use 9090/9091; pick 9092 for the dev compactor.
+addr = "127.0.0.1:9092"
+
 [compactor_options]
 poll_interval = "5s"
 max_sst_size = 67108864

--- a/silo-compactor/Cargo.toml
+++ b/silo-compactor/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 slatedb = { version = "0.12.0", features = ["compaction_filters"] }
 slatedb-common = "0.12.0"
 object_store = { version = "0.12", features = ["gcp"] }
+prometheus = "0.13"
 
 # silo pulls in codec/keys/job types for the compaction filter. default-features
 # are disabled so we don't transitively pull kube/k8s through silo (silo-compactor

--- a/silo-compactor/src/compaction_filter.rs
+++ b/silo-compactor/src/compaction_filter.rs
@@ -42,6 +42,8 @@ use slatedb::{
 };
 use tracing::{debug, info, warn};
 
+use crate::metrics::CompactorMetrics;
+
 /// Terminal status strings as stored in IDX_STATUS_TIME keys.
 const TERMINAL_STATUSES: &[&str] = &["Succeeded", "Failed", "Cancelled"];
 
@@ -153,6 +155,9 @@ pub struct CompletedJobCompactionFilterSupplier {
     /// Soft cap on the pre-scanned [`ExpiredSet`]. `0` disables the
     /// pre-scan entirely (every `is_job_expired` becomes a point read).
     expired_set_max_entries: usize,
+    /// Optional Prometheus metrics handle + the shard label to tag emitted
+    /// counters with. Both are populated together via [`with_metrics`].
+    metrics: Option<(Arc<CompactorMetrics>, String)>,
 }
 
 /// Everything needed to open a short-lived [`DbReader`].
@@ -171,6 +176,7 @@ impl CompletedJobCompactionFilterSupplier {
             retention,
             reader_ctx: Some(ReaderContext { db_path, store }),
             expired_set_max_entries: DEFAULT_EXPIRED_SET_MAX_ENTRIES,
+            metrics: None,
         }
     }
 
@@ -181,12 +187,21 @@ impl CompletedJobCompactionFilterSupplier {
         self
     }
 
+    /// Attach a Prometheus metrics handle. Counters/histograms emitted by
+    /// produced filters will carry `shard_label` so multi-shard pods share
+    /// one registry without collisions.
+    pub fn with_metrics(mut self, metrics: Arc<CompactorMetrics>, shard_label: String) -> Self {
+        self.metrics = Some((metrics, shard_label));
+        self
+    }
+
     #[cfg(test)]
     fn new_without_reader(retention: Duration) -> Self {
         Self {
             retention,
             reader_ctx: None,
             expired_set_max_entries: DEFAULT_EXPIRED_SET_MAX_ENTRIES,
+            metrics: None,
         }
     }
 }
@@ -230,20 +245,35 @@ impl CompactionFilterSupplier for CompletedJobCompactionFilterSupplier {
         let expired = match reader.as_ref() {
             Some(r) => {
                 let started = Instant::now();
-                match build_expired_set(r, cutoff_ms, self.expired_set_max_entries).await {
+                let result = build_expired_set(r, cutoff_ms, self.expired_set_max_entries).await;
+                let elapsed = started.elapsed();
+                match result {
                     Ok(Some(set)) => {
+                        if let Some((m, shard)) = &self.metrics {
+                            m.record_filter_pre_scan(
+                                shard,
+                                elapsed.as_secs_f64(),
+                                set.len() as u64,
+                            );
+                        }
                         info!(
                             entries = set.len(),
-                            elapsed_ms = started.elapsed().as_millis() as u64,
+                            elapsed_ms = elapsed.as_millis() as u64,
                             cap = self.expired_set_max_entries,
                             "completed_jobs filter: pre-scan ready"
                         );
                         Some(Arc::new(set))
                     }
                     Ok(None) => {
+                        if let Some((m, shard)) = &self.metrics {
+                            // Pre-scan ran but exceeded the cap (or was disabled): record
+                            // wall-clock so dashboards show "pre-scan happened but didn't
+                            // build a set" without polluting entry counts.
+                            m.record_filter_pre_scan(shard, elapsed.as_secs_f64(), 0);
+                        }
                         warn!(
                             cap = self.expired_set_max_entries,
-                            elapsed_ms = started.elapsed().as_millis() as u64,
+                            elapsed_ms = elapsed.as_millis() as u64,
                             "completed_jobs filter: pre-scan exceeded cap or disabled, \
                              falling back to per-row point reads"
                         );
@@ -273,6 +303,7 @@ impl CompactionFilterSupplier for CompletedJobCompactionFilterSupplier {
             dropped_idx_metadata: 0,
             dropped_attempt: 0,
             dropped_job_cancelled: 0,
+            metrics: self.metrics.clone(),
         }))
     }
 }
@@ -300,6 +331,10 @@ pub struct CompletedJobCompactionFilter {
     dropped_idx_metadata: u64,
     dropped_attempt: u64,
     dropped_job_cancelled: u64,
+
+    /// Optional Prometheus metrics handle, paired with the shard label that
+    /// emitted counters/histograms should be tagged with.
+    metrics: Option<(Arc<CompactorMetrics>, String)>,
 }
 
 impl CompletedJobCompactionFilter {
@@ -451,6 +486,19 @@ impl CompactionFilter for CompletedJobCompactionFilter {
     async fn on_compaction_end(&mut self) -> Result<(), CompactionFilterError> {
         let total = self.total_dropped();
 
+        if let Some((m, shard)) = &self.metrics {
+            for (prefix, n) in [
+                ("job_info", self.dropped_job_info),
+                ("job_status", self.dropped_status),
+                ("idx_status_time", self.dropped_idx_status_time),
+                ("idx_metadata", self.dropped_idx_metadata),
+                ("attempt", self.dropped_attempt),
+                ("job_cancelled", self.dropped_job_cancelled),
+            ] {
+                m.record_filter_rows_dropped(shard, prefix, n);
+            }
+        }
+
         if total > 0 {
             debug!(
                 total,
@@ -514,6 +562,7 @@ mod tests {
             dropped_idx_metadata: 0,
             dropped_attempt: 0,
             dropped_job_cancelled: 0,
+            metrics: None,
         }
     }
 

--- a/silo-compactor/src/config.rs
+++ b/silo-compactor/src/config.rs
@@ -19,6 +19,34 @@ pub struct AppConfig {
     pub compactor_options: Option<slatedb::config::CompactorOptions>,
     #[serde(default)]
     pub compaction_filter: CompactionFilterConfig,
+    #[serde(default)]
+    pub metrics: MetricsConfig,
+}
+
+/// Prometheus metrics endpoint configuration. Mirrors `silo::settings::MetricsConfig`
+/// so operators see the same `[metrics]` block in compactor and silo configs.
+#[derive(Debug, Deserialize, Clone)]
+pub struct MetricsConfig {
+    #[serde(default = "default_metrics_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_metrics_addr")]
+    pub addr: String,
+}
+
+impl Default for MetricsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_metrics_enabled(),
+            addr: default_metrics_addr(),
+        }
+    }
+}
+
+fn default_metrics_enabled() -> bool {
+    true
+}
+fn default_metrics_addr() -> String {
+    "0.0.0.0:9090".into()
 }
 
 /// Compaction filter selection. Defaults to [`CompactionFilterConfig::None`]
@@ -292,6 +320,29 @@ mod tests {
         assert_eq!(cfg.coordinator.mode, CoordinatorMode::K8sDeployment);
         assert!(cfg.compactor_options.is_none());
         assert_eq!(cfg.compaction_filter, CompactionFilterConfig::None);
+        assert!(cfg.metrics.enabled);
+        assert_eq!(cfg.metrics.addr, "0.0.0.0:9090");
+    }
+
+    #[test]
+    fn parses_explicit_metrics_block() {
+        let toml_str = r#"
+            [storage]
+            backend = "fs"
+            path = "/tmp/silo/%shard%"
+
+            [shard_discovery]
+            backend = "etcd"
+            cluster_prefix = "silo-dev"
+            etcd_endpoints = ["http://127.0.0.1:2379"]
+
+            [metrics]
+            enabled = false
+            addr = "127.0.0.1:9091"
+        "#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        assert!(!cfg.metrics.enabled);
+        assert_eq!(cfg.metrics.addr, "127.0.0.1:9091");
     }
 
     #[test]

--- a/silo-compactor/src/coordinator.rs
+++ b/silo-compactor/src/coordinator.rs
@@ -8,6 +8,7 @@ use tracing::{debug, info, warn};
 use crate::assignment::compute_assignment;
 use crate::config::{AppConfig, CompactionFilterConfig, CoordinatorMode, ShardDiscoveryBackend};
 use crate::error::CompactorError;
+use crate::metrics::CompactorMetrics;
 use crate::pod_discovery::{K8sPodDiscovery, PodDiscovery, StaticPodDiscovery};
 use crate::shard_loader::ShardMapLoader;
 use crate::shard_loader::etcd::EtcdShardMapLoader;
@@ -30,10 +31,14 @@ pub struct Coordinator {
     worker_backoff: Duration,
     workers: HashMap<ShardId, WorkerHandle>,
     pod_change_rx: Option<mpsc::Receiver<()>>,
+    metrics: Option<Arc<CompactorMetrics>>,
 }
 
 impl Coordinator {
-    pub async fn from_config(cfg: AppConfig) -> Result<Self, CompactorError> {
+    pub async fn from_config(
+        cfg: AppConfig,
+        metrics: Option<Arc<CompactorMetrics>>,
+    ) -> Result<Self, CompactorError> {
         let self_pod_name = cfg
             .resolve_self_pod_name()
             .map_err(|e| CompactorError::Config(e.to_string()))?;
@@ -125,6 +130,7 @@ impl Coordinator {
             worker_backoff: cfg.coordinator.worker_restart_backoff,
             workers: HashMap::new(),
             pod_change_rx,
+            metrics,
         })
     }
 
@@ -192,8 +198,14 @@ impl Coordinator {
                 Arc::clone(&self.compactor_options),
                 Arc::clone(&self.filter_config),
                 self.worker_backoff,
+                self.metrics.clone(),
             );
             self.workers.insert(*shard, handle);
+        }
+
+        if let Some(m) = &self.metrics {
+            m.set_shards_owned(desired.len());
+            m.set_workers_running(self.workers.len());
         }
 
         info!(

--- a/silo-compactor/src/lib.rs
+++ b/silo-compactor/src/lib.rs
@@ -3,6 +3,7 @@ pub mod compaction_filter;
 pub mod config;
 pub mod coordinator;
 pub mod error;
+pub mod metrics;
 pub mod pod_discovery;
 pub mod shard_loader;
 pub mod shard_map;

--- a/silo-compactor/src/main.rs
+++ b/silo-compactor/src/main.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use clap::Parser;
 use silo_compactor::config::{AppConfig, LogFormat};
 use silo_compactor::coordinator::Coordinator;
+use silo_compactor::metrics::{self, CompactorMetrics};
 use tracing::{error, info};
 
 #[derive(Parser)]
@@ -23,18 +25,59 @@ async fn main() -> anyhow::Result<()> {
 
     info!(config = %args.config.display(), "starting silo-compactor");
 
-    let coordinator = Coordinator::from_config(cfg).await?;
+    let metrics: Option<Arc<CompactorMetrics>> = if cfg.metrics.enabled {
+        match metrics::init() {
+            Ok(m) => Some(Arc::new(m)),
+            Err(e) => {
+                error!(error = %e, "failed to initialize metrics, continuing without metrics");
+                None
+            }
+        }
+    } else {
+        None
+    };
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    // Fan out shutdown to the metrics HTTP server, which needs a
+    // broadcast::Receiver<()> for axum's graceful_shutdown.
+    let (metrics_shutdown_tx, _metrics_shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
+
+    let metrics_handle = match metrics.as_ref() {
+        Some(m) => match cfg.metrics.addr.parse::<std::net::SocketAddr>() {
+            Ok(addr) => {
+                let registry = Arc::clone(m.registry());
+                let shutdown_rx = metrics_shutdown_tx.subscribe();
+                info!(addr = %addr, "starting metrics endpoint");
+                Some(tokio::spawn(async move {
+                    if let Err(e) = silo::metrics::serve_registry(addr, registry, shutdown_rx).await
+                    {
+                        error!(error = %e, "metrics server error");
+                    }
+                }))
+            }
+            Err(e) => {
+                error!(addr = %cfg.metrics.addr, error = %e, "invalid metrics addr; metrics endpoint disabled");
+                None
+            }
+        },
+        None => None,
+    };
+
+    let coordinator = Coordinator::from_config(cfg, metrics.clone()).await?;
+
     let signal_task = tokio::spawn(async move {
         wait_for_shutdown_signal().await;
         let _ = shutdown_tx.send(true);
+        let _ = metrics_shutdown_tx.send(());
     });
 
     if let Err(e) = coordinator.run(shutdown_rx).await {
         error!(error = %e, "coordinator exited with error");
     }
     signal_task.abort();
+    if let Some(h) = metrics_handle {
+        h.abort();
+    }
     Ok(())
 }
 

--- a/silo-compactor/src/metrics.rs
+++ b/silo-compactor/src/metrics.rs
@@ -1,0 +1,216 @@
+//! Prometheus metrics for silo-compactor.
+//!
+//! Mirrors the pattern in `silo::metrics`: a single `Registry` is built up
+//! with both compactor-specific instruments (worker restarts, shard
+//! ownership, compaction-filter row counts) and the shared SlateDB per-shard
+//! instruments via [`silo::metrics::SlatedbShardMetrics`]. The HTTP endpoint
+//! is served by [`silo::metrics::serve_registry`].
+
+use std::sync::Arc;
+
+use prometheus::{CounterVec, Gauge, HistogramOpts, HistogramVec, Opts, Registry};
+use silo::metrics::SlatedbShardMetrics;
+
+/// Histogram buckets (seconds) for compaction-filter pre-scans, which iterate
+/// IDX_STATUS_TIME in memory. Typical ranges are ms to a few seconds.
+const PRE_SCAN_BUCKETS_SECS: &[f64] = &[
+    0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
+];
+
+/// Compactor metrics handle. Cheaply cloneable.
+#[derive(Clone)]
+pub struct CompactorMetrics {
+    registry: Arc<Registry>,
+    shards_owned: Gauge,
+    workers_running: Gauge,
+    worker_restarts: CounterVec,
+    compactions_started: CounterVec,
+    compactor_run_errors: CounterVec,
+    compaction_filter_rows_dropped: CounterVec,
+    compaction_filter_pre_scan_duration: HistogramVec,
+    compaction_filter_pre_scan_entries: CounterVec,
+    pub slatedb: SlatedbShardMetrics,
+}
+
+impl CompactorMetrics {
+    pub fn registry(&self) -> &Arc<Registry> {
+        &self.registry
+    }
+
+    pub fn set_shards_owned(&self, count: usize) {
+        self.shards_owned.set(count as f64);
+    }
+
+    pub fn set_workers_running(&self, count: usize) {
+        self.workers_running.set(count as f64);
+    }
+
+    pub fn record_worker_restart(&self, shard: &str) {
+        self.worker_restarts.with_label_values(&[shard]).inc();
+    }
+
+    /// Record that a slatedb compactor was successfully opened for `shard` and
+    /// is about to start running.
+    pub fn record_compactor_started(&self, shard: &str) {
+        self.compactions_started.with_label_values(&[shard]).inc();
+    }
+
+    /// Record a compactor `run()` returning with an error.
+    pub fn record_compactor_run_error(&self, shard: &str) {
+        self.compactor_run_errors.with_label_values(&[shard]).inc();
+    }
+
+    pub fn record_filter_rows_dropped(&self, shard: &str, prefix: &str, n: u64) {
+        if n == 0 {
+            return;
+        }
+        self.compaction_filter_rows_dropped
+            .with_label_values(&[shard, prefix])
+            .inc_by(n as f64);
+    }
+
+    pub fn record_filter_pre_scan(&self, shard: &str, duration_secs: f64, entries: u64) {
+        self.compaction_filter_pre_scan_duration
+            .with_label_values(&[shard])
+            .observe(duration_secs);
+        self.compaction_filter_pre_scan_entries
+            .with_label_values(&[shard])
+            .inc_by(entries as f64);
+    }
+}
+
+/// Build a fresh registry and register all compactor metrics.
+pub fn init() -> anyhow::Result<CompactorMetrics> {
+    let registry = Registry::new();
+
+    let shards_owned = register(
+        &registry,
+        Gauge::new(
+            "silo_compactor_shards_owned",
+            "Number of shards currently assigned to this compactor pod",
+        )?,
+    )?;
+
+    let workers_running = register(
+        &registry,
+        Gauge::new(
+            "silo_compactor_workers_running",
+            "Number of per-shard compactor workers currently spawned on this pod",
+        )?,
+    )?;
+
+    let worker_restarts = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_compactor_worker_restarts_total",
+                "Total per-shard compactor worker restarts (slatedb compactor errored and was retried)",
+            ),
+            &["shard"],
+        )?,
+    )?;
+
+    let compactions_started = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_compactor_compactor_started_total",
+                "Total times a slatedb compactor was successfully opened for a shard",
+            ),
+            &["shard"],
+        )?,
+    )?;
+
+    let compactor_run_errors = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_compactor_run_errors_total",
+                "Total times slatedb's compactor.run() returned an error",
+            ),
+            &["shard"],
+        )?,
+    )?;
+
+    let compaction_filter_rows_dropped = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_compactor_compaction_filter_rows_dropped_total",
+                "Rows dropped by the completed-jobs compaction filter, by key prefix",
+            ),
+            &["shard", "prefix"],
+        )?,
+    )?;
+
+    let compaction_filter_pre_scan_duration = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_compactor_compaction_filter_pre_scan_duration_seconds",
+                "Wall-clock duration of the IDX_STATUS_TIME pre-scan that builds the expired (tenant, job_id) set",
+            )
+            .buckets(PRE_SCAN_BUCKETS_SECS.to_vec()),
+            &["shard"],
+        )?,
+    )?;
+
+    let compaction_filter_pre_scan_entries = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_compactor_compaction_filter_pre_scan_entries_total",
+                "Cumulative number of entries inserted into the expired-set during IDX_STATUS_TIME pre-scans",
+            ),
+            &["shard"],
+        )?,
+    )?;
+
+    let slatedb = SlatedbShardMetrics::register(&registry, "silo_compactor_")?;
+
+    Ok(CompactorMetrics {
+        registry: Arc::new(registry),
+        shards_owned,
+        workers_running,
+        worker_restarts,
+        compactions_started,
+        compactor_run_errors,
+        compaction_filter_rows_dropped,
+        compaction_filter_pre_scan_duration,
+        compaction_filter_pre_scan_entries,
+        slatedb,
+    })
+}
+
+fn register<C>(registry: &Registry, metric: C) -> anyhow::Result<C>
+where
+    C: prometheus::core::Collector + Clone + 'static,
+{
+    registry.register(Box::new(metric.clone()))?;
+    Ok(metric)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_registers_all_metrics() {
+        let m = init().expect("init metrics");
+        m.set_shards_owned(3);
+        m.set_workers_running(3);
+        m.record_worker_restart("shard-a");
+        m.record_compactor_started("shard-a");
+        m.record_filter_rows_dropped("shard-a", "job_info", 7);
+        m.record_filter_pre_scan("shard-a", 0.123, 42);
+
+        // Sanity: gather and ensure our compactor-specific metrics are present
+        // in the families. (slatedb_* counters/gauges only emit families once
+        // a label combination is touched, which requires a real recorder.)
+        let families = m.registry().gather();
+        let names: Vec<_> = families.iter().map(|f| f.get_name().to_string()).collect();
+        assert!(names.contains(&"silo_compactor_shards_owned".to_string()));
+        assert!(names.contains(&"silo_compactor_worker_restarts_total".to_string()));
+        assert!(names.contains(&"silo_compactor_compaction_filter_rows_dropped_total".to_string()));
+    }
+}

--- a/silo-compactor/src/worker.rs
+++ b/silo-compactor/src/worker.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use slatedb_common::metrics::DefaultMetricsRecorder;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -8,8 +9,13 @@ use tracing::{info, warn};
 use crate::compaction_filter::CompletedJobCompactionFilterSupplier;
 use crate::config::CompactionFilterConfig;
 use crate::error::CompactorError;
+use crate::metrics::CompactorMetrics;
 use crate::shard_map::ShardId;
 use crate::storage::{Backend, path_for_shard, resolve_object_store};
+
+/// Period at which per-shard slatedb stats are polled and translated into
+/// Prometheus instruments. Roughly matches silo's per-shard cadence.
+const SLATEDB_STAT_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Handle to a per-shard compactor task. Drop the handle to stop the worker:
 /// call `shutdown().await` first to wait for graceful shutdown.
@@ -28,6 +34,7 @@ impl WorkerHandle {
 
 /// Spawn a tokio task that runs slatedb's standalone compactor for `shard_id`,
 /// restarting on transient errors with `restart_backoff` between attempts.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_worker(
     shard_id: ShardId,
     backend: Backend,
@@ -35,6 +42,7 @@ pub fn spawn_worker(
     compactor_options: Arc<Option<slatedb::config::CompactorOptions>>,
     filter_config: Arc<CompactionFilterConfig>,
     restart_backoff: Duration,
+    metrics: Option<Arc<CompactorMetrics>>,
 ) -> WorkerHandle {
     let cancel = CancellationToken::new();
     let cancel_for_task = cancel.clone();
@@ -46,6 +54,7 @@ pub fn spawn_worker(
             compactor_options,
             filter_config,
             restart_backoff,
+            metrics,
             cancel_for_task,
         )
         .await;
@@ -57,6 +66,7 @@ pub fn spawn_worker(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_supervisor(
     shard_id: ShardId,
     backend: Backend,
@@ -64,8 +74,10 @@ async fn run_supervisor(
     compactor_options: Arc<Option<slatedb::config::CompactorOptions>>,
     filter_config: Arc<CompactionFilterConfig>,
     restart_backoff: Duration,
+    metrics: Option<Arc<CompactorMetrics>>,
     cancel: CancellationToken,
 ) {
+    let shard_label = shard_id.to_string();
     loop {
         if cancel.is_cancelled() {
             return;
@@ -76,6 +88,7 @@ async fn run_supervisor(
             &path_template,
             compactor_options.as_ref().clone(),
             filter_config.as_ref(),
+            metrics.as_ref(),
             &cancel,
         )
         .await
@@ -85,6 +98,10 @@ async fn run_supervisor(
                 return;
             }
             Err(e) => {
+                if let Some(m) = &metrics {
+                    m.record_compactor_run_error(&shard_label);
+                    m.record_worker_restart(&shard_label);
+                }
                 warn!(
                     shard = %shard_id,
                     error = %e,
@@ -106,8 +123,10 @@ async fn run_once(
     path_template: &str,
     compactor_options: Option<slatedb::config::CompactorOptions>,
     filter_config: &CompactionFilterConfig,
+    metrics: Option<&Arc<CompactorMetrics>>,
     cancel: &CancellationToken,
 ) -> Result<(), CompactorError> {
+    let shard_label = shard_id.to_string();
     let shard_path = path_for_shard(path_template, shard_id);
     let resolved = resolve_object_store(backend, &shard_path)?;
 
@@ -120,10 +139,22 @@ async fn run_once(
 
     let canonical_path = resolved.canonical_path;
     let store = resolved.store;
+    // Per-shard slatedb metrics recorder: passed to the CompactorBuilder so
+    // slatedb populates it during `compactor.run()`, then translated into our
+    // Prometheus registry by the poller task below.
+    let recorder = metrics
+        .is_some()
+        .then(|| Arc::new(DefaultMetricsRecorder::new()));
+
     let mut builder = slatedb::CompactorBuilder::new(canonical_path.clone(), Arc::clone(&store))
         .with_merge_operator(silo::job_store_shard::counter_merge_operator());
     if let Some(opts) = compactor_options {
         builder = builder.with_options(opts);
+    }
+    if let Some(rec) = &recorder {
+        builder = builder.with_metrics_recorder(
+            Arc::clone(rec) as Arc<dyn slatedb_common::metrics::MetricsRecorder>
+        );
     }
     if let CompactionFilterConfig::CompletedJobs {
         retention_secs,
@@ -138,6 +169,9 @@ async fn run_once(
         if let Some(cap) = expired_set_max_entries {
             supplier = supplier.with_max_expired_entries(*cap);
         }
+        if let Some(m) = metrics {
+            supplier = supplier.with_metrics(Arc::clone(m), shard_label.clone());
+        }
         info!(
             shard = %shard_id,
             retention_secs = *retention_secs,
@@ -148,12 +182,41 @@ async fn run_once(
     }
     let compactor = builder.build();
 
+    if let Some(m) = metrics {
+        m.record_compactor_started(&shard_label);
+    }
+
+    // Poller task: every SLATEDB_STAT_POLL_INTERVAL, snapshot the slatedb
+    // recorder and translate into our Prometheus registry. Stops when the
+    // worker is cancelled or the compactor exits.
+    let poller = match (metrics, &recorder) {
+        (Some(m), Some(rec)) => {
+            let m = Arc::clone(m);
+            let rec = Arc::clone(rec);
+            let shard_label = shard_label.clone();
+            let poller_cancel = cancel.clone();
+            Some(tokio::spawn(async move {
+                let mut tick = tokio::time::interval(SLATEDB_STAT_POLL_INTERVAL);
+                tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                loop {
+                    tokio::select! {
+                        _ = tick.tick() => {
+                            m.slatedb.update(&shard_label, &rec);
+                        }
+                        _ = poller_cancel.cancelled() => break,
+                    }
+                }
+            }))
+        }
+        _ => None,
+    };
+
     let mut run_task = tokio::spawn({
         let compactor = compactor.clone();
         async move { compactor.run().await }
     });
 
-    tokio::select! {
+    let result = tokio::select! {
         result = &mut run_task => match result {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => Err(CompactorError::Slatedb(e.to_string())),
@@ -168,5 +231,18 @@ async fn run_once(
             let _ = run_task.await;
             Ok(())
         }
+    };
+
+    // Stop the poller and flush one final snapshot so trailing counter
+    // deltas (e.g. the last compaction's bytes_compacted) make it into
+    // Prometheus before the recorder is dropped.
+    if let Some(handle) = poller {
+        handle.abort();
+        let _ = handle.await;
     }
+    if let (Some(m), Some(rec)) = (metrics, &recorder) {
+        m.slatedb.update(&shard_label, rec);
+    }
+
+    result
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -100,39 +100,53 @@ pub struct Metrics {
     // Concurrency metrics
     concurrency_tickets_granted: Counter,
 
-    // SlateDB storage counters (per-shard, monotonically increasing in SlateDB)
-    slatedb_get_requests: CounterVec,
-    slatedb_scan_requests: CounterVec,
-    slatedb_write_ops: CounterVec,
-    slatedb_write_batch_count: CounterVec,
-    slatedb_backpressure_count: CounterVec,
-    slatedb_wal_buffer_flushes: CounterVec,
-    slatedb_immutable_memtable_flushes: CounterVec,
-    slatedb_sst_filter_positives: CounterVec,
-    slatedb_sst_filter_negatives: CounterVec,
-    slatedb_sst_filter_false_positives: CounterVec,
-    slatedb_bytes_compacted: CounterVec,
-    slatedb_flush_requests: CounterVec,
+    /// SlateDB per-shard counters and gauges. Shared with silo-compactor via
+    /// the `metric_prefix` constructor argument.
+    pub slatedb: SlatedbShardMetrics,
+}
 
-    // SlateDB storage gauges (per-shard, point-in-time values)
-    slatedb_wal_buffer_estimated_bytes: GaugeVec,
-    slatedb_running_compactions: GaugeVec,
-    slatedb_last_compaction_ts_sec: GaugeVec,
-    slatedb_l0_sst_count: GaugeVec,
-    slatedb_total_mem_size_bytes: GaugeVec,
+/// SlateDB per-shard metric instruments plus the previous-value map needed
+/// to translate SlateDB's absolute counters into Prometheus `inc_by(delta)`.
+///
+/// Registers a fixed set of `<prefix>slatedb_*` counters and gauges against a
+/// shared `Registry`. Used by both the silo server (prefix `silo_`) and the
+/// silo-compactor binary (prefix `silo_compactor_`) so the same translation
+/// logic powers both.
+#[derive(Clone)]
+pub struct SlatedbShardMetrics {
+    // Counters (monotonically increasing in SlateDB)
+    get_requests: CounterVec,
+    scan_requests: CounterVec,
+    write_ops: CounterVec,
+    write_batch_count: CounterVec,
+    backpressure_count: CounterVec,
+    wal_buffer_flushes: CounterVec,
+    immutable_memtable_flushes: CounterVec,
+    sst_filter_positives: CounterVec,
+    sst_filter_negatives: CounterVec,
+    sst_filter_false_positives: CounterVec,
+    bytes_compacted: CounterVec,
+    flush_requests: CounterVec,
 
-    // SlateDB cache counters (per-shard, monotonically increasing)
-    slatedb_cache_data_block_hit: CounterVec,
-    slatedb_cache_data_block_miss: CounterVec,
-    slatedb_cache_index_hit: CounterVec,
-    slatedb_cache_index_miss: CounterVec,
-    slatedb_cache_filter_hit: CounterVec,
-    slatedb_cache_filter_miss: CounterVec,
+    // Gauges (point-in-time)
+    wal_buffer_estimated_bytes: GaugeVec,
+    running_compactions: GaugeVec,
+    last_compaction_ts_sec: GaugeVec,
+    l0_sst_count: GaugeVec,
+    total_mem_size_bytes: GaugeVec,
+
+    // Cache counters
+    cache_data_block_hit: CounterVec,
+    cache_data_block_miss: CounterVec,
+    cache_index_hit: CounterVec,
+    cache_index_miss: CounterVec,
+    cache_filter_hit: CounterVec,
+    cache_filter_miss: CounterVec,
 
     /// Tracks previous SlateDB counter values per (stat_name, shard) for delta computation.
     /// SlateDB exposes counters as absolute values via `stat.get()`, but Prometheus counters
     /// only support `inc_by(delta)`, so we compute deltas between polls.
-    slatedb_prev_values: Arc<Mutex<HashMap<(String, String), f64>>>,
+    prev_values: Arc<Mutex<HashMap<(String, String), f64>>>,
 }
 
 impl Metrics {
@@ -308,58 +322,184 @@ impl Metrics {
     /// statistics to Prometheus metrics. Counter-type stats are tracked via deltas
     /// since Prometheus counters only support `inc_by()`, not `set()`.
     pub fn update_slatedb_stats(&self, shard: &str, recorder: &DefaultMetricsRecorder) {
+        self.slatedb.update(shard, recorder);
+    }
+}
+
+impl SlatedbShardMetrics {
+    /// Register the full set of SlateDB per-shard counters and gauges against
+    /// `registry`. `metric_prefix` is prepended to every metric name so silo
+    /// (`silo_`) and silo-compactor (`silo_compactor_`) can coexist on the same
+    /// scrape config without collisions.
+    pub fn register(registry: &Registry, metric_prefix: &str) -> anyhow::Result<Self> {
+        let p = metric_prefix;
+        let counter = |name: &str, help: &str| -> anyhow::Result<CounterVec> {
+            Ok(register(
+                registry,
+                CounterVec::new(Opts::new(format!("{p}{name}"), help), &["shard"])?,
+            ))
+        };
+        let gauge = |name: &str, help: &str| -> anyhow::Result<GaugeVec> {
+            Ok(register(
+                registry,
+                GaugeVec::new(Opts::new(format!("{p}{name}"), help), &["shard"])?,
+            ))
+        };
+
+        Ok(Self {
+            get_requests: counter(
+                "slatedb_get_requests_total",
+                "Total number of GET (read) requests to SlateDB",
+            )?,
+            scan_requests: counter(
+                "slatedb_scan_requests_total",
+                "Total number of scan (range query) requests to SlateDB",
+            )?,
+            write_ops: counter(
+                "slatedb_write_ops_total",
+                "Total number of individual write operations to SlateDB",
+            )?,
+            write_batch_count: counter(
+                "slatedb_write_batch_count_total",
+                "Total number of write batches to SlateDB",
+            )?,
+            backpressure_count: counter(
+                "slatedb_backpressure_count_total",
+                "Number of times writes were blocked by back-pressure in SlateDB",
+            )?,
+            wal_buffer_flushes: counter(
+                "slatedb_wal_buffer_flushes_total",
+                "Total number of WAL buffer flushes in SlateDB",
+            )?,
+            immutable_memtable_flushes: counter(
+                "slatedb_immutable_memtable_flushes_total",
+                "Total number of immutable memtable flushes to SSTs in SlateDB",
+            )?,
+            sst_filter_positives: counter(
+                "slatedb_sst_filter_positives_total",
+                "Total SST filter true positives (key exists, filter says yes)",
+            )?,
+            sst_filter_negatives: counter(
+                "slatedb_sst_filter_negatives_total",
+                "Total SST filter true negatives (key absent, filter says no)",
+            )?,
+            sst_filter_false_positives: counter(
+                "slatedb_sst_filter_false_positives_total",
+                "Total SST filter false positives (key absent, but filter said yes)",
+            )?,
+            bytes_compacted: counter(
+                "slatedb_bytes_compacted_total",
+                "Total number of bytes compacted by SlateDB compactor",
+            )?,
+            flush_requests: counter(
+                "slatedb_flush_requests_total",
+                "Total number of flush requests to SlateDB",
+            )?,
+            wal_buffer_estimated_bytes: gauge(
+                "slatedb_wal_buffer_estimated_bytes",
+                "Estimated bytes buffered in the SlateDB WAL buffer",
+            )?,
+            running_compactions: gauge(
+                "slatedb_running_compactions",
+                "Number of compactions currently running in SlateDB",
+            )?,
+            last_compaction_ts_sec: gauge(
+                "slatedb_last_compaction_ts_seconds",
+                "Unix timestamp (seconds) of the last compaction in SlateDB",
+            )?,
+            l0_sst_count: gauge(
+                "slatedb_l0_sst_count",
+                "Number of Level-0 SSTs in SlateDB (high values indicate compaction lag)",
+            )?,
+            total_mem_size_bytes: gauge(
+                "slatedb_total_mem_size_bytes",
+                "Total memory usage of SlateDB",
+            )?,
+            cache_data_block_hit: counter(
+                "slatedb_cache_data_block_hit_total",
+                "Total SlateDB data block cache hits",
+            )?,
+            cache_data_block_miss: counter(
+                "slatedb_cache_data_block_miss_total",
+                "Total SlateDB data block cache misses",
+            )?,
+            cache_index_hit: counter(
+                "slatedb_cache_index_hit_total",
+                "Total SlateDB index block cache hits",
+            )?,
+            cache_index_miss: counter(
+                "slatedb_cache_index_miss_total",
+                "Total SlateDB index block cache misses",
+            )?,
+            cache_filter_hit: counter(
+                "slatedb_cache_filter_hit_total",
+                "Total SlateDB bloom filter cache hits",
+            )?,
+            cache_filter_miss: counter(
+                "slatedb_cache_filter_miss_total",
+                "Total SlateDB bloom filter cache misses",
+            )?,
+            prev_values: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    /// Translate a snapshot of SlateDB's internal counters/gauges into the
+    /// registered Prometheus instruments. Counters are converted to deltas
+    /// against the previous snapshot since Prometheus counters only support
+    /// `inc_by()`.
+    pub fn update(&self, shard: &str, recorder: &DefaultMetricsRecorder) {
         // Counter-type stats: monotonically increasing in SlateDB
         // REQUEST_COUNT uses an "op" label to distinguish get/scan/flush
         let labeled_counter_mappings: &[(&str, &[(&str, &str)], &CounterVec)] = &[
             (
                 slatedb::db_stats::REQUEST_COUNT,
                 &[("op", "get")],
-                &self.slatedb_get_requests,
+                &self.get_requests,
             ),
             (
                 slatedb::db_stats::REQUEST_COUNT,
                 &[("op", "scan")],
-                &self.slatedb_scan_requests,
+                &self.scan_requests,
             ),
             (
                 slatedb::db_stats::REQUEST_COUNT,
                 &[("op", "flush")],
-                &self.slatedb_flush_requests,
+                &self.flush_requests,
             ),
         ];
         let counter_mappings: &[(&str, &CounterVec)] = &[
-            (slatedb::db_stats::WRITE_OPS, &self.slatedb_write_ops),
+            (slatedb::db_stats::WRITE_OPS, &self.write_ops),
             (
                 slatedb::db_stats::WRITE_BATCH_COUNT,
-                &self.slatedb_write_batch_count,
+                &self.write_batch_count,
             ),
             (
                 slatedb::db_stats::BACKPRESSURE_COUNT,
-                &self.slatedb_backpressure_count,
+                &self.backpressure_count,
             ),
             (
                 slatedb::db_stats::WAL_BUFFER_FLUSHES,
-                &self.slatedb_wal_buffer_flushes,
+                &self.wal_buffer_flushes,
             ),
             (
                 slatedb::db_stats::IMMUTABLE_MEMTABLE_FLUSHES,
-                &self.slatedb_immutable_memtable_flushes,
+                &self.immutable_memtable_flushes,
             ),
             (
                 slatedb::db_stats::SST_FILTER_POSITIVE_COUNT,
-                &self.slatedb_sst_filter_positives,
+                &self.sst_filter_positives,
             ),
             (
                 slatedb::db_stats::SST_FILTER_NEGATIVE_COUNT,
-                &self.slatedb_sst_filter_negatives,
+                &self.sst_filter_negatives,
             ),
             (
                 slatedb::db_stats::SST_FILTER_FALSE_POSITIVE_COUNT,
-                &self.slatedb_sst_filter_false_positives,
+                &self.sst_filter_false_positives,
             ),
             (
                 slatedb::compactor::stats::BYTES_COMPACTED,
-                &self.slatedb_bytes_compacted,
+                &self.bytes_compacted,
             ),
         ];
 
@@ -368,32 +508,32 @@ impl Metrics {
             (
                 slatedb::db_cache_stats::ACCESS_COUNT,
                 &[("entry_kind", "data_block"), ("result", "hit")],
-                &self.slatedb_cache_data_block_hit,
+                &self.cache_data_block_hit,
             ),
             (
                 slatedb::db_cache_stats::ACCESS_COUNT,
                 &[("entry_kind", "data_block"), ("result", "miss")],
-                &self.slatedb_cache_data_block_miss,
+                &self.cache_data_block_miss,
             ),
             (
                 slatedb::db_cache_stats::ACCESS_COUNT,
                 &[("entry_kind", "index"), ("result", "hit")],
-                &self.slatedb_cache_index_hit,
+                &self.cache_index_hit,
             ),
             (
                 slatedb::db_cache_stats::ACCESS_COUNT,
                 &[("entry_kind", "index"), ("result", "miss")],
-                &self.slatedb_cache_index_miss,
+                &self.cache_index_miss,
             ),
             (
                 slatedb::db_cache_stats::ACCESS_COUNT,
                 &[("entry_kind", "filter"), ("result", "hit")],
-                &self.slatedb_cache_filter_hit,
+                &self.cache_filter_hit,
             ),
             (
                 slatedb::db_cache_stats::ACCESS_COUNT,
                 &[("entry_kind", "filter"), ("result", "miss")],
-                &self.slatedb_cache_filter_miss,
+                &self.cache_filter_miss,
             ),
         ];
 
@@ -401,27 +541,27 @@ impl Metrics {
         let gauge_mappings: &[(&str, &GaugeVec)] = &[
             (
                 slatedb::db_stats::WAL_BUFFER_ESTIMATED_BYTES,
-                &self.slatedb_wal_buffer_estimated_bytes,
+                &self.wal_buffer_estimated_bytes,
             ),
             (
                 slatedb::compactor::stats::RUNNING_COMPACTIONS,
-                &self.slatedb_running_compactions,
+                &self.running_compactions,
             ),
             (
                 slatedb::compactor::stats::LAST_COMPACTION_TS_SEC,
-                &self.slatedb_last_compaction_ts_sec,
+                &self.last_compaction_ts_sec,
             ),
-            (slatedb::db_stats::L0_SST_COUNT, &self.slatedb_l0_sst_count),
+            (slatedb::db_stats::L0_SST_COUNT, &self.l0_sst_count),
             (
                 slatedb::db_stats::TOTAL_MEM_SIZE_BYTES,
-                &self.slatedb_total_mem_size_bytes,
+                &self.total_mem_size_bytes,
             ),
         ];
 
         let snapshot = recorder.snapshot();
 
         {
-            let mut prev_values = self.slatedb_prev_values.lock().expect("lock poisoned");
+            let mut prev_values = self.prev_values.lock().expect("lock poisoned");
 
             // Helper to extract a numeric value from a metric
             let extract_value = |metric: &slatedb_common::metrics::Metric| -> Option<f64> {
@@ -736,261 +876,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
-    // SlateDB storage counters (monotonically increasing in SlateDB)
-    let slatedb_get_requests = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_get_requests_total",
-                "Total number of GET (read) requests to SlateDB",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_scan_requests = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_scan_requests_total",
-                "Total number of scan (range query) requests to SlateDB",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_write_ops = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_write_ops_total",
-                "Total number of individual write operations to SlateDB",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_write_batch_count = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_write_batch_count_total",
-                "Total number of write batches to SlateDB",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_backpressure_count = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_backpressure_count_total",
-                "Number of times writes were blocked by back-pressure in SlateDB",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_wal_buffer_flushes = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_wal_buffer_flushes_total",
-                "Total number of WAL buffer flushes in SlateDB",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_immutable_memtable_flushes = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_immutable_memtable_flushes_total",
-                "Total number of immutable memtable flushes to SSTs in SlateDB",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_sst_filter_positives = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_sst_filter_positives_total",
-                "Total SST filter true positives (key exists, filter says yes)",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_sst_filter_negatives = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_sst_filter_negatives_total",
-                "Total SST filter true negatives (key absent, filter says no)",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_sst_filter_false_positives = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_sst_filter_false_positives_total",
-                "Total SST filter false positives (key absent, but filter said yes)",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_bytes_compacted = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_bytes_compacted_total",
-                "Total number of bytes compacted by SlateDB compactor",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    // SlateDB storage gauges (point-in-time values)
-    let slatedb_wal_buffer_estimated_bytes = register(
-        &registry,
-        GaugeVec::new(
-            Opts::new(
-                "silo_slatedb_wal_buffer_estimated_bytes",
-                "Estimated bytes buffered in the SlateDB WAL buffer",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_running_compactions = register(
-        &registry,
-        GaugeVec::new(
-            Opts::new(
-                "silo_slatedb_running_compactions",
-                "Number of compactions currently running in SlateDB",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_last_compaction_ts_sec = register(
-        &registry,
-        GaugeVec::new(
-            Opts::new(
-                "silo_slatedb_last_compaction_ts_seconds",
-                "Unix timestamp (seconds) of the last compaction in SlateDB",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_flush_requests = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_flush_requests_total",
-                "Total number of flush requests to SlateDB",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_l0_sst_count = register(
-        &registry,
-        GaugeVec::new(
-            Opts::new(
-                "silo_slatedb_l0_sst_count",
-                "Number of Level-0 SSTs in SlateDB (high values indicate compaction lag)",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_total_mem_size_bytes = register(
-        &registry,
-        GaugeVec::new(
-            Opts::new(
-                "silo_slatedb_total_mem_size_bytes",
-                "Total memory usage of SlateDB",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    // SlateDB cache counters
-    let slatedb_cache_data_block_hit = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_cache_data_block_hit_total",
-                "Total SlateDB data block cache hits",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_cache_data_block_miss = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_cache_data_block_miss_total",
-                "Total SlateDB data block cache misses",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_cache_index_hit = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_cache_index_hit_total",
-                "Total SlateDB index block cache hits",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_cache_index_miss = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_cache_index_miss_total",
-                "Total SlateDB index block cache misses",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_cache_filter_hit = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_cache_filter_hit_total",
-                "Total SlateDB bloom filter cache hits",
-            ),
-            &["shard"],
-        )?,
-    );
-
-    let slatedb_cache_filter_miss = register(
-        &registry,
-        CounterVec::new(
-            Opts::new(
-                "silo_slatedb_cache_filter_miss_total",
-                "Total SlateDB bloom filter cache misses",
-            ),
-            &["shard"],
-        )?,
-    );
+    let slatedb = SlatedbShardMetrics::register(&registry, "silo_")?;
 
     Ok(Metrics {
         registry: Arc::new(registry),
@@ -1016,37 +902,14 @@ pub fn init() -> anyhow::Result<Metrics> {
         lease_reaper_duration,
         lease_reaper_scans_total,
         concurrency_tickets_granted,
-        slatedb_get_requests,
-        slatedb_scan_requests,
-        slatedb_write_ops,
-        slatedb_write_batch_count,
-        slatedb_backpressure_count,
-        slatedb_wal_buffer_flushes,
-        slatedb_immutable_memtable_flushes,
-        slatedb_sst_filter_positives,
-        slatedb_sst_filter_negatives,
-        slatedb_sst_filter_false_positives,
-        slatedb_bytes_compacted,
-        slatedb_flush_requests,
-        slatedb_wal_buffer_estimated_bytes,
-        slatedb_running_compactions,
-        slatedb_last_compaction_ts_sec,
-        slatedb_l0_sst_count,
-        slatedb_total_mem_size_bytes,
-        slatedb_cache_data_block_hit,
-        slatedb_cache_data_block_miss,
-        slatedb_cache_index_hit,
-        slatedb_cache_index_miss,
-        slatedb_cache_filter_hit,
-        slatedb_cache_filter_miss,
-        slatedb_prev_values: Arc::new(Mutex::new(HashMap::new())),
+        slatedb,
     })
 }
 
-/// Axum handler for the `/metrics` endpoint.
-async fn metrics_handler(State(metrics): State<Metrics>) -> impl IntoResponse {
+/// Axum handler that gathers a registry and encodes it in Prometheus text format.
+async fn registry_handler(State(registry): State<Arc<Registry>>) -> impl IntoResponse {
     let encoder = TextEncoder::new();
-    let metric_families = metrics.registry.gather();
+    let metric_families = registry.gather();
 
     let mut buffer = Vec::new();
     match encoder.encode(&metric_families, &mut buffer) {
@@ -1066,18 +929,17 @@ async fn metrics_handler(State(metrics): State<Metrics>) -> impl IntoResponse {
     }
 }
 
-/// Run the Prometheus metrics HTTP server.
+/// Serve a Prometheus `/metrics` endpoint backed by `registry`.
 ///
-/// Listens on the given address and serves metrics at `/metrics`.
-/// Shuts down gracefully when shutdown signal is received.
-pub async fn run_metrics_server(
+/// Used by both the silo server and silo-compactor binaries.
+pub async fn serve_registry(
     addr: SocketAddr,
-    metrics: Metrics,
+    registry: Arc<Registry>,
     mut shutdown: broadcast::Receiver<()>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let app = Router::new()
-        .route("/metrics", get(metrics_handler))
-        .with_state(metrics);
+        .route("/metrics", get(registry_handler))
+        .with_state(registry);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     debug!(addr = %addr, "metrics server started");
@@ -1090,6 +952,15 @@ pub async fn run_metrics_server(
         .await?;
 
     Ok(())
+}
+
+/// Run the Prometheus metrics HTTP server backed by silo's `Metrics` registry.
+pub async fn run_metrics_server(
+    addr: SocketAddr,
+    metrics: Metrics,
+    shutdown: broadcast::Receiver<()>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    serve_registry(addr, metrics.registry.clone(), shutdown).await
 }
 
 /// Map a tonic status code to a short uppercase label matching the gRPC spec


### PR DESCRIPTION
## Summary
- Extract `SlatedbShardMetrics` and `serve_registry` from `silo::metrics` so the slatedb→Prometheus translation and HTTP scaffolding are reusable; silo's existing `Metrics` and `run_metrics_server` keep their public shape via thin delegators.
- New `silo-compactor::metrics::CompactorMetrics` registers `silo_compactor_*` instruments (shards_owned, workers_running, worker_restarts_total, compactor_started_total, run_errors_total, compaction_filter rows_dropped per prefix, pre-scan duration/entries) plus the shared `SlatedbShardMetrics` so each shard's slatedb stats are surfaced.
- Worker creates a per-shard `DefaultMetricsRecorder`, wires it through `slatedb::CompactorBuilder::with_metrics_recorder`, and runs a 5s poller that translates the recorder into Prometheus and flushes one final snapshot at shutdown. Coordinator updates the shards_owned/workers_running gauges after each reconcile. Compaction filter emits per-prefix dropped counts at `on_compaction_end` and observes pre-scan duration/entries.
- New `[metrics] enabled/addr` block on `AppConfig` (default `0.0.0.0:9090`, mirrors silo). Added to `example_configs/compactor-dev.toml` and the local-test compactor config + deployment ConfigMap. Production manifest changes (containerPort, Service entry) are a follow-up in `global-infrastructure`.

## Test plan
- [x] `cargo test -p silo-compactor --lib` (28 pass)
- [x] `cargo test -p silo --lib`
- [x] `cargo clippy -p silo-compactor --no-deps --all-targets -- -D warnings`
- [x] `cargo fmt`
- [ ] Smoke test the dev stack (`scripts/deploy-local-orbstack.mts`), drive load through silo, and confirm `curl http://127.0.0.1:9092/metrics` shows `silo_compactor_slatedb_running_compactions{shard=...}` toggling and `silo_compactor_slatedb_bytes_compacted_total{shard=...}` increasing after a compaction cycle.
- [ ] Verify `silo_compactor_shards_owned` matches the worker count from coordinator logs.