### PR TITLE
Extract siloctl to its own crate; gate datafusion behind `server` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5377,7 +5377,7 @@ dependencies = [
 
 [[package]]
 name = "silo"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -5423,6 +5423,7 @@ dependencies = [
  "serde",
  "serde_json",
  "silo-macros",
+ "siloctl",
  "slatedb",
  "slatedb-common",
  "storekey",
@@ -5511,6 +5512,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "siloctl"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "clap",
+ "flate2",
+ "hex",
+ "rmp-serde",
+ "serde_json",
+ "silo",
+ "tokio",
+ "tonic 0.12.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
-members = [".", "silo-macros", "silo-autoscaler", "silo-compactor"]
+members = [".", "silo-macros", "silo-autoscaler", "silo-compactor", "siloctl"]
 
 [package]
 authors = ["Harry Brundage <harry@gadget.dev>"]
 edition = "2024"
 name = "silo"
 description = "A background job server on top of object storage"
-version = "0.2.0"
+version = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -63,7 +63,7 @@ datafusion = { version = "50", features = [
     "datetime_expressions",
     "regex_expressions",
     "recursive_protection",
-] }
+], optional = true }
 hyper = { version = "1", features = ["client", "http1", "server"] }
 hyper-util = { version = "0.1", features = ["full"] }
 http-body-util = "0.1"
@@ -73,7 +73,7 @@ askama_axum = "0.4"
 tower = "0.4"
 tower-http = { version = "0.5", features = ["fs"] }
 rand = "0.9"
-datafusion-sql = "50"
+datafusion-sql = { version = "50", optional = true }
 hostname = "0.4"
 pprof = { version = "0.15", features = ["prost-codec", "frame-pointer"] }
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
@@ -86,11 +86,16 @@ base64 = "0.22"
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
 
 [features]
-default = ["k8s"]
+default = ["k8s", "server"]
 dst = ["turmoil"]
 k8s = ["kube", "k8s-openapi", "chrono"]
+# `server` enables the modules required by the silo daemon (SQL query engine,
+# arrow IPC, web UI). Disable to build lightweight clients (siloctl, compactor)
+# without paying the datafusion compile cost.
+server = ["dep:datafusion", "dep:datafusion-sql"]
 
 [dev-dependencies]
+siloctl = { path = "siloctl" }
 mad-turmoil = "0.2"
 rand = "0.9"
 fastrand = "2"                                                      # For deterministic simulation - seed must be set explicitly
@@ -114,6 +119,13 @@ strip = false # do not strip symbols for profiling
 # frame pointers are preserved. Without this, production profiles will have
 # incomplete call stacks.
 
+[[bin]]
+name = "silo"
+path = "src/main.rs"
+# The silo daemon binary pulls in the gRPC server and SQL query engine,
+# which require the `server` feature (datafusion).
+required-features = ["server"]
+
 [[bench]]
 name = "job_shard_throughput"
 harness = false
@@ -121,6 +133,7 @@ harness = false
 [[bench]]
 name = "query_performance"
 harness = false
+required-features = ["server"]
 
 [[bench]]
 name = "big_shard_operations"
@@ -129,6 +142,7 @@ harness = false
 [[bench]]
 name = "query_profile"
 harness = false
+required-features = ["server"]
 
 [[bench]]
 name = "task_scanner_profile"

--- a/siloctl/Cargo.toml
+++ b/siloctl/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "siloctl"
+version = "0.2.0"
+edition = "2024"
+description = "Administration CLI for Silo job queue clusters"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "siloctl"
+path = "src/main.rs"
+
+[dependencies]
+# silo without `server` feature avoids the datafusion compile cost; siloctl
+# only needs cluster_client::AuthInterceptor, pb types, settings, shard_range.
+silo = { path = "..", default-features = false }
+
+clap = { version = "4.3", features = ["derive", "env"] }
+tonic = { version = "0.12", features = ["transport"] }
+tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
+serde_json = "1.0"
+rmp-serde = "1.3"
+flate2 = "1"
+anyhow = "1"
+hex = "0.4"
+base64 = "0.22"

--- a/siloctl/src/lib.rs
+++ b/siloctl/src/lib.rs
@@ -7,16 +7,16 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-use crate::cluster_client::AuthInterceptor;
-use crate::pb::silo_client::SiloClient;
-use crate::pb::{
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use silo::cluster_client::AuthInterceptor;
+use silo::pb::silo_client::SiloClient;
+use silo::pb::{
     CancelJobRequest, CompactShardRequest, ConfigureShardRequest, CpuProfileRequest,
     DeleteJobRequest, ExpediteJobRequest, ForceReleaseShardRequest, GetClusterInfoRequest,
     GetJobRequest, GetJobResultRequest, GetSplitStatusRequest, HeapProfileRequest, QueryRequest,
     RequestSplitRequest, RestartJobRequest,
 };
-use flate2::Compression;
-use flate2::write::GzEncoder;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 
@@ -349,7 +349,7 @@ pub async fn job_result<W: Write>(
     let status = job_status_to_string(response.status);
 
     match response.result {
-        Some(crate::pb::get_job_result_response::Result::SuccessData(data)) => {
+        Some(silo::pb::get_job_result_response::Result::SuccessData(data)) => {
             let raw = extract_serialized_bytes(&data);
             if opts.json {
                 let json_output = serde_json::json!({
@@ -366,7 +366,7 @@ pub async fn job_result<W: Write>(
                 writeln!(out, "{}", format_bytes(&raw, format)?)?;
             }
         }
-        Some(crate::pb::get_job_result_response::Result::Failure(failure)) => {
+        Some(silo::pb::get_job_result_response::Result::Failure(failure)) => {
             let error_data = failure
                 .error_data
                 .map(|d| extract_serialized_bytes(&d))
@@ -388,7 +388,7 @@ pub async fn job_result<W: Write>(
                 writeln!(out, "{}", format_bytes(&error_data, format)?)?;
             }
         }
-        Some(crate::pb::get_job_result_response::Result::Cancelled(cancelled)) => {
+        Some(silo::pb::get_job_result_response::Result::Cancelled(cancelled)) => {
             if opts.json {
                 let json_output = serde_json::json!({
                     "id": response.id,
@@ -414,9 +414,9 @@ pub async fn job_result<W: Write>(
     Ok(())
 }
 
-fn extract_serialized_bytes(data: &crate::pb::SerializedBytes) -> Vec<u8> {
+fn extract_serialized_bytes(data: &silo::pb::SerializedBytes) -> Vec<u8> {
     match &data.encoding {
-        Some(crate::pb::serialized_bytes::Encoding::Msgpack(bytes)) => bytes.clone(),
+        Some(silo::pb::serialized_bytes::Encoding::Msgpack(bytes)) => bytes.clone(),
         None => vec![],
     }
 }
@@ -564,7 +564,7 @@ pub async fn query<W: Write>(
             .iter()
             .filter_map(|row| {
                 row.encoding.as_ref().and_then(|enc| match enc {
-                    crate::pb::serialized_bytes::Encoding::Msgpack(data) => {
+                    silo::pb::serialized_bytes::Encoding::Msgpack(data) => {
                         rmp_serde::from_slice::<serde_json::Value>(data).ok()
                     }
                 })
@@ -597,7 +597,7 @@ pub async fn query<W: Write>(
             .iter()
             .filter_map(|row| {
                 row.encoding.as_ref().and_then(|enc| match enc {
-                    crate::pb::serialized_bytes::Encoding::Msgpack(data) => {
+                    silo::pb::serialized_bytes::Encoding::Msgpack(data) => {
                         rmp_serde::from_slice::<serde_json::Value>(data).ok()
                     }
                 })
@@ -834,7 +834,7 @@ pub async fn shard_split<W: Write>(
         point
     } else if auto {
         // Compute numeric midpoint of the shard's hash-space range
-        let range = crate::shard_range::ShardRange::new(
+        let range = silo::shard_range::ShardRange::new(
             shard_owner.range_start.clone(),
             shard_owner.range_end.clone(),
         );
@@ -845,7 +845,7 @@ pub async fn shard_split<W: Write>(
                 shard_owner.range_end
             )
         })?;
-        crate::shard_range::format_hash_boundary(mid)
+        silo::shard_range::format_hash_boundary(mid)
     } else {
         return Err(anyhow::anyhow!(
             "Either --at <split-point> or --auto must be specified"
@@ -1096,7 +1096,7 @@ pub async fn validate_config<W: Write>(
     out: &mut W,
     config_path: &Path,
 ) -> anyhow::Result<()> {
-    match crate::settings::AppConfig::load(Some(config_path)) {
+    match silo::settings::AppConfig::load(Some(config_path)) {
         Ok(_cfg) => {
             if opts.json {
                 writeln!(
@@ -1131,7 +1131,7 @@ pub fn tenant_hash<W: Write>(
     out: &mut W,
     tenant_id: &str,
 ) -> anyhow::Result<()> {
-    let hashed = crate::shard_range::hash_tenant(tenant_id);
+    let hashed = silo::shard_range::hash_tenant(tenant_id);
 
     if opts.json {
         let json_output = serde_json::json!({
@@ -1159,11 +1159,11 @@ pub async fn tenant_locate<W: Write>(
         .await?
         .into_inner();
 
-    let hashed = crate::shard_range::hash_tenant(tenant_id);
+    let hashed = silo::shard_range::hash_tenant(tenant_id);
 
     // Find the shard whose range contains the hashed tenant
     let owner = response.shard_owners.iter().find(|s| {
-        let range = crate::shard_range::ShardRange::new(s.range_start.clone(), s.range_end.clone());
+        let range = silo::shard_range::ShardRange::new(s.range_start.clone(), s.range_end.clone());
         range.contains(&hashed)
     });
 
@@ -1218,11 +1218,11 @@ pub async fn tenant_locate<W: Write>(
 
 /// Compute the midpoint of a hash-space range defined by hex-encoded u64 boundaries.
 ///
-/// Delegates to [`ShardRange::midpoint`](crate::shard_range::ShardRange::midpoint)
+/// Delegates to [`ShardRange::midpoint`](silo::shard_range::ShardRange::midpoint)
 /// and formats the result as a 16-character hex string.
 pub fn compute_midpoint(start: &str, end: &str) -> Option<String> {
-    let range = crate::shard_range::ShardRange::new(start, end);
+    let range = silo::shard_range::ShardRange::new(start, end);
     range
         .midpoint()
-        .map(crate::shard_range::format_hash_boundary)
+        .map(silo::shard_range::format_hash_boundary)
 }

--- a/siloctl/src/main.rs
+++ b/siloctl/src/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand, ValueEnum};
-use silo::siloctl::{self, BytesOutputFormat, GlobalOptions};
+use siloctl::{self, BytesOutputFormat, GlobalOptions};
 
 #[derive(Parser, Debug)]
 #[command(name = "siloctl")]

--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -36,11 +36,13 @@ use tracing::{debug, trace, warn};
 
 use crate::coordination::{Coordinator, ShardOwnerMap, SplitCleanupStatus};
 use crate::factory::ShardFactory;
+#[cfg(feature = "server")]
+use crate::pb::QueryRequest;
 use crate::pb::silo_client::SiloClient;
 use crate::pb::{
     CancelJobRequest, ColumnInfo, CompactShardRequest, GetJobRequest, GetJobResponse,
     GetNodeInfoRequest, GetShardStorageInfoRequest, GetShardStorageInfoResponse, JobStatus,
-    QueryRequest, RequestSplitRequest, RequestSplitResponse, SerializedBytes, serialized_bytes,
+    RequestSplitRequest, RequestSplitResponse, SerializedBytes, serialized_bytes,
 };
 use crate::shard_range::ShardId;
 
@@ -438,6 +440,7 @@ impl ClusterClient {
     }
 
     /// Query a specific shard, routing to the appropriate node
+    #[cfg(feature = "server")]
     pub async fn query_shard(
         &self,
         shard_id: &ShardId,
@@ -456,6 +459,7 @@ impl ClusterClient {
     }
 
     /// Query a local shard directly
+    #[cfg(feature = "server")]
     async fn query_local_shard(
         &self,
         shard_id: &ShardId,
@@ -510,6 +514,7 @@ impl ClusterClient {
     }
 
     /// Query a remote shard via gRPC
+    #[cfg(feature = "server")]
     async fn query_remote_shard(
         &self,
         shard_id: &ShardId,
@@ -548,6 +553,7 @@ impl ClusterClient {
     }
 
     /// Query all shards in the cluster and combine results
+    #[cfg(feature = "server")]
     pub async fn query_all_shards(
         &self,
         sql: &str,
@@ -576,6 +582,7 @@ impl ClusterClient {
     }
 
     /// Get all shard IDs in the cluster
+    #[cfg(feature = "server")]
     async fn get_all_shard_ids(&self) -> Result<Vec<ShardId>, ClusterClientError> {
         if let Some(coordinator) = &self.coordinator {
             let owner_map = coordinator
@@ -678,7 +685,7 @@ impl ClusterClient {
                     .map_err(|e| ClusterClientError::QueryFailed(e.to_string()))?;
                 attempt_views
                     .into_iter()
-                    .map(|a| crate::server::job_attempt_view_to_proto(&a))
+                    .map(|a| crate::pb_convert::job_attempt_view_to_proto(&a))
                     .collect()
             } else {
                 Vec::new()
@@ -687,14 +694,14 @@ impl ClusterClient {
             // For succeeded jobs, populate the result field
             let result = if job_status.kind == crate::job::JobStatusKind::Succeeded {
                 if !attempts.is_empty() {
-                    crate::server::result_from_proto_attempts(&attempts)
+                    crate::pb_convert::result_from_proto_attempts(&attempts)
                 } else {
                     let latest = shard
                         .get_latest_job_attempt(tenant, job_id)
                         .await
                         .map_err(|e| ClusterClientError::QueryFailed(e.to_string()))?;
                     latest.and_then(|a| {
-                        let proto = crate::server::job_attempt_view_to_proto(&a);
+                        let proto = crate::pb_convert::job_attempt_view_to_proto(&a);
                         proto.result
                     })
                 }
@@ -715,7 +722,7 @@ impl ClusterClient {
                 limits: job_view
                     .limits()
                     .into_iter()
-                    .map(crate::server::job_limit_to_proto_limit)
+                    .map(crate::pb_convert::job_limit_to_proto_limit)
                     .collect(),
                 metadata: job_view.metadata().into_iter().collect(),
                 status: status.into(),

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -32,7 +32,9 @@ pub use helpers::now_epoch_ms;
 
 use slatedb::Db;
 use slatedb_common::metrics::DefaultMetricsRecorder;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
+#[cfg(feature = "server")]
+use std::sync::OnceLock;
 use std::time::Duration;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
@@ -44,6 +46,7 @@ use crate::job::{JobStatus, JobStatusKind, JobView};
 use crate::job_attempt::JobAttemptView;
 use crate::keys::{attempt_key, job_info_key, job_status_key};
 use crate::metrics::Metrics;
+#[cfg(feature = "server")]
 use crate::query::ShardQueryEngine;
 use crate::settings::DatabaseConfig;
 use crate::shard_range::ShardRange;
@@ -94,6 +97,7 @@ pub struct JobStoreShard {
     pub(crate) db: Arc<Db>,
     pub(crate) brokers: Arc<TaskBrokerRegistry>,
     pub(crate) concurrency: Arc<ConcurrencyManager>,
+    #[cfg(feature = "server")]
     query_engine: OnceLock<ShardQueryEngine>,
     pub(crate) rate_limiter: Arc<dyn RateLimitClient>,
     /// Optional WAL close configuration - present when using local WAL storage
@@ -379,6 +383,7 @@ impl JobStoreShard {
             db,
             brokers,
             concurrency,
+            #[cfg(feature = "server")]
             query_engine: OnceLock::new(),
             rate_limiter,
             wal_close_config,
@@ -411,6 +416,7 @@ impl JobStoreShard {
     ///
     /// This is the low-level query engine for single-shard queries, typically used
     /// by gRPC handlers. For cluster-wide queries, use `ClusterQueryEngine`.
+    #[cfg(feature = "server")]
     pub fn query_engine(self: &Arc<Self>) -> &ShardQueryEngine {
         self.query_engine.get_or_init(|| {
             ShardQueryEngine::new(Arc::clone(self), "jobs").expect("Failed to create query engine")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "server")]
 pub mod arrow_ipc;
 pub mod cluster_client;
+#[cfg(feature = "server")]
 pub mod cluster_query;
 pub mod codec;
 pub mod concurrency;
@@ -13,6 +15,8 @@ pub mod job_attempt;
 pub mod job_store_shard;
 pub mod keys;
 pub mod metrics;
+pub mod pb_convert;
+#[cfg(feature = "server")]
 pub mod query;
 pub mod retry;
 pub mod routing_client;
@@ -24,6 +28,7 @@ pub mod task_broker;
 pub mod trace;
 #[cfg(feature = "dst")]
 pub mod turmoil_object_store;
+#[cfg(feature = "server")]
 pub mod webui;
 pub use silo_macros::test;
 pub mod fb {
@@ -40,8 +45,8 @@ pub mod pb {
         include!(concat!(env!("OUT_DIR"), "/pb.gubernator.rs"));
     }
 }
+#[cfg(feature = "server")]
 pub mod server;
-pub mod siloctl;
 
 #[cfg(unix)]
 #[global_allocator]

--- a/src/pb_convert.rs
+++ b/src/pb_convert.rs
@@ -1,0 +1,114 @@
+//! Pure-Rust conversion helpers between internal types and generated protobuf
+//! types, plus shared gRPC metadata keys. Lives outside the `server` module so
+//! it remains compileable without the heavy `server` feature (datafusion).
+
+use crate::job_attempt::AttemptStatus as JobAttemptStatus;
+use crate::pb::{AttemptStatus, ConcurrencyLimit, Limit, SerializedBytes, limit, serialized_bytes};
+
+/// gRPC metadata key for shard owner address on redirect
+pub const SHARD_OWNER_ADDR_METADATA_KEY: &str = "x-silo-shard-owner-addr";
+/// gRPC metadata key for shard owner node ID on redirect
+pub const SHARD_OWNER_NODE_METADATA_KEY: &str = "x-silo-shard-owner-node";
+
+/// Convert a job::Limit to a proto Limit
+pub fn job_limit_to_proto_limit(job_limit: crate::job::Limit) -> Limit {
+    match job_limit {
+        crate::job::Limit::Concurrency(c) => Limit {
+            limit: Some(limit::Limit::Concurrency(ConcurrencyLimit {
+                key: c.key,
+                max_concurrency: c.max_concurrency,
+            })),
+        },
+        crate::job::Limit::RateLimit(r) => Limit {
+            limit: Some(limit::Limit::RateLimit(crate::pb::GubernatorRateLimit {
+                name: r.name,
+                unique_key: r.unique_key,
+                limit: r.limit,
+                duration_ms: r.duration_ms,
+                hits: r.hits,
+                algorithm: r.algorithm.as_u8() as i32,
+                behavior: r.behavior,
+                retry_policy: Some(crate::pb::RateLimitRetryPolicy {
+                    initial_backoff_ms: r.retry_policy.initial_backoff_ms,
+                    max_backoff_ms: r.retry_policy.max_backoff_ms,
+                    backoff_multiplier: r.retry_policy.backoff_multiplier,
+                    max_retries: r.retry_policy.max_retries,
+                }),
+            })),
+        },
+        crate::job::Limit::FloatingConcurrency(f) => Limit {
+            limit: Some(limit::Limit::FloatingConcurrency(
+                crate::pb::FloatingConcurrencyLimit {
+                    key: f.key,
+                    default_max_concurrency: f.default_max_concurrency,
+                    refresh_interval_ms: f.refresh_interval_ms,
+                    metadata: f.metadata.into_iter().collect(),
+                },
+            )),
+        },
+    }
+}
+
+/// Convert a JobAttemptView to a proto JobAttempt
+pub fn job_attempt_view_to_proto(
+    attempt: &crate::job_attempt::JobAttemptView,
+) -> crate::pb::JobAttempt {
+    let state = attempt.state();
+    let (status, finished_at_ms, result, error_code, error_data) = match state {
+        JobAttemptStatus::Running => (AttemptStatus::Running, None, None, None, None),
+        JobAttemptStatus::Succeeded {
+            finished_at_ms,
+            result,
+        } => (
+            AttemptStatus::Succeeded,
+            Some(finished_at_ms),
+            Some(SerializedBytes {
+                encoding: Some(serialized_bytes::Encoding::Msgpack(result)),
+            }),
+            None,
+            None,
+        ),
+        JobAttemptStatus::Failed {
+            finished_at_ms,
+            error_code,
+            error,
+        } => (
+            AttemptStatus::Failed,
+            Some(finished_at_ms),
+            None,
+            Some(error_code),
+            Some(SerializedBytes {
+                encoding: Some(serialized_bytes::Encoding::Msgpack(error)),
+            }),
+        ),
+        JobAttemptStatus::Cancelled { finished_at_ms } => (
+            AttemptStatus::Cancelled,
+            Some(finished_at_ms),
+            None,
+            None,
+            None,
+        ),
+    };
+
+    crate::pb::JobAttempt {
+        job_id: attempt.job_id().to_string(),
+        attempt_number: attempt.attempt_number(),
+        task_id: attempt.task_id().to_string(),
+        status: status.into(),
+        started_at_ms: attempt.started_at_ms(),
+        finished_at_ms,
+        result,
+        error_code,
+        error_data,
+    }
+}
+
+/// Extract the result from a list of proto JobAttempts.
+/// Returns the result from the last succeeded attempt, if any.
+pub fn result_from_proto_attempts(attempts: &[crate::pb::JobAttempt]) -> Option<SerializedBytes> {
+    attempts
+        .iter()
+        .rev()
+        .find(|a| a.status == i32::from(AttemptStatus::Succeeded))
+        .and_then(|a| a.result.clone())
+}

--- a/src/routing_client.rs
+++ b/src/routing_client.rs
@@ -20,7 +20,7 @@ use crate::cluster_client::{
     ClientConfig, InterceptedSiloClient, create_silo_client_lazy, ensure_http_scheme,
 };
 use crate::pb::GetClusterInfoRequest;
-use crate::server::SHARD_OWNER_ADDR_METADATA_KEY;
+use crate::pb_convert::SHARD_OWNER_ADDR_METADATA_KEY;
 
 /// Information about a shard owner in the cluster.
 #[derive(Debug, Clone)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,7 +24,7 @@ pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("silo
 use crate::coordination::{Coordinator, ShardSplitter};
 use crate::factory::ShardFactory;
 use crate::job::{GubernatorAlgorithm, GubernatorRateLimit, JobStatusKind, RateLimitRetryPolicy};
-use crate::job_attempt::{AttemptOutcome, AttemptStatus as JobAttemptStatus};
+use crate::job_attempt::AttemptOutcome;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::metrics::Metrics;
 use crate::pb::silo_server::{Silo, SiloServer};
@@ -46,10 +46,10 @@ fn job_status_kind_to_proto(kind: JobStatusKind) -> JobStatus {
     }
 }
 
-/// gRPC metadata key for shard owner address on redirect
-pub const SHARD_OWNER_ADDR_METADATA_KEY: &str = "x-silo-shard-owner-addr";
-/// gRPC metadata key for shard owner node ID on redirect  
-pub const SHARD_OWNER_NODE_METADATA_KEY: &str = "x-silo-shard-owner-node";
+pub use crate::pb_convert::{
+    SHARD_OWNER_ADDR_METADATA_KEY, SHARD_OWNER_NODE_METADATA_KEY, job_attempt_view_to_proto,
+    job_limit_to_proto_limit, result_from_proto_attempts,
+};
 
 /// Convert a proto Limit to a job::Limit
 fn proto_limit_to_job_limit(proto: Limit) -> Option<crate::job::Limit> {
@@ -96,109 +96,6 @@ fn proto_limit_to_job_limit(proto: Limit) -> Option<crate::job::Limit> {
             },
         )),
     }
-}
-
-/// Convert a job::Limit to a proto Limit
-pub fn job_limit_to_proto_limit(job_limit: crate::job::Limit) -> Limit {
-    match job_limit {
-        crate::job::Limit::Concurrency(c) => Limit {
-            limit: Some(limit::Limit::Concurrency(ConcurrencyLimit {
-                key: c.key,
-                max_concurrency: c.max_concurrency,
-            })),
-        },
-        crate::job::Limit::RateLimit(r) => Limit {
-            limit: Some(limit::Limit::RateLimit(crate::pb::GubernatorRateLimit {
-                name: r.name,
-                unique_key: r.unique_key,
-                limit: r.limit,
-                duration_ms: r.duration_ms,
-                hits: r.hits,
-                algorithm: r.algorithm.as_u8() as i32,
-                behavior: r.behavior,
-                retry_policy: Some(crate::pb::RateLimitRetryPolicy {
-                    initial_backoff_ms: r.retry_policy.initial_backoff_ms,
-                    max_backoff_ms: r.retry_policy.max_backoff_ms,
-                    backoff_multiplier: r.retry_policy.backoff_multiplier,
-                    max_retries: r.retry_policy.max_retries,
-                }),
-            })),
-        },
-        crate::job::Limit::FloatingConcurrency(f) => Limit {
-            limit: Some(limit::Limit::FloatingConcurrency(
-                crate::pb::FloatingConcurrencyLimit {
-                    key: f.key,
-                    default_max_concurrency: f.default_max_concurrency,
-                    refresh_interval_ms: f.refresh_interval_ms,
-                    metadata: f.metadata.into_iter().collect(),
-                },
-            )),
-        },
-    }
-}
-
-/// Convert a JobAttemptView to a proto JobAttempt
-pub fn job_attempt_view_to_proto(
-    attempt: &crate::job_attempt::JobAttemptView,
-) -> crate::pb::JobAttempt {
-    let state = attempt.state();
-    let (status, finished_at_ms, result, error_code, error_data) = match state {
-        JobAttemptStatus::Running => (AttemptStatus::Running, None, None, None, None),
-        JobAttemptStatus::Succeeded {
-            finished_at_ms,
-            result,
-        } => (
-            AttemptStatus::Succeeded,
-            Some(finished_at_ms),
-            Some(SerializedBytes {
-                encoding: Some(serialized_bytes::Encoding::Msgpack(result)),
-            }),
-            None,
-            None,
-        ),
-        JobAttemptStatus::Failed {
-            finished_at_ms,
-            error_code,
-            error,
-        } => (
-            AttemptStatus::Failed,
-            Some(finished_at_ms),
-            None,
-            Some(error_code),
-            Some(SerializedBytes {
-                encoding: Some(serialized_bytes::Encoding::Msgpack(error)),
-            }),
-        ),
-        JobAttemptStatus::Cancelled { finished_at_ms } => (
-            AttemptStatus::Cancelled,
-            Some(finished_at_ms),
-            None,
-            None,
-            None,
-        ),
-    };
-
-    crate::pb::JobAttempt {
-        job_id: attempt.job_id().to_string(),
-        attempt_number: attempt.attempt_number(),
-        task_id: attempt.task_id().to_string(),
-        status: status.into(),
-        started_at_ms: attempt.started_at_ms(),
-        finished_at_ms,
-        result,
-        error_code,
-        error_data,
-    }
-}
-
-/// Extract the result from a list of proto JobAttempts.
-/// Returns the result from the last succeeded attempt, if any.
-pub fn result_from_proto_attempts(attempts: &[crate::pb::JobAttempt]) -> Option<SerializedBytes> {
-    attempts
-        .iter()
-        .rev()
-        .find(|a| a.status == i32::from(AttemptStatus::Succeeded))
-        .and_then(|a| a.result.clone())
 }
 
 /// Convert a `LeasedTask` into a proto `Task` message.

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -13,7 +13,7 @@ use grpc_integration_helpers::{
 use silo::pb::silo_client::SiloClient;
 use silo::pb::*;
 use silo::settings::AppConfig;
-use silo::siloctl::{self, BytesOutputFormat, GlobalOptions};
+use siloctl::{self, BytesOutputFormat, GlobalOptions};
 
 // Global mutex to serialize profiler tests - both profilers use process-global state.
 static PROFILE_TEST_MUTEX: Mutex<()> = Mutex::new(());


### PR DESCRIPTION
## Summary

- Make `datafusion` / `datafusion-sql` optional and gate the SQL/Arrow modules (`arrow_ipc`, `query`, `cluster_query`, `webui`, `server`) and the silo daemon binary behind a new `server` feature (in default features). Pure-Rust pb conversion helpers move from `server.rs` to a new non-gated `pb_convert` module so `cluster_client` / `routing_client` can still use them.
- Move `siloctl` to its own workspace crate that depends on `silo` with `default-features = false`. siloctl was already a thin gRPC client — it never needed datafusion, but lived in the silo crate so it paid the compile cost.
- `cargo build -p siloctl` no longer pulls datafusion into its dep tree; `silo-compactor` (already `default-features = false`) also benefits. Default `cargo build` of the silo daemon is unchanged.

The existing siloctl integration tests stay in `silo/tests/` (they need the server) and reach the new crate through a dev-dependency.

## Test plan

- [x] `cargo build` (default) — silo daemon builds with datafusion as before
- [x] `cargo build -p siloctl` — succeeds; `cargo tree -p siloctl | grep datafusion` is empty
- [x] `cargo build -p silo-compactor` — succeeds; `cargo tree -p silo-compactor | grep datafusion` is empty
- [x] `cargo check --features dst` — DST feature still builds (orthogonal to `server`)
- [x] `cargo check --tests` — all tests still compile, including `tests/siloctl_tests.rs`
- [x] `cargo test --lib` — passes
- [ ] Smoke: run a local silo, exercise `siloctl cluster info`, `siloctl tenant hash foo`, `siloctl validate-config`, `siloctl query <shard> "SELECT 1"`