### PR TITLE
Bound process_grants peak memory with per-pass cap

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -94,6 +94,16 @@ impl From<crate::codec::CodecError> for ConcurrencyError {
 /// `job_store_shard::get_jobs_status_batch` for the same reason.
 const STATUS_LOOKUP_CONCURRENCY: usize = 64;
 
+/// Max grants written in a single `process_grants` pass. A single
+/// `request_grant_count` accumulation can be arbitrarily large (every
+/// release between scanner wakeups adds to it), and without a per-pass
+/// cap the scanner would materialize `count` `ScannedRequest`s, issue
+/// `count` buffered status gets, and accumulate `count` edits in a
+/// single `WriteBatch` before committing. Capping per pass bounds peak
+/// memory; the outer loop iterates as many passes as needed to drain
+/// the requested count.
+const MAX_GRANTS_PER_PASS: usize = 256;
+
 /// Result of attempting to enqueue a job with concurrency limits
 #[derive(Debug)]
 pub enum RequestTicketOutcome {
@@ -812,18 +822,25 @@ impl ConcurrencyManager {
         }
 
         let mut max_concurrency: Option<(usize, ConcurrencyLimitType)> = None;
-        let mut batch = WriteBatch::new();
-        let mut grants: Vec<(String, String)> = Vec::new();
-        let mut stale_and_corrupt_count: usize = 0;
+        let mut all_granted_groups: Vec<String> = Vec::new();
+        let mut total_granted: usize = 0;
         let mut iter_exhausted = false;
         let mut capacity_exhausted = false;
 
         // Scan→validate→grant loop: keeps pulling from the iterator until we've
-        // granted `count` requests, or hit the end / capacity limit. Each iteration
-        // scans a batch of candidates, validates them concurrently, then reserves
-        // slots for valid ones. Stale/corrupt entries are cleaned up along the way.
-        while grants.len() < count as usize && !iter_exhausted && !capacity_exhausted {
-            let needed = count as usize - grants.len();
+        // granted `count` requests, or hit the end / capacity limit. Each pass
+        // scans up to `MAX_GRANTS_PER_PASS` candidates, validates them concurrently,
+        // reserves slots for valid ones, and commits the batch. Stale/corrupt entries
+        // are cleaned up along the way. Bounding per-pass scan size caps peak memory
+        // (the scanned Vec, buffered status results, and WriteBatch all scale with it),
+        // so a large accumulated `count` is drained over multiple bounded passes
+        // rather than one unbounded one.
+        while total_granted < count as usize && !iter_exhausted && !capacity_exhausted {
+            let needed = (count as usize - total_granted).min(MAX_GRANTS_PER_PASS);
+
+            let mut batch = WriteBatch::new();
+            let mut grants: Vec<(String, String)> = Vec::new();
+            let mut stale_and_corrupt_count: usize = 0;
 
             // --- Scan batch of candidates ---
             let mut scanned: Vec<ScannedRequest> = Vec::new();
@@ -924,10 +941,11 @@ impl ConcurrencyManager {
                 });
             }
 
-            if scanned.is_empty() {
-                break;
-            }
-
+            // If the scan yielded no candidates, fall through to the per-pass
+            // commit so any stale-delete edits accumulated above (malformed
+            // entries) still get written, then let the outer while guard
+            // (which checks `iter_exhausted`) terminate the loop.
+            //
             // --- Batch validate status ---
             // Use `buffered` (order-preserving) rather than `join_all` so that
             // we cap in-flight slatedb reads at STATUS_LOOKUP_CONCURRENCY. Each
@@ -1010,7 +1028,7 @@ impl ConcurrencyManager {
             // --- Reserve in-memory slots and accumulate grant edits ---
             let limit = max_concurrency.map(|(l, _)| l).unwrap_or(1);
             for req in &valid_requests {
-                if grants.len() >= count as usize {
+                if total_granted + grants.len() >= count as usize {
                     break;
                 }
 
@@ -1059,58 +1077,66 @@ impl ConcurrencyManager {
 
                 grants.push((req.request_id.clone(), req.task_group.clone()));
             }
-        }
 
-        // Single combined counter decrement for all grants + stale/corrupt deletions
-        let total_counter_decrement = grants.len() + stale_and_corrupt_count;
-        if total_counter_decrement > 0 {
-            batch.merge(
-                concurrency_requester_counter_key(tenant, queue),
-                encode_counter(-(total_counter_decrement as i64)),
-            );
-        }
-
-        if grants.is_empty() && stale_and_corrupt_count == 0 {
-            return Vec::new();
-        }
-
-        // --- Single durable write ---
-        if let Err(e) = db
-            .write_with_options(
-                batch,
-                &WriteOptions {
-                    await_durable: true,
-                },
-            )
-            .await
-        {
-            for (request_id, _) in &grants {
-                self.counts.release_reservation(tenant, queue, request_id);
+            // --- Per-pass commit ---
+            // Combined counter decrement for this pass's grants + stale/corrupt deletions.
+            let pass_decrement = grants.len() + stale_and_corrupt_count;
+            if pass_decrement > 0 {
+                batch.merge(
+                    concurrency_requester_counter_key(tenant, queue),
+                    encode_counter(-(pass_decrement as i64)),
+                );
             }
-            tracing::warn!(
-                error = %e,
-                count = grants.len(),
-                "grant scanner: batch write failed, rolled back all reservations"
-            );
-            return Vec::new();
-        }
 
-        for (request_id, task_group) in &grants {
-            tracing::debug!(
-                queue = %queue,
-                request_id = %request_id,
-                task_group = %task_group,
-                "grant scanner: granted concurrency ticket"
-            );
-        }
-
-        if let Some(ref m) = self.metrics {
-            for _ in 0..grants.len() {
-                m.record_concurrency_ticket_granted();
+            // Skip the durable write if this pass produced no edits (e.g. every
+            // scanned status lookup returned an error). The iterator has still
+            // advanced, so the outer loop continues until iter_exhausted.
+            if grants.is_empty() && stale_and_corrupt_count == 0 {
+                continue;
             }
+
+            if let Err(e) = db
+                .write_with_options(
+                    batch,
+                    &WriteOptions {
+                        await_durable: true,
+                    },
+                )
+                .await
+            {
+                // Roll back only this pass's reservations; prior committed passes stand.
+                for (request_id, _) in &grants {
+                    self.counts.release_reservation(tenant, queue, request_id);
+                }
+                tracing::warn!(
+                    error = %e,
+                    pass_grants = grants.len(),
+                    prior_grants = total_granted,
+                    "grant scanner: batch write failed, rolled back this pass's reservations"
+                );
+                return all_granted_groups;
+            }
+
+            for (request_id, task_group) in &grants {
+                tracing::debug!(
+                    queue = %queue,
+                    request_id = %request_id,
+                    task_group = %task_group,
+                    "grant scanner: granted concurrency ticket"
+                );
+            }
+
+            if let Some(ref m) = self.metrics {
+                for _ in 0..grants.len() {
+                    m.record_concurrency_ticket_granted();
+                }
+            }
+
+            total_granted += grants.len();
+            all_granted_groups.extend(grants.into_iter().map(|(_, tg)| tg));
         }
 
-        grants.into_iter().map(|(_, tg)| tg).collect()
+        all_granted_groups
     }
 }
 

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2034,3 +2034,103 @@ async fn grant_scanner_handles_backlog_larger_than_status_lookup_concurrency() {
     );
     assert_eq!(count_concurrency_holders(shard.db()).await, N);
 }
+
+/// Regression test for `MAX_GRANTS_PER_PASS` bounding in `process_grants`.
+///
+/// A single `request_grant_count` accumulation can be arbitrarily large (every
+/// release between scanner wakeups adds to it). Without a per-pass cap, the
+/// scanner would materialize `count` `ScannedRequest`s, issue `count` buffered
+/// status gets, and accumulate `count` edits in one `WriteBatch` before
+/// committing. The cap forces the scanner to drain a large `count` over multiple
+/// bounded passes — this test verifies that an end-to-end drain of a backlog
+/// larger than `MAX_GRANTS_PER_PASS` (256) still grants every waiter.
+#[silo::test]
+async fn grant_scanner_drains_backlog_larger_than_max_per_pass() {
+    // Sized to cross the per-pass cap (256) by enough to require at least three
+    // passes, exercising the multi-pass commit path.
+    const N: usize = 600;
+
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "max-per-pass-q";
+    let tenant = "max-per-pass-tenant";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: N as u32,
+    });
+
+    shard.stop_grant_scanner();
+
+    // Fill all N slots with holders.
+    for i in 0..N {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("holder-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+    let mut holder_tasks = Vec::with_capacity(N);
+    while holder_tasks.len() < N {
+        let tasks = shard.dequeue("w", "tg", N).await.unwrap().tasks;
+        assert!(!tasks.is_empty(), "dequeue should return holders");
+        for t in tasks {
+            holder_tasks.push(t.attempt().task_id().to_string());
+        }
+    }
+
+    // Enqueue N waiters — each becomes a request (capacity is full).
+    for i in 0..N {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("waiter-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+    assert_eq!(count_concurrency_requests(shard.db()).await, N);
+
+    // Release all holders to free capacity.
+    for task_id in &holder_tasks {
+        shard
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .unwrap();
+    }
+
+    // One process_grants call asks for N grants. Internally this must run as
+    // multiple bounded passes (each ≤ MAX_GRANTS_PER_PASS = 256) and still
+    // return all N grants.
+    let granted = shard
+        .process_concurrency_grants(tenant, queue, N as u32)
+        .await;
+    assert_eq!(
+        granted.len(),
+        N,
+        "all {} waiters should be granted via multiple bounded passes",
+        N
+    );
+
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "all request records should be consumed"
+    );
+    assert_eq!(count_concurrency_holders(shard.db()).await, N);
+}


### PR DESCRIPTION
## Summary

A single accumulated `count` in `pending_grants` can be arbitrarily large — every `request_grant` call between scanner wakeups adds to it, and the scanner drains the whole map in one shot. Before this change, `process_grants` materialized `count` `ScannedRequest`s, issued `count` buffered `db.get(job_status_key)` lookups, and accumulated `count` edits in a single `WriteBatch` before one durable write. Peak memory scaled linearly with the backlog, on top of the already-existing `STATUS_LOOKUP_CONCURRENCY = 64` cap on in-flight slatedb reads.

This PR caps each pass at `MAX_GRANTS_PER_PASS = 256` and commits per pass instead of accumulating.

- `needed = (count - total_granted).min(MAX_GRANTS_PER_PASS)` per outer iteration
- `WriteBatch`, per-pass `grants` Vec, and `stale_and_corrupt_count` moved inside the loop
- Per-pass durable write; on failure, only the current pass's reservations are rolled back (prior passes already committed and stand)
- Counter decrement is still merged into the same batch so it commits atomically with each pass's grants + stale deletions
- The slatedb iterator persists across passes — we don't rescan the same prefix

This is orthogonal to the CPU-side suggestions (batch the per-grant gets, cache parsed grant state, reconsider `FuturesOrdered`) and is the smaller, more contained change.

## Test plan

- [x] New regression test `grant_scanner_drains_backlog_larger_than_max_per_pass` — N=600 backlog (>2× cap), one `process_concurrency_grants(N)` call, asserts all 600 waiters granted via multiple bounded passes
- [x] All 22 existing tests in `job_store_shard_concurrency_tests` pass, including:
  - `grant_scanner_skips_stale_requests_and_grants_valid_ones`
  - `grant_scanner_handles_all_stale_requests` (covers stale-only passes)
  - `grant_scanner_handles_backlog_larger_than_status_lookup_concurrency` (N=200, exercises the buffered status pipeline)
- [x] All 97 concurrency-related tests across `concurrency_*`, `concurrent_grant_race_tests`, `floating_concurrency_tests`, `retry_tests`, `counter_reconcile_tests` pass
- [x] `cargo fmt` clean, no new clippy warnings in `src/concurrency.rs`