### PR TITLE
Forward SlateDB object-store metrics to Prometheus

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,7 +34,7 @@ use prometheus::{
     Counter, CounterVec, Encoder, Gauge, GaugeVec, HistogramOpts, HistogramVec, Opts, Registry,
     TextEncoder, core::Collector,
 };
-use slatedb_common::metrics::{DefaultMetricsRecorder, MetricValue};
+use slatedb_common::metrics::{DefaultMetricsRecorder, LATENCY_BOUNDARIES, MetricValue};
 use tokio::sync::broadcast;
 use tower::{Layer, Service};
 use tracing::{debug, error};
@@ -60,6 +60,13 @@ const READY_TO_START_LATENCY_MS_BUCKETS: &[f64] = &[
     1.0, 10.0, 50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 30000.0, 60000.0, 300000.0, 600000.0,
     1800000.0, 3600000.0,
 ];
+
+// SlateDB's `instrumented_object_store::stats` module is `pub(crate)` upstream,
+// so we hardcode these names. Once https://github.com/slatedb/slatedb/pull/1628
+// lands and we upgrade, replace these with `slatedb::instrumented_object_store::stats::*`.
+const OS_REQUEST_COUNT: &str = "slatedb.object_store.request_count";
+const OS_ERROR_COUNT: &str = "slatedb.object_store.error_count";
+const OS_REQUEST_DURATION_SECONDS: &str = "slatedb.object_store.request_duration_seconds";
 
 /// Silo metrics handle containing all metric instruments.
 #[derive(Clone)]
@@ -143,10 +150,20 @@ pub struct SlatedbShardMetrics {
     cache_filter_hit: CounterVec,
     cache_filter_miss: CounterVec,
 
+    // Object store metrics (per component/store_type/op/api)
+    object_store_requests: CounterVec,
+    object_store_errors: CounterVec,
+    object_store_request_duration: HistogramVec,
+
     /// Tracks previous SlateDB counter values per (stat_name, shard) for delta computation.
     /// SlateDB exposes counters as absolute values via `stat.get()`, but Prometheus counters
     /// only support `inc_by(delta)`, so we compute deltas between polls.
     prev_values: Arc<Mutex<HashMap<(String, String), f64>>>,
+
+    /// Tracks previous cumulative bucket counts for SlateDB histograms, keyed
+    /// the same way as `prev_values`. Needed because the `prometheus` crate
+    /// exposes histograms only via `observe(x)`, so we re-observe deltas.
+    prev_histogram_buckets: Arc<Mutex<HashMap<(String, String), Vec<u64>>>>,
 }
 
 impl Metrics {
@@ -345,6 +362,25 @@ impl SlatedbShardMetrics {
                 GaugeVec::new(Opts::new(format!("{p}{name}"), help), &["shard"])?,
             ))
         };
+        let labeled_counter =
+            |name: &str, help: &str, labels: &[&str]| -> anyhow::Result<CounterVec> {
+                Ok(register(
+                    registry,
+                    CounterVec::new(Opts::new(format!("{p}{name}"), help), labels)?,
+                ))
+            };
+        let labeled_histogram =
+            |name: &str, help: &str, labels: &[&str]| -> anyhow::Result<HistogramVec> {
+                Ok(register(
+                    registry,
+                    HistogramVec::new(
+                        HistogramOpts::new(format!("{p}{name}"), help)
+                            .buckets(LATENCY_BOUNDARIES.to_vec()),
+                        labels,
+                    )?,
+                ))
+            };
+        let os_labels: &[&str] = &["shard", "component", "store_type", "op", "api"];
 
         Ok(Self {
             get_requests: counter(
@@ -439,7 +475,23 @@ impl SlatedbShardMetrics {
                 "slatedb_cache_filter_miss_total",
                 "Total SlateDB bloom filter cache misses",
             )?,
+            object_store_requests: labeled_counter(
+                "slatedb_object_store_requests_total",
+                "Total SlateDB object-store API calls (per component/store_type/op/api)",
+                os_labels,
+            )?,
+            object_store_errors: labeled_counter(
+                "slatedb_object_store_errors_total",
+                "Total SlateDB object-store API errors (per component/store_type/op/api)",
+                os_labels,
+            )?,
+            object_store_request_duration: labeled_histogram(
+                "slatedb_object_store_request_duration_seconds",
+                "SlateDB object-store API call latency (per component/store_type/op/api)",
+                os_labels,
+            )?,
             prev_values: Arc::new(Mutex::new(HashMap::new())),
+            prev_histogram_buckets: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -622,6 +674,116 @@ impl SlatedbShardMetrics {
                 gauge.with_label_values(&[shard]).set(value);
             }
         }
+
+        // Object-store metrics: variable label sets (component/store_type/op/api).
+        // Counters use the same delta-vs-previous trick as the rest of `update`;
+        // the histogram is delta-translated bucket-by-bucket through `observe()`
+        // since the `prometheus` crate has no public bucket-counter API.
+        {
+            let mut prev_values = self.prev_values.lock().expect("lock poisoned");
+            let mut prev_histogram_buckets =
+                self.prev_histogram_buckets.lock().expect("lock poisoned");
+
+            for (stat_name, counter_vec) in [
+                (OS_REQUEST_COUNT, &self.object_store_requests),
+                (OS_ERROR_COUNT, &self.object_store_errors),
+            ] {
+                for metric in snapshot.by_name(stat_name) {
+                    let current = match metric.value {
+                        MetricValue::Counter(v) => v as f64,
+                        _ => continue,
+                    };
+                    let vals = os_label_values(&metric.labels);
+                    let key = (os_prev_key(stat_name, &vals), shard.to_string());
+                    let prev = prev_values.get(&key).copied().unwrap_or(0.0);
+                    if current > prev {
+                        counter_vec
+                            .with_label_values(&[shard, &vals[0], &vals[1], &vals[2], &vals[3]])
+                            .inc_by(current - prev);
+                    }
+                    prev_values.insert(key, current);
+                }
+            }
+
+            for metric in snapshot.by_name(OS_REQUEST_DURATION_SECONDS) {
+                let (boundaries, bucket_counts) = match &metric.value {
+                    MetricValue::Histogram {
+                        boundaries,
+                        bucket_counts,
+                        ..
+                    } => (boundaries, bucket_counts),
+                    _ => continue,
+                };
+                let vals = os_label_values(&metric.labels);
+                let key = (
+                    os_prev_key(OS_REQUEST_DURATION_SECONDS, &vals),
+                    shard.to_string(),
+                );
+                let prev = prev_histogram_buckets
+                    .get(&key)
+                    .cloned()
+                    .unwrap_or_default();
+                let prom_histogram = self
+                    .object_store_request_duration
+                    .with_label_values(&[shard, &vals[0], &vals[1], &vals[2], &vals[3]]);
+                for (i, &current_count) in bucket_counts.iter().enumerate() {
+                    let prev_count = prev.get(i).copied().unwrap_or(0);
+                    let delta = current_count.saturating_sub(prev_count);
+                    if delta == 0 {
+                        continue;
+                    }
+                    let observe_value = value_for_bucket(boundaries, i);
+                    for _ in 0..delta {
+                        prom_histogram.observe(observe_value);
+                    }
+                }
+                prev_histogram_buckets.insert(key, bucket_counts.clone());
+            }
+        }
+    }
+}
+
+/// Pull the four object-store label values out of a `slatedb_common` metric's
+/// labels, in the order our Prometheus instrument expects them.
+fn os_label_values(labels: &[(String, String)]) -> [String; 4] {
+    let lookup = |key: &str| {
+        labels
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.clone())
+            .unwrap_or_default()
+    };
+    [
+        lookup("component"),
+        lookup("store_type"),
+        lookup("op"),
+        lookup("api"),
+    ]
+}
+
+/// Build a stable key for tracking previous values across polls for an
+/// object-store series.
+fn os_prev_key(stat_name: &str, vals: &[String; 4]) -> String {
+    format!(
+        "{stat_name}/component={},store_type={},op={},api={}",
+        vals[0], vals[1], vals[2], vals[3]
+    )
+}
+
+/// Pick a value strictly inside histogram bucket `idx` for both SlateDB's `<`
+/// bucketing semantics and Prometheus's `<=` semantics, given the bucket
+/// boundary list. SlateDB's `bucket_counts` has length `boundaries.len() + 1`
+/// (the last entry being the overflow bucket).
+fn value_for_bucket(boundaries: &[f64], idx: usize) -> f64 {
+    if boundaries.is_empty() {
+        return 0.0;
+    }
+    if idx == 0 {
+        boundaries[0] / 2.0
+    } else if idx < boundaries.len() {
+        (boundaries[idx - 1] + boundaries[idx]) / 2.0
+    } else {
+        boundaries[boundaries.len() - 1] * 1.5
     }
 }
 

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -545,6 +545,143 @@ async fn test_metrics_slatedb_multiple_shards() {
 }
 
 #[silo::test]
+async fn test_metrics_slatedb_object_store() {
+    let (metrics, _app) = create_metrics_router();
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let object_store = std::sync::Arc::new(
+        object_store::local::LocalFileSystem::new_with_prefix(tmpdir.path()).unwrap(),
+    );
+    let recorder = std::sync::Arc::new(slatedb_common::metrics::DefaultMetricsRecorder::new());
+    let db = slatedb::DbBuilder::new("test-db", object_store)
+        .with_metrics_recorder(recorder.clone())
+        .build()
+        .await
+        .unwrap();
+
+    // Drive WAL puts and a flush so we get object-store activity on the
+    // main store as well (SST writes), not just WAL writes.
+    for i in 0..32u32 {
+        db.put(format!("key{i}").as_bytes(), &vec![b'v'; 1024])
+            .await
+            .unwrap();
+    }
+    db.flush().await.unwrap();
+
+    metrics.update_slatedb_stats("0", &recorder);
+
+    let body = gather_metrics_text(&metrics);
+
+    // TYPE lines should be present.
+    assert!(
+        body.contains("# TYPE silo_slatedb_object_store_requests_total counter"),
+        "object_store_requests_total should be a counter type"
+    );
+    assert!(
+        body.contains("# TYPE silo_slatedb_object_store_errors_total counter"),
+        "object_store_errors_total should be a counter type"
+    );
+    assert!(
+        body.contains("# TYPE silo_slatedb_object_store_request_duration_seconds histogram"),
+        "object_store_request_duration_seconds should be a histogram type"
+    );
+
+    // At least one PUT request line should be present and non-zero. We don't
+    // pin down `store_type` here because either main or wal will have seen
+    // writes; both are valid signals.
+    let request_lines: Vec<&str> = body
+        .lines()
+        .filter(|l| {
+            !l.starts_with('#')
+                && l.contains("silo_slatedb_object_store_requests_total{")
+                && l.contains("shard=\"0\"")
+                && l.contains("op=\"put\"")
+        })
+        .collect();
+    assert!(
+        !request_lines.is_empty(),
+        "should have at least one put request series, body:\n{body}"
+    );
+    let any_nonzero = request_lines.iter().any(|l| !l.trim_end().ends_with(" 0"));
+    assert!(
+        any_nonzero,
+        "at least one put request series should be > 0, lines: {request_lines:?}"
+    );
+
+    // Histogram buckets and _count/_sum should be present and the count for at
+    // least one put series should be > 0.
+    let bucket_lines: Vec<&str> = body
+        .lines()
+        .filter(|l| {
+            !l.starts_with('#')
+                && l.contains("silo_slatedb_object_store_request_duration_seconds_bucket")
+                && l.contains("shard=\"0\"")
+                && l.contains("op=\"put\"")
+        })
+        .collect();
+    assert!(
+        !bucket_lines.is_empty(),
+        "should have histogram bucket lines for put"
+    );
+    let count_lines: Vec<&str> = body
+        .lines()
+        .filter(|l| {
+            !l.starts_with('#')
+                && l.contains("silo_slatedb_object_store_request_duration_seconds_count")
+                && l.contains("shard=\"0\"")
+                && l.contains("op=\"put\"")
+        })
+        .collect();
+    let any_count_nonzero = count_lines.iter().any(|l| !l.trim_end().ends_with(" 0"));
+    assert!(
+        any_count_nonzero,
+        "histogram count for at least one put series should be > 0, lines: {count_lines:?}"
+    );
+
+    // Label cardinality: we should see more than one (store_type, op, api)
+    // combination across the request counter — at minimum WAL puts and SST
+    // puts produce distinct `store_type` values, but reads of the manifest
+    // also produce `op="get"` series in `component="db"` style code paths.
+    let distinct_label_sets: std::collections::HashSet<&str> = body
+        .lines()
+        .filter(|l| !l.starts_with('#') && l.contains("silo_slatedb_object_store_requests_total{"))
+        .filter_map(|l| {
+            l.split_once('{')
+                .and_then(|(_, rest)| rest.split_once('}'))
+                .map(|(labels, _)| labels)
+        })
+        .collect();
+    assert!(
+        distinct_label_sets.len() >= 2,
+        "expected at least 2 distinct object-store label combinations, got {}: {:?}",
+        distinct_label_sets.len(),
+        distinct_label_sets
+    );
+
+    // Idempotency: calling update again without further activity must not
+    // double-count counters or histogram buckets.
+    metrics.update_slatedb_stats("0", &recorder);
+    let body2 = gather_metrics_text(&metrics);
+    let extract_first_count = |body: &str| -> Option<f64> {
+        body.lines()
+            .find(|l| {
+                !l.starts_with('#')
+                    && l.contains("silo_slatedb_object_store_request_duration_seconds_count")
+                    && l.contains("shard=\"0\"")
+                    && l.contains("op=\"put\"")
+            })
+            .and_then(|l| l.rsplit_once(' ').and_then(|(_, v)| v.parse::<f64>().ok()))
+    };
+    assert_eq!(
+        extract_first_count(&body),
+        extract_first_count(&body2),
+        "histogram count must be stable across no-op polls"
+    );
+
+    db.close().await.unwrap();
+}
+
+#[silo::test]
 async fn test_metrics_ready_to_start_latency() {
     let (metrics, _app) = create_metrics_router();
 


### PR DESCRIPTION
## Summary

- Exposes SlateDB's `InstrumentedObjectStore` metrics (request count, error count, request duration histogram) to Prometheus, per-shard, labeled by `component`/`store_type`/`op`/`api`. The data was already being recorded into each shard's `DefaultMetricsRecorder`; this change reads it on each `update_slatedb_stats` poll and translates it into Prometheus counters and histogram series.
- New silo metrics: `silo_slatedb_object_store_requests_total`, `silo_slatedb_object_store_errors_total`, `silo_slatedb_object_store_request_duration_seconds` (and the matching `silo_compactor_*` series under the compactor binary's prefix).
- Motivation: diagnose immutable memtable flush stalls. Combined with existing `silo_slatedb_immutable_memtable_flushes_total` and `silo_slatedb_l0_sst_count`, slow PUTs to main object storage now show up directly as a tail-latency spike on `silo_slatedb_object_store_request_duration_seconds{op="put",store_type="main"}`.

## Implementation notes

- `slatedb::instrumented_object_store::stats` is `pub(crate)` upstream, so the three stat-name strings are hardcoded in `metrics.rs` with a comment pointing at https://github.com/slatedb/slatedb/pull/1628 for the post-upgrade follow-up.
- Histogram delta translation re-`observe()`s per-bucket midpoints since the `prometheus` crate exposes histograms only via `observe(x)`. Bucket distribution is preserved exactly (so `histogram_quantile()` is faithful); the reported `_sum` is approximate by midpoints. Acceptable for the latency-tail analysis the metric is built for.
- Reuses `slatedb_common::metrics::LATENCY_BOUNDARIES` directly so the Prometheus bucket boundaries align with SlateDB's source histogram, which is what makes the bucket-by-bucket translation lossless on the count side.
- silo-compactor inherits the same metrics for free via the existing prefix-based registration in `silo-compactor/src/metrics.rs`.

## Test plan

- [x] `cargo check -p silo` and `cargo check -p silo-compactor` clean.
- [x] `cargo test -p silo --test metrics_tests` — all 9 tests pass, including the new `test_metrics_slatedb_object_store` covering: TYPE lines for the 3 new instruments, non-zero put request counter, histogram bucket/count lines, ≥2 distinct label combinations, and idempotency of repeat polls.
- [ ] Manual smoke after deploy: `curl <metrics_port>/metrics | grep object_store` against a staging shard, confirm series appear with realistic label combinations and non-zero histogram counts.