### PR TITLE
Upgrade slatedb to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,7 +3136,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4659,7 +4659,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5550,9 +5550,9 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slatedb"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5a80caa3ae5d5ca404b3c22a4d7ba235798a011641eda24b629d1b7fc203dc"
+checksum = "e6519858d579386cb814c761e494bccac59410596db96938627340528d3c6b7b"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5598,9 +5598,9 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f4df716813038071acf5a21046494493dcce21e8d1b90d04035d01a23e45c2"
+checksum = "933cf6a6059814219f35b1b96b84b3481a53ec57d64f2fd7b000effad86cba7f"
 dependencies = [
  "chrono",
  "log",
@@ -5610,9 +5610,9 @@ dependencies = [
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be31b387569b0d71ea08b0ad94ed8cb0c2e8cb8b31e737086c79bbe90c978249"
+checksum = "f5ab6739c5e58a326fd815e8e5bc72688612bb771d81304b036c42c63bbcfbde"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5712,7 +5712,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ version = "0.3.0"
 [dependencies]
 clap = { version = "4.3.14", features = ["derive", "env"] }
 futures = "0.3"
-slatedb = "0.12.0"
-slatedb-common = "0.12.0"
+slatedb = "0.12.1"
+slatedb-common = "0.12.1"
 object_store = { version = "0.12", features = ["gcp"] }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/silo-compactor/Cargo.toml
+++ b/silo-compactor/Cargo.toml
@@ -9,8 +9,8 @@ name = "silo-compactor"
 path = "src/main.rs"
 
 [dependencies]
-slatedb = { version = "0.12.0", features = ["compaction_filters"] }
-slatedb-common = "0.12.0"
+slatedb = { version = "0.12.1", features = ["compaction_filters"] }
+slatedb-common = "0.12.1"
 object_store = { version = "0.12", features = ["gcp"] }
 prometheus = "0.13"
 


### PR DESCRIPTION
## Summary

The standalone compactor (`silo-compactor`) was failing in production whenever the `completed_jobs` compaction filter ran. The filter opens a short-lived `DbReader` per compaction job to point-read `JOB_STATUS` and pre-scan `IDX_STATUS_TIME`, and that open was returning:

> Invalid error: wal store reconfiguration unsupported

Silo opens shards with `[database.wal]` configured (in production: `fs:///var/silo/wal-%shard%`), so SlateDB writes the manifest with `wal_object_store_uri = Some(_)`. The compactor's `DbReaderBuilder` does not configure a WAL object store, so SlateDB's manifest validator rejects the open as a reconfiguration. Concretely, the failing code is `DbReaderBuilder::build()` at `slatedb 0.12.0/src/db/builder.rs:1340-1343`, raised from `silo-compactor/src/compaction_filter.rs:223`. The standalone `CompactorBuilder` itself does not need a WAL store and is not affected — only the per-job reader the filter opens to make drop decisions.

slatedb 0.12.1 removes `wal_object_store_uri` from `ManifestV2`, so newly-written manifests no longer carry the flag that the validator compares against and the DbReader open succeeds without the compactor having to mirror silo's WAL config.

## Changes

- `slatedb` and `slatedb-common`: `0.12.0` -> `0.12.1` in the workspace root and `silo-compactor`.
- `Cargo.lock` updated to match.

No source changes — the API surface is unchanged.

## Test plan

- [x] `cargo build --workspace --all-targets` (verified locally; clean build)
- [x] `cargo test -p silo-compactor` in CI
- [x] `cargo test --workspace` in CI
- [x] Once merged and rolled out, watch the staging compactor logs for "completed_jobs filter: failed to open DbReader" warnings — they should stop firing for shards whose manifests get rewritten under 0.12.1.