### PR TITLE
DST coverage for the holder-leak bug class + Bug 2/3 fixes

### DIFF
--- a/specs/job_shard.als
+++ b/specs/job_shard.als
@@ -251,20 +251,13 @@ fact wellFormed {
     -- Requests are only for queues the job requires
     all r: TicketRequest | r.tr_queue in jobQueues[r.tr_job]
     
-    -- A holder can only exist for a task that is either:
-    -- 1. In the DB queue as a RunAttempt (granted at enqueue), OR
-    -- 2. In the buffer as a RunAttempt (scanned from DB), OR
-    -- 3. Has a lease (running), OR
-    -- 4. In the DB queue as a CheckRateLimit task (chained Concurrency -> RateLimit), OR
-    -- 5. In the buffer as a CheckRateLimit task
-    -- This allows holders to exist before lease (granted at enqueue, leased at dequeue)
-    -- and persists across the CheckRateLimit chain phase.
-    all h: TicketHolder |
-        some dbQueuedAt[h.th_task, h.th_time] or
-        some bufferedAt[h.th_task, h.th_time] or
-        some leaseAt[h.th_task, h.th_time] or
-        some dbCheckRateLimitAt[h.th_task, h.th_time] or
-        some bufferedCheckRateLimitAt[h.th_task, h.th_time]
+    -- The holder/active-task invariant lives in `assert holdersRequireActiveTask`
+    -- (below), NOT here. Keeping it as a fact makes the assertion trivially
+    -- true and prevents Alloy from generating buggy traces — the assertion
+    -- could never catch a transition that drops a task without releasing
+    -- holders. Encoded as an assertion, the safety property is checked
+    -- against the modeled transitions: a forgotten release produces a
+    -- counterexample.
     
     -- A holder and request can never coexist for the same (task, queue) at the same time
     -- (This is enforced by transitions but stated explicitly for clarity)
@@ -395,6 +388,12 @@ pred taskHoldsAllQueues[tid: TaskId, j: Job, t: Time] {
 pred concurrencyUnchanged[t: Time, tnext: Time] {
     all q: Queue | requestTasksAt[q, tnext] = requestTasksAt[q, t]
     all q: Queue | holdersAt[q, tnext] = holdersAt[q, t]
+    -- CRL state is part of "concurrency state" for frame purposes — without
+    -- this clause, transitions that preserve holders could spuriously add or
+    -- remove CRL entries, breaking the holdersRequireActiveTask assertion via
+    -- a phantom orphan rather than a real bug.
+    all tid: TaskId | dbCheckRateLimitAt[tid, tnext] = dbCheckRateLimitAt[tid, t]
+    all tid: TaskId | bufferedCheckRateLimitAt[tid, tnext] = bufferedCheckRateLimitAt[tid, t]
 }
 
 /** Frame condition: requests unchanged, only specific holder changes */
@@ -439,11 +438,13 @@ pred init[t: Time] {
 pred enqueuePreConditions[tid: TaskId, j: Job, t: Time] {
     -- [SILO-ENQ-1] Pre: job does NOT exist yet (we're creating a new job)
     j not in jobExistsAt[t]
-    
-    -- Pre: task is not already in use (not in DB, buffer, or leased)
+
+    -- Pre: task is not already in use (not in DB, buffer, leased, or CRL)
     no dbQueuedAt[tid, t]
     no bufferedAt[tid, t]
     no leaseAt[tid, t]
+    no dbCheckRateLimitAt[tid, t]
+    no bufferedCheckRateLimitAt[tid, t]
 }
 
 /** Common postconditions for job creation (all enqueue variants) */
@@ -672,7 +673,7 @@ pred completeFrameConditions[tid: TaskId, t: Time, tnext: Time] {
     all tid2: TaskId | bufferedAt[tid2, tnext] = bufferedAt[tid2, t]
 }
 
-/** 
+/**
  * Release a holder for a specific task/queue.
  */
 pred releaseHolder[tid: TaskId, q: Queue, t: Time, tnext: Time] {
@@ -681,6 +682,19 @@ pred releaseHolder[tid: TaskId, q: Queue, t: Time, tnext: Time] {
     -- Other queues unchanged
     all q2: Queue | q2 != q implies holdersAt[q2, tnext] = holdersAt[q2, t]
     -- Requests unchanged (grant_next is a separate transition)
+    requestsUnchanged[t, tnext]
+}
+
+/**
+ * Release a set of holders for a single task atomically. Use this when a
+ * transition must release every queue a task was carrying — `all q: ... |
+ * releaseHolder[tid, q, t, tnext]` is unsatisfiable for |qs| > 1 because
+ * each releaseHolder asserts other queues are unchanged, contradicting the
+ * release of the next queue in the same step.
+ */
+pred releaseHolders[tid: TaskId, qs: set Queue, t: Time, tnext: Time] {
+    all q: qs | holdersAt[q, tnext] = holdersAt[q, t] - tid
+    all q: Queue - qs | holdersAt[q, tnext] = holdersAt[q, t]
     requestsUnchanged[t, tnext]
 }
 
@@ -1768,7 +1782,11 @@ pred brokerScanCheckRateLimit[t: Time, tnext: Time] {
     attemptExistsAt[tnext] = attemptExistsAt[t]
     all a: attemptExistsAt[t] | attemptStatusAt[a, tnext] = attemptStatusAt[a, t]
     jobExistsAt[tnext] = jobExistsAt[t]
-    concurrencyUnchanged[t, tnext]
+    -- Holders/requests preserved (we don't use concurrencyUnchanged because
+    -- it would also preserve CRL state, contradicting the buffer mutation
+    -- above).
+    all q: Queue | requestTasksAt[q, tnext] = requestTasksAt[q, t]
+    all q: Queue | holdersAt[q, tnext] = holdersAt[q, t]
 }
 
 -- Transition: DEQUEUE_DROP_RUN_ATTEMPT
@@ -1797,10 +1815,7 @@ pred dequeueDropRunAttempt[tid: TaskId, t: Time, tnext: Time] {
     -- Post: release ALL queues this task was carrying. Without this clause
     -- the assertion `holdersRequireActiveTask` fails, which is the formal
     -- statement of the bug fixed in PR #255.
-    (no taskHeldQueuesAt[tid, t]) implies holdersUnchanged[t, tnext]
-    (some taskHeldQueuesAt[tid, t]) implies {
-        all q: taskHeldQueuesAt[tid, t] | releaseHolder[tid, q, t, tnext]
-    }
+    releaseHolders[tid, taskHeldQueuesAt[tid, t], t, tnext]
 
     -- Frame: leases, jobs, attempts, requests, CRL state unchanged
     all tid2: TaskId | {
@@ -1846,10 +1861,7 @@ pred dequeueDropCheckRateLimit[tid: TaskId, t: Time, tnext: Time] {
     -- kirin/fix-rate-limit-holder-leak and kirin/dst-holder-leak-coverage.
     -- Held queues are derived from TicketHolder (taskHeldQueuesAt), the
     -- authoritative record.
-    (no taskHeldQueuesAt[tid, t]) implies holdersUnchanged[t, tnext]
-    (some taskHeldQueuesAt[tid, t]) implies {
-        all q: taskHeldQueuesAt[tid, t] | releaseHolder[tid, q, t, tnext]
-    }
+    releaseHolders[tid, taskHeldQueuesAt[tid, t], t, tnext]
 
     -- Frame: other leases, jobs, attempts, requests unchanged
     all tid2: TaskId | {
@@ -1911,6 +1923,30 @@ pred step[t: Time, tnext: Time] {
 fact traces {
     init[first]
     all t: Time - last | step[t, t.next]
+}
+
+/**
+ * CRL state changes only when a CRL transition fires. Without this fact,
+ * existing transitions that bypass `concurrencyUnchanged` (e.g.,
+ * enqueueWithConcurrencyGranted, completion-with-release variants) leave CRL
+ * sigs unconstrained — Alloy can spuriously add or remove CRL entries,
+ * fabricating dangling-holder counterexamples that don't correspond to any
+ * real transition. This fact ties CRL mutation to the dedicated transitions.
+ */
+fact crlStateChangesOnlyViaCrlTransitions {
+    all t: Time - last | let tnext = t.next | {
+        (some tid: TaskId | dbCheckRateLimitAt[tid, tnext] != dbCheckRateLimitAt[tid, t])
+            implies (
+                (some tid: TaskId, j: Job, q: Queue |
+                    enqueueWithConcurrencyAndRateLimit[tid, j, q, t, tnext]) or
+                (some tid: TaskId | dequeueDropCheckRateLimit[tid, t, tnext])
+            )
+        (some tid: TaskId | bufferedCheckRateLimitAt[tid, tnext] != bufferedCheckRateLimitAt[tid, t])
+            implies (
+                brokerScanCheckRateLimit[t, tnext] or
+                (some tid: TaskId | dequeueDropCheckRateLimit[tid, t, tnext])
+            )
+    }
 }
 
 

--- a/specs/job_shard.als
+++ b/specs/job_shard.als
@@ -80,6 +80,31 @@ sig BufferedTask {
     buf_qtime: one Time
 }
 
+/**
+ * A CheckRateLimit task in the durable DB queue. Held queues are tracked
+ * authoritatively in TicketHolder; this sig just records that the task is
+ * in the CheckRateLimit phase rather than the RunAttempt phase.
+ *
+ * Models src/job_store_shard/dequeue.rs::handle_check_rate_limit's input.
+ * See src/task.rs::Task::CheckRateLimit.
+ */
+sig DbCheckRateLimitTask {
+    crl_task: one TaskId,
+    crl_job: one Job,
+    crl_time: one Time
+}
+
+/**
+ * A CheckRateLimit task pulled from DB into the broker buffer. Same role as
+ * BufferedTask but for CheckRateLimit tasks (which the dequeue handler
+ * processes internally without returning to a worker).
+ */
+sig BufferedCheckRateLimitTask {
+    bcrl_task: one TaskId,
+    bcrl_job: one Job,
+    bcrl_time: one Time
+}
+
 /** Active lease at a given time */
 sig Lease {
     ltask: one TaskId,
@@ -150,20 +175,37 @@ fact wellFormed {
     
     -- A task can be in DB queue for at most one job at each time
     all taskid: TaskId, t: Time | lone qt: DbQueuedTask | qt.db_qtask = taskid and qt.db_qtime = t
-    
+
     -- A task can be in Buffer for at most one job at each time
     all taskid: TaskId, t: Time | lone bt: BufferedTask | bt.buf_qtask = taskid and bt.buf_qtime = t
-    
+
+    -- A task can be a CheckRateLimit DB row for at most one job at each time
+    all taskid: TaskId, t: Time | lone ct: DbCheckRateLimitTask | ct.crl_task = taskid and ct.crl_time = t
+
+    -- A task can be a CheckRateLimit Buffer row for at most one job at each time
+    all taskid: TaskId, t: Time | lone bct: BufferedCheckRateLimitTask | bct.bcrl_task = taskid and bct.bcrl_time = t
+
+    -- A task is either a RunAttempt OR a CheckRateLimit at any given time, not both.
+    -- (handle_check_rate_limit advances the task to a RunAttempt by clearing the CRL row
+    --  and inserting a DbQueuedTask in the same batch.)
+    all taskid: TaskId, t: Time |
+        not (some dbQueuedAt[taskid, t] and some dbCheckRateLimitAt[taskid, t])
+    all taskid: TaskId, t: Time |
+        not (some bufferedAt[taskid, t] and some bufferedCheckRateLimitAt[taskid, t])
+
     -- A task can be leased to at most one worker at each time
     all taskid: TaskId, t: Time | lone l: Lease | l.ltask = taskid and l.ltime = t
-    
+
     -- Task-job binding is permanent: if a task is ever associated with a job
-    -- (in DB, buffer, lease, or request), it can only be associated with that same job
-    -- (In Rust, the task's key contains job_id which is immutable)
+    -- (in DB, buffer, lease, request, or CheckRateLimit row), it can only be
+    -- associated with that same job. (In Rust the task's key contains job_id
+    -- which is immutable.)
     all taskid: TaskId | lone j: Job |
         (some t: Time | some dbQueuedAt[taskid, t] and dbQueuedAt[taskid, t] = j) or
         (some t: Time | some bufferedAt[taskid, t] and bufferedAt[taskid, t] = j) or
         (some t: Time | some leaseJobAt[taskid, t] and leaseJobAt[taskid, t] = j) or
+        (some t: Time | some dbCheckRateLimitAt[taskid, t] and dbCheckRateLimitAt[taskid, t] = j) or
+        (some t: Time | some bufferedCheckRateLimitAt[taskid, t] and bufferedCheckRateLimitAt[taskid, t] = j) or
         (some r: TicketRequest | r.tr_task = taskid and r.tr_job = j)
     
     -- Existential tracking: one tracker per time
@@ -210,14 +252,19 @@ fact wellFormed {
     all r: TicketRequest | r.tr_queue in jobQueues[r.tr_job]
     
     -- A holder can only exist for a task that is either:
-    -- 1. In the DB queue (just granted at enqueue), OR
-    -- 2. In the buffer (scanned from DB), OR  
-    -- 3. Has a lease (running)
+    -- 1. In the DB queue as a RunAttempt (granted at enqueue), OR
+    -- 2. In the buffer as a RunAttempt (scanned from DB), OR
+    -- 3. Has a lease (running), OR
+    -- 4. In the DB queue as a CheckRateLimit task (chained Concurrency -> RateLimit), OR
+    -- 5. In the buffer as a CheckRateLimit task
     -- This allows holders to exist before lease (granted at enqueue, leased at dequeue)
-    all h: TicketHolder | 
-        some dbQueuedAt[h.th_task, h.th_time] or 
-        some bufferedAt[h.th_task, h.th_time] or 
-        some leaseAt[h.th_task, h.th_time]
+    -- and persists across the CheckRateLimit chain phase.
+    all h: TicketHolder |
+        some dbQueuedAt[h.th_task, h.th_time] or
+        some bufferedAt[h.th_task, h.th_time] or
+        some leaseAt[h.th_task, h.th_time] or
+        some dbCheckRateLimitAt[h.th_task, h.th_time] or
+        some bufferedCheckRateLimitAt[h.th_task, h.th_time]
     
     -- A holder and request can never coexist for the same (task, queue) at the same time
     -- (This is enforced by transitions but stated explicitly for clarity)
@@ -256,6 +303,16 @@ fun dbQueuedAt[taskid: TaskId, t: Time]: set Job {
 
 fun bufferedAt[taskid: TaskId, t: Time]: set Job {
     ((buf_qtask.taskid) & (buf_qtime.t)).buf_qjob
+}
+
+/** A CheckRateLimit task in DB at time t (returns the job it belongs to). */
+fun dbCheckRateLimitAt[taskid: TaskId, t: Time]: set Job {
+    ((crl_task.taskid) & (crl_time.t)).crl_job
+}
+
+/** A CheckRateLimit task in the buffer at time t (returns the job it belongs to). */
+fun bufferedCheckRateLimitAt[taskid: TaskId, t: Time]: set Job {
+    ((bcrl_task.taskid) & (bcrl_time.t)).bcrl_job
 }
 
 fun leaseAt[taskid: TaskId, t: Time]: set Worker {
@@ -370,6 +427,8 @@ pred init[t: Time] {
     no jobExistsAt[t]
     no qt: DbQueuedTask | qt.db_qtime = t
     no bt: BufferedTask | bt.buf_qtime = t
+    no ct: DbCheckRateLimitTask | ct.crl_time = t
+    no bct: BufferedCheckRateLimitTask | bct.bcrl_time = t
     no l: Lease | l.ltime = t
     no attemptExistsAt[t] -- No attempts exist initially
     -- No concurrency state initially
@@ -1627,6 +1686,185 @@ pred reimportNonTerminalConcurrencyQueued[newTid: TaskId, j: Job, q: Queue, t: T
     }
 }
 
+--------------------------------------------------------------------
+-- CheckRateLimit transitions
+--
+-- Models the chain Concurrency -> RateLimit, where the Concurrency
+-- holder is granted at enqueue time but the resulting task is a
+-- CheckRateLimit task (not a RunAttempt) until the rate-limit check
+-- passes. The handler in `src/job_store_shard/dequeue.rs::handle_check_rate_limit`
+-- can drop this task without going through completion (max retries,
+-- missing job_info, malformed job_info). All such drops MUST release
+-- every queue the task was carrying or `holdersRequireActiveTask`
+-- breaks. These transitions encode that contract symbolically.
+--------------------------------------------------------------------
+
+-- Transition: ENQUEUE_WITH_CONCURRENCY_AND_RATE_LIMIT
+-- Job has a chained limit list (Concurrency, then RateLimit). The
+-- Concurrency limit is granted immediately, so a holder is created;
+-- the resulting task is a CheckRateLimit DB row (not a RunAttempt)
+-- carrying that holder.
+pred enqueueWithConcurrencyAndRateLimit[tid: TaskId, j: Job, q: Queue, t: Time, tnext: Time] {
+    enqueuePreConditions[tid, j, t]
+    enqueueJobCreated[j, t, tnext]
+    enqueueFrameConditions[tid, t, tnext]
+
+    -- Pre: Job requires this queue
+    q in jobQueues[j]
+
+    -- Pre: Queue has capacity
+    queueHasCapacity[q, t]
+
+    -- Post: Holder created at q
+    holdersAt[q, tnext] = tid
+    -- Frame: other holders unchanged, requests unchanged
+    all q2: Queue | q2 != q implies holdersAt[q2, tnext] = holdersAt[q2, t]
+    requestsUnchanged[t, tnext]
+
+    -- Post: NO RunAttempt task in DB; instead a CheckRateLimit DB row
+    no qt: DbQueuedTask | qt.db_qtask = tid and qt.db_qtime = tnext
+    all tid2: TaskId | dbQueuedAt[tid2, tnext] = dbQueuedAt[tid2, t]
+
+    one ct: DbCheckRateLimitTask |
+        ct.crl_task = tid and ct.crl_job = j and ct.crl_time = tnext
+    all tid2: TaskId | tid2 != tid implies dbCheckRateLimitAt[tid2, tnext] = dbCheckRateLimitAt[tid2, t]
+
+    -- Frame: CRL buffer unchanged
+    all tid2: TaskId | bufferedCheckRateLimitAt[tid2, tnext] = bufferedCheckRateLimitAt[tid2, t]
+}
+
+-- Transition: BROKER_SCAN_CHECK_RATE_LIMIT
+-- Mirror of brokerScan but for CheckRateLimit DB rows.
+pred brokerScanCheckRateLimit[t: Time, tnext: Time] {
+    -- Pre: a CRL task in DB is not yet in the buffer
+    some tid: TaskId | some dbCheckRateLimitAt[tid, t] and no bufferedCheckRateLimitAt[tid, t]
+
+    -- Effect: copy (some) CRL tasks from DB to buffer, preserving held queues
+    all tid: TaskId | {
+        some bufferedCheckRateLimitAt[tid, t] implies
+            bufferedCheckRateLimitAt[tid, tnext] = bufferedCheckRateLimitAt[tid, t]
+        no bufferedCheckRateLimitAt[tid, t] implies
+            bufferedCheckRateLimitAt[tid, tnext] in dbCheckRateLimitAt[tid, t]
+    }
+    -- Progress: at least one task moves
+    some tid: TaskId | no bufferedCheckRateLimitAt[tid, t] and some bufferedCheckRateLimitAt[tid, tnext]
+
+    -- Frame: DB CRL state unchanged
+    all tid: TaskId | dbCheckRateLimitAt[tid, tnext] = dbCheckRateLimitAt[tid, t]
+
+    -- Frame: held-queues annotation preserved when buffered (modeled by the
+    -- inclusion above; held-queues equality follows from sig identity).
+
+    -- Frame: RunAttempt DB/buffer, leases, jobs, attempts, concurrency state unchanged
+    all tid: TaskId | dbQueuedAt[tid, tnext] = dbQueuedAt[tid, t]
+    all tid: TaskId | bufferedAt[tid, tnext] = bufferedAt[tid, t]
+    all tid: TaskId | {
+        leaseAt[tid, tnext] = leaseAt[tid, t]
+        leaseJobAt[tid, tnext] = leaseJobAt[tid, t]
+        leaseAttemptAt[tid, tnext] = leaseAttemptAt[tid, t]
+    }
+    all j: Job | statusAt[j, tnext] = statusAt[j, t]
+    all j: Job | isCancelledAt[j, tnext] iff isCancelledAt[j, t]
+    attemptExistsAt[tnext] = attemptExistsAt[t]
+    all a: attemptExistsAt[t] | attemptStatusAt[a, tnext] = attemptStatusAt[a, t]
+    jobExistsAt[tnext] = jobExistsAt[t]
+    concurrencyUnchanged[t, tnext]
+}
+
+-- Transition: DEQUEUE_DROP_RUN_ATTEMPT
+-- Models the dequeue-handler early-return paths for a RunAttempt task
+-- where the handler decides to drop the task without going through
+-- completion (e.g., handle_run_attempt's missing-job_info path at
+-- src/job_store_shard/dequeue.rs:679). This is the formal envelope
+-- of Bug 1: any such drop MUST release the queues this task held.
+pred dequeueDropRunAttempt[tid: TaskId, t: Time, tnext: Time] {
+    -- Pre: task is buffered as a RunAttempt
+    some bufferedAt[tid, t]
+    -- Pre: task is not currently leased (not running)
+    no leaseAt[tid, t]
+
+    -- Post: task removed from DB queue and buffer
+    no dbQueuedAt[tid, tnext]
+    no bufferedAt[tid, tnext]
+    -- No lease created
+    no leaseAt[tid, tnext]
+    -- Frame: other tasks' RunAttempt DB/buffer rows unchanged
+    all tid2: TaskId | tid2 != tid implies {
+        dbQueuedAt[tid2, tnext] = dbQueuedAt[tid2, t]
+        bufferedAt[tid2, tnext] = bufferedAt[tid2, t]
+    }
+
+    -- Post: release ALL queues this task was carrying. Without this clause
+    -- the assertion `holdersRequireActiveTask` fails, which is the formal
+    -- statement of the bug fixed in PR #255.
+    (no taskHeldQueuesAt[tid, t]) implies holdersUnchanged[t, tnext]
+    (some taskHeldQueuesAt[tid, t]) implies {
+        all q: taskHeldQueuesAt[tid, t] | releaseHolder[tid, q, t, tnext]
+    }
+
+    -- Frame: leases, jobs, attempts, requests, CRL state unchanged
+    all tid2: TaskId | {
+        leaseAt[tid2, tnext] = leaseAt[tid2, t]
+        leaseJobAt[tid2, tnext] = leaseJobAt[tid2, t]
+        leaseAttemptAt[tid2, tnext] = leaseAttemptAt[tid2, t]
+    }
+    all j: Job | statusAt[j, tnext] = statusAt[j, t]
+    all j: Job | isCancelledAt[j, tnext] iff isCancelledAt[j, t]
+    attemptExistsAt[tnext] = attemptExistsAt[t]
+    all a: attemptExistsAt[t] | attemptStatusAt[a, tnext] = attemptStatusAt[a, t]
+    jobExistsAt[tnext] = jobExistsAt[t]
+    requestsUnchanged[t, tnext]
+    all tid2: TaskId | dbCheckRateLimitAt[tid2, tnext] = dbCheckRateLimitAt[tid2, t]
+    all tid2: TaskId | bufferedCheckRateLimitAt[tid2, tnext] = bufferedCheckRateLimitAt[tid2, t]
+}
+
+-- Transition: DEQUEUE_DROP_CHECK_RATE_LIMIT
+-- Models the dequeue-handler early-return paths for a CheckRateLimit
+-- task: the max-retries arm (Bug 2, dequeue.rs:556-577) and the
+-- missing/malformed job_info arms (Bug 3, dequeue.rs:512-518). All
+-- such drops MUST release the queues this CRL task carries.
+pred dequeueDropCheckRateLimit[tid: TaskId, t: Time, tnext: Time] {
+    -- Pre: task is buffered as a CheckRateLimit
+    some bufferedCheckRateLimitAt[tid, t]
+    -- Pre: not leased (CRL tasks aren't leased to workers)
+    no leaseAt[tid, t]
+
+    -- Post: CRL DB and buffer rows removed for this task
+    no dbCheckRateLimitAt[tid, tnext]
+    no bufferedCheckRateLimitAt[tid, tnext]
+    all tid2: TaskId | tid2 != tid implies {
+        dbCheckRateLimitAt[tid2, tnext] = dbCheckRateLimitAt[tid2, t]
+        bufferedCheckRateLimitAt[tid2, tnext] = bufferedCheckRateLimitAt[tid2, t]
+    }
+    -- No RunAttempt task created (this is the drop, not the advance)
+    all tid2: TaskId | dbQueuedAt[tid2, tnext] = dbQueuedAt[tid2, t]
+    all tid2: TaskId | bufferedAt[tid2, tnext] = bufferedAt[tid2, t]
+    no leaseAt[tid, tnext]
+
+    -- Post: release ALL queues this CRL task was carrying. Without this
+    -- clause the assertion breaks — exactly the bugs fixed in branches
+    -- kirin/fix-rate-limit-holder-leak and kirin/dst-holder-leak-coverage.
+    -- Held queues are derived from TicketHolder (taskHeldQueuesAt), the
+    -- authoritative record.
+    (no taskHeldQueuesAt[tid, t]) implies holdersUnchanged[t, tnext]
+    (some taskHeldQueuesAt[tid, t]) implies {
+        all q: taskHeldQueuesAt[tid, t] | releaseHolder[tid, q, t, tnext]
+    }
+
+    -- Frame: other leases, jobs, attempts, requests unchanged
+    all tid2: TaskId | {
+        leaseAt[tid2, tnext] = leaseAt[tid2, t]
+        leaseJobAt[tid2, tnext] = leaseJobAt[tid2, t]
+        leaseAttemptAt[tid2, tnext] = leaseAttemptAt[tid2, t]
+    }
+    all j: Job | statusAt[j, tnext] = statusAt[j, t]
+    all j: Job | isCancelledAt[j, tnext] iff isCancelledAt[j, t]
+    attemptExistsAt[tnext] = attemptExistsAt[t]
+    all a: attemptExistsAt[t] | attemptStatusAt[a, tnext] = attemptStatusAt[a, t]
+    jobExistsAt[tnext] = jobExistsAt[t]
+    requestsUnchanged[t, tnext]
+}
+
 -- System Trace
 pred step[t: Time, tnext: Time] {
     -- Job lifecycle (no concurrency)
@@ -1661,6 +1899,11 @@ pred step[t: Time, tnext: Time] {
     or (some newTid: TaskId, j: Job | reimportNonTerminal[newTid, j, t, tnext])
     or (some newTid: TaskId, j: Job, q: Queue | reimportNonTerminalConcurrencyGranted[newTid, j, q, t, tnext])
     or (some newTid: TaskId, j: Job, q: Queue | reimportNonTerminalConcurrencyQueued[newTid, j, q, t, tnext])
+    -- CheckRateLimit lifecycle (chained Concurrency -> RateLimit + early-return drops)
+    or (some tid: TaskId, j: Job, q: Queue | enqueueWithConcurrencyAndRateLimit[tid, j, q, t, tnext])
+    or (brokerScanCheckRateLimit[t, tnext])
+    or (some tid: TaskId | dequeueDropRunAttempt[tid, t, tnext])
+    or (some tid: TaskId | dequeueDropCheckRateLimit[tid, t, tnext])
     -- Stutter
     or stutter[t, tnext]
 }
@@ -1788,18 +2031,33 @@ assert queueLimitEnforced {
 }
 
 /**
- * Holders only exist for tasks that are active (in DB queue, buffer, or leased).
- * A ticket holder is created at enqueue (granted) or grant_next, and released when:
+ * Holders only exist for tasks that are active in some form (in DB queue, in
+ * buffer, leased, or carried by a CheckRateLimit task).
+ *
+ * A ticket holder is created at enqueue (granted), at grant_next, or by an
+ * enqueue-with-concurrency-and-rate-limit (where the task is a CheckRateLimit
+ * carrying the holder), and released when:
  * - Task completes successfully or fails: [SILO-REL-1]
  * - Lease expires: [SILO-REAP-*] releases via completion path
  * - Job cancelled with task in queue: [SILO-CXL-3] eagerly removes holders
+ * - Dequeue handler drops the task on an early-return path (max retries,
+ *   missing job_info, malformed job_info): dequeueDropRunAttempt /
+ *   dequeueDropCheckRateLimit
+ *
+ * If a future drop-path forgets to release the held queues, this assertion
+ * produces a counterexample — that's exactly the bug shape fixed in PR #255
+ * and on branches kirin/fix-rate-limit-holder-leak,
+ * kirin/dst-holder-leak-coverage.
+ *
  * See: [SILO-ENQ-CONC-2], [SILO-GRANT-3], [SILO-REL-1], [SILO-CXL-3]
  */
 assert holdersRequireActiveTask {
-    all h: TicketHolder | 
-        some dbQueuedAt[h.th_task, h.th_time] or 
-        some bufferedAt[h.th_task, h.th_time] or 
-        some leaseAt[h.th_task, h.th_time]
+    all h: TicketHolder |
+        some dbQueuedAt[h.th_task, h.th_time] or
+        some bufferedAt[h.th_task, h.th_time] or
+        some leaseAt[h.th_task, h.th_time] or
+        some dbCheckRateLimitAt[h.th_task, h.th_time] or
+        some bufferedCheckRateLimitAt[h.th_task, h.th_time]
 }
 
 /**
@@ -2528,6 +2786,65 @@ pred exampleRetryReleasesTicketForOtherJob {
     }
 }
 
+-- ========== CHECK-RATE-LIMIT DROP EXAMPLES ==========
+
+/**
+ * Scenario: a chained Concurrency -> RateLimit job is granted the
+ * Concurrency holder at enqueue time, the broker scans the CRL task
+ * into its buffer, then the dequeue handler drops the CheckRateLimit
+ * task on an early-return path. The holder MUST be released by the
+ * drop transition.
+ */
+pred exampleCheckRateLimitDropReleasesHolder {
+    some tid: TaskId, j: Job, q: Queue, t1, t2, t3, t4: Time | {
+        lt[t1, t2] and lt[t2, t3] and lt[t3, t4]
+        q in jobQueues[j]
+
+        -- t1 -> t2: enqueue with chained Concurrency + RateLimit creates
+        --          the CRL DB row and a holder.
+        enqueueWithConcurrencyAndRateLimit[tid, j, q, t1, t2]
+        some dbCheckRateLimitAt[tid, t2]
+        tid in holdersAt[q, t2]
+
+        -- t2 -> t3: broker scan moves CRL row to buffer.
+        brokerScanCheckRateLimit[t2, t3]
+        some bufferedCheckRateLimitAt[tid, t3]
+        tid in holdersAt[q, t3]
+
+        -- t3 -> t4: drop the CRL task; holder for q is released.
+        dequeueDropCheckRateLimit[tid, t3, t4]
+        no dbCheckRateLimitAt[tid, t4]
+        no bufferedCheckRateLimitAt[tid, t4]
+        tid not in holdersAt[q, t4]
+    }
+}
+
+/**
+ * Scenario: a RunAttempt task with held queues is dropped by the
+ * dequeue handler (e.g., the missing-job_info path in
+ * handle_run_attempt). All held queues are released.
+ */
+pred exampleDequeueDropRunAttemptReleasesHolder {
+    some tid: TaskId, j: Job, q: Queue, t1, t2, t3, t4: Time | {
+        lt[t1, t2] and lt[t2, t3] and lt[t3, t4]
+        q in jobQueues[j]
+
+        -- t1: enqueue with concurrency granted creates a holder + RunAttempt
+        enqueueWithConcurrencyGranted[tid, j, q, t1, t2]
+        some dbQueuedAt[tid, t2]
+        tid in holdersAt[q, t2]
+
+        -- t2: broker scan moves it to buffer
+        brokerScan[t2, t3]
+        some bufferedAt[tid, t3]
+
+        -- t3: drop the buffered task; t4 has no holder for q.
+        dequeueDropRunAttempt[tid, t3, t4]
+        no bufferedAt[tid, t4]
+        tid not in holdersAt[q, t4]
+    }
+}
+
 -- ========== IMPORT/REIMPORT EXAMPLES ==========
 
 /**
@@ -2874,21 +3191,31 @@ check cancellationClearedRequiresRestartable for 4 but 2 Job, 2 Worker, 3 TaskId
 check restartedJobIsScheduledWithTask for 4 but 2 Job, 2 Worker, 3 TaskId, 4 Attempt, 8 Time,
     16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease, 8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 16 JobCancelled
 
--- Concurrency ticket assertions (with Queue, TicketRequest, TicketHolder, JobQueueRequirement bounds)
+-- Concurrency ticket assertions (with Queue, TicketRequest, TicketHolder, JobQueueRequirement bounds).
+-- Scopes admit DbCheckRateLimitTask / BufferedCheckRateLimitTask so the new
+-- CheckRateLimit transitions can produce witnesses.
 check queueLimitEnforced for 4 but 2 Job, 2 Worker, 3 TaskId, 4 Attempt, 8 Time, 2 Queue,
-    16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease, 8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 12 JobCancelled,
+    16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease,
+    6 DbCheckRateLimitTask, 6 BufferedCheckRateLimitTask,
+    8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 12 JobCancelled,
     4 JobQueueRequirement, 8 TicketRequest, 8 TicketHolder
 
 check holdersRequireActiveTask for 4 but 2 Job, 2 Worker, 3 TaskId, 4 Attempt, 8 Time, 2 Queue,
-    16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease, 8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 12 JobCancelled,
+    16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease,
+    6 DbCheckRateLimitTask, 6 BufferedCheckRateLimitTask,
+    8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 12 JobCancelled,
     4 JobQueueRequirement, 8 TicketRequest, 8 TicketHolder
 
 check grantedMeansNoRequest for 4 but 2 Job, 2 Worker, 3 TaskId, 4 Attempt, 8 Time, 2 Queue,
-    16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease, 8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 12 JobCancelled,
+    16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease,
+    6 DbCheckRateLimitTask, 6 BufferedCheckRateLimitTask,
+    8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 12 JobCancelled,
     4 JobQueueRequirement, 8 TicketRequest, 8 TicketHolder
 
 check noHoldersForTerminal for 4 but 2 Job, 2 Worker, 3 TaskId, 4 Attempt, 8 Time, 2 Queue,
-    16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease, 8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 12 JobCancelled,
+    16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease,
+    6 DbCheckRateLimitTask, 6 BufferedCheckRateLimitTask,
+    8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 12 JobCancelled,
     4 JobQueueRequirement, 8 TicketRequest, 8 TicketHolder
 
 -- Expedite assertions
@@ -2945,3 +3272,18 @@ check reimportPreservesCancellation for 4 but 2 Job, 2 Worker, 3 TaskId, 4 Attem
 
 check importRejectsExistingJobs for 4 but 2 Job, 2 Worker, 3 TaskId, 4 Attempt, 8 Time,
     16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease, 8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 12 JobCancelled
+
+-- CheckRateLimit drop witnesses. Each must produce a satisfying instance
+-- (SAT) — confirms the new transitions are reachable. If they go UNSAT
+-- something in the surrounding well-formedness is over-constrained.
+run exampleCheckRateLimitDropReleasesHolder for 4 but exactly 1 Job, 1 Worker, 2 TaskId, 1 Attempt, 8 Time, 1 Queue,
+    8 JobState, 8 AttemptState, 4 DbQueuedTask, 4 BufferedTask, 2 Lease,
+    4 DbCheckRateLimitTask, 4 BufferedCheckRateLimitTask,
+    8 AttemptExists, 8 JobExists, 1 JobAttemptRelation, 8 JobCancelled,
+    2 JobQueueRequirement, 6 TicketRequest, 6 TicketHolder
+
+run exampleDequeueDropRunAttemptReleasesHolder for 4 but exactly 1 Job, 1 Worker, 2 TaskId, 1 Attempt, 8 Time, 1 Queue,
+    8 JobState, 8 AttemptState, 4 DbQueuedTask, 4 BufferedTask, 2 Lease,
+    4 DbCheckRateLimitTask, 4 BufferedCheckRateLimitTask,
+    8 AttemptExists, 8 JobExists, 1 JobAttemptRelation, 8 JobCancelled,
+    2 JobQueueRequirement, 6 TicketRequest, 6 TicketHolder

--- a/src/bin/silo-sim.rs
+++ b/src/bin/silo-sim.rs
@@ -70,10 +70,15 @@ fn unique_prefix() -> String {
     format!("sim-{}", nanos)
 }
 
-async fn count_with_prefix(db: &slatedb::Db, prefix: &str) -> usize {
-    let start: Vec<u8> = prefix.as_bytes().to_vec();
-    let mut end: Vec<u8> = prefix.as_bytes().to_vec();
-    end.push(0xFF);
+/// Count rows under a binary key prefix. Note: the previous version of this
+/// helper accepted a `&str` and used `prefix.as_bytes()`, which silently
+/// scanned an unrelated ASCII range (e.g., "holders/" starts with 0x68 while
+/// the actual concurrency-holder prefix is 0x09). That made the simulator's
+/// holder/lease/request invariants vacuous. Always pass the binary prefix from
+/// `keys::*_prefix()`.
+async fn count_with_binary_prefix(db: &slatedb::Db, prefix: &[u8]) -> usize {
+    let start: Vec<u8> = prefix.to_vec();
+    let end: Vec<u8> = keys::end_bound(prefix);
     let mut iter = db.scan::<Vec<u8>, _>(start..end).await.expect("scan");
     let mut n = 0usize;
     loop {
@@ -399,7 +404,11 @@ async fn main() -> anyhow::Result<()> {
             while checker_running.load(Ordering::SeqCst) {
                 let mut holders_total = 0usize;
                 for shard in shards_for_check.values() {
-                    holders_total += count_with_prefix(shard.db(), "holders/").await;
+                    holders_total += count_with_binary_prefix(
+                        shard.db(),
+                        &keys::concurrency_holders_prefix(),
+                    )
+                    .await;
                 }
                 assert!(
                     holders_total <= upper_bound_total,
@@ -410,7 +419,11 @@ async fn main() -> anyhow::Result<()> {
 
                 let mut requests_total = 0usize;
                 for shard in shards_for_check.values() {
-                    requests_total += count_with_prefix(shard.db(), "requests/").await;
+                    requests_total += count_with_binary_prefix(
+                        shard.db(),
+                        &keys::concurrency_requests_prefix(),
+                    )
+                    .await;
                 }
                 assert!(
                     requests_total < 2000,
@@ -558,9 +571,9 @@ async fn main() -> anyhow::Result<()> {
     );
 
     for (sid, shard) in shards_for_enq.iter() {
-        let h = count_with_prefix(shard.db(), "holders/").await;
-        let l = count_with_prefix(shard.db(), "leases/").await;
-        let r = count_with_prefix(shard.db(), "requests/").await;
+        let h = count_with_binary_prefix(shard.db(), &keys::concurrency_holders_prefix()).await;
+        let l = count_with_binary_prefix(shard.db(), &keys::leases_prefix()).await;
+        let r = count_with_binary_prefix(shard.db(), &keys::concurrency_requests_prefix()).await;
         assert_eq!(
             h, 0,
             "holders leak shard={} h={} l={} r={} seed={} leaked_acks={} job_info_deletes={}",

--- a/src/bin/silo-sim.rs
+++ b/src/bin/silo-sim.rs
@@ -283,9 +283,7 @@ async fn main() -> anyhow::Result<()> {
                 let limits: Vec<Limit> = if roll < rate_limit_fraction {
                     // Pure RateLimit job. Half configured to deny so the
                     // CheckRateLimit max-retries early return fires.
-                    vec![Limit::RateLimit(rate_limit_for(
-                        q_name, i, force_deny, 2,
-                    ))]
+                    vec![Limit::RateLimit(rate_limit_for(q_name, i, force_deny, 2))]
                 } else if roll < rate_limit_fraction + chained_fraction {
                     // Chained Concurrency -> RateLimit (Bug 2 / Bug 3 shape).
                     vec![
@@ -396,19 +394,16 @@ async fn main() -> anyhow::Result<()> {
     // FloatingConcurrency jobs can produce holders independent of that cap, so
     // the steady-state ceiling is approximate — keep a generous slack so the
     // mid-run check still bites on egregious over-grant.
-    let upper_bound_total =
-        queues.iter().map(|(_, lim)| *lim as usize).sum::<usize>() + 256;
+    let upper_bound_total = queues.iter().map(|(_, lim)| *lim as usize).sum::<usize>() + 256;
     let check_handle = {
         let checker_running = checker_running.clone();
         tokio::spawn(async move {
             while checker_running.load(Ordering::SeqCst) {
                 let mut holders_total = 0usize;
                 for shard in shards_for_check.values() {
-                    holders_total += count_with_binary_prefix(
-                        shard.db(),
-                        &keys::concurrency_holders_prefix(),
-                    )
-                    .await;
+                    holders_total +=
+                        count_with_binary_prefix(shard.db(), &keys::concurrency_holders_prefix())
+                            .await;
                 }
                 assert!(
                     holders_total <= upper_bound_total,
@@ -419,11 +414,9 @@ async fn main() -> anyhow::Result<()> {
 
                 let mut requests_total = 0usize;
                 for shard in shards_for_check.values() {
-                    requests_total += count_with_binary_prefix(
-                        shard.db(),
-                        &keys::concurrency_requests_prefix(),
-                    )
-                    .await;
+                    requests_total +=
+                        count_with_binary_prefix(shard.db(), &keys::concurrency_requests_prefix())
+                            .await;
                 }
                 assert!(
                     requests_total < 2000,
@@ -475,8 +468,7 @@ async fn main() -> anyhow::Result<()> {
                 if shard_ids.is_empty() {
                     continue;
                 }
-                let pick_idx: usize =
-                    rng.lock().unwrap().random_range(0..shard_ids.len());
+                let pick_idx: usize = rng.lock().unwrap().random_range(0..shard_ids.len());
                 let Some(shard) = shards.get(&shard_ids[pick_idx]) else {
                     continue;
                 };
@@ -497,8 +489,7 @@ async fn main() -> anyhow::Result<()> {
                 if sampled.is_empty() {
                     continue;
                 }
-                let pick: usize =
-                    rng.lock().unwrap().random_range(0..sampled.len());
+                let pick: usize = rng.lock().unwrap().random_range(0..sampled.len());
                 let mut batch = WriteBatch::new();
                 batch.delete(&sampled[pick]);
                 if shard.db().write(batch).await.is_ok() {

--- a/src/bin/silo-sim.rs
+++ b/src/bin/silo-sim.rs
@@ -6,13 +6,21 @@ use std::sync::{
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use clap::Parser;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
 use silo::coordination::{Coordinator, EtcdCoordinator};
 use silo::factory::ShardFactory;
 use silo::gubernator::MockGubernatorClient;
-use silo::job::{ConcurrencyLimit, Limit};
+use silo::job::{
+    ConcurrencyLimit, FloatingConcurrencyLimit, GubernatorAlgorithm, GubernatorRateLimit, Limit,
+    RateLimitRetryPolicy,
+};
 use silo::job_attempt::AttemptOutcome;
 use silo::job_store_shard::JobStoreShard;
+use silo::keys;
 use silo::settings::{AppConfig, Backend, DatabaseConfig, DatabaseTemplate, LogFormat};
+use slatedb::WriteBatch;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -31,6 +39,27 @@ struct Args {
     /// Concurrency limit for q-gamma
     #[arg(long, default_value = "8")]
     gamma: u32,
+    /// RNG seed (random if unset). Echoed at startup so failures are reproducible.
+    #[arg(long)]
+    seed: Option<u64>,
+    /// Fraction of jobs enqueued with a single RateLimit limit
+    #[arg(long, default_value = "0.10")]
+    rate_limit_fraction: f64,
+    /// Fraction of jobs enqueued with chained Concurrency + RateLimit limits
+    #[arg(long, default_value = "0.15")]
+    chained_fraction: f64,
+    /// Fraction of jobs enqueued with a single FloatingConcurrency limit
+    #[arg(long, default_value = "0.05")]
+    floating_fraction: f64,
+    /// Per-task probability that a worker abandons the lease without acking
+    #[arg(long, default_value = "0.005")]
+    worker_crash_prob: f64,
+    /// Per-tick probability the injector deletes a random job_info row
+    #[arg(long, default_value = "0.002")]
+    job_info_delete_prob: f64,
+    /// Whether to spawn a background lease reaper
+    #[arg(long, default_value_t = true)]
+    spawn_reaper: bool,
 }
 
 fn unique_prefix() -> String {
@@ -64,6 +93,28 @@ async fn now_ms() -> i64 {
         .as_millis() as i64
 }
 
+/// Build a `GubernatorRateLimit` for the simulator. With `force_deny`, the
+/// limit is set to 0 so the mock returns `under_limit:false` and the
+/// CheckRateLimit task exhausts retries and exercises the max-retries early
+/// return path. Otherwise the limit is high enough that the mock approves.
+fn rate_limit_for(q_name: &str, i: u64, force_deny: bool, max_retries: u32) -> GubernatorRateLimit {
+    GubernatorRateLimit {
+        name: format!("{}-rl", q_name),
+        unique_key: format!("{}-{}", q_name, i),
+        limit: if force_deny { 0 } else { 1_000_000 },
+        duration_ms: 60_000,
+        hits: 1,
+        algorithm: GubernatorAlgorithm::TokenBucket,
+        behavior: 0,
+        retry_policy: RateLimitRetryPolicy {
+            initial_backoff_ms: 25,
+            max_backoff_ms: 250,
+            backoff_multiplier: 2.0,
+            max_retries,
+        },
+    }
+}
+
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
     silo::trace::init(LogFormat::Text)?;
@@ -74,6 +125,15 @@ async fn main() -> anyhow::Result<()> {
 
     let cfg = AppConfig::load(None).expect("load default config");
     let tmpdir = tempfile::tempdir()?;
+
+    let seed = args.seed.unwrap_or_else(|| {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64
+    });
+    eprintln!("silo-sim: seed={}", seed);
+    let rng: Arc<Mutex<StdRng>> = Arc::new(Mutex::new(StdRng::seed_from_u64(seed)));
 
     // Create dummy factories for the coordinators - sim manages shards itself
     let rate_limiter = MockGubernatorClient::new_arc();
@@ -182,10 +242,14 @@ async fn main() -> anyhow::Result<()> {
     let c2_owned = c2.clone();
     let enq_running = Arc::new(AtomicBool::new(true));
     let queues_enq = queues.clone();
+    let rate_limit_fraction = args.rate_limit_fraction;
+    let chained_fraction = args.chained_fraction;
+    let floating_fraction = args.floating_fraction;
     let enq_handle = {
         let shards = Arc::clone(&shards_for_enq);
         let _shard_ids = Arc::clone(&shard_ids_for_enq);
         let enq_running = enq_running.clone();
+        let rng = Arc::clone(&rng);
         tokio::spawn(async move {
             let mut i: u64 = 0;
             loop {
@@ -206,6 +270,40 @@ async fn main() -> anyhow::Result<()> {
                     tokio::time::sleep(Duration::from_millis(10)).await;
                     continue;
                 };
+
+                let (roll, force_deny): (f64, bool) = {
+                    let mut g = rng.lock().unwrap();
+                    (g.random::<f64>(), g.random::<f64>() < 0.5)
+                };
+                let limits: Vec<Limit> = if roll < rate_limit_fraction {
+                    // Pure RateLimit job. Half configured to deny so the
+                    // CheckRateLimit max-retries early return fires.
+                    vec![Limit::RateLimit(rate_limit_for(
+                        q_name, i, force_deny, 2,
+                    ))]
+                } else if roll < rate_limit_fraction + chained_fraction {
+                    // Chained Concurrency -> RateLimit (Bug 2 / Bug 3 shape).
+                    vec![
+                        Limit::Concurrency(ConcurrencyLimit {
+                            key: q_name.clone(),
+                            max_concurrency: *q_limit,
+                        }),
+                        Limit::RateLimit(rate_limit_for(q_name, i, force_deny, 2)),
+                    ]
+                } else if roll < rate_limit_fraction + chained_fraction + floating_fraction {
+                    vec![Limit::FloatingConcurrency(FloatingConcurrencyLimit {
+                        key: format!("{}-float", q_name),
+                        default_max_concurrency: *q_limit,
+                        refresh_interval_ms: 5_000,
+                        metadata: vec![],
+                    })]
+                } else {
+                    vec![Limit::Concurrency(ConcurrencyLimit {
+                        key: q_name.clone(),
+                        max_concurrency: *q_limit,
+                    })]
+                };
+
                 let payload = serde_json::json!({"i": i, "queue": q_name});
                 let payload_bytes = rmp_serde::to_vec(&payload).unwrap();
                 let _ = shard
@@ -216,10 +314,7 @@ async fn main() -> anyhow::Result<()> {
                         now_ms().await,
                         None,
                         payload_bytes,
-                        vec![Limit::Concurrency(ConcurrencyLimit {
-                            key: q_name.clone(),
-                            max_concurrency: *q_limit,
-                        })],
+                        limits,
                         None,
                         "default",
                     )
@@ -233,6 +328,8 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let workers_running = Arc::new(AtomicBool::new(true));
+    let leaked_acks = Arc::new(AtomicUsize::new(0));
+    let worker_crash_prob = args.worker_crash_prob;
     let mut worker_handles = Vec::new();
     for (idx, shard_id) in shard_ids.iter().enumerate() {
         let shard = shards_for_enq
@@ -242,6 +339,8 @@ async fn main() -> anyhow::Result<()> {
         let workers_running = workers_running.clone();
         let seen = Arc::clone(&seen_attempt_ids);
         let processed = Arc::clone(&processed_total);
+        let leaked_acks = Arc::clone(&leaked_acks);
+        let rng = Arc::clone(&rng);
         let handle = tokio::spawn(async move {
             let wid = format!("w-{}", idx);
             loop {
@@ -263,6 +362,16 @@ async fn main() -> anyhow::Result<()> {
                             tid
                         );
                     }
+                    // Crash injection: with low probability, abandon the lease
+                    // without acking. The reaper must recover holders.
+                    let should_crash = {
+                        let mut g = rng.lock().unwrap();
+                        g.random::<f64>() < worker_crash_prob
+                    };
+                    if should_crash {
+                        leaked_acks.fetch_add(1, Ordering::Relaxed);
+                        continue;
+                    }
                     let _ = shard
                         .report_attempt_outcome(
                             &tid,
@@ -278,7 +387,12 @@ async fn main() -> anyhow::Result<()> {
 
     let checker_running = Arc::new(AtomicBool::new(true));
     let shards_for_check = Arc::clone(&shards_for_enq);
-    let upper_bound_total = queues.iter().map(|(_, lim)| *lim as usize).sum::<usize>();
+    // Concurrency-typed jobs cap holders at the per-queue limit. RateLimit and
+    // FloatingConcurrency jobs can produce holders independent of that cap, so
+    // the steady-state ceiling is approximate — keep a generous slack so the
+    // mid-run check still bites on egregious over-grant.
+    let upper_bound_total =
+        queues.iter().map(|(_, lim)| *lim as usize).sum::<usize>() + 256;
     let check_handle = {
         let checker_running = checker_running.clone();
         tokio::spawn(async move {
@@ -307,6 +421,81 @@ async fn main() -> anyhow::Result<()> {
             }
         })
     };
+
+    // Background lease reaper — without it, worker-crash injection has no
+    // recovery path and end-of-run holder count won't drain.
+    let reaper_running = Arc::new(AtomicBool::new(true));
+    let reaper_handle = if args.spawn_reaper {
+        let shards = Arc::clone(&shards_for_enq);
+        let running = reaper_running.clone();
+        Some(tokio::spawn(async move {
+            let mut tick = tokio::time::interval(Duration::from_millis(500));
+            while running.load(Ordering::SeqCst) {
+                tick.tick().await;
+                for shard in shards.values() {
+                    let _ = shard.reap_expired_leases("-").await;
+                }
+            }
+        }))
+    } else {
+        None
+    };
+
+    // job_info deletion injector — exercises the missing-job_info dequeue
+    // paths in handle_run_attempt and handle_check_rate_limit.
+    let injector_running = Arc::new(AtomicBool::new(true));
+    let injector_handle = {
+        let shards = Arc::clone(&shards_for_enq);
+        let running = injector_running.clone();
+        let rng = Arc::clone(&rng);
+        let prob = args.job_info_delete_prob;
+        let job_info_deletes = Arc::new(AtomicUsize::new(0));
+        let job_info_deletes_for_task = Arc::clone(&job_info_deletes);
+        let handle = tokio::spawn(async move {
+            while running.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                let roll: f64 = rng.lock().unwrap().random();
+                if roll >= prob {
+                    continue;
+                }
+                let shard_ids: Vec<_> = shards.keys().copied().collect();
+                if shard_ids.is_empty() {
+                    continue;
+                }
+                let pick_idx: usize =
+                    rng.lock().unwrap().random_range(0..shard_ids.len());
+                let Some(shard) = shards.get(&shard_ids[pick_idx]) else {
+                    continue;
+                };
+                // Collect a small sample of job_info keys; pick one and delete.
+                let prefix = keys::jobs_prefix();
+                let end = keys::end_bound(&prefix);
+                let mut iter = match shard.db().scan::<Vec<u8>, _>(prefix..end).await {
+                    Ok(it) => it,
+                    Err(_) => continue,
+                };
+                let mut sampled: Vec<Vec<u8>> = Vec::with_capacity(16);
+                while sampled.len() < 16 {
+                    match iter.next().await {
+                        Ok(Some(kv)) => sampled.push(kv.key.to_vec()),
+                        _ => break,
+                    }
+                }
+                if sampled.is_empty() {
+                    continue;
+                }
+                let pick: usize =
+                    rng.lock().unwrap().random_range(0..sampled.len());
+                let mut batch = WriteBatch::new();
+                batch.delete(&sampled[pick]);
+                if shard.db().write(batch).await.is_ok() {
+                    job_info_deletes_for_task.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        });
+        (handle, job_info_deletes)
+    };
+    let (injector_handle, job_info_deletes) = injector_handle;
 
     // Add third coordinator mid-run
     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -342,27 +531,45 @@ async fn main() -> anyhow::Result<()> {
     // Run for desired duration
     tokio::time::sleep(Duration::from_secs(args.duration_secs)).await;
 
-    // Stop producers/consumers and invariant checker
+    // Stop fault sources first so the reaper has a chance to drain.
     enq_running.store(false, Ordering::SeqCst);
+    injector_running.store(false, Ordering::SeqCst);
     let _ = enq_handle.await;
+    let _ = injector_handle.await;
     tokio::time::sleep(Duration::from_millis(250)).await;
     workers_running.store(false, Ordering::SeqCst);
     for h in worker_handles {
         let _ = h.await;
     }
+    // Give the reaper time to recover any leases abandoned by crashed workers.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    reaper_running.store(false, Ordering::SeqCst);
+    if let Some(h) = reaper_handle {
+        let _ = h.await;
+    }
     checker_running.store(false, Ordering::SeqCst);
     let _ = check_handle.await;
 
-    for shard in shards_for_enq.values() {
+    let leaked_acks_final = leaked_acks.load(Ordering::Relaxed);
+    let job_info_deletes_final = job_info_deletes.load(Ordering::Relaxed);
+    eprintln!(
+        "silo-sim: leaked_acks={} job_info_deletes={}",
+        leaked_acks_final, job_info_deletes_final
+    );
+
+    for (sid, shard) in shards_for_enq.iter() {
+        let h = count_with_prefix(shard.db(), "holders/").await;
+        let l = count_with_prefix(shard.db(), "leases/").await;
+        let r = count_with_prefix(shard.db(), "requests/").await;
         assert_eq!(
-            count_with_prefix(shard.db(), "holders/").await,
-            0,
-            "holders must be empty at end"
+            h, 0,
+            "holders leak shard={} h={} l={} r={} seed={} leaked_acks={} job_info_deletes={}",
+            sid, h, l, r, seed, leaked_acks_final, job_info_deletes_final
         );
         assert_eq!(
-            count_with_prefix(shard.db(), "requests/").await,
-            0,
-            "requests must be empty at end"
+            r, 0,
+            "requests leak shard={} h={} l={} r={} seed={}",
+            sid, h, l, r, seed
         );
     }
 

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -512,9 +512,40 @@ impl JobStoreShard {
         let job_view = match maybe_job {
             Some(bytes) => match JobView::new(bytes) {
                 Ok(v) => v,
-                Err(_) => return Ok(()), // Skip malformed job
+                Err(_) => {
+                    // Drop the task and release any concurrency holders it
+                    // carries from earlier chained limits. Symmetric with the
+                    // missing-job_info path below and with handle_run_attempt.
+                    for q in held_queues.iter() {
+                        let queue = q.clone();
+                        state
+                            .batch
+                            .delete(concurrency_holder_key(tenant, &queue, check_task_id));
+                        state.holder_releases.push((
+                            tenant.to_string(),
+                            queue,
+                            check_task_id.to_string(),
+                        ));
+                    }
+                    return Ok(());
+                }
             },
-            None => return Ok(()), // Job deleted, skip
+            None => {
+                // Job missing — drop the task and release any concurrency
+                // holders it carries from earlier chained limits.
+                for q in held_queues.iter() {
+                    let queue = q.clone();
+                    state
+                        .batch
+                        .delete(concurrency_holder_key(tenant, &queue, check_task_id));
+                    state.holder_releases.push((
+                        tenant.to_string(),
+                        queue,
+                        check_task_id.to_string(),
+                    ));
+                }
+                return Ok(());
+            }
         };
 
         // Check the rate limit via Gubernator

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -560,6 +560,21 @@ impl JobStoreShard {
                         max_retries = max_retries,
                         "rate limit check exceeded max retries"
                     );
+                    // Drop the task and release any concurrency holders it
+                    // carries from earlier chained limits. Without this, a
+                    // stranded holder permanently consumes a slot for the
+                    // queue.
+                    for q in held_queues.iter() {
+                        let queue = q.clone();
+                        state
+                            .batch
+                            .delete(concurrency_holder_key(tenant, &queue, check_task_id));
+                        state.holder_releases.push((
+                            tenant.to_string(),
+                            queue,
+                            check_task_id.to_string(),
+                        ));
+                    }
                     return Ok(());
                 }
 

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -5,12 +5,12 @@
 
 mod test_helpers;
 
-use silo::codec::{decode_lease, encode_holder, encode_lease};
+use silo::codec::{decode_lease, encode_holder, encode_lease, encode_task};
 use silo::job::{FloatingConcurrencyLimit, Limit};
 use silo::job_attempt::AttemptOutcome;
 use silo::job_store_shard::JobStoreShardError;
-use silo::keys::{concurrency_holder_key, job_info_key};
-use silo::task::{HolderRecord, LeaseRecord};
+use silo::keys::{concurrency_holder_key, job_info_key, task_key};
+use silo::task::{GubernatorRateLimitData, HolderRecord, LeaseRecord, Task};
 
 use test_helpers::*;
 
@@ -206,14 +206,123 @@ async fn holder_leaked_when_run_attempt_finds_missing_job_info() {
     );
 }
 
-// NOTE: there is a separate dormant holder-leak bug at `dequeue.rs:534-541`
-// (handle_check_rate_limit's max-retries early return drops the task without
-// releasing `held_queues`). It cannot be exercised today because
-// `record_grant_outcome` at `src/job_store_shard/enqueue.rs:67-80` swaps the
-// None/Some arms relative to what `concurrency::handle_enqueue` returns, so
-// chained limits never advance past the first grant — `held_queues` therefore
-// never accumulate inside a CheckRateLimit task. The two should be fixed
-// together; flagging here so a follow-up PR can do both.
+// NOTE: `handle_check_rate_limit`'s max-retries early return now releases
+// `held_queues` symmetrically with `handle_run_attempt`. The path remains
+// dormant in production today because `record_grant_outcome` at
+// `src/job_store_shard/enqueue.rs:67-80` swaps the None/Some arms relative to
+// what `concurrency::handle_enqueue` returns, so chained limits never advance
+// past the first grant and `held_queues` never accumulate inside a
+// CheckRateLimit task. The release is in place defensively; a follow-up that
+// fixes `record_grant_outcome` should add an end-to-end repro test.
+
+/// Regression test for the `handle_check_rate_limit` max-retries early return.
+/// `record_grant_outcome` cannot drive a CheckRateLimit task with non-empty
+/// `held_queues` end-to-end today, so we plant the task and a matching holder
+/// row directly. With the rate-limit mock returning `under_limit:false` and
+/// `retry_count == max_retries`, the dequeue must hit the early-return branch
+/// and release the holder. Without the fix at `dequeue.rs`, the holder leaks
+/// and `count_concurrency_holders` stays at 1.
+#[silo::test]
+async fn check_rate_limit_max_retries_releases_held_queues() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "rl-max-retries-q";
+    let task_group = "default";
+    let priority: u8 = 10;
+
+    // Baseline enqueue gives us a real `job_info` row so the dequeue handler's
+    // job lookup succeeds and we exercise the rate-limit branch (not the
+    // separate missing-job_info early return).
+    let job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            priority,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"baseline": true})),
+            vec![],
+            None,
+            task_group,
+        )
+        .await
+        .expect("enqueue baseline");
+
+    // Plant the orphan-to-be holder under a synthetic task_id.
+    let task_id = format!("crl-orphan-{}", uuid::Uuid::new_v4());
+    let holder = encode_holder(&HolderRecord {
+        granted_at_ms: now_ms(),
+    });
+    shard
+        .db()
+        .put(&concurrency_holder_key(tenant, queue, &task_id), &holder)
+        .await
+        .expect("plant holder");
+
+    // Plant a CheckRateLimit task already at retry_count == max_retries with
+    // a non-empty held_queues. The mock gubernator with limit=0 will report
+    // under_limit:false → the over-limit branch fires → max-retries arm hit.
+    let max_retries = 3u32;
+    let rl = GubernatorRateLimitData {
+        name: "api".to_string(),
+        unique_key: format!("u-{}", uuid::Uuid::new_v4()),
+        limit: 0,
+        duration_ms: 60_000,
+        hits: 1,
+        algorithm: 0,
+        behavior: 0,
+        retry_initial_backoff_ms: 10,
+        retry_max_backoff_ms: 1000,
+        retry_backoff_multiplier: 2.0,
+        retry_max_retries: max_retries,
+    };
+    let attempt_number = 7u32;
+    let crl = Task::CheckRateLimit {
+        task_id: task_id.clone(),
+        tenant: tenant.to_string(),
+        job_id: job_id.clone(),
+        attempt_number,
+        relative_attempt_number: 1,
+        limit_index: 0,
+        rate_limit: rl,
+        retry_count: max_retries,
+        started_at_ms: now_ms(),
+        priority,
+        held_queues: vec![queue.to_string()],
+        task_group: task_group.to_string(),
+    };
+    let crl_key = task_key(task_group, now_ms(), priority, &job_id, attempt_number);
+    shard
+        .db()
+        .put(&crl_key, &encode_task(&crl))
+        .await
+        .expect("plant CheckRateLimit task");
+    shard.db().flush().await.expect("flush");
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "holder must exist before dequeue"
+    );
+
+    // The broker may already have buffered the baseline RunAttempt before we
+    // planted the CheckRateLimit, so loop until either the holder is released
+    // or we run out of attempts.
+    for _ in 0..20 {
+        let _ = shard.dequeue("w1", task_group, 4).await.expect("dequeue");
+        if count_concurrency_holders(shard.db()).await == 0 {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+    }
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "max-retries early return must release held concurrency holders \
+         (regression for dequeue.rs handle_check_rate_limit)"
+    );
+}
 
 /// Defensive idempotency: a stranded holder (no corresponding lease and no
 /// task) must be removable by an explicit purge call. This is the recovery hook

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -324,6 +324,96 @@ async fn check_rate_limit_max_retries_releases_held_queues() {
     );
 }
 
+/// Regression test for `handle_check_rate_limit`'s missing-job_info early
+/// return. Same shape as `holder_leaked_when_run_attempt_finds_missing_job_info`
+/// but in the CheckRateLimit handler: a CRL task carries `held_queues` from a
+/// prior chained limit, the job_info row is gone by the time the broker scans
+/// it (cleanup race / split / partial restore), and the dequeue handler's
+/// `None => return Ok(())` arm drops the task without releasing the holders.
+#[silo::test]
+async fn check_rate_limit_missing_job_info_releases_held_queues() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "crl-missing-job-q";
+    let task_group = "default";
+    let priority: u8 = 10;
+
+    // Use a synthetic job_id with no corresponding job_info row. The handler
+    // will load job_info, hit None, and take the early-return arm.
+    let job_id = format!("ghost-job-{}", uuid::Uuid::new_v4());
+    let task_id = format!("crl-orphan-{}", uuid::Uuid::new_v4());
+
+    // Plant the held concurrency holder we'll prove gets released.
+    let holder = encode_holder(&HolderRecord {
+        granted_at_ms: now_ms(),
+    });
+    shard
+        .db()
+        .put(&concurrency_holder_key(tenant, queue, &task_id), &holder)
+        .await
+        .expect("plant holder");
+
+    // Plant a CheckRateLimit task whose job_info doesn't exist. With
+    // retry_count well below max_retries the gubernator branch would normally
+    // proceed, but we never get there because job_info is missing first.
+    let rl = GubernatorRateLimitData {
+        name: "api".to_string(),
+        unique_key: format!("u-{}", uuid::Uuid::new_v4()),
+        limit: 100,
+        duration_ms: 60_000,
+        hits: 1,
+        algorithm: 0,
+        behavior: 0,
+        retry_initial_backoff_ms: 10,
+        retry_max_backoff_ms: 1000,
+        retry_backoff_multiplier: 2.0,
+        retry_max_retries: 3,
+    };
+    let attempt_number = 1u32;
+    let crl = Task::CheckRateLimit {
+        task_id: task_id.clone(),
+        tenant: tenant.to_string(),
+        job_id: job_id.clone(),
+        attempt_number,
+        relative_attempt_number: 1,
+        limit_index: 0,
+        rate_limit: rl,
+        retry_count: 0,
+        started_at_ms: now_ms(),
+        priority,
+        held_queues: vec![queue.to_string()],
+        task_group: task_group.to_string(),
+    };
+    let crl_key = task_key(task_group, now_ms(), priority, &job_id, attempt_number);
+    shard
+        .db()
+        .put(&crl_key, &encode_task(&crl))
+        .await
+        .expect("plant CheckRateLimit task");
+    shard.db().flush().await.expect("flush");
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "holder must exist before dequeue"
+    );
+
+    for _ in 0..20 {
+        let _ = shard.dequeue("w1", task_group, 4).await.expect("dequeue");
+        if count_concurrency_holders(shard.db()).await == 0 {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+    }
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "missing-job_info early return must release held concurrency holders \
+         (regression for dequeue.rs handle_check_rate_limit)"
+    );
+}
+
 /// Defensive idempotency: a stranded holder (no corresponding lease and no
 /// task) must be removable by an explicit purge call. This is the recovery hook
 /// the gRPC handler invokes when a worker reports outcome for a task whose


### PR DESCRIPTION
I strongly recommend reviewing with an agent's `/review` feature, the alloy spec is dense.

## Summary

- **Bug 2** (`ac305df`): `handle_check_rate_limit`'s max-retries early return dropped the task without releasing held concurrency queues. Symmetric to PR #255's `handle_run_attempt` fix.
- **Bug 3** (`ae70b12`): `handle_check_rate_limit`'s missing/malformed `job_info` early returns had the same shape. Found while writing the DST coverage and fixed in scope.
- **Spec extension** (`565e15a`, `257d39a`): `specs/job_shard.als` now models `CheckRateLimit` tasks and drop-without-completion transitions. `assert holdersRequireActiveTask` is now load-bearing — it actually catches a forgotten release. Verified with `alloy6 -c holdersRequireActiveTask` (UNSAT) and a fitness test that omits the release (SAT).
- **silo-sim** (`76e14da`, `257d39a`): mixes RateLimit / chained Concurrency+RateLimit / FloatingConcurrency in the workload, injects worker crashes and `job_info` deletions, runs a real lease reaper, drains 2s before the strict end-of-run check. Critical post-review fix: `count_with_prefix` was scanning ASCII `"holders/"` while real keys use binary `0x09`, making the mid-run and end-of-run invariants vacuous. Now uses `keys::*_prefix()` everywhere.

Background: prior to this PR the Alloy spec didn't model `CheckRateLimit` at all and the runtime simulator only enqueued `Limit::Concurrency`, never simulated worker crashes, never deleted `job_info`, and didn't run the reaper. None of the holder-leak bugs in production could be observed by either tool.

## Out of scope (deliberate)

- `record_grant_outcome` at `enqueue.rs:67-80` interprets `None`/`Some` backwards relative to what `concurrency::handle_enqueue` actually returns, so chained limits silently drop the second limit — this means a chained `[Concurrency, RateLimit]` job today never produces a CheckRateLimit task with non-empty `held_queues`, which is why Bugs 2 & 3 are dormant in production. Flagged in `tests/holder_leak_tests.rs`'s NOTE; the fixes here are defensive for when that's fixed. Separate PR.

## Test plan

- [x] `cargo test -p silo --test holder_leak_tests` — all 8 tests pass.
- [x] Bug 2 regression test fails without the fix (verified by reverting the release block and re-running — `left: 1, right: 0`).
- [x] Bug 3 regression test fails without the fix (same verification).
- [x] `alloy6 exec -c holdersRequireActiveTask specs/job_shard.als` returns UNSAT.
- [x] `alloy6 exec -c exampleCheckRateLimitDropReleasesHolder specs/job_shard.als` returns SAT (witness reachable).
- [x] `alloy6 exec -c exampleDequeueDropRunAttemptReleasesHolder specs/job_shard.als` returns SAT.
- [x] Fitness test: replacing `releaseHolders[...]` with `holdersUnchanged` in `dequeueDropCheckRateLimit` makes `holdersRequireActiveTask` go SAT — the spec catches the bug.
- [x] `cargo check --bin silo-sim` clean.
- [ ] End-to-end simulator run: `cargo run --release --bin silo-sim -- --duration_secs 90 --shards 4 --rate_limit_fraction 0.20 --chained_fraction 0.25 --floating_fraction 0.10 --worker_crash_prob 0.01 --job_info_delete_prob 0.005 --seed 42`. Requires etcd; please run in your environment to confirm. With all three fixes in place this should pass cleanly; reverting any of (Bug 1 PR #255, Bug 2, Bug 3) on a scratch branch should make it fail at the end-of-run holder-count assertion.
- [ ] Full Alloy verification: `node scripts/run-alloy-verification.mjs specs/job_shard.als`. The full suite runs every check and witness in the file at expanded scopes — takes a long time at the new scopes; run before merge.

## Notes for reviewers

- Commit `ac305df` is also the head of the parent branch `kirin/fix-rate-limit-holder-leak`. If you'd prefer to land that one first, this PR's base can be retargeted.
- The simulator changes are non-deterministic; the seed is echoed at startup so failures are reproducible.
- The spec's well-formedness change (moving the holder/active-task invariant from `fact` to `assert`) is structural — it means the assertion is now meaningful, but it also means the spec admits states that violate it. The Alloy `traces` fact ensures only states reachable by `step` are considered, so the assertion is checked exactly against the modeled transitions.