### PR TITLE
Emit reaped lease count and log lease reaper errors

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -103,6 +103,7 @@ pub struct Metrics {
     ready_to_start_latency_ms: HistogramVec,
     lease_reaper_duration: HistogramVec,
     lease_reaper_scans_total: CounterVec,
+    lease_reaper_leases_reaped_total: CounterVec,
 
     // Concurrency metrics
     concurrency_tickets_granted: Counter,
@@ -326,6 +327,13 @@ impl Metrics {
         self.lease_reaper_scans_total
             .with_label_values(&[shard])
             .inc();
+    }
+
+    /// Record the number of expired leases reaped during a scan.
+    pub fn record_lease_reaper_reaped(&self, shard: &str, count: u64) {
+        self.lease_reaper_leases_reaped_total
+            .with_label_values(&[shard])
+            .inc_by(count as f64);
     }
 
     /// Record a concurrency ticket being granted.
@@ -1029,6 +1037,17 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let lease_reaper_leases_reaped_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_lease_reaper_leases_reaped_total",
+                "Total number of expired leases reaped",
+            ),
+            &["shard"],
+        )?,
+    );
+
     // Concurrency metrics
     let concurrency_tickets_granted = register(
         &registry,
@@ -1063,6 +1082,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         ready_to_start_latency_ms,
         lease_reaper_duration,
         lease_reaper_scans_total,
+        lease_reaper_leases_reaped_total,
         concurrency_tickets_granted,
         slatedb,
     })

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -104,6 +104,7 @@ pub struct Metrics {
     lease_reaper_duration: HistogramVec,
     lease_reaper_scans_total: CounterVec,
     lease_reaper_leases_reaped_total: CounterVec,
+    lease_reaper_errors_total: CounterVec,
 
     // Concurrency metrics
     concurrency_tickets_granted: Counter,
@@ -334,6 +335,13 @@ impl Metrics {
         self.lease_reaper_leases_reaped_total
             .with_label_values(&[shard])
             .inc_by(count as f64);
+    }
+
+    /// Record a lease reaper scan failure.
+    pub fn record_lease_reaper_error(&self, shard: &str) {
+        self.lease_reaper_errors_total
+            .with_label_values(&[shard])
+            .inc();
     }
 
     /// Record a concurrency ticket being granted.
@@ -1048,6 +1056,17 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let lease_reaper_errors_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_lease_reaper_errors_total",
+                "Total number of expired lease reaper scan failures",
+            ),
+            &["shard"],
+        )?,
+    );
+
     // Concurrency metrics
     let concurrency_tickets_granted = register(
         &registry,
@@ -1083,6 +1102,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         lease_reaper_duration,
         lease_reaper_scans_total,
         lease_reaper_leases_reaped_total,
+        lease_reaper_errors_total,
         concurrency_tickets_granted,
         slatedb,
     })

--- a/src/server.rs
+++ b/src/server.rs
@@ -2028,12 +2028,27 @@ where
                     // Use default tenant "-" for system-level reaping
                     for (shard_id, shard) in instances.iter() {
                         let reap_start = std::time::Instant::now();
-                        let _ = shard.reap_expired_leases("-").await;
+                        let result = shard.reap_expired_leases("-").await;
+                        let shard_label = shard_id.to_string();
                         if let Some(ref m) = reaper_metrics {
                             m.record_lease_reaper_duration(
-                                &shard_id.to_string(),
+                                &shard_label,
                                 reap_start.elapsed().as_secs_f64(),
                             );
+                        }
+                        match result {
+                            Ok(reaped) => {
+                                if let Some(ref m) = reaper_metrics {
+                                    m.record_lease_reaper_reaped(&shard_label, reaped as u64);
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    shard = %shard_label,
+                                    error = %e,
+                                    "lease reaper failed"
+                                );
+                            }
                         }
 
                         // Collect SlateDB storage metrics for this shard

--- a/src/server.rs
+++ b/src/server.rs
@@ -2043,6 +2043,9 @@ where
                                 }
                             }
                             Err(e) => {
+                                if let Some(ref m) = reaper_metrics {
+                                    m.record_lease_reaper_error(&shard_label);
+                                }
                                 warn!(
                                     shard = %shard_label,
                                     error = %e,


### PR DESCRIPTION
## Summary
- The reaper loop in `server.rs` was discarding the `Result` from `reap_expired_leases`, so reaper errors were silently swallowed and the returned reaped count was never observed.
- Adds a new Prometheus counter `silo_lease_reaper_leases_reaped_total{shard}` (via `Metrics::record_lease_reaper_reaped`) and increments it with the count returned per shard scan.
- On `Err`, the reaper now logs a `warn!` with shard id and error instead of dropping silently. Duration is still recorded unconditionally so error scans remain visible in the existing histogram.

## Test plan
- [ ] `cargo check --all-targets` passes locally
- [ ] Verify `silo_lease_reaper_leases_reaped_total` appears on the metrics endpoint after a shard performs a reap
- [ ] Force a reaper error (e.g. transient DB failure in a test) and confirm the warning log fires