### PR TITLE
Add Default impls to DatabaseTemplate / DatabaseConfig

### DIFF
--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -339,14 +339,11 @@ async fn open_shard_at_path(path: &str, flush_interval_ms: u64) -> Arc<JobStoreS
         name: "golden-bench".to_string(),
         backend: silo::settings::Backend::Fs,
         path: path.to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(slatedb::config::Settings {
             flush_interval: Some(Duration::from_millis(flush_interval_ms)),
             ..Default::default()
         }),
-        memory_cache: None,
+        ..Default::default()
     };
     JobStoreShard::open(&cfg, NullGubernatorClient::new(), None, ShardRange::full())
         .await

--- a/benches/job_shard_throughput.rs
+++ b/benches/job_shard_throughput.rs
@@ -11,14 +11,11 @@ async fn open_temp_shard(flush_interval_ms: u64) -> (tempfile::TempDir, Arc<JobS
         name: "bench-shard".to_string(),
         backend: Backend::Fs,
         path: tmp.path().to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(slatedb::config::Settings {
             flush_interval: Some(Duration::from_millis(flush_interval_ms)),
             ..Default::default()
         }),
-        memory_cache: None,
+        ..Default::default()
     };
     let shard = JobStoreShard::open(&cfg, NullGubernatorClient::new(), None, ShardRange::full())
         .await

--- a/src/bin/silo-sim.rs
+++ b/src/bin/silo-sim.rs
@@ -85,12 +85,7 @@ async fn main() -> anyhow::Result<()> {
                 .join("node-a-%shard%")
                 .to_string_lossy()
                 .to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         rate_limiter.clone(),
         None,
@@ -103,12 +98,7 @@ async fn main() -> anyhow::Result<()> {
                 .join("node-b-%shard%")
                 .to_string_lossy()
                 .to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         rate_limiter.clone(),
         None,
@@ -156,15 +146,12 @@ async fn main() -> anyhow::Result<()> {
                 .join(shard_id.to_string())
                 .to_string_lossy()
                 .to_string(),
-            wal: None,
-            apply_wal_on_close: true,
             // Fast flushes for simulation
-            enable_counter_reconciliation: false,
             slatedb: Some(slatedb::config::Settings {
                 flush_interval: Some(Duration::from_millis(10)),
                 ..Default::default()
             }),
-            memory_cache: None,
+            ..Default::default()
         };
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range).await?;
         shards.insert(*shard_id, shard);
@@ -321,12 +308,7 @@ async fn main() -> anyhow::Result<()> {
                 .join("node-c-%shard%")
                 .to_string_lossy()
                 .to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         rate_limiter.clone(),
         None,

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -83,19 +83,13 @@ impl ShardFactory {
     #[doc(hidden)]
     pub fn new_noop() -> Self {
         use crate::gubernator::NullGubernatorClient;
-        use crate::settings::Backend;
 
         Self {
             instances: DashMap::new(),
             template: DatabaseTemplate {
-                backend: Backend::Memory,
                 path: "/noop".to_string(),
-                wal: None,
                 apply_wal_on_close: false,
-                concurrency_reconcile_interval_ms: 5000,
-                enable_counter_reconciliation: false,
-                slatedb: None,
-                memory_cache: None,
+                ..Default::default()
             },
             rate_limiter: NullGubernatorClient::new(),
             metrics: None,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -238,6 +238,21 @@ pub struct DatabaseTemplate {
     pub memory_cache: Option<MemoryCacheConfig>,
 }
 
+impl Default for DatabaseTemplate {
+    fn default() -> Self {
+        Self {
+            backend: Backend::default(),
+            path: "/tmp/silo-%shard%".to_string(),
+            wal: None,
+            apply_wal_on_close: default_apply_wal_on_close(),
+            concurrency_reconcile_interval_ms: default_concurrency_reconcile_interval_ms(),
+            enable_counter_reconciliation: default_enable_counter_reconciliation(),
+            slatedb: None,
+            memory_cache: None,
+        }
+    }
+}
+
 /// Configuration for SlateDB's in-memory caches.
 ///
 /// SlateDB maintains two separate in-memory caches:
@@ -499,6 +514,21 @@ pub struct DatabaseConfig {
     pub memory_cache: Option<MemoryCacheConfig>,
 }
 
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self {
+            name: "shard".to_string(),
+            backend: Backend::default(),
+            path: "/tmp/silo-shard".to_string(),
+            wal: None,
+            apply_wal_on_close: default_apply_wal_on_close(),
+            enable_counter_reconciliation: default_enable_counter_reconciliation(),
+            slatedb: None,
+            memory_cache: None,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum Backend {
@@ -511,6 +541,15 @@ pub enum Backend {
     /// Only available when the `dst` feature is enabled.
     #[cfg(feature = "dst")]
     TurmoilFs,
+}
+
+impl Default for Backend {
+    /// In-memory backend is the natural default for tests and benches; production
+    /// deployments specify `backend` explicitly via TOML, which still requires the
+    /// field (no `#[serde(default)]` is added).
+    fn default() -> Self {
+        Backend::Memory
+    }
 }
 
 impl Backend {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -645,14 +645,9 @@ impl AppConfig {
             logging: LoggingConfig::default(),
             metrics: MetricsConfig::default(),
             database: DatabaseTemplate {
+                // Override the test-friendly Memory default with Fs for production fallback.
                 backend: Backend::Fs,
-                path: "/tmp/silo-%shard%".to_string(),
-                wal: None,
-                apply_wal_on_close: true,
-                concurrency_reconcile_interval_ms: default_concurrency_reconcile_interval_ms(),
-                enable_counter_reconciliation: default_enable_counter_reconciliation(),
-                slatedb: None,
-                memory_cache: None,
+                ..Default::default()
             },
         };
 

--- a/tests/cleanup_reacquire_tests.rs
+++ b/tests/cleanup_reacquire_tests.rs
@@ -62,11 +62,8 @@ async fn background_cleanup_spawns_when_cleanup_pending() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range.clone())
@@ -97,11 +94,8 @@ async fn background_cleanup_spawns_when_cleanup_pending() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range.clone())
@@ -163,11 +157,8 @@ async fn background_cleanup_resumes_when_cleanup_was_running() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range.clone())
@@ -193,11 +184,8 @@ async fn background_cleanup_resumes_when_cleanup_was_running() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range.clone())
@@ -251,11 +239,8 @@ async fn background_cleanup_runs_compaction_when_cleanup_done() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range.clone())
@@ -277,11 +262,8 @@ async fn background_cleanup_runs_compaction_when_cleanup_done() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range.clone())
@@ -320,11 +302,8 @@ async fn no_cleanup_when_already_complete() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range.clone())
@@ -349,11 +328,8 @@ async fn no_cleanup_when_already_complete() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range.clone())
@@ -391,11 +367,8 @@ async fn cleanup_cancelled_on_shard_close() {
         name: "test".to_string(),
         backend: Backend::Fs,
         path: path.clone(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range.clone())
@@ -452,11 +425,8 @@ async fn cleanup_progress_saved_on_cancellation() {
         name: "test".to_string(),
         backend: Backend::Fs,
         path: path.clone(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     // Create shard with data
@@ -547,11 +517,8 @@ async fn cleanup_result_indicates_cancellation() {
         name: "test".to_string(),
         backend: Backend::Fs,
         path: path.clone(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range.clone())
@@ -614,11 +581,8 @@ async fn cleanup_handles_multiple_close_calls() {
         name: "test".to_string(),
         backend: Backend::Fs,
         path: path.clone(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, range.clone())
@@ -657,11 +621,8 @@ async fn full_reacquisition_cycle_triggers_cleanup() {
         name: "test".to_string(),
         backend: Backend::Fs,
         path: path.clone(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     // Phase 1: Create shard, enqueue data, simulate split state
@@ -770,11 +731,8 @@ async fn interrupted_cleanup_resumes_on_reacquisition() {
         name: "test".to_string(),
         backend: Backend::Fs,
         path: path.clone(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     // Phase 1: Start cleanup and interrupt it

--- a/tests/cluster_client_tests.rs
+++ b/tests/cluster_client_tests.rs
@@ -20,14 +20,8 @@ fn make_test_factory_with_shards(num_shards: u32) -> (Arc<ShardFactory>, ShardMa
     let tmpdir = tempfile::tempdir().unwrap();
     let factory = Arc::new(ShardFactory::new(
         DatabaseTemplate {
-            backend: Backend::Memory,
             path: tmpdir.path().join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,
@@ -781,12 +775,7 @@ fn make_test_app_config(tmp: &tempfile::TempDir) -> AppConfig {
         database: DatabaseTemplate {
             backend: Backend::Fs,
             path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
     }
 }

--- a/tests/cluster_info_cache_tests.rs
+++ b/tests/cluster_info_cache_tests.rs
@@ -173,12 +173,7 @@ async fn create_test_service() -> (SiloService, Arc<HangingCoordinator>) {
         DatabaseTemplate {
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,

--- a/tests/cluster_query_integration_tests.rs
+++ b/tests/cluster_query_integration_tests.rs
@@ -14,7 +14,7 @@ use silo::gubernator::MockGubernatorClient;
 use silo::pb::silo_client::SiloClient;
 use silo::pb::{EnqueueRequest, SerializedBytes, serialized_bytes};
 use silo::server::run_server;
-use silo::settings::{Backend, DatabaseTemplate};
+use silo::settings::DatabaseTemplate;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -37,14 +37,8 @@ fn make_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
         std::env::temp_dir().join(format!("silo-cluster-query-test-{}-{}", prefix, node_id));
     Arc::new(ShardFactory::new(
         DatabaseTemplate {
-            backend: Backend::Memory,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,

--- a/tests/cluster_query_tests.rs
+++ b/tests/cluster_query_tests.rs
@@ -28,12 +28,7 @@ async fn create_multi_shard_factory(
     let template = DatabaseTemplate {
         backend: Backend::Fs,
         path: format!("{}/%shard%", base_path),
-        wal: None,
-        apply_wal_on_close: true,
-        concurrency_reconcile_interval_ms: 5000,
-        enable_counter_reconciliation: false,
-        slatedb: None,
-        memory_cache: None,
+        ..Default::default()
     };
 
     let rate_limiter = MockGubernatorClient::new_arc();

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -1578,11 +1578,8 @@ async fn concurrency_lazy_hydration_on_shard_reopen() {
         name: "test".to_string(),
         backend: Backend::Fs,
         path: tmp.path().to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(test_helpers::fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
     let rate_limiter = MockGubernatorClient::new_arc();
     let queue = "lazy_q".to_string();
@@ -1714,11 +1711,8 @@ async fn concurrency_no_overgrant_with_lazy_hydration() {
         name: "test".to_string(),
         backend: Backend::Fs,
         path: tmp.path().to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(test_helpers::fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
     let rate_limiter = MockGubernatorClient::new_arc();
     let queue = "overgrant_q".to_string();

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -628,6 +628,34 @@ path = "/tmp/silo-%shard%"
     assert!(from_default.memory_cache.is_none() && from_toml.database.memory_cache.is_none());
 }
 
+/// Parallel drift guard for `DatabaseConfig`. Although it isn't deserialized
+/// from TOML on any production path, it derives `Deserialize` and shares the
+/// same `#[serde(default = ...)]` free functions as `DatabaseTemplate`, so the
+/// invariant is symmetric and worth pinning explicitly.
+#[silo::test]
+fn database_config_default_matches_toml_defaults() {
+    let from_default = DatabaseConfig::default();
+    let from_toml: DatabaseConfig = toml::from_str(
+        r#"
+name = "shard"
+backend = "memory"
+path = "/tmp/silo-shard"
+"#,
+    )
+    .expect("parse TOML");
+    assert_eq!(
+        from_default.apply_wal_on_close,
+        from_toml.apply_wal_on_close
+    );
+    assert_eq!(
+        from_default.enable_counter_reconciliation,
+        from_toml.enable_counter_reconciliation
+    );
+    assert!(from_default.wal.is_none() && from_toml.wal.is_none());
+    assert!(from_default.slatedb.is_none() && from_toml.slatedb.is_none());
+    assert!(from_default.memory_cache.is_none() && from_toml.memory_cache.is_none());
+}
+
 #[silo::test]
 fn parse_toml_server_statement_timeout_uses_default() {
     let toml_str = r#"

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -32,12 +32,7 @@ async fn open_fs_db_from_config() {
         database: DatabaseTemplate {
             backend: Backend::Fs,
             path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
     };
 
@@ -81,10 +76,8 @@ async fn shard_with_local_wal_has_wal_close_config() {
             backend: Backend::Fs,
             path: wal_dir.path().to_string_lossy().to_string(),
         }),
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     let rate_limiter = MockGubernatorClient::new_arc();
@@ -114,11 +107,8 @@ async fn shard_without_local_wal_has_no_wal_close_config() {
         name: "test".to_string(),
         backend: Backend::Fs,
         path: data_dir.path().to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     let rate_limiter = MockGubernatorClient::new_arc();
@@ -147,10 +137,8 @@ async fn close_with_flush_wal_removes_local_wal_directory() {
             backend: Backend::Fs,
             path: wal_dir.path().to_string_lossy().to_string(),
         }),
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     let rate_limiter = MockGubernatorClient::new_arc();
@@ -197,9 +185,8 @@ async fn close_without_flush_wal_preserves_local_wal_directory() {
             path: wal_dir.path().to_string_lossy().to_string(),
         }),
         apply_wal_on_close: false, // Disable apply on close
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     let rate_limiter = MockGubernatorClient::new_arc();
@@ -244,10 +231,8 @@ async fn data_persists_after_close_with_flush_and_reopen() {
                 backend: Backend::Fs,
                 path: wal_dir.path().to_string_lossy().to_string(),
             }),
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let rate_limiter = MockGubernatorClient::new_arc();
@@ -278,10 +263,8 @@ async fn data_persists_after_close_with_flush_and_reopen() {
                 backend: Backend::Fs,
                 path: new_wal_dir.path().to_string_lossy().to_string(),
             }),
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let rate_limiter = MockGubernatorClient::new_arc();
@@ -317,11 +300,7 @@ async fn factory_close_all_flushes_all_shards_wal() {
             backend: Backend::Fs,
             path: wal_dir.path().join("%shard%").to_string_lossy().to_string(),
         }),
-        apply_wal_on_close: true,
-        concurrency_reconcile_interval_ms: 5000,
-        enable_counter_reconciliation: false,
-        slatedb: None,
-        memory_cache: None,
+        ..Default::default()
     };
 
     let rate_limiter = MockGubernatorClient::new_arc();
@@ -618,6 +597,37 @@ enable_counter_reconciliation = true
     assert!(cfg.database.enable_counter_reconciliation);
 }
 
+/// Guards against the manual `Default` impl on `DatabaseTemplate` drifting away
+/// from the serde defaults. If a future field is added with a `#[serde(default)]`
+/// but is not mirrored in the `Default` impl (or vice versa), this fails.
+#[silo::test]
+fn database_template_default_matches_toml_defaults() {
+    let from_default = DatabaseTemplate::default();
+    let from_toml: AppConfig = toml::from_str(
+        r#"
+[database]
+backend = "memory"
+path = "/tmp/silo-%shard%"
+"#,
+    )
+    .expect("parse TOML");
+    assert_eq!(
+        from_default.apply_wal_on_close,
+        from_toml.database.apply_wal_on_close
+    );
+    assert_eq!(
+        from_default.concurrency_reconcile_interval_ms,
+        from_toml.database.concurrency_reconcile_interval_ms
+    );
+    assert_eq!(
+        from_default.enable_counter_reconciliation,
+        from_toml.database.enable_counter_reconciliation
+    );
+    assert!(from_default.wal.is_none() && from_toml.database.wal.is_none());
+    assert!(from_default.slatedb.is_none() && from_toml.database.slatedb.is_none());
+    assert!(from_default.memory_cache.is_none() && from_toml.database.memory_cache.is_none());
+}
+
 #[silo::test]
 fn parse_toml_server_statement_timeout_uses_default() {
     let toml_str = r#"
@@ -832,16 +842,12 @@ async fn factory_passes_slatedb_settings_to_shards() {
     let template = DatabaseTemplate {
         backend: Backend::Fs,
         path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        concurrency_reconcile_interval_ms: 5000,
-        enable_counter_reconciliation: false,
         slatedb: Some(slatedb::config::Settings {
             flush_interval: Some(std::time::Duration::from_millis(25)),
             l0_sst_size_bytes: 16777216, // 16MB
             ..Default::default()
         }),
-        memory_cache: None,
+        ..Default::default()
     };
 
     let rate_limiter = MockGubernatorClient::new_arc();

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -34,12 +34,7 @@ fn make_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
             // Use Fs backend for split tests because SlateDB cloning requires a real object store
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,
@@ -1997,12 +1992,7 @@ mod splitter_unit_tests {
             DatabaseTemplate {
                 backend: Backend::Fs,
                 path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-                wal: None,
-                apply_wal_on_close: true,
-                concurrency_reconcile_interval_ms: 5000,
-                enable_counter_reconciliation: false,
-                slatedb: None,
-                memory_cache: None,
+                ..Default::default()
             },
             MockGubernatorClient::new_arc(),
             None,

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -38,12 +38,7 @@ fn make_test_factory(node_id: &str) -> Arc<ShardFactory> {
             // Use Fs backend for split tests because SlateDB cloning requires a real object store
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,
@@ -3750,12 +3745,7 @@ async fn etcd_shard_close_failure_keeps_ownership() {
         DatabaseTemplate {
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,
@@ -3839,12 +3829,7 @@ async fn etcd_shard_close_failure_during_shutdown_keeps_ownership() {
         DatabaseTemplate {
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -13,12 +13,7 @@ fn make_fs_factory(tmp: &tempfile::TempDir) -> Arc<ShardFactory> {
     let template = DatabaseTemplate {
         backend: Backend::Fs,
         path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        concurrency_reconcile_interval_ms: 5000,
-        enable_counter_reconciliation: false,
-        slatedb: None,
-        memory_cache: None,
+        ..Default::default()
     };
     Arc::new(ShardFactory::new(
         template,
@@ -43,11 +38,7 @@ fn make_fs_factory_with_wal(
             backend: Backend::Fs,
             path: wal_tmp.path().join("%shard%").to_string_lossy().to_string(),
         }),
-        apply_wal_on_close: true,
-        concurrency_reconcile_interval_ms: 5000,
-        enable_counter_reconciliation: false,
-        slatedb: None,
-        memory_cache: None,
+        ..Default::default()
     };
     Arc::new(ShardFactory::new(
         template,
@@ -356,12 +347,7 @@ async fn open_invalid_template_no_placeholder() {
         DatabaseTemplate {
             backend: Backend::Fs,
             path: "/tmp/no-placeholder-here".to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,
@@ -385,12 +371,7 @@ async fn open_invalid_template_bad_boundary() {
         DatabaseTemplate {
             backend: Backend::Fs,
             path: "/tmp/prefix%shard%".to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,

--- a/tests/grpc_integration_helpers.rs
+++ b/tests/grpc_integration_helpers.rs
@@ -61,12 +61,7 @@ pub async fn create_test_factory() -> anyhow::Result<(Arc<ShardFactory>, tempfil
     let template = DatabaseTemplate {
         backend: Backend::Fs,
         path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        concurrency_reconcile_interval_ms: 5000,
-        enable_counter_reconciliation: false,
-        slatedb: None,
-        memory_cache: None,
+        ..Default::default()
     };
     let rate_limiter = MockGubernatorClient::new_arc();
     let factory = ShardFactory::new(template, rate_limiter, None);
@@ -102,12 +97,7 @@ pub async fn setup_multi_shard_server(
     let template = DatabaseTemplate {
         backend: Backend::Fs,
         path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        concurrency_reconcile_interval_ms: 5000,
-        enable_counter_reconciliation: false,
-        slatedb: None,
-        memory_cache: None,
+        ..Default::default()
     };
     let rate_limiter = MockGubernatorClient::new_arc();
     let factory = Arc::new(ShardFactory::new(template, rate_limiter, None));

--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -71,12 +71,7 @@ async fn grpc_server_lease_tasks_multi_shard() -> anyhow::Result<()> {
         let template = DatabaseTemplate {
             backend: Backend::Fs,
             path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         };
         let rate_limiter = MockGubernatorClient::new_arc();
         let factory = ShardFactory::new(template, rate_limiter, None);
@@ -742,12 +737,7 @@ async fn grpc_server_reset_shards_clears_fs_backend_data() -> anyhow::Result<()>
         let template = DatabaseTemplate {
             backend: Backend::Fs,
             path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         };
         let rate_limiter = MockGubernatorClient::new_arc();
         let factory = ShardFactory::new(template, rate_limiter, None);
@@ -931,12 +921,7 @@ async fn grpc_server_reset_shards_with_relative_path() -> anyhow::Result<()> {
             // Use the path as-is (could be absolute from tempdir, but the key is
             // to ensure path handling is consistent)
             path: format!("{}/%shard%", relative_path),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         };
         let rate_limiter = MockGubernatorClient::new_arc();
         let factory = ShardFactory::new(template, rate_limiter, None);
@@ -1058,14 +1043,8 @@ async fn grpc_server_reset_shards_clears_memory_backend_data() -> anyhow::Result
 
         // Use Memory backend to exercise the object store deletion path
         let template = DatabaseTemplate {
-            backend: Backend::Memory,
             path: "test-memory-%shard%".to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         };
         let rate_limiter = MockGubernatorClient::new_arc();
         let factory = ShardFactory::new(template, rate_limiter, None);
@@ -1186,12 +1165,7 @@ async fn setup_test_server_production_path(
     let template = DatabaseTemplate {
         backend: Backend::Fs,
         path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        concurrency_reconcile_interval_ms: 5000,
-        enable_counter_reconciliation: false,
-        slatedb: None,
-        memory_cache: None,
+        ..Default::default()
     };
     let rate_limiter = MockGubernatorClient::new_arc();
     let factory = Arc::new(ShardFactory::new(template, rate_limiter, None));

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -54,12 +54,7 @@ fn make_test_factory(node_id: &str) -> Arc<ShardFactory> {
             // Use Fs backend for split tests because SlateDB cloning requires a real object store
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,
@@ -5472,12 +5467,7 @@ async fn k8s_shard_close_failure_keeps_lease() {
         DatabaseTemplate {
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,
@@ -5547,12 +5537,7 @@ async fn k8s_shard_close_failure_during_shutdown_keeps_lease() {
         DatabaseTemplate {
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,

--- a/tests/none_coordinator_tests.rs
+++ b/tests/none_coordinator_tests.rs
@@ -4,19 +4,13 @@ use std::time::Duration;
 use silo::coordination::{Coordinator, NoneCoordinator};
 use silo::factory::ShardFactory;
 use silo::gubernator::MockGubernatorClient;
-use silo::settings::{Backend, DatabaseTemplate};
+use silo::settings::DatabaseTemplate;
 
 fn make_test_factory() -> Arc<ShardFactory> {
     Arc::new(ShardFactory::new(
         DatabaseTemplate {
-            backend: Backend::Memory,
             path: "unused".to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,

--- a/tests/rate_limit_tests.rs
+++ b/tests/rate_limit_tests.rs
@@ -46,11 +46,8 @@ async fn open_shard_with_gubernator()
         name: "test".to_string(),
         backend: Backend::Fs,
         path: tmp.path().to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(test_helpers::fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
     let shard = JobStoreShard::open(&cfg, gubernator.clone(), None, ShardRange::full())
         .await

--- a/tests/server_split_paused_tests.rs
+++ b/tests/server_split_paused_tests.rs
@@ -183,12 +183,7 @@ async fn create_test_service(paused: bool) -> (SiloService, Arc<MockPausedCoordi
         DatabaseTemplate {
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,
@@ -599,12 +594,7 @@ async fn enqueue_fails_when_k8s_api_unreachable_during_split() {
         DatabaseTemplate {
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         MockGubernatorClient::new_arc(),
         None,

--- a/tests/shard_cleanup_tests.rs
+++ b/tests/shard_cleanup_tests.rs
@@ -578,11 +578,8 @@ async fn reopening_shard_after_cleanup_preserves_status() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(test_helpers::fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, ShardRange::full())
@@ -627,11 +624,8 @@ async fn reopening_shard_after_cleanup_preserves_status() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(test_helpers::fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, ShardRange::full())
@@ -705,11 +699,8 @@ async fn shard_created_at_preserved_across_reopen() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(test_helpers::fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, ShardRange::full())
@@ -734,11 +725,8 @@ async fn shard_created_at_preserved_across_reopen() {
             name: "test".to_string(),
             backend: Backend::Fs,
             path: path.clone(),
-            wal: None,
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(test_helpers::fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, ShardRange::full())

--- a/tests/shard_counters_tests.rs
+++ b/tests/shard_counters_tests.rs
@@ -653,10 +653,8 @@ async fn counters_survive_close_and_reopen() {
                 backend: Backend::Fs,
                 path: config.wal_dir.path().to_string_lossy().to_string(),
             }),
-            apply_wal_on_close: true,
-            enable_counter_reconciliation: false,
             slatedb: Some(test_helpers::fast_flush_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         };
 
         let shard2 = silo::job_store_shard::JobStoreShard::open(

--- a/tests/split_aware_processing_tests.rs
+++ b/tests/split_aware_processing_tests.rs
@@ -417,11 +417,8 @@ async fn create_shard_with_uncleaned_data(
         name: "test".to_string(),
         backend: Backend::Fs,
         path: tmp.path().to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     let shard = JobStoreShard::open(&cfg, rate_limiter.clone(), None, ShardRange::full())
@@ -618,11 +615,8 @@ async fn concurrency_hydration_ignores_uncleaned_holders() {
         name: "test".to_string(),
         backend: Backend::Fs,
         path: tmp.path().to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     // Phase 1: Create jobs with concurrency limits for both in-range and out-of-range tenants

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -67,11 +67,8 @@ pub async fn open_temp_shard_with_metrics() -> (
         name: "test".to_string(),
         backend: Backend::Fs,
         path: tmp.path().to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
     let metrics = silo::metrics::init().expect("init metrics");
     let shard = JobStoreShard::open(
@@ -124,11 +121,8 @@ pub async fn open_temp_shard_with_range(
         name: "test".to_string(),
         backend: Backend::Fs,
         path: tmp.path().to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
     let shard = JobStoreShard::open(&cfg, rate_limiter, None, range)
         .await
@@ -145,12 +139,9 @@ pub async fn open_temp_shard_with_rate_limiter(
         name: "test".to_string(),
         backend: Backend::Fs,
         path: tmp.path().to_string_lossy().to_string(),
-        wal: None,
-        apply_wal_on_close: true,
         // Use fast flush interval for tests to speed them up
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
     let shard = JobStoreShard::open(&cfg, rate_limiter, None, ShardRange::full())
         .await
@@ -192,9 +183,8 @@ pub async fn open_temp_shard_with_local_wal_and_rate_limiter(
             path: wal_dir.path().to_string_lossy().to_string(),
         }),
         apply_wal_on_close: flush_on_close,
-        enable_counter_reconciliation: false,
         slatedb: Some(fast_flush_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     };
 
     let shard = JobStoreShard::open(&cfg, rate_limiter, None, ShardRange::full())

--- a/tests/turmoil_runner/helpers.rs
+++ b/tests/turmoil_runner/helpers.rs
@@ -293,12 +293,8 @@ pub fn dst_turmoilfs_database_template(
     silo::settings::DatabaseTemplate {
         backend: Backend::TurmoilFs,
         path,
-        wal: None,
-        apply_wal_on_close: true,
-        concurrency_reconcile_interval_ms: 5000,
-        enable_counter_reconciliation: false,
         slatedb: Some(dst_slatedb_settings()),
-        memory_cache: None,
+        ..Default::default()
     }
 }
 
@@ -319,14 +315,9 @@ pub async fn setup_server(port: u16) -> turmoil::Result<()> {
         logging: LoggingConfig::default(),
         metrics: silo::settings::MetricsConfig::default(),
         database: silo::settings::DatabaseTemplate {
-            backend: Backend::Memory,
             path: "mem://shard-{shard}".to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
             slatedb: Some(dst_slatedb_settings()),
-            memory_cache: None,
+            ..Default::default()
         },
     };
 

--- a/tests/webui_tests.rs
+++ b/tests/webui_tests.rs
@@ -32,12 +32,7 @@ async fn setup_test_state_with_tenancy(
         DatabaseTemplate {
             backend: Backend::Fs,
             path: tmp.path().join("%shard%").to_string_lossy().to_string(),
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         rate_limiter,
         None,
@@ -408,12 +403,7 @@ async fn setup_multi_shard_state_with_tenancy(
         DatabaseTemplate {
             backend: Backend::Fs,
             path: path_with_shard,
-            wal: None,
-            apply_wal_on_close: true,
-            concurrency_reconcile_interval_ms: 5000,
-            enable_counter_reconciliation: false,
-            slatedb: None,
-            memory_cache: None,
+            ..Default::default()
         },
         rate_limiter,
         None,


### PR DESCRIPTION
## Summary
- Adds manual `Default` impls for `DatabaseTemplate`, `DatabaseConfig`, and `Backend`. Tests and benches now construct these via `..Default::default()`, so future field additions stop fanning out into every test literal (PR #273 hit 26 files / 72 insertions for one new boolean).
- Defaults mirror the existing `#[serde(default = ...)]` functions, so a struct built from `Default::default()` matches a struct deserialized from a minimal TOML. Adds `database_template_default_matches_toml_defaults` to guard against drift.
- Migrates all existing `DatabaseTemplate` / `DatabaseConfig` literals in `src/`, `tests/`, and `benches/` to `..Default::default()`, dropping the boilerplate fields whose values match the new defaults.

## Notes on safety
- `Default` is purely additive — no existing literal stops compiling.
- Production TOML parsing is unchanged: `backend` and `path` remain required at the TOML level (no `#[serde(default)]` added). The `Default` value picks `Backend::Memory` and a temp path because they're only used by Rust callers (tests, benches, `ShardFactory::new_noop`).
- `OpenShardOptions` is intentionally not touched (only 4 call sites; cost-of-change is small).

## Diff
**26 files / -223 lines net.** Bulk of the diff is the test-literal migration — runtime behavior is unchanged because each removed field had the same value as the new `Default`.

## Test plan
- [x] `cargo check --tests --benches --all-features` — clean
- [x] `cargo test --test config_and_db_tests` — 34/34 (including the new `database_template_default_matches_toml_defaults`)
- [x] `cargo test --test counter_reconcile_tests` — 8/8
- [x] `cargo test --test factory_tests` — 11/11
- [x] `cargo test --test shard_counters_tests` — 17/17
- [x] `cargo test --test shard_cleanup_tests` — 11/11