### PR TITLE
Emit prometheus metrics from slatedb's Db::subscribe channel

### DIFF
--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -407,6 +407,11 @@ impl JobStoreShard {
         // missed in-memory notifications or transient scanner failures.
         shard.spawn_concurrency_reconcile_task(range.clone());
 
+        // Watch slatedb's status channel and emit prometheus metrics on each
+        // change (durable_seq advances, manifest revisions). No-op when
+        // metrics are disabled.
+        shard.spawn_db_status_watcher();
+
         // Periodically reconcile job counters from JOB_INFO/JOB_STATUS truth.
         // Only enabled when the deployment runs the standalone compactor, which
         // drops terminal job rows without a writable Db handle and therefore
@@ -517,6 +522,59 @@ impl JobStoreShard {
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Spawn a background task that mirrors slatedb's `Db::subscribe` watch
+    /// channel into prometheus gauges and a manifest-revision counter. Exits
+    /// when the shard's cancellation token is cancelled (during `close()`)
+    /// or when the underlying `Db` is dropped (sender side closes).
+    ///
+    /// No-op when metrics are disabled — avoids spawning an idle task per
+    /// shard in test/bench configurations that opt out of metrics.
+    fn spawn_db_status_watcher(self: &Arc<Self>) {
+        let Some(metrics) = self.metrics.clone() else {
+            return;
+        };
+        let shard_name = self.name.clone();
+        let cancellation = self.cancellation.clone();
+        let mut rx = self.db.subscribe();
+
+        tokio::spawn(async move {
+            // Emit initial values so gauges aren't empty until the first
+            // change. The first watch read also seeds the manifest-revision
+            // dedup key without bumping the counter.
+            let initial = rx.borrow_and_update().clone();
+            let mut prev_manifest_id = initial.current_manifest.id;
+            metrics.record_db_status(&shard_name, &initial, false);
+
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => {
+                        tracing::debug!(
+                            shard = %shard_name,
+                            "stopping slatedb status watcher (shard closing)"
+                        );
+                        break;
+                    }
+                    changed = rx.changed() => {
+                        if changed.is_err() {
+                            // Sender dropped — the Db was dropped without a
+                            // close(). Treat the same as cancellation.
+                            tracing::debug!(
+                                shard = %shard_name,
+                                "stopping slatedb status watcher (db dropped)"
+                            );
+                            break;
+                        }
+                        let status = rx.borrow_and_update().clone();
+                        let manifest_changed = status.current_manifest.id != prev_manifest_id;
+                        prev_manifest_id = status.current_manifest.id;
+                        metrics.record_db_status(&shard_name, &status, manifest_changed);
+                    }
+                }
+            }
+        });
     }
 
     fn spawn_concurrency_reconcile_task(self: &Arc<Self>, range: ShardRange) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -109,6 +109,14 @@ pub struct Metrics {
     // Concurrency metrics
     concurrency_tickets_granted: Counter,
 
+    // SlateDB watcher metrics (driven by Db::subscribe)
+    slatedb_durable_seq: GaugeVec,
+    slatedb_manifest_revisions: CounterVec,
+    slatedb_manifest_last_l0_seq: GaugeVec,
+    slatedb_manifest_l0_count: GaugeVec,
+    slatedb_manifest_compacted_count: GaugeVec,
+    slatedb_manifest_checkpoints_count: GaugeVec,
+
     /// SlateDB per-shard counters and gauges. Shared with silo-compactor via
     /// the `metric_prefix` constructor argument.
     pub slatedb: SlatedbShardMetrics,
@@ -245,6 +253,41 @@ impl Metrics {
         self.broker_inflight_size
             .with_label_values(&[shard, task_group])
             .set(size as f64);
+    }
+
+    /// Record a SlateDB `DbStatus` snapshot observed via `Db::subscribe`.
+    ///
+    /// `manifest_changed` should be `true` only when `status.current_manifest`
+    /// differs from the previously-observed manifest for this shard, so the
+    /// `silo_slatedb_manifest_revisions_total` counter increments once per
+    /// distinct manifest revision rather than on every status update.
+    pub fn record_db_status(
+        &self,
+        shard: &str,
+        status: &slatedb::DbStatus,
+        manifest_changed: bool,
+    ) {
+        let manifest = &status.current_manifest.manifest;
+        self.slatedb_durable_seq
+            .with_label_values(&[shard])
+            .set(status.durable_seq as f64);
+        self.slatedb_manifest_last_l0_seq
+            .with_label_values(&[shard])
+            .set(manifest.last_l0_seq as f64);
+        self.slatedb_manifest_l0_count
+            .with_label_values(&[shard])
+            .set(manifest.l0.len() as f64);
+        self.slatedb_manifest_compacted_count
+            .with_label_values(&[shard])
+            .set(manifest.compacted.len() as f64);
+        self.slatedb_manifest_checkpoints_count
+            .with_label_values(&[shard])
+            .set(manifest.checkpoints.len() as f64);
+        if manifest_changed {
+            self.slatedb_manifest_revisions
+                .with_label_values(&[shard])
+                .inc();
+        }
     }
 
     /// Record broker scan duration in seconds.
@@ -1076,6 +1119,73 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    // SlateDB watcher metrics (driven by Db::subscribe)
+    let slatedb_durable_seq = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_slatedb_durable_seq",
+                "SlateDB durable sequence number from Db::subscribe (last seq persisted to object storage)",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_manifest_revisions = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_slatedb_manifest_revisions_total",
+                "Number of distinct SlateDB manifest revisions observed via Db::subscribe",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_manifest_last_l0_seq = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_slatedb_manifest_last_l0_seq",
+                "last_l0_seq field of the current SlateDB manifest",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_manifest_l0_count = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_slatedb_manifest_l0_count",
+                "Number of L0 SSTs in the current SlateDB manifest",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_manifest_compacted_count = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_slatedb_manifest_compacted_count",
+                "Number of compacted sorted runs in the current SlateDB manifest",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let slatedb_manifest_checkpoints_count = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_slatedb_manifest_checkpoints_count",
+                "Number of active checkpoints in the current SlateDB manifest",
+            ),
+            &["shard"],
+        )?,
+    );
+
     let slatedb = SlatedbShardMetrics::register(&registry, "silo_")?;
 
     Ok(Metrics {
@@ -1104,6 +1214,12 @@ pub fn init() -> anyhow::Result<Metrics> {
         lease_reaper_leases_reaped_total,
         lease_reaper_errors_total,
         concurrency_tickets_granted,
+        slatedb_durable_seq,
+        slatedb_manifest_revisions,
+        slatedb_manifest_last_l0_seq,
+        slatedb_manifest_l0_count,
+        slatedb_manifest_compacted_count,
+        slatedb_manifest_checkpoints_count,
         slatedb,
     })
 }


### PR DESCRIPTION
## Summary

- Spawns a per-shard tokio task at shard open that watches slatedb's `Db::subscribe()` channel and mirrors `DbStatus` into prometheus metrics.
- New metrics (all labeled by `shard`):
  - `silo_slatedb_durable_seq` (gauge) — current durable sequence number, the last write seq persisted to object storage.
  - `silo_slatedb_manifest_revisions_total` (counter) — bumped once per distinct `VersionedManifest.id` observed.
  - `silo_slatedb_manifest_last_l0_seq`, `silo_slatedb_manifest_l0_count`, `silo_slatedb_manifest_compacted_count`, `silo_slatedb_manifest_checkpoints_count` (gauges) — current LSM/checkpoint counts, no longer requiring an on-demand `db.manifest()` call.
- Watcher exits via the existing per-shard `CancellationToken` on `close()` (cancellation is signaled before `db.close()`), and also tolerates the sender side closing if a `Db` is dropped without a graceful close. No-op when `metrics` is disabled, so we don't spawn an idle task per shard in test/bench paths.

## Why

A stalled `durable_seq` is the cleanest signal that flushes have wedged, and watching manifest churn / L0 / compacted / checkpoint counts gives a live LSM-health view that previously was only reachable with synchronous `db.manifest()` reads in admin/cleanup paths.

## Test plan

- [ ] `cargo check -p silo` and `cargo clippy -p silo --lib --bins` (clean — no new warnings)
- [ ] `cargo test -p silo metrics_tests`
- [ ] Smoke test: open a shard, write + flush, scrape `/metrics`, confirm `silo_slatedb_durable_seq` > 0 and `silo_slatedb_manifest_revisions_total` >= 1
- [ ] Close the shard and confirm the `"stopping slatedb status watcher (shard closing)"` debug log fires (no orphan task)
- [ ] Manual smoke against staging via `scripts/deploy-local-orbstack.mts` and watch the gauges move under load