### PR TITLE
Propagate parent trace context from clients

### DIFF
--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -29,10 +29,13 @@ use std::time::Duration;
 
 use dashmap::DashMap;
 use futures::future::join_all;
+use opentelemetry::propagation::Injector;
+use tonic::metadata::{MetadataKey, MetadataMap};
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint};
 use tonic::{Request, Status, metadata::MetadataValue};
 use tracing::{debug, trace, warn};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::coordination::{Coordinator, ShardOwnerMap, SplitCleanupStatus};
 use crate::factory::ShardFactory;
@@ -144,8 +147,30 @@ pub fn ensure_http_scheme(addr: &str) -> String {
     }
 }
 
-/// Client-side gRPC interceptor that injects a Bearer auth token into outgoing requests.
-/// When `header_value` is `None`, this is a no-op pass-through.
+/// `Injector` view over `tonic::metadata::MetadataMap` so the OTel propagator
+/// can write `traceparent` / `tracestate` straight into outgoing gRPC metadata.
+struct MetadataMapInjector<'a>(&'a mut MetadataMap);
+
+impl<'a> Injector for MetadataMapInjector<'a> {
+    fn set(&mut self, key: &str, value: String) {
+        // gRPC metadata keys must be lower-case ASCII. The OTel propagator
+        // already emits lower-case W3C keys, but be defensive and skip
+        // anything that won't parse rather than panic.
+        if let (Ok(name), Ok(val)) = (
+            MetadataKey::<tonic::metadata::Ascii>::from_bytes(key.as_bytes()),
+            value.parse::<MetadataValue<tonic::metadata::Ascii>>(),
+        ) {
+            self.0.insert(name, val);
+        }
+    }
+}
+
+/// Client-side gRPC interceptor that decorates every outbound request:
+///   - injects W3C Trace Context (`traceparent`/`tracestate`) from the active
+///     OTel context, so peer silo servers stitch their spans under the caller's
+///     trace_id (paired with `crate::grpc_trace::GrpcTraceLayer` on the
+///     server). Always-on; a no-op when no propagator/span is active.
+///   - injects a Bearer auth token when `token` is set.
 #[derive(Clone)]
 pub struct AuthInterceptor {
     header_value: Option<MetadataValue<tonic::metadata::Ascii>>,
@@ -165,6 +190,16 @@ impl AuthInterceptor {
 
 impl tonic::service::Interceptor for AuthInterceptor {
     fn call(&mut self, mut req: Request<()>) -> Result<Request<()>, Status> {
+        // Inject the active span's OTel context into the request metadata.
+        // tracing::Span::current() reflects whatever span the calling task is
+        // running inside; for an inbound request being forwarded to a peer,
+        // that's typically the GrpcTraceLayer's span carrying the caller's
+        // parent trace.
+        let cx = tracing::Span::current().context();
+        opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.inject_context(&cx, &mut MetadataMapInjector(req.metadata_mut()));
+        });
+
         if let Some(ref val) = self.header_value {
             req.metadata_mut().insert("authorization", val.clone());
         }

--- a/src/grpc_trace.rs
+++ b/src/grpc_trace.rs
@@ -1,0 +1,100 @@
+//! Tower layer that extracts W3C Trace Context (`traceparent` / `tracestate`)
+//! from incoming gRPC request headers and attaches it as the parent of the
+//! request's tracing span.
+//!
+//! When workers propagate `traceparent` on their RPCs, every `tracing` event
+//! emitted while handling that request will carry the worker's `trace_id`,
+//! letting a single trace stitch together worker-side and silo-side activity.
+//!
+//! The layer is a no-op when no propagator is installed or when the incoming
+//! request has no `traceparent`. Pair with `trace::install_propagator()` to
+//! enable W3C Trace Context globally.
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use opentelemetry::propagation::Extractor;
+use tonic::codegen::http::{HeaderMap, HeaderValue};
+use tower::{Layer, Service};
+use tracing::Instrument;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+/// `Extractor` view over `http::HeaderMap` so the OTel propagator can pull
+/// `traceparent` / `tracestate` straight from a tonic request.
+struct HeaderMapExtractor<'a>(&'a HeaderMap<HeaderValue>);
+
+impl<'a> Extractor for HeaderMapExtractor<'a> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|k| k.as_str()).collect()
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct GrpcTraceLayer;
+
+impl GrpcTraceLayer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<S> Layer<S> for GrpcTraceLayer {
+    type Service = GrpcTraceService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        GrpcTraceService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct GrpcTraceService<S> {
+    inner: S,
+}
+
+type HttpRequest<T> = tonic::codegen::http::Request<T>;
+type HttpResponse<T> = tonic::codegen::http::Response<T>;
+
+impl<S, ReqBody, ResBody> Service<HttpRequest<ReqBody>> for GrpcTraceService<S>
+where
+    S: Service<HttpRequest<ReqBody>, Response = HttpResponse<ResBody>> + Clone + Send + 'static,
+    <S as Service<HttpRequest<ReqBody>>>::Future: Send + 'static,
+    <S as Service<HttpRequest<ReqBody>>>::Error: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = HttpResponse<ResBody>;
+    type Error = <S as Service<HttpRequest<ReqBody>>>::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: HttpRequest<ReqBody>) -> Self::Future {
+        // Pull the parent context out of the headers. If no propagator is
+        // installed or no traceparent was sent, this returns an empty Context
+        // and `set_parent` is a no-op below.
+        let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&HeaderMapExtractor(req.headers()))
+        });
+
+        // The method is the last path segment, e.g. `/silo.v1.Silo/LeaseTasks` -> `LeaseTasks`.
+        let method = req
+            .uri()
+            .path()
+            .rsplit_once('/')
+            .map(|(_, m)| m.to_string())
+            .unwrap_or_else(|| req.uri().path().to_string());
+
+        let span = tracing::info_span!("grpc_request", rpc.method = %method);
+        span.set_parent(parent_cx);
+
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        Box::pin(async move { inner.call(req).await }.instrument(span))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod concurrency;
 pub mod coordination;
 pub mod dst_events;
 pub mod factory;
+pub mod grpc_trace;
 pub mod gubernator;
 pub mod heap_profile;
 pub mod job;

--- a/src/server.rs
+++ b/src/server.rs
@@ -2085,6 +2085,10 @@ where
         // evicted streams cause RST_STREAM with code 5 (STREAM_CLOSED)
         // on late frames, which surfaces as gRPC INTERNAL errors.
         .http2_max_pending_accept_reset_streams(Some(1000))
+        // Extract W3C Trace Context first so subsequent layers (and the
+        // request handler itself) emit spans/log lines under the caller's
+        // trace_id when `traceparent` is propagated.
+        .layer(crate::grpc_trace::GrpcTraceLayer::new())
         .layer(crate::metrics::GrpcMetricsLayer::new(metrics.clone()))
         .add_service(health_service)
         .add_service(reflection_service)

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex, Once};
 use opentelemetry::KeyValue;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::{Resource, runtime, trace as sdktrace};
 use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::{EnvFilter, filter::LevelFilter, prelude::*};
@@ -50,6 +51,12 @@ impl<'a> MakeWriter<'a> for DebugFileWriter {
 pub fn init(log_format: LogFormat) -> anyhow::Result<()> {
     let mut init_result: Option<anyhow::Result<()>> = None;
     INIT.call_once(|| {
+        // Install the W3C Trace Context propagator regardless of whether OTLP
+        // export is configured. This is what lets the gRPC trace layer extract
+        // `traceparent` from incoming requests and link silo spans to the
+        // caller's trace. With no propagator installed, `extract` returns an
+        // empty context and the layer is a no-op.
+        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
         let result = {
             let env_filter = build_env_filter();
 

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -1,4 +1,10 @@
-import { type Counter, type Meter, metrics } from "@opentelemetry/api";
+import {
+  context as otelContext,
+  type Counter,
+  type Meter,
+  metrics,
+  propagation,
+} from "@opentelemetry/api";
 import xxhashInit from "xxhash-wasm";
 import type { ClientOptions } from "@grpc/grpc-js";
 import { ChannelCredentials, credentials, Metadata } from "@grpc/grpc-js";
@@ -1188,6 +1194,39 @@ function protoAttemptToPublic(attempt: ProtoJobAttempt): JobAttempt {
   };
 }
 
+/**
+ * Inject the active OpenTelemetry context (W3C `traceparent` / `tracestate`,
+ * Baggage, etc.) into outgoing gRPC metadata so the silo server can stitch
+ * its spans/log lines into the caller's trace.
+ *
+ * Always-on: when no propagator is configured globally, OTel's default is a
+ * noop and this is a few extra function calls per RPC. When a propagator IS
+ * configured but no span is active, the carrier is left untouched.
+ */
+const tracePropagationInterceptor: RpcInterceptor = {
+  interceptUnary(next, method, input, rpcOptions) {
+    injectTraceContext(rpcOptions);
+    return next(method, input, rpcOptions);
+  },
+  interceptServerStreaming(next, method, input, rpcOptions) {
+    injectTraceContext(rpcOptions);
+    return next(method, input, rpcOptions);
+  },
+};
+
+function injectTraceContext(rpcOptions: RpcOptions): void {
+  if (!rpcOptions.meta) {
+    rpcOptions.meta = {};
+  }
+  // Setter targets the `meta` plain-object carrier used by protobuf-ts; lower-case
+  // keys are required by HTTP/2 and what the silo Rust extractor expects.
+  propagation.inject(otelContext.active(), rpcOptions.meta, {
+    set(carrier, key, value) {
+      (carrier as Record<string, string>)[key.toLowerCase()] = value;
+    },
+  });
+}
+
 /** Connection to a single server */
 interface ServerConnection {
   address: string;
@@ -1446,11 +1485,15 @@ export class SiloGRPCClient {
   private _getOrCreateConnection(address: string): ServerConnection {
     let conn = this._connections.get(address);
     if (!conn) {
+      const interceptors: RpcInterceptor[] = [tracePropagationInterceptor];
+      if (this._authInterceptor) {
+        interceptors.push(this._authInterceptor);
+      }
       const transport = new GrpcTransport({
         host: address,
         channelCredentials: this._channelCredentials,
         clientOptions: this._grpcClientOptions,
-        ...(this._authInterceptor ? { interceptors: [this._authInterceptor] } : {}),
+        interceptors,
       });
       const client = new SiloClient(transport);
       conn = { address, transport, client };

--- a/typescript_client/src/worker.ts
+++ b/typescript_client/src/worker.ts
@@ -1,4 +1,10 @@
-import type { Meter } from "@opentelemetry/api";
+import {
+  context as otelContext,
+  type Meter,
+  SpanStatusCode,
+  trace,
+  type Tracer,
+} from "@opentelemetry/api";
 import PQueue from "p-queue";
 import { serializeError } from "serialize-error";
 import type { Task as ProtoTask } from "./pb/silo";
@@ -260,6 +266,8 @@ export class SiloWorker<
   private _pollCounter: number = 0;
   /** OpenTelemetry metrics */
   private readonly _metrics: WorkerMetrics;
+  /** OpenTelemetry tracer for per-task lifecycle spans */
+  private readonly _tracer: Tracer;
 
   public constructor(options: SiloWorkerOptions<Payload, Metadata, Result>) {
     this._client = options.client;
@@ -284,6 +292,10 @@ export class SiloWorker<
     // Initialize metrics
     const meter = getWorkerMeter(options.meter);
     this._metrics = new WorkerMetrics(meter, this._taskGroup, () => this.availableTaskSlots);
+    // Tracer for per-task lifecycle spans. Uses the global TracerProvider; when
+    // none is configured this resolves to a noop tracer and all the span calls
+    // below are zero-cost.
+    this._tracer = trace.getTracer("silo-worker");
   }
 
   /**
@@ -516,29 +528,57 @@ export class SiloWorker<
   private _enqueueTask(protoTask: ProtoTask): void {
     const task = transformTask<Payload, Metadata>(protoTask);
 
+    // Open a per-task lifecycle span that covers heartbeats, the user
+    // handler, and the eventual reportOutcome. LeaseTasks intentionally sits
+    // outside this span — a single batch lease can produce N tasks and they
+    // shouldn't share a span. The gRPC client interceptor reads
+    // otelContext.active() on each outbound RPC, so any silo call made while
+    // taskContext is active will carry traceparent for this span.
+    const span = this._tracer.startSpan("silo.task.lifecycle", {
+      attributes: {
+        "silo.task_id": task.id,
+        "silo.shard": task.shard,
+        "silo.tenant": task.tenantId ?? "",
+        "silo.worker_id": this._workerId,
+        "silo.job_id": task.jobId,
+        "silo.task_group": this._taskGroup,
+        "silo.attempt_number": task.attemptNumber,
+      },
+    });
+    const taskContext = trace.setSpan(otelContext.active(), span);
+
     // Create TaskExecution to manage this task's state
     const execution = new TaskExecution(task, this._workerId, this._client);
     this._activeExecutions.set(task.id, execution);
 
-    // Start heartbeat for this task immediately
-    const heartbeatInterval = setInterval(() => {
+    // Start heartbeat for this task immediately. setInterval callbacks fire at
+    // the top of the event loop and don't inherit any context that was active
+    // when setInterval was called, so we explicitly bind the heartbeat fn to
+    // taskContext — without this every Heartbeat RPC would be its own root
+    // trace instead of a child of the lifecycle span.
+    const heartbeatFn = otelContext.bind(taskContext, () => {
       this._sendHeartbeatForTask(execution).catch((error) => {
         this._onError(error instanceof Error ? error : new Error(String(error)), {
           taskId: task.id,
         });
       });
-    }, this._heartbeatIntervalMs);
+    });
+    const heartbeatInterval = setInterval(heartbeatFn, this._heartbeatIntervalMs);
     this._heartbeatIntervals.set(task.id, heartbeatInterval);
 
-    // Add task to the queue for execution
+    // Add task to the queue for execution. Bind the queued callback so the
+    // await chain inside (handler invocation + reportOutcome) inherits
+    // taskContext even though p-queue defers execution to a future microtask.
+    const queuedFn = otelContext.bind(taskContext, async () => {
+      await this._executeTaskWithExecution(execution);
+    });
     this._taskQueue
-      .add(async () => {
-        await this._executeTaskWithExecution(execution);
-      })
+      .add(queuedFn)
       .catch((error) => {
-        this._onError(error instanceof Error ? error : new Error(String(error)), {
-          taskId: task.id,
-        });
+        const e = error instanceof Error ? error : new Error(String(error));
+        span.recordException(e);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
+        this._onError(e, { taskId: task.id });
       })
       .finally(() => {
         // Stop heartbeat for this task
@@ -549,6 +589,7 @@ export class SiloWorker<
         }
         // Remove from active executions
         this._activeExecutions.delete(task.id);
+        span.end();
       });
   }
 


### PR DESCRIPTION
This change allows us to extract the traceparent and tracestate from requests headers so that the are propogated through the entire RPC call chain.
- Worker → silo (TS client → Rust server): TS interceptor injects active span's traceparent → Rust GrpcTraceLayer extracts → silo handler logs carry the worker's trace_id.
- Silo → silo (Rust client → Rust server): AuthInterceptor injects current span's traceparent → peer's GrpcTraceLayer extracts → peer's handler logs carry the same trace_id.
- Worker → silo A → silo B: full chain stitches together as a single trace, parent → child → grandchild spans.
- Silo background tasks → silo: any background task instrumented with a tracing span propagates that span's trace.
- Silo plain task without instrumentation → silo: empty context, peer starts a new root trace. No worse than today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the gRPC client/server request pipeline for every RPC by adding always-on trace-context injection/extraction, which could cause metadata/compatibility or performance issues if misconfigured. No changes to auth/authorization logic or data handling beyond adding tracing headers.
> 
> **Overview**
> Adds end-to-end W3C Trace Context propagation across the system so logs/spans on downstream silos share the caller’s `trace_id`.
> 
> On the Rust side, introduces a new `GrpcTraceLayer` that extracts `traceparent`/`tracestate` from incoming gRPC headers and sets it as the parent of a per-request span, and wires this layer into the server stack ahead of metrics. Outbound silo-to-silo RPCs now inject the active OpenTelemetry context via the existing `AuthInterceptor` (which still adds the Bearer `authorization` header).
> 
> On the TypeScript client, adds a gRPC interceptor that injects the active OpenTelemetry context into outgoing metadata and ensures it composes with the existing auth interceptor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49b76d8a3df41f1578366965b3635f2af804a28a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->