### PR TITLE
Add FlushShard RPC for synchronous slatedb flush

### DIFF
--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -600,6 +600,17 @@ message CompactShardResponse {
   string status = 1; // Status message describing the compaction result.
 }
 
+// Request to flush a shard's SlateDB instance to object storage.
+// Returns once the flush has completed durably.
+message FlushShardRequest {
+  string shard = 1; // The shard ID (UUID) to flush.
+}
+
+// Response after the flush has completed.
+message FlushShardResponse {
+  string status = 1; // Status message describing the flush result.
+}
+
 // Request to get a shard's LSM tree / storage state from its owning node.
 message GetShardStorageInfoRequest {
   string shard = 1; // The shard ID (UUID).
@@ -743,6 +754,10 @@ service Silo {
   // Merges all L0 SSTs and sorted runs into a single sorted run, removing tombstones.
   // This is useful for reclaiming space after bulk deletes or high job throughput.
   rpc CompactShard(CompactShardRequest) returns (CompactShardResponse);
+
+  // Flush a shard's SlateDB instance to object storage and wait for durability.
+  // The shard must be owned by this node. Returns only after the flush completes.
+  rpc FlushShard(FlushShardRequest) returns (FlushShardResponse);
 
   // Get storage (LSM tree) information for a shard.
   // Returns details about L0 SSTs, sorted runs, and sizes.

--- a/siloctl/src/lib.rs
+++ b/siloctl/src/lib.rs
@@ -13,9 +13,9 @@ use silo::cluster_client::AuthInterceptor;
 use silo::pb::silo_client::SiloClient;
 use silo::pb::{
     CancelJobRequest, CompactShardRequest, ConfigureShardRequest, CpuProfileRequest,
-    DeleteJobRequest, ExpediteJobRequest, ForceReleaseShardRequest, GetClusterInfoRequest,
-    GetJobRequest, GetJobResultRequest, GetSplitStatusRequest, HeapProfileRequest, QueryRequest,
-    RequestSplitRequest, RestartJobRequest,
+    DeleteJobRequest, ExpediteJobRequest, FlushShardRequest, ForceReleaseShardRequest,
+    GetClusterInfoRequest, GetJobRequest, GetJobResultRequest, GetSplitStatusRequest,
+    HeapProfileRequest, QueryRequest, RequestSplitRequest, RestartJobRequest,
 };
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
@@ -1072,6 +1072,40 @@ pub async fn shard_compact<W: Write>(
 
     let response = client
         .compact_shard(CompactShardRequest {
+            shard: shard.to_string(),
+        })
+        .await?
+        .into_inner();
+
+    if opts.json {
+        let json_output = serde_json::json!({
+            "shard_id": shard,
+            "status": response.status,
+        });
+        writeln!(out, "{}", serde_json::to_string_pretty(&json_output)?)?;
+    } else {
+        writeln!(out, "{}", response.status)?;
+    }
+
+    Ok(())
+}
+
+/// Flush a shard's slatedb to object storage and wait for the flush to complete.
+pub async fn shard_flush<W: Write>(
+    opts: &GlobalOptions,
+    out: &mut W,
+    shard: &str,
+) -> anyhow::Result<()> {
+    let mut client =
+        connect_to_shard_owner(&opts.address, shard, opts.auth_token.as_deref()).await?;
+
+    if !opts.json {
+        writeln!(out, "Flushing shard {}...", shard)?;
+        out.flush()?;
+    }
+
+    let response = client
+        .flush_shard(FlushShardRequest {
             shard: shard.to_string(),
         })
         .await?

--- a/siloctl/src/main.rs
+++ b/siloctl/src/main.rs
@@ -155,6 +155,11 @@ enum ShardAction {
         /// Shard ID (UUID) to compact
         shard: String,
     },
+    /// Flush a shard's slatedb to object storage and wait for completion
+    Flush {
+        /// Shard ID (UUID) to flush
+        shard: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -299,6 +304,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
             ShardAction::Compact { shard } => {
                 siloctl::shard_compact(&opts, &mut stdout, shard).await
             }
+            ShardAction::Flush { shard } => siloctl::shard_flush(&opts, &mut stdout, shard).await,
         },
         Command::Tenant { action } => match action {
             TenantAction::Locate { tenant_id } => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1916,6 +1916,28 @@ impl Silo for SiloService {
         }))
     }
 
+    async fn flush_shard(
+        &self,
+        req: Request<FlushShardRequest>,
+    ) -> Result<Response<FlushShardResponse>, Status> {
+        let r = req.into_inner();
+        let shard_id = Self::parse_shard_id(&r.shard)?;
+
+        let shard = self.factory.get(&shard_id).ok_or_else(|| {
+            Status::not_found(format!("shard {} not found on this node", r.shard))
+        })?;
+
+        shard
+            .db()
+            .flush()
+            .await
+            .map_err(|e| Status::internal(format!("flush failed: {}", e)))?;
+
+        Ok(Response::new(FlushShardResponse {
+            status: format!("flushed shard {}", r.shard),
+        }))
+    }
+
     async fn get_shard_storage_info(
         &self,
         req: Request<GetShardStorageInfoRequest>,

--- a/tests/routing_client_tests.rs
+++ b/tests/routing_client_tests.rs
@@ -223,6 +223,13 @@ impl Silo for CountingClusterInfoService {
         Self::unimplemented("compact_shard")
     }
 
+    async fn flush_shard(
+        &self,
+        _request: Request<FlushShardRequest>,
+    ) -> Result<Response<FlushShardResponse>, Status> {
+        Self::unimplemented("flush_shard")
+    }
+
     async fn get_shard_storage_info(
         &self,
         _request: Request<GetShardStorageInfoRequest>,

--- a/typescript_client/src/pb/silo.client.ts
+++ b/typescript_client/src/pb/silo.client.ts
@@ -6,6 +6,8 @@ import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import { Silo } from "./silo";
 import type { GetShardStorageInfoResponse } from "./silo";
 import type { GetShardStorageInfoRequest } from "./silo";
+import type { FlushShardResponse } from "./silo";
+import type { FlushShardRequest } from "./silo";
 import type { CompactShardResponse } from "./silo";
 import type { CompactShardRequest } from "./silo";
 import type { ForceReleaseShardResponse } from "./silo";
@@ -262,6 +264,13 @@ export interface ISiloClient {
      * @generated from protobuf rpc: CompactShard
      */
     compactShard(input: CompactShardRequest, options?: RpcOptions): UnaryCall<CompactShardRequest, CompactShardResponse>;
+    /**
+     * Flush a shard's SlateDB instance to object storage and wait for durability.
+     * The shard must be owned by this node. Returns only after the flush completes.
+     *
+     * @generated from protobuf rpc: FlushShard
+     */
+    flushShard(input: FlushShardRequest, options?: RpcOptions): UnaryCall<FlushShardRequest, FlushShardResponse>;
     /**
      * Get storage (LSM tree) information for a shard.
      * Returns details about L0 SSTs, sorted runs, and sizes.
@@ -554,6 +563,16 @@ export class SiloClient implements ISiloClient, ServiceInfo {
         return stackIntercept<CompactShardRequest, CompactShardResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * Flush a shard's SlateDB instance to object storage and wait for durability.
+     * The shard must be owned by this node. Returns only after the flush completes.
+     *
+     * @generated from protobuf rpc: FlushShard
+     */
+    flushShard(input: FlushShardRequest, options?: RpcOptions): UnaryCall<FlushShardRequest, FlushShardResponse> {
+        const method = this.methods[25], opt = this._transport.mergeOptions(options);
+        return stackIntercept<FlushShardRequest, FlushShardResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
      * Get storage (LSM tree) information for a shard.
      * Returns details about L0 SSTs, sorted runs, and sizes.
      * The shard must be owned by this node.
@@ -561,7 +580,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: GetShardStorageInfo
      */
     getShardStorageInfo(input: GetShardStorageInfoRequest, options?: RpcOptions): UnaryCall<GetShardStorageInfoRequest, GetShardStorageInfoResponse> {
-        const method = this.methods[25], opt = this._transport.mergeOptions(options);
+        const method = this.methods[26], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetShardStorageInfoRequest, GetShardStorageInfoResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -1620,6 +1620,29 @@ export interface CompactShardResponse {
     status: string; // Status message describing the compaction result.
 }
 /**
+ * Request to flush a shard's SlateDB instance to object storage.
+ * Returns once the flush has completed durably.
+ *
+ * @generated from protobuf message silo.v1.FlushShardRequest
+ */
+export interface FlushShardRequest {
+    /**
+     * @generated from protobuf field: string shard = 1
+     */
+    shard: string; // The shard ID (UUID) to flush.
+}
+/**
+ * Response after the flush has completed.
+ *
+ * @generated from protobuf message silo.v1.FlushShardResponse
+ */
+export interface FlushShardResponse {
+    /**
+     * @generated from protobuf field: string status = 1
+     */
+    status: string; // Status message describing the flush result.
+}
+/**
  * Request to get a shard's LSM tree / storage state from its owning node.
  *
  * @generated from protobuf message silo.v1.GetShardStorageInfoRequest
@@ -6755,6 +6778,100 @@ class CompactShardResponse$Type extends MessageType<CompactShardResponse> {
  */
 export const CompactShardResponse = new CompactShardResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class FlushShardRequest$Type extends MessageType<FlushShardRequest> {
+    constructor() {
+        super("silo.v1.FlushShardRequest", [
+            { no: 1, name: "shard", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<FlushShardRequest>): FlushShardRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.shard = "";
+        if (value !== undefined)
+            reflectionMergePartial<FlushShardRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: FlushShardRequest): FlushShardRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string shard */ 1:
+                    message.shard = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: FlushShardRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string shard = 1; */
+        if (message.shard !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.shard);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.FlushShardRequest
+ */
+export const FlushShardRequest = new FlushShardRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class FlushShardResponse$Type extends MessageType<FlushShardResponse> {
+    constructor() {
+        super("silo.v1.FlushShardResponse", [
+            { no: 1, name: "status", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<FlushShardResponse>): FlushShardResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.status = "";
+        if (value !== undefined)
+            reflectionMergePartial<FlushShardResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: FlushShardResponse): FlushShardResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string status */ 1:
+                    message.status = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: FlushShardResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string status = 1; */
+        if (message.status !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.status);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.FlushShardResponse
+ */
+export const FlushShardResponse = new FlushShardResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class GetShardStorageInfoRequest$Type extends MessageType<GetShardStorageInfoRequest> {
     constructor() {
         super("silo.v1.GetShardStorageInfoRequest", [
@@ -6972,5 +7089,6 @@ export const Silo = new ServiceType("silo.v1.Silo", [
     { name: "ResetShards", options: {}, I: ResetShardsRequest, O: ResetShardsResponse },
     { name: "ForceReleaseShard", options: {}, I: ForceReleaseShardRequest, O: ForceReleaseShardResponse },
     { name: "CompactShard", options: {}, I: CompactShardRequest, O: CompactShardResponse },
+    { name: "FlushShard", options: {}, I: FlushShardRequest, O: FlushShardResponse },
     { name: "GetShardStorageInfo", options: {}, I: GetShardStorageInfoRequest, O: GetShardStorageInfoResponse }
 ]);


### PR DESCRIPTION
for debugging and assisting in verifying that the issue I'm seeing is tokio task starvation before I invest into wiring up tokio-console

## Summary
- New `FlushShard` gRPC on `service Silo`: awaits `shard.db().flush()` before responding, so the client returns only once the in-memory state is durable in object storage.
- New `siloctl shard flush <SHARD>` subcommand, routed to the shard's owning node via `connect_to_shard_owner` (same pattern as `siloctl shard compact`).
- Regenerated `typescript_client/src/pb/*` to expose the new RPC.

Useful before snapshots, debugging, or staged restarts when operators need confirmation that an arbitrary shard has been flushed.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --no-deps` — no new warnings
- [x] `cargo fmt --all`
- [x] `pnpm -C typescript_client run proto:generate && pnpm -C typescript_client run typecheck` clean
- [x] `siloctl shard --help` lists `flush`
- [ ] Local end-to-end: pick a shard from `siloctl cluster info`, run `siloctl shard flush <SHARD>`, expect "flushed shard …" and exit 0
- [ ] Verify `--json` output shape
- [ ] Verify a non-owner address still routes correctly via cluster-info redirect
- [ ] Verify a malformed shard ID returns `InvalidArgument`