### PR TITLE
Decouple SlateDB metrics scrape from the lease reaper

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -2007,8 +2007,7 @@ where
         .set_serving::<SiloServer<SiloService>>()
         .await;
 
-    // Periodic reaper that iterates all shards every 1s for lease reaping,
-    // and collects SlateDB metrics from each shard.
+    // Periodic reaper that iterates all shards every 1s for lease reaping.
     let (tick_tx, mut tick_rx) = broadcast::channel::<()>(1);
     let reaper_factory = factory.clone();
     let reaper_metrics = metrics.clone();
@@ -2053,15 +2052,32 @@ where
                                 );
                             }
                         }
+                    }
+                }
+                _ = tick_rx.recv() => { break; }
+            }
+        }
+    });
 
-                        // Collect SlateDB storage metrics for this shard
-                        if let Some(ref m) = reaper_metrics {
+    // Periodic SlateDB metrics scrape, decoupled from the reaper so a
+    // backpressured write in `reap_expired_leases` can't stall observability.
+    let metrics_factory = factory.clone();
+    let metrics_for_scrape = metrics.clone();
+    let mut metrics_tick_rx = tick_tx.subscribe();
+    let metrics_scrape: JoinHandle<()> = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+        loop {
+            tokio::select! {
+                biased;
+                _ = interval.tick() => {
+                    if let Some(ref m) = metrics_for_scrape {
+                        for (shard_id, shard) in metrics_factory.instances().iter() {
                             let recorder = shard.slatedb_metrics_recorder();
                             m.update_slatedb_stats(&shard_id.to_string(), recorder);
                         }
                     }
                 }
-                _ = tick_rx.recv() => { break; }
+                _ = metrics_tick_rx.recv() => { break; }
             }
         }
     });
@@ -2101,5 +2117,6 @@ where
     // handles the ordered close→release-lease sequence, which is critical for
     // permanent leases. factory.close_all() in main.rs serves as a safety net.
     reaper.await.ok();
+    metrics_scrape.await.ok();
     Ok(())
 }


### PR DESCRIPTION
## Summary
- The `slatedb_*` Prometheus metrics were updated at the bottom of the per-shard lease reaper loop, after `reap_expired_leases().await`. Reap does slatedb writes, which can park in `maybe_apply_backpressure` for up to 30s — during a backpressure event the scrape for that shard and every shard later in the iteration freezes, so `silo_slatedb_backpressure_count_total`, `l0_sst_count`, `total_mem_size_bytes`, etc. all stop moving in Prometheus exactly when you need them.
- Moves the SlateDB metrics scrape into its own 1s tokio task that iterates `factory.instances()` independently of the reaper. Subscribes to the existing shutdown broadcast and joins on the new handle alongside the reaper.

## Test plan
- [ ] `cargo check` passes (already run locally)
- [ ] `cargo fmt` clean (already run locally)
- [ ] After deploy to staging, verify `silo_slatedb_*` series keep updating during a synthetic backpressure event (e.g. lower `max_unflushed_bytes` and drive writes), while `silo_lease_reaper_duration_seconds` reflects the stall.