### PR TITLE
Add siloctl flake package for faster downstream builds

### DIFF
--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -101,6 +101,21 @@
         cargoArtifacts = cargoArtifactsCompactor;
         doCheck = false;
       });
+
+      # Administration CLI. Builds only the siloctl crate, which depends on
+      # silo with default-features = false — skipping the datafusion compile
+      # so downstream flake consumers that just want siloctl build much faster.
+      siloctlArgs = {
+        inherit src;
+        strictDeps = true;
+        nativeBuildInputs = [ pkgs.protobuf pkgs.flatbuffers ];
+        cargoExtraArgs = "--package siloctl";
+      };
+      cargoArtifactsSiloctl = craneLib.buildDepsOnly siloctlArgs;
+      siloctl = craneLib.buildPackage (siloctlArgs // {
+        cargoArtifacts = cargoArtifactsSiloctl;
+        doCheck = false;
+      });
     in
     {
       packages.default = silo;
@@ -108,5 +123,6 @@
       packages.silo-debug = silo-debug;
       packages.silo-autoscaler = silo-autoscaler;
       packages.silo-compactor = silo-compactor;
+      packages.siloctl = siloctl;
     };
 }


### PR DESCRIPTION
## Summary
- Expose `packages.siloctl` in the flake that builds only the `siloctl` crate via `cargoExtraArgs = "--package siloctl"`, mirroring the existing `silo-autoscaler` and `silo-compactor` outputs.
- siloctl's `silo` dep already sets `default-features = false`, so this package skips the datafusion compile that the default `silo` package incurs through the `server` feature — substantially faster for flake consumers that only need the CLI.

Downstream consumers should switch from `silo-flake.packages.\${system}.default` to `silo-flake.packages.\${system}.siloctl`.

## Test plan
- [ ] `nix build .#siloctl` succeeds and produces a working `siloctl` binary
- [ ] Confirm wall-clock build time is meaningfully shorter than `nix build .#silo` on a cold cache