### PR TITLE
Include siloctl in silo-docker-dev image

### DIFF
--- a/nix/modules/docker.nix
+++ b/nix/modules/docker.nix
@@ -37,6 +37,7 @@
           paths = [
             # use debug silo for faster builds
             self'.packages.silo-debug
+            self'.packages.siloctl
             pkgs.cacert
             # Shell and core utilities
             pkgs.bashInteractive


### PR DESCRIPTION
## Summary
- siloctl stopped being included in the dev container after 9dae4e2 extracted it to its own crate (silo-debug no longer produces a siloctl bin).
- Add `self'.packages.siloctl` to the `silo-docker-dev` devEnv so it's back on PATH for in-cluster admin work.

## Test plan
- [ ] `scripts/deploy-local-orbstack.mts` rebuilds the dev image and `kubectl exec` into a silo pod shows `siloctl` on PATH.