### PR TITLE
Add optional tokio-console support for silo dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,13 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build silo server
         shell: bash
-        run: cargo build
+        # Match the feature flags + RUSTFLAGS that process-compose uses for
+        # silo-1/silo-2 so the cargo run in process-compose hits the cache
+        # instead of triggering a fresh dep recompile under watchexec (which
+        # starves the silo nodes and causes topology refresh to fail).
+        env:
+          RUSTFLAGS: "--cfg tokio_unstable -C force-frame-pointers=yes"
+        run: cargo build -p silo --features tokio-console --bin silo
       - name: Run background processes
         shell: bash
         # Start only the processes the TS tests need. silo-compactor is not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+dependencies = [
+ "futures-core",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "tonic 0.12.3",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.3",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1165,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2631,6 +2679,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,7 +2976,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4461,7 +4522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4494,7 +4555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -4620,7 +4681,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.32",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -4657,7 +4718,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5389,6 +5450,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "console-subscriber",
  "criterion",
  "crossbeam-skiplist",
  "dashmap",
@@ -6087,6 +6149,7 @@ dependencies = [
  "slab",
  "socket2 0.6.0",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 slatedb = "0.12.1"
 slatedb-common = "0.12.1"
 object_store = { version = "0.12", features = ["gcp"] }
-tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "tracing"] }
+tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 rmp = "0.8"
 rmp-serde = "1.3"
@@ -94,7 +94,7 @@ k8s = ["kube", "k8s-openapi", "chrono"]
 # arrow IPC, web UI). Disable to build lightweight clients (siloctl, compactor)
 # without paying the datafusion compile cost.
 server = ["dep:datafusion", "dep:datafusion-sql"]
-tokio-console = ["dep:console-subscriber"]
+tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 
 [dev-dependencies]
 siloctl = { path = "siloctl" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 slatedb = "0.12.1"
 slatedb-common = "0.12.1"
 object_store = { version = "0.12", features = ["gcp"] }
-tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "tracing"] }
 serde = { version = "1.0", features = ["derive"] }
 rmp = "0.8"
 rmp-serde = "1.3"
@@ -38,6 +38,7 @@ prost-types = "0.13"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-perfetto = "0.1"
+console-subscriber = { version = "0.4", optional = true }
 silo-macros = { path = "silo-macros" }
 tokio-stream = "0.1"
 tokio-util = "0.7"
@@ -93,6 +94,7 @@ k8s = ["kube", "k8s-openapi", "chrono"]
 # arrow IPC, web UI). Disable to build lightweight clients (siloctl, compactor)
 # without paying the datafusion compile cost.
 server = ["dep:datafusion", "dep:datafusion-sql"]
+tokio-console = ["dep:console-subscriber"]
 
 [dev-dependencies]
 siloctl = { path = "siloctl" }

--- a/nix/modules/devshell.nix
+++ b/nix/modules/devshell.nix
@@ -86,6 +86,7 @@
           pnpm # Package manager for TypeScript client
           kubectl # for interacting with local K8S API server
           watchexec # Auto-reload for development
+          tokio-console # tokio task inspector; pairs with --features tokio-console builds
           grpcurl # For health checking gRPC servers
           toxiproxy # Network fault injection proxy for testing
           sccache # Shared compilation cache across worktrees

--- a/nix/modules/docker.nix
+++ b/nix/modules/docker.nix
@@ -63,6 +63,8 @@
             pkgs.jq
             # grpcurl for testing gRPC endpoints
             pkgs.grpcurl
+            # tokio-console for inspecting silo's async runtime
+            pkgs.tokio-console
             # Archive tools
             pkgs.gnutar
             pkgs.gzip

--- a/process-compose.yml
+++ b/process-compose.yml
@@ -76,7 +76,10 @@ processes:
         --ignore target \
         --ignore tmp \
         --ignore '*.lock' \
-        -- cargo run --bin silo -- -c example_configs/dev-node1.toml
+        -- cargo run --bin silo --features tokio-console -- -c example_configs/dev-node1.toml
+    environment:
+      - RUSTFLAGS=--cfg tokio_unstable -C force-frame-pointers=yes
+      - TOKIO_CONSOLE_BIND=127.0.0.1:6669
     depends_on:
       etcd:
         condition: process_healthy
@@ -107,7 +110,10 @@ processes:
         --ignore target \
         --ignore tmp \
         --ignore '*.lock' \
-        -- cargo run --bin silo -- -c example_configs/dev-node2.toml
+        -- cargo run --bin silo --features tokio-console -- -c example_configs/dev-node2.toml
+    environment:
+      - RUSTFLAGS=--cfg tokio_unstable -C force-frame-pointers=yes
+      - TOKIO_CONSOLE_BIND=127.0.0.1:6670
     depends_on:
       etcd:
         condition: process_healthy

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -16,6 +16,20 @@ fn build_env_filter() -> EnvFilter {
     EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
 }
 
+#[cfg(feature = "tokio-console")]
+fn console_layer() -> Option<console_subscriber::ConsoleLayer> {
+    let (layer, server) = console_subscriber::ConsoleLayer::builder()
+        .with_default_env()
+        .build();
+    tokio::spawn(async move { server.serve().await.expect("console subscriber server") });
+    Some(layer)
+}
+
+#[cfg(not(feature = "tokio-console"))]
+fn console_layer() -> Option<tracing_subscriber::layer::Identity> {
+    None
+}
+
 /// A thread-safe file writer for the debug log layer.
 #[derive(Clone)]
 struct DebugFileWriter {
@@ -124,7 +138,9 @@ fn init_fmt_only<L>(fmt_layer: L) -> anyhow::Result<()>
 where
     L: tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync + 'static,
 {
-    let base = tracing_subscriber::registry().with(fmt_layer);
+    let base = tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(console_layer());
 
     if let Some(path) = std::env::var_os("SILO_PERFETTO") {
         let file = std::fs::File::create(path)?;
@@ -175,7 +191,8 @@ where
 
     let base = tracing_subscriber::registry()
         .with(fmt_layer)
-        .with(file_layer);
+        .with(file_layer)
+        .with(console_layer());
 
     // Note: Perfetto and OTEL are not supported when using debug file logging
     // to keep the type system manageable. This is fine for CI debugging use case.


### PR DESCRIPTION
## Summary
- Adds `console-subscriber` as an optional dependency behind a new `tokio-console` Cargo feature (off by default)
- Wires `ConsoleLayer` into the tracing subscriber registry in `src/trace.rs`
- Updates `process-compose.yml` to build with `--features tokio-console` and bind silo-1 to port 6669, silo-2 to port 6670
- Adds `tokio-console` CLI to the nix devshell and `silo-docker-dev` image

## Usage
```bash
# Start the dev cluster (process-compose builds with the feature automatically)
dev

# In a separate terminal, connect to silo-1:
tokio-console http://127.0.0.1:6669

# Or silo-2:
tokio-console http://127.0.0.1:6670
```

## Test plan
- [ ] `cargo check` passes (default features, no console-subscriber linked)
- [ ] `cargo check --features tokio-console` passes
- [ ] `dev` starts both silo instances with console subscriber listening
- [ ] `tokio-console http://127.0.0.1:6669` connects and shows live task tree