### PR TITLE
Add siloctl dump-tasks for production deadlock diagnosis

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(tokio_unstable)");
+    println!("cargo::rustc-check-cfg=cfg(tokio_taskdump)");
+
     // Tell cargo to only rerun this build script if the proto files change
     println!("cargo:rerun-if-changed=proto/silo.proto");
     println!("cargo:rerun-if-changed=proto/gubernator.proto");

--- a/nix/modules/devshell.nix
+++ b/nix/modules/devshell.nix
@@ -95,7 +95,7 @@
         # Match RUSTFLAGS with rust.nix to avoid cache invalidation between nix build and local dev
         shellHook = ''
           export SILO_PROJECT_ROOT="$(pwd)"
-          export RUSTFLAGS="-C force-frame-pointers=yes"
+          export RUSTFLAGS="--cfg tokio_unstable -C force-frame-pointers=yes"
           export TOXIPROXY_CONFIG="${toxiproxyConfig}"
           # Only use sccache locally -- in CI it has no warm cache and adds overhead
           if [ -z "''${CI:-}" ]; then

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -44,7 +44,7 @@
         # Enable frame pointers for profiling support - pprof uses frame-pointer
         # based unwinding, which requires the compiler to actually preserve them
         CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";  # Better inlining visibility
-        RUSTFLAGS = "-C force-frame-pointers=yes";
+        RUSTFLAGS = "--cfg tokio_unstable --cfg tokio_taskdump -C force-frame-pointers=yes";
       };
       
       # Build dependencies separately for caching

--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -632,6 +632,15 @@ message GetShardStorageInfoResponse {
   repeated SortedRunInfo sorted_runs = 5; // Details of each sorted run.
 }
 
+// Request to dump all in-flight tokio async task backtraces.
+message DumpTasksRequest {}
+
+// Response containing formatted async task backtraces.
+message DumpTasksResponse {
+  string dump = 1;          // Formatted async task backtraces.
+  uint32 task_count = 2;    // Number of tasks captured.
+}
+
 // The Silo job queue service.
 service Silo {
   // Get cluster topology for client-side routing.
@@ -763,4 +772,8 @@ service Silo {
   // Returns details about L0 SSTs, sorted runs, and sizes.
   // The shard must be owned by this node.
   rpc GetShardStorageInfo(GetShardStorageInfoRequest) returns (GetShardStorageInfoResponse);
+
+  // Dump all in-flight tokio async task backtraces from this node.
+  // Used for diagnosing deadlocks and stuck tasks in production.
+  rpc DumpTasks(DumpTasksRequest) returns (DumpTasksResponse);
 }

--- a/siloctl/src/lib.rs
+++ b/siloctl/src/lib.rs
@@ -13,9 +13,10 @@ use silo::cluster_client::AuthInterceptor;
 use silo::pb::silo_client::SiloClient;
 use silo::pb::{
     CancelJobRequest, CompactShardRequest, ConfigureShardRequest, CpuProfileRequest,
-    DeleteJobRequest, ExpediteJobRequest, FlushShardRequest, ForceReleaseShardRequest,
-    GetClusterInfoRequest, GetJobRequest, GetJobResultRequest, GetSplitStatusRequest,
-    HeapProfileRequest, QueryRequest, RequestSplitRequest, RestartJobRequest,
+    DeleteJobRequest, DumpTasksRequest, ExpediteJobRequest, FlushShardRequest,
+    ForceReleaseShardRequest, GetClusterInfoRequest, GetJobRequest, GetJobResultRequest,
+    GetSplitStatusRequest, HeapProfileRequest, QueryRequest, RequestSplitRequest,
+    RestartJobRequest,
 };
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
@@ -1259,4 +1260,23 @@ pub fn compute_midpoint(start: &str, end: &str) -> Option<String> {
     range
         .midpoint()
         .map(silo::shard_range::format_hash_boundary)
+}
+
+pub async fn dump_tasks<W: Write>(opts: &GlobalOptions, out: &mut W) -> anyhow::Result<()> {
+    let mut client = connect(&opts.address, opts.auth_token.as_deref()).await?;
+    let response = client.dump_tasks(DumpTasksRequest {}).await?.into_inner();
+
+    if opts.json {
+        let json_output = serde_json::json!({
+            "task_count": response.task_count,
+            "dump": response.dump,
+        });
+        writeln!(out, "{}", serde_json::to_string_pretty(&json_output)?)?;
+    } else {
+        writeln!(out, "Async Task Dump ({} tasks)", response.task_count)?;
+        writeln!(out, "{}", "=".repeat(40))?;
+        write!(out, "{}", response.dump)?;
+    }
+
+    Ok(())
 }

--- a/siloctl/src/lib.rs
+++ b/siloctl/src/lib.rs
@@ -60,7 +60,8 @@ async fn connect(address: &str, auth_token: Option<&str>) -> anyhow::Result<Auth
     let url = ensure_http_scheme(address);
     let channel = Channel::from_shared(url)?.connect().await?;
     let interceptor = AuthInterceptor::new(auth_token.map(|s| s.to_string()));
-    Ok(SiloClient::with_interceptor(channel, interceptor))
+    Ok(SiloClient::with_interceptor(channel, interceptor)
+        .max_decoding_message_size(128 * 1024 * 1024))
 }
 
 /// Connect to the node that owns a specific shard.

--- a/siloctl/src/main.rs
+++ b/siloctl/src/main.rs
@@ -108,6 +108,8 @@ enum Command {
         #[arg(short = 'c', long = "config")]
         config: PathBuf,
     },
+    /// Dump all in-flight async task backtraces from a Silo node
+    DumpTasks,
 }
 
 #[derive(Subcommand, Debug)]
@@ -324,6 +326,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
         Command::ValidateConfig { config } => {
             siloctl::validate_config(&opts, &mut stdout, config).await
         }
+        Command::DumpTasks => siloctl::dump_tasks(&opts, &mut stdout).await,
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1970,14 +1970,14 @@ impl Silo for SiloService {
         {
             let handle = tokio::runtime::Handle::current();
             let dump = handle.dump().await;
-            let tasks = dump.tasks();
-            let task_count = tasks.len() as u32;
 
             let mut output = String::new();
-            for (i, task) in tasks.iter().enumerate() {
+            let mut task_count: u32 = 0;
+            for (i, task) in dump.tasks().iter().enumerate() {
                 use std::fmt::Write;
                 writeln!(output, "task {i}:").unwrap();
                 writeln!(output, "{}", task.trace()).unwrap();
+                task_count = (i + 1) as u32;
             }
 
             tracing::info!(task_count, "async task dump captured");

--- a/src/server.rs
+++ b/src/server.rs
@@ -1956,6 +1956,49 @@ impl Silo for SiloService {
 
         Ok(Response::new(lsm.into()))
     }
+
+    async fn dump_tasks(
+        &self,
+        _req: Request<DumpTasksRequest>,
+    ) -> Result<Response<DumpTasksResponse>, Status> {
+        #[cfg(all(
+            tokio_unstable,
+            tokio_taskdump,
+            target_os = "linux",
+            any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+        ))]
+        {
+            let handle = tokio::runtime::Handle::current();
+            let dump = handle.dump().await;
+            let tasks = dump.tasks();
+            let task_count = tasks.len() as u32;
+
+            let mut output = String::new();
+            for (i, task) in tasks.iter().enumerate() {
+                use std::fmt::Write;
+                writeln!(output, "task {i}:").unwrap();
+                writeln!(output, "{}", task.trace()).unwrap();
+            }
+
+            tracing::info!(task_count, "async task dump captured");
+            Ok(Response::new(DumpTasksResponse {
+                dump: output,
+                task_count,
+            }))
+        }
+
+        #[cfg(not(all(
+            tokio_unstable,
+            tokio_taskdump,
+            target_os = "linux",
+            any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+        )))]
+        {
+            Err(Status::unimplemented(
+                "task dump requires Linux (aarch64/x86_64) with --cfg tokio_unstable --cfg tokio_taskdump",
+            ))
+        }
+    }
 }
 
 /// Create an auth interceptor that validates Bearer tokens on incoming gRPC requests.

--- a/tests/routing_client_tests.rs
+++ b/tests/routing_client_tests.rs
@@ -236,6 +236,13 @@ impl Silo for CountingClusterInfoService {
     ) -> Result<Response<GetShardStorageInfoResponse>, Status> {
         Self::unimplemented("get_shard_storage_info")
     }
+
+    async fn dump_tasks(
+        &self,
+        _request: Request<DumpTasksRequest>,
+    ) -> Result<Response<DumpTasksResponse>, Status> {
+        Self::unimplemented("dump_tasks")
+    }
 }
 
 async fn setup_counting_cluster_info_server(

--- a/typescript_client/src/pb/silo.client.ts
+++ b/typescript_client/src/pb/silo.client.ts
@@ -4,6 +4,8 @@
 import type { RpcTransport } from "@protobuf-ts/runtime-rpc";
 import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import { Silo } from "./silo";
+import type { DumpTasksResponse } from "./silo";
+import type { DumpTasksRequest } from "./silo";
 import type { GetShardStorageInfoResponse } from "./silo";
 import type { GetShardStorageInfoRequest } from "./silo";
 import type { FlushShardResponse } from "./silo";
@@ -279,6 +281,13 @@ export interface ISiloClient {
      * @generated from protobuf rpc: GetShardStorageInfo
      */
     getShardStorageInfo(input: GetShardStorageInfoRequest, options?: RpcOptions): UnaryCall<GetShardStorageInfoRequest, GetShardStorageInfoResponse>;
+    /**
+     * Dump all in-flight tokio async task backtraces from this node.
+     * Used for diagnosing deadlocks and stuck tasks in production.
+     *
+     * @generated from protobuf rpc: DumpTasks
+     */
+    dumpTasks(input: DumpTasksRequest, options?: RpcOptions): UnaryCall<DumpTasksRequest, DumpTasksResponse>;
 }
 /**
  * The Silo job queue service.
@@ -582,5 +591,15 @@ export class SiloClient implements ISiloClient, ServiceInfo {
     getShardStorageInfo(input: GetShardStorageInfoRequest, options?: RpcOptions): UnaryCall<GetShardStorageInfoRequest, GetShardStorageInfoResponse> {
         const method = this.methods[26], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetShardStorageInfoRequest, GetShardStorageInfoResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * Dump all in-flight tokio async task backtraces from this node.
+     * Used for diagnosing deadlocks and stuck tasks in production.
+     *
+     * @generated from protobuf rpc: DumpTasks
+     */
+    dumpTasks(input: DumpTasksRequest, options?: RpcOptions): UnaryCall<DumpTasksRequest, DumpTasksResponse> {
+        const method = this.methods[27], opt = this._transport.mergeOptions(options);
+        return stackIntercept<DumpTasksRequest, DumpTasksResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -1700,6 +1700,28 @@ export interface GetShardStorageInfoResponse {
     sortedRuns: SortedRunInfo[]; // Details of each sorted run.
 }
 /**
+ * Request to dump all in-flight tokio async task backtraces.
+ *
+ * @generated from protobuf message silo.v1.DumpTasksRequest
+ */
+export interface DumpTasksRequest {
+}
+/**
+ * Response containing formatted async task backtraces.
+ *
+ * @generated from protobuf message silo.v1.DumpTasksResponse
+ */
+export interface DumpTasksResponse {
+    /**
+     * @generated from protobuf field: string dump = 1
+     */
+    dump: string; // Formatted async task backtraces.
+    /**
+     * @generated from protobuf field: uint32 task_count = 2
+     */
+    taskCount: number; // Number of tasks captured.
+}
+/**
  * Rate limiting algorithm for Gubernator-based limits.
  *
  * @generated from protobuf enum silo.v1.GubernatorAlgorithm
@@ -7060,6 +7082,99 @@ class GetShardStorageInfoResponse$Type extends MessageType<GetShardStorageInfoRe
  * @generated MessageType for protobuf message silo.v1.GetShardStorageInfoResponse
  */
 export const GetShardStorageInfoResponse = new GetShardStorageInfoResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class DumpTasksRequest$Type extends MessageType<DumpTasksRequest> {
+    constructor() {
+        super("silo.v1.DumpTasksRequest", []);
+    }
+    create(value?: PartialMessage<DumpTasksRequest>): DumpTasksRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<DumpTasksRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: DumpTasksRequest): DumpTasksRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: DumpTasksRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.DumpTasksRequest
+ */
+export const DumpTasksRequest = new DumpTasksRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class DumpTasksResponse$Type extends MessageType<DumpTasksResponse> {
+    constructor() {
+        super("silo.v1.DumpTasksResponse", [
+            { no: 1, name: "dump", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "task_count", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+        ]);
+    }
+    create(value?: PartialMessage<DumpTasksResponse>): DumpTasksResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.dump = "";
+        message.taskCount = 0;
+        if (value !== undefined)
+            reflectionMergePartial<DumpTasksResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: DumpTasksResponse): DumpTasksResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string dump */ 1:
+                    message.dump = reader.string();
+                    break;
+                case /* uint32 task_count */ 2:
+                    message.taskCount = reader.uint32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: DumpTasksResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string dump = 1; */
+        if (message.dump !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.dump);
+        /* uint32 task_count = 2; */
+        if (message.taskCount !== 0)
+            writer.tag(2, WireType.Varint).uint32(message.taskCount);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.DumpTasksResponse
+ */
+export const DumpTasksResponse = new DumpTasksResponse$Type();
 /**
  * @generated ServiceType for protobuf service silo.v1.Silo
  */
@@ -7090,5 +7205,6 @@ export const Silo = new ServiceType("silo.v1.Silo", [
     { name: "ForceReleaseShard", options: {}, I: ForceReleaseShardRequest, O: ForceReleaseShardResponse },
     { name: "CompactShard", options: {}, I: CompactShardRequest, O: CompactShardResponse },
     { name: "FlushShard", options: {}, I: FlushShardRequest, O: FlushShardResponse },
-    { name: "GetShardStorageInfo", options: {}, I: GetShardStorageInfoRequest, O: GetShardStorageInfoResponse }
+    { name: "GetShardStorageInfo", options: {}, I: GetShardStorageInfoRequest, O: GetShardStorageInfoResponse },
+    { name: "DumpTasks", options: {}, I: DumpTasksRequest, O: DumpTasksResponse }
 ]);


### PR DESCRIPTION
## Summary
- Adds `DumpTasks` gRPC RPC to silo that calls `tokio::runtime::Handle::dump()` to capture async task backtraces
- Adds `siloctl dump-tasks` subcommand that fetches the dump and prints to stdout
- Adds `--cfg tokio_unstable` to devshell RUSTFLAGS (was previously only in `.cargo/config.toml` which gets overridden by the env var)
- Adds `--cfg tokio_taskdump` to production nix build RUSTFLAGS (Linux-only; causes compile error on macOS)

## Usage
```bash
# From a production pod or via port-forward
siloctl dump-tasks > dump.txt
siloctl dump-tasks -a http://silo-0:7450

# JSON output
siloctl --json dump-tasks
```

On non-Linux platforms (local macOS dev), the RPC returns UNIMPLEMENTED with a clear message.

## Test plan
- [x] `cargo check` passes on macOS (handler returns UNIMPLEMENTED)
- [x] `cargo check --package siloctl` passes
- [ ] On Linux: `siloctl dump-tasks` against a running silo returns async task backtraces showing `.await` locations