### PR TITLE
Periodically force-reopen stuck shard leases

### DIFF
--- a/specs/coordination.als
+++ b/specs/coordination.als
@@ -126,6 +126,25 @@ sig ShardLease {
 }
 
 /**
+ * Marker that a shard's local SlateDB instance has finished flushing
+ * its WAL to durable storage and the lease holder can safely release.
+ *
+ * In the implementation this corresponds to a successful `factory.close`
+ * that completed within the close timeout. If close fails (e.g., object
+ * storage unreachable), the closeable marker is dropped — the lease
+ * holder must retry by force-reopening the shard (fresh SlateDB instance
+ * with WAL recovery) and then attempting close again.
+ *
+ * [SILO-COORD-INV-15] A node may only release a shard lease while the
+ * shard is closeable. This makes the close-before-release invariant
+ * explicit at the spec level.
+ */
+sig ShardCloseable {
+    closeable_shard: one Shard,
+    closeable_time: one Time
+}
+
+/**
  * Tracks an in-progress shard split operation.
  * The split creates two child shards from one parent.
  */
@@ -451,6 +470,14 @@ fun shardsHeldBy[n: Node, t: Time]: set Shard {
 /** Check if a shard has any lease holder at time t */
 pred hasLeaseHolder[s: Shard, t: Time] {
     some leaseHolder[s, t]
+}
+
+/**
+ * Check if a shard's data is closeable (flushed to durable storage and
+ * ready to release) at time t. See ShardCloseable.
+ */
+pred shardCloseable[s: Shard, t: Time] {
+    some c: ShardCloseable | c.closeable_shard = s and c.closeable_time = t
 }
 
 /**
@@ -1300,19 +1327,22 @@ fact wellFormed {
 pred init[t: Time] {
     -- No node memberships
     no m: NodeMembership | m.member_time = t
-    
+
     -- No flapped nodes
     no f: NodeFlapped | f.flapped_time = t
-    
+
     -- No shards in shard map
     no sme: ShardMapEntry | sme.sme_time = t
-    
+
     -- No leases
     no l: ShardLease | l.lease_time = t
-    
+
+    -- No closeable markers (no lease holders means no closeable shards either)
+    no c: ShardCloseable | c.closeable_time = t
+
     -- No splits in progress
     no sp: SplitInProgress | sp.split_time = t
-    
+
     -- No worker state
     no c: WorkerRouteCache | c.wrc_time = t
     no r: WorkerRequest | r.wreq_time = t
@@ -1371,6 +1401,16 @@ pred leaseFrame[t: Time, tnext: Time] {
     all s: Shard | leaseHolder[s, tnext] = leaseHolder[s, t]
 }
 
+/** Closeable state unchanged for all shards except the specified one */
+pred closeableFrameExcept[s: Shard, t: Time, tnext: Time] {
+    all s2: Shard | s2 != s implies (shardCloseable[s2, tnext] iff shardCloseable[s2, t])
+}
+
+/** All closeable state unchanged */
+pred closeableFrame[t: Time, tnext: Time] {
+    all s: Shard | shardCloseable[s, tnext] iff shardCloseable[s, t]
+}
+
 /** Split state unchanged for all shards except the specified one */
 pred splitFrameExcept[s: Shard, t: Time, tnext: Time] {
     all s2: Shard | s2 != s implies {
@@ -1406,6 +1446,7 @@ pred stutter[t: Time, tnext: Time] {
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrame[t, tnext]
     workerFrame[t, tnext]
 }
@@ -1427,6 +1468,12 @@ pred step[t: Time, tnext: Time] {
     or (some n: Node, s: Shard | leaseAcquireStep[n, s, t, tnext])
     or (some n: Node, s: Shard | leaseReleaseStep[n, s, t, tnext])
     or (some s: Shard | forceReleaseLeaseStep[s, t, tnext])
+
+    -- Close lifecycle (per [SILO-COORD-INV-15]): a node can fail a
+    -- close attempt (closeable -> not-closeable) and later force-reopen
+    -- to recover (not-closeable -> closeable).
+    or (some n: Node, s: Shard | closeAttemptFailedStep[n, s, t, tnext])
+    or (some n: Node, s: Shard | forceReopenStep[n, s, t, tnext])
     
     -- Split transitions
     or (some n: Node, s: Shard, sp: SplitPoint, left, right: Shard | 
@@ -1465,6 +1512,7 @@ pred nodeJoinStep[n: Node, addr: Addr, t: Time, tnext: Time] {
     membershipFrameExcept[n, t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrame[t, tnext]
     workerFrame[t, tnext]
 }
@@ -1485,6 +1533,7 @@ pred nodeLeaveStep[n: Node, t: Time, tnext: Time] {
     membershipFrameExcept[n, t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrame[t, tnext]
     workerFrame[t, tnext]
 }
@@ -1502,8 +1551,11 @@ pred nodeFlapStep[n: Node, t: Time, tnext: Time] {
     not isMember[n, tnext]
     hasFlapped[n, tnext]
 
-    -- Permanent leases: all leases are preserved through flap
+    -- Permanent leases: all leases are preserved through flap.
+    -- Closeable state is also preserved (a flap doesn't change WAL flush
+    -- progress; on recovery the node can resume close attempts).
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
 
     -- All incomplete splits are abandoned when the node crashes.
     -- The shard map update is the commit point - if children don't exist in the shard map,
@@ -1544,6 +1596,7 @@ pred nodeRecoverStep[n: Node, t: Time, tnext: Time] {
     membershipFrameExcept[n, t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrame[t, tnext]
     workerFrame[t, tnext]
 }
@@ -1565,25 +1618,33 @@ pred shardCreateInitialStep[s: Shard, t: Time, tnext: Time] {
     membershipFrame[t, tnext]
     shardMapFrameExcept[s, t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrame[t, tnext]
     workerFrame[t, tnext]
 }
 
-/** Lease acquire with full frame conditions */
+/** Lease acquire with full frame conditions.
+ *
+ * A freshly acquired shard is `closeable` — the local SlateDB instance has
+ * just been opened (or recovered from WAL) and there is no half-flushed
+ * state. Subsequent close attempts may flip closeable false; force-reopen
+ * brings it back true. */
 pred leaseAcquireStep[n: Node, s: Shard, t: Time, tnext: Time] {
     -- Preconditions
     shardExists[s, t]
     not hasLeaseHolder[s, t]
     isMember[n, t]
     not hasFlapped[n, t]
-    
+
     -- Postconditions
     holdsLease[n, s, tnext]
-    
+    shardCloseable[s, tnext]
+
     -- Frame conditions
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrameExcept[s, t, tnext]
+    closeableFrameExcept[s, t, tnext]
     splitFrame[t, tnext]
     workerFrame[t, tnext]
 }
@@ -1592,37 +1653,111 @@ pred leaseAcquireStep[n: Node, s: Shard, t: Time, tnext: Time] {
  * [SILO-COORD-INV-4] A partitioned node cannot release its leases: mutation
  * requires current membership. The node retains the lease through the partition
  * and must re-establish membership before it can release (or an operator can
- * force-release via forceReleaseLeaseStep). */
+ * force-release via forceReleaseLeaseStep).
+ *
+ * [SILO-COORD-INV-15] Release requires the shard to be `closeable` —
+ * i.e., a successful close (WAL flushed) has occurred since the last
+ * acquire/force-reopen. This makes close-before-release explicit in the
+ * spec and rules out releasing a lease while WAL data remains unflushed. */
 pred leaseReleaseStep[n: Node, s: Shard, t: Time, tnext: Time] {
     -- Preconditions
     holdsLease[n, s, t]
+    shardCloseable[s, t]
     isMember[n, t]
     not hasFlapped[n, t]
 
     -- Postconditions
     not hasLeaseHolder[s, tnext]
+    not shardCloseable[s, tnext]
 
     -- Frame conditions
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrameExcept[s, t, tnext]
+    closeableFrameExcept[s, t, tnext]
     splitFrame[t, tnext]
     workerFrame[t, tnext]
 }
 
 /** Force-release a shard lease with full frame conditions.
- * Operator escape hatch for permanently lost nodes. */
+ * Operator escape hatch for permanently lost nodes. Force-release does NOT
+ * require closeable (that's the whole point — the operator is overriding
+ * a stuck lease) and clears closeable on the way out. */
 pred forceReleaseLeaseStep[s: Shard, t: Time, tnext: Time] {
     -- Preconditions
     hasLeaseHolder[s, t]
 
     -- Postconditions
     not hasLeaseHolder[s, tnext]
+    not shardCloseable[s, tnext]
 
     -- Frame conditions
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrameExcept[s, t, tnext]
+    closeableFrameExcept[s, t, tnext]
+    splitFrame[t, tnext]
+    workerFrame[t, tnext]
+}
+
+/**
+ * Close attempt failed: the lease holder tried to flush the shard's WAL
+ * (e.g., during a release because the node is no longer the desired
+ * owner) but the close timed out or errored — typically because the
+ * object store is unreachable. The shard becomes not-closeable until a
+ * subsequent `forceReopenStep` re-opens it fresh.
+ *
+ * Pre: holds lease and shard is currently closeable.
+ * Post: still holds lease, no longer closeable.
+ */
+pred closeAttemptFailedStep[n: Node, s: Shard, t: Time, tnext: Time] {
+    -- Preconditions
+    holdsLease[n, s, t]
+    shardCloseable[s, t]
+
+    -- Postconditions
+    holdsLease[n, s, tnext]
+    not shardCloseable[s, tnext]
+
+    -- Frame conditions
+    membershipFrame[t, tnext]
+    shardMapFrame[t, tnext]
+    leaseFrame[t, tnext]
+    closeableFrameExcept[s, t, tnext]
+    splitFrame[t, tnext]
+    workerFrame[t, tnext]
+}
+
+/**
+ * Force-reopen + successful close: the lease holder re-opens the shard
+ * fresh (triggering WAL recovery) and successfully flushes to durable
+ * storage. This is the retry path that unsticks a lease after a previous
+ * close failure. The lease itself does not change — only the closeable
+ * marker flips back true.
+ *
+ * Pre: holds lease and shard is currently NOT closeable.
+ * Post: still holds lease, now closeable.
+ *
+ * Models a *successful* iteration of the periodic re-open + close retry
+ * loop. Failed iterations are stutters with respect to lease state and
+ * leave closeable false (so the loop will keep firing).
+ */
+pred forceReopenStep[n: Node, s: Shard, t: Time, tnext: Time] {
+    -- Preconditions
+    holdsLease[n, s, t]
+    not shardCloseable[s, t]
+    isMember[n, t]
+    not hasFlapped[n, t]
+
+    -- Postconditions
+    holdsLease[n, s, tnext]
+    shardCloseable[s, tnext]
+
+    -- Frame conditions
+    membershipFrame[t, tnext]
+    shardMapFrame[t, tnext]
+    leaseFrame[t, tnext]
+    closeableFrameExcept[s, t, tnext]
     splitFrame[t, tnext]
     workerFrame[t, tnext]
 }
@@ -1653,6 +1788,7 @@ pred splitRequestStep[n: Node, s: Shard, sp: SplitPoint, leftChild: Shard, right
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrameExcept[s, t, tnext]
     workerFrame[t, tnext]
 }
@@ -1678,6 +1814,7 @@ pred splitPauseTrafficStep[n: Node, s: Shard, t: Time, tnext: Time] {
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrameExcept[s, t, tnext]
     workerFrame[t, tnext]
 }
@@ -1703,6 +1840,7 @@ pred splitCloneDbStep[n: Node, s: Shard, t: Time, tnext: Time] {
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrameExcept[s, t, tnext]
     workerFrame[t, tnext]
 }
@@ -1767,6 +1905,15 @@ pred splitUpdateMapStep[n: Node, s: Shard, t: Time, tnext: Time] {
         all s2: Shard | s2 != s and s2 != orig.split_leftChild and s2 != orig.split_rightChild implies
             leaseHolder[s2, tnext] = leaseHolder[s2, t]
     }
+    -- The parent's closeable marker is dropped along with its lease; children
+    -- have no closeable state until acquired.
+    not shardCloseable[s, tnext]
+    some orig: splitFor[s, t] | {
+        not shardCloseable[orig.split_leftChild, tnext]
+        not shardCloseable[orig.split_rightChild, tnext]
+        all s2: Shard | s2 != s and s2 != orig.split_leftChild and s2 != orig.split_rightChild implies
+            (shardCloseable[s2, tnext] iff shardCloseable[s2, t])
+    }
     splitFrameExcept[s, t, tnext]
     workerFrame[t, tnext]
 }
@@ -1781,11 +1928,12 @@ pred splitCleanupStep[n: Node, s: Shard, t: Time, tnext: Time] {
     
     -- Postconditions: Split record deleted
     not splitInProgressFor[s, tnext]
-    
+
     -- Frame conditions
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     workerFrame[t, tnext]
 }
 
@@ -1823,6 +1971,7 @@ pred splitAbandonStep[n: Node, s: Shard, t: Time, tnext: Time] {
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrameExcept[s, t, tnext]
     workerFrame[t, tnext]
 }
@@ -1873,6 +2022,7 @@ pred splitResumeStep_UNUSED[n: Node, s: Shard, t: Time, tnext: Time] {
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrameExcept[s, t, tnext]
     workerFrame[t, tnext]
 }
@@ -1906,6 +2056,7 @@ pred splitCleanupStartStep[n: Node, s: Shard, t: Time, tnext: Time] {
     membershipFrame[t, tnext]
     shardMapFrameExcept[s, t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrame[t, tnext]
     workerFrame[t, tnext]
 }
@@ -1929,6 +2080,7 @@ pred splitCleanupCompleteStep[n: Node, s: Shard, t: Time, tnext: Time] {
     membershipFrame[t, tnext]
     shardMapFrameExcept[s, t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrame[t, tnext]
     workerFrame[t, tnext]
 }
@@ -1952,6 +2104,7 @@ pred compactShardStep[n: Node, s: Shard, t: Time, tnext: Time] {
     membershipFrame[t, tnext]
     shardMapFrameExcept[s, t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrame[t, tnext]
     workerFrame[t, tnext]
 }
@@ -1969,6 +2122,7 @@ pred workerCacheInitStep[w: Worker, tenant: TenantId, s: Shard, t: Time, tnext: 
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrame[t, tnext]
     -- Worker frame except for this (worker, tenant) pair
     all w2: Worker, t2: TenantId | (w2 != w or t2 != tenant) implies
@@ -1996,6 +2150,7 @@ pred workerRefreshTopologyStep[w: Worker, tenant: TenantId, t: Time, tnext: Time
     membershipFrame[t, tnext]
     shardMapFrame[t, tnext]
     leaseFrame[t, tnext]
+    closeableFrame[t, tnext]
     splitFrame[t, tnext]
     -- Worker frame except for this (worker, tenant) pair
     all w2: Worker, t2: TenantId | (w2 != w or t2 != tenant) implies
@@ -2101,6 +2256,30 @@ assert flapPreservesLeases {
     all n: Node, t: Time, tnext: Time |
         nodeFlapStep[n, t, tnext] implies
             (all s: Shard | leaseHolder[s, tnext] = leaseHolder[s, t])
+}
+
+/**
+ * [SILO-COORD-INV-15] Close-before-release: a normal lease release can
+ * only fire while the shard is closeable, i.e., immediately after a
+ * successful close (or fresh acquire). This rules out releasing a lease
+ * while WAL data remains unflushed. The retry path makes this property
+ * eventually achievable: closeAttemptFailedStep flips closeable false,
+ * but forceReopenStep can flip it back true once the underlying object
+ * store is reachable again.
+ */
+assert closeableBeforeRelease {
+    all n: Node, s: Shard, t: Time, tnext: Time |
+        leaseReleaseStep[n, s, t, tnext] implies shardCloseable[s, t]
+}
+
+/**
+ * Force-reopen preserves the lease: only `closeable` flips. This
+ * prevents the retry path from accidentally handing the shard to
+ * another node mid-recovery.
+ */
+assert forceReopenPreservesLease {
+    all n: Node, s: Shard, t: Time, tnext: Time |
+        forceReopenStep[n, s, t, tnext] implies leaseHolder[s, tnext] = leaseHolder[s, t]
 }
 
 /**
@@ -2763,4 +2942,16 @@ check runtimeSplitAbandonPreservesParent for 3 but
     6 NodeMembership, 6 NodeFlapped, 12 ShardMapEntry, 6 ShardLease,
     6 SplitInProgress, 0 WorkerRouteCache, 0 WorkerRequest, 0 WorkerRetryableError,
     8 TenantOrder
+
+check closeableBeforeRelease for 3 but
+    2 Node, 2 Shard, 2 Addr, 3 TenantId, 6 Time, 1 SplitPoint, 0 Worker,
+    6 NodeMembership, 6 NodeFlapped, 6 ShardMapEntry, 6 ShardLease,
+    6 ShardCloseable, 6 SplitInProgress, 0 WorkerRouteCache, 0 WorkerRequest,
+    0 WorkerRetryableError, 6 TenantOrder
+
+check forceReopenPreservesLease for 3 but
+    2 Node, 2 Shard, 2 Addr, 3 TenantId, 6 Time, 1 SplitPoint, 0 Worker,
+    6 NodeMembership, 6 NodeFlapped, 6 ShardMapEntry, 6 ShardLease,
+    6 ShardCloseable, 6 SplitInProgress, 0 WorkerRouteCache, 0 WorkerRequest,
+    0 WorkerRetryableError, 6 TenantOrder
 

--- a/src/coordination/etcd.rs
+++ b/src/coordination/etcd.rs
@@ -1001,6 +1001,8 @@ impl EtcdShardGuard {
                     desired: true,
                     phase: ShardPhase::Held,
                     ownership_token: Some(()),
+                    release_attempts: 0,
+                    next_release_attempt: None,
                 },
             ),
             client,
@@ -1068,6 +1070,25 @@ impl EtcdShardGuard {
 
         let _ = self.client.kv_client().txn(txn).await?;
         Ok(())
+    }
+
+    /// Record a failed close-during-release: increment the attempt counter,
+    /// schedule the next retry per `release_backoff_delay` (with jitter), and
+    /// revert phase to Held so the run loop tries again after the backoff.
+    async fn record_release_failure(&self, err: &str) {
+        let mut st = self.ctx.state.lock().await;
+        st.release_attempts = st.release_attempts.saturating_add(1);
+        let base = crate::coordination::release_backoff_delay(st.release_attempts);
+        let delay = crate::coordination::jitter_backoff(base, &self.ctx.shard_id);
+        st.next_release_attempt = Some(std::time::Instant::now() + delay);
+        st.phase = ShardPhase::Held;
+        warn!(
+            shard_id = %self.ctx.shard_id,
+            error = %err,
+            attempts = st.release_attempts,
+            retry_in_secs = delay.as_secs(),
+            "failed to close shard for release; reverting to Held with backoff"
+        );
     }
 
     pub async fn run(
@@ -1199,8 +1220,17 @@ impl EtcdShardGuard {
                         debug!(shard_id = %self.ctx.shard_id, "shard: release start (delay)");
                         tokio::time::sleep(Duration::from_millis(100)).await;
 
+                        // If a previous release attempt failed, honour the
+                        // exponential backoff before trying again. Wakes early
+                        // on shutdown or if `desired` flips back to true.
+                        let pending_deadline =
+                            self.ctx.state.lock().await.next_release_attempt;
+                        if let Some(deadline) = pending_deadline {
+                            self.ctx.wait_until_or_change(deadline).await;
+                        }
+
                         let mut cancelled = false;
-                        let was_held = {
+                        let (was_held, attempts) = {
                             let mut st = self.ctx.state.lock().await;
                             if st.phase == ShardPhase::ShuttingDown {
                                 // fall through
@@ -1209,12 +1239,55 @@ impl EtcdShardGuard {
                                 cancelled = true;
                                 debug!(shard_id = %self.ctx.shard_id, "shard: release cancelled");
                             }
-                            st.has_token()
+                            (st.has_token(), st.release_attempts)
                         };
                         if cancelled {
                             return;
                         }
                         if was_held {
+                            // On retry attempts (after a previous close failed),
+                            // give ourselves a fresh SlateDB instance via
+                            // factory.force_reopen so the new close has a real
+                            // chance of flushing the WAL. The first attempt
+                            // (attempts == 0) skips this — the shard is already
+                            // open from acquire/reclaim.
+                            if attempts > 0 {
+                                let range = {
+                                    let map = shard_map.lock().await;
+                                    map.get_shard(&self.ctx.shard_id)
+                                        .map(|info| info.range.clone())
+                                };
+                                if let Some(range) = range {
+                                    match factory
+                                        .force_reopen(&self.ctx.shard_id, &range)
+                                        .await
+                                    {
+                                        Ok(_) => {
+                                            dst_events::emit(DstEvent::ShardForceReopened {
+                                                node_id: self.node_id.clone(),
+                                                shard_id: self.ctx.shard_id.to_string(),
+                                            });
+                                            debug!(
+                                                shard_id = %self.ctx.shard_id,
+                                                attempts = attempts,
+                                                "shard: force-reopened for close retry"
+                                            );
+                                        }
+                                        Err(e) => {
+                                            // Re-open failed; treat as another
+                                            // close failure and back off.
+                                            self.record_release_failure(&e.to_string()).await;
+                                            return;
+                                        }
+                                    }
+                                } else {
+                                    debug!(
+                                        shard_id = %self.ctx.shard_id,
+                                        "shard: not in shard map; skipping force_reopen and trying close directly"
+                                    );
+                                }
+                            }
+
                             // Close the shard before releasing ownership
                             match factory.close(&self.ctx.shard_id).await {
                                 Ok(()) => {
@@ -1229,6 +1302,8 @@ impl EtcdShardGuard {
                                         let mut st = self.ctx.state.lock().await;
                                         st.ownership_token = None;
                                         st.phase = ShardPhase::Idle;
+                                        st.release_attempts = 0;
+                                        st.next_release_attempt = None;
                                     }
                                     {
                                         let mut owned = owned_arc.lock().await;
@@ -1241,19 +1316,14 @@ impl EtcdShardGuard {
                                     debug!(shard_id = %self.ctx.shard_id, "shard: release done");
                                 }
                                 Err(e) => {
-                                    // Close failed - revert to Held so reconciliation retries
-                                    tracing::error!(
-                                        shard_id = %self.ctx.shard_id,
-                                        error = %e,
-                                        "failed to close shard, reverting to Held to prevent data loss"
-                                    );
-                                    let mut st = self.ctx.state.lock().await;
-                                    st.phase = ShardPhase::Held;
+                                    self.record_release_failure(&e.to_string()).await;
                                 }
                             }
                         } else {
                             let mut st = self.ctx.state.lock().await;
                             st.phase = ShardPhase::Idle;
+                            st.release_attempts = 0;
+                            st.next_release_attempt = None;
                             debug!(shard_id = %self.ctx.shard_id, "shard: release noop");
                         }
                     }

--- a/src/coordination/k8s.rs
+++ b/src/coordination/k8s.rs
@@ -1591,6 +1591,8 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                         resource_version,
                         lease_uid,
                     }),
+                    release_attempts: 0,
+                    next_release_attempt: None,
                 },
             ),
             backend,
@@ -1604,6 +1606,25 @@ impl<B: K8sBackend> K8sShardGuard<B> {
 
     fn lease_name(&self) -> String {
         keys::k8s_shard_lease_name(&self.cluster_prefix, &self.ctx.shard_id)
+    }
+
+    /// Record a failed close-during-release: increment the attempt counter,
+    /// schedule the next retry per `release_backoff_delay` (with jitter), and
+    /// revert phase to Held so the run loop tries again after the backoff.
+    async fn record_release_failure(&self, err: &str) {
+        let mut st = self.ctx.state.lock().await;
+        st.release_attempts = st.release_attempts.saturating_add(1);
+        let base = crate::coordination::release_backoff_delay(st.release_attempts);
+        let delay = crate::coordination::jitter_backoff(base, &self.ctx.shard_id);
+        st.next_release_attempt = Some(std::time::Instant::now() + delay);
+        st.phase = ShardPhase::Held;
+        warn!(
+            shard_id = %self.ctx.shard_id,
+            error = %err,
+            attempts = st.release_attempts,
+            retry_in_secs = delay.as_secs(),
+            "failed to close shard for release; reverting to Held with backoff"
+        );
     }
 
     pub async fn run(
@@ -1804,19 +1825,62 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                         (self.ctx.shard_id.as_uuid().as_u64_pair().0.wrapping_mul(17)) % 20;
                     tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
 
-                    let cancelled = {
+                    // If a previous release attempt failed, honour exponential
+                    // backoff before retrying. Wakes early on shutdown / desired flip.
+                    let pending_deadline = self.ctx.state.lock().await.next_release_attempt;
+                    if let Some(deadline) = pending_deadline {
+                        self.ctx.wait_until_or_change(deadline).await;
+                    }
+
+                    let (cancelled, attempts) = {
                         let mut st = self.ctx.state.lock().await;
                         if st.phase == ShardPhase::ShuttingDown {
-                            false
+                            (false, st.release_attempts)
                         } else if st.desired {
                             st.phase = ShardPhase::Held;
-                            true
+                            (true, st.release_attempts)
                         } else {
-                            false
+                            (false, st.release_attempts)
                         }
                     };
 
                     if !cancelled {
+                        // On retry attempts (after a previous close failed),
+                        // give ourselves a fresh SlateDB instance via
+                        // factory.force_reopen so the new close has a real
+                        // chance of flushing the WAL.
+                        if attempts > 0 {
+                            let range = {
+                                let map = shard_map.lock().await;
+                                map.get_shard(&self.ctx.shard_id)
+                                    .map(|info| info.range.clone())
+                            };
+                            if let Some(range) = range {
+                                match factory.force_reopen(&self.ctx.shard_id, &range).await {
+                                    Ok(_) => {
+                                        dst_events::emit(DstEvent::ShardForceReopened {
+                                            node_id: self.node_id.clone(),
+                                            shard_id: self.ctx.shard_id.to_string(),
+                                        });
+                                        debug!(
+                                            shard_id = %self.ctx.shard_id,
+                                            attempts = attempts,
+                                            "k8s shard: force-reopened for close retry"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        self.record_release_failure(&e.to_string()).await;
+                                        continue;
+                                    }
+                                }
+                            } else {
+                                debug!(
+                                    shard_id = %self.ctx.shard_id,
+                                    "k8s shard: not in shard map; skipping force_reopen and trying close directly"
+                                );
+                            }
+                        }
+
                         // Close the shard before releasing the lease
                         match factory.close(&self.ctx.shard_id).await {
                             Ok(()) => {
@@ -1859,6 +1923,8 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                                     let mut st = self.ctx.state.lock().await;
                                     st.ownership_token = None;
                                     st.phase = ShardPhase::Idle;
+                                    st.release_attempts = 0;
+                                    st.next_release_attempt = None;
                                 }
                                 let mut owned = owned_arc.lock().await;
                                 owned.remove(&self.ctx.shard_id);
@@ -1869,14 +1935,7 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                                 debug!(shard_id = %self.ctx.shard_id, "k8s shard: released");
                             }
                             Err(e) => {
-                                // Close failed - revert to Held so reconciliation retries
-                                tracing::error!(
-                                    shard_id = %self.ctx.shard_id,
-                                    error = %e,
-                                    "failed to close shard, reverting to Held to prevent data loss"
-                                );
-                                let mut st = self.ctx.state.lock().await;
-                                st.phase = ShardPhase::Held;
+                                self.record_release_failure(&e.to_string()).await;
                             }
                         }
                     }

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -193,6 +193,14 @@ pub struct ShardGuardState<T> {
     pub desired: bool,
     pub phase: ShardPhase,
     pub ownership_token: Option<T>,
+    /// Number of consecutive failed release attempts. Used by the Releasing
+    /// branch to drive exponential backoff and force_reopen retries when a
+    /// shard's close keeps failing (e.g., WAL flush blocked on object store).
+    /// Reset to 0 when desired flips back to true or after a successful release.
+    pub release_attempts: u32,
+    /// If Some, the Releasing branch should sleep until this instant before
+    /// the next close attempt. None means no pending backoff.
+    pub next_release_attempt: Option<std::time::Instant>,
 }
 
 impl<T> ShardGuardState<T> {
@@ -202,6 +210,8 @@ impl<T> ShardGuardState<T> {
             desired: false,
             phase: ShardPhase::Idle,
             ownership_token: None,
+            release_attempts: 0,
+            next_release_attempt: None,
         }
     }
 
@@ -243,6 +253,28 @@ impl<T> Default for ShardGuardState<T> {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Compute the backoff delay for the Nth (1-indexed) consecutive release
+/// attempt that has failed. Schedule: 5s, 10s, 20s, 40s, 80s, 160s, then
+/// capped at 300s (5min). A small per-shard jitter is layered on at the
+/// call site using the shard ID as a deterministic seed (DST-friendly).
+pub fn release_backoff_delay(attempts: u32) -> Duration {
+    if attempts == 0 {
+        return Duration::ZERO;
+    }
+    let exp = (attempts - 1).min(6);
+    let secs = 5u64 << exp; // 5, 10, 20, 40, 80, 160, 320 -> capped below
+    Duration::from_secs(secs.min(300))
+}
+
+/// Add deterministic 0-10% jitter to a backoff duration using the shard ID
+/// as a seed. Keeps DST replays stable while spreading retries across shards.
+pub fn jitter_backoff(base: Duration, shard_id: &ShardId) -> Duration {
+    let seed = shard_id.as_uuid().as_u64_pair().0;
+    let jitter_pct = (seed % 11) as u32; // 0..=10
+    let jitter_ms = (base.as_millis() as u64 * jitter_pct as u64) / 100;
+    base + Duration::from_millis(jitter_ms)
 }
 
 /// Common context for a shard guard that's shared across backends.
@@ -296,6 +328,23 @@ impl<T> ShardGuardContext<T> {
         }
     }
 
+    /// Sleep until `deadline`, returning early if a notification (e.g.,
+    /// `desired` flipped) or shutdown signal arrives.
+    pub async fn wait_until_or_change(&self, deadline: std::time::Instant) {
+        let now = std::time::Instant::now();
+        if deadline <= now {
+            return;
+        }
+        let dur = deadline - now;
+        let mut shutdown_rx = self.shutdown.clone();
+        tokio::select! {
+            biased;
+            _ = self.notify.notified() => {}
+            _ = shutdown_rx.changed() => {}
+            _ = tokio::time::sleep(dur) => {}
+        }
+    }
+
     /// Set the desired ownership state for this shard guard.
     /// No-op if the guard is already shutting down or shut down.
     pub async fn set_desired(&self, desired: bool) {
@@ -309,6 +358,12 @@ impl<T> ShardGuardContext<T> {
             let prev_desired = st.desired;
             let prev_phase = st.phase;
             st.desired = desired;
+            if desired {
+                // We want this shard back — clear any pending release backoff so
+                // that if it flips false again later, we start fresh from attempt 0.
+                st.release_attempts = 0;
+                st.next_release_attempt = None;
+            }
             debug!(shard_id = %self.shard_id, prev_desired = prev_desired, desired = desired, phase = %prev_phase, "shard: set_desired");
             self.notify.notify_one();
         }

--- a/src/dst_events.rs
+++ b/src/dst_events.rs
@@ -68,6 +68,14 @@ pub enum DstEvent {
     /// A node successfully closed a shard's storage (flushed to object storage).
     ShardClosed { node_id: String, shard_id: String },
 
+    /// A node force-reopened a shard after a failed close, to retry flushing
+    /// against a fresh SlateDB instance. Emitted from the coordination layer's
+    /// release-retry path when the previous close failed (e.g., WAL flush
+    /// blocked on object storage). Invalidates any prior `ShardClosed` for
+    /// the same (node, shard) — a fresh `ShardClosed` must precede the next
+    /// `ShardReleased`.
+    ShardForceReopened { node_id: String, shard_id: String },
+
     /// A node released ownership of a shard.
     ShardReleased { node_id: String, shard_id: String },
 }

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -359,6 +359,38 @@ impl ShardFactory {
         Ok(())
     }
 
+    /// Force a fresh re-open of a shard after a failed close.
+    ///
+    /// Used by the coordination layer when a shard's close has failed (e.g., the
+    /// WAL flush is blocked because object storage is unreachable) and the in-memory
+    /// SlateDB instance is in a half-closed state where retrying close on the same
+    /// instance won't make progress. Drops the cached entry, gives the old shard
+    /// a brief window to release file locks, then re-opens via the normal `open`
+    /// path. Re-open triggers SlateDB WAL recovery, so any unflushed data on the
+    /// local WAL is replayed and a subsequent `close` has a fresh attempt at
+    /// flushing it to object storage.
+    ///
+    /// External holders of the previous `Arc<JobStoreShard>` will continue to see
+    /// the old (cancelled) instance until they drop their reference — same as
+    /// after a successful `close`.
+    pub async fn force_reopen(
+        &self,
+        shard_id: &ShardId,
+        range: &ShardRange,
+    ) -> Result<Arc<JobStoreShard>, JobStoreShardError> {
+        if let Some((_, entry)) = self.instances.remove(shard_id) {
+            if let Some(shard) = entry.get() {
+                // Best-effort drain with a short timeout. We don't care if this
+                // succeeds — the point is to give SlateDB a chance to release
+                // file locks before we open a fresh instance against the same
+                // data path. Drop the Arc immediately after.
+                let drain_timeout = Duration::from_secs(2);
+                let _ = tokio::time::timeout(drain_timeout, shard.close()).await;
+            }
+        }
+        self.open(shard_id, range).await
+    }
+
     /// Reset a specific shard: close it, delete all data, and reopen fresh.
     /// This is intended for testing/development only.
     pub async fn reset(

--- a/tests/coordination_mod_tests.rs
+++ b/tests/coordination_mod_tests.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use silo::coordination::{
     CoordinationError, CoordinatorBase, MemberInfo, ShardGuardState, ShardOwnerMap, ShardPhase,
+    jitter_backoff, release_backoff_delay,
 };
 use silo::factory::ShardFactory;
 use silo::shard_range::{ShardId, ShardMap};
@@ -97,6 +98,35 @@ fn shard_guard_state_default() {
     assert!(!state.desired);
     assert!(!state.has_token());
     assert!(state.ownership_token.is_none());
+    assert_eq!(state.release_attempts, 0);
+    assert!(state.next_release_attempt.is_none());
+}
+
+#[silo::test]
+fn release_backoff_delay_grows_then_caps() {
+    assert_eq!(release_backoff_delay(0), Duration::ZERO);
+    assert_eq!(release_backoff_delay(1), Duration::from_secs(5));
+    assert_eq!(release_backoff_delay(2), Duration::from_secs(10));
+    assert_eq!(release_backoff_delay(3), Duration::from_secs(20));
+    assert_eq!(release_backoff_delay(4), Duration::from_secs(40));
+    assert_eq!(release_backoff_delay(5), Duration::from_secs(80));
+    assert_eq!(release_backoff_delay(6), Duration::from_secs(160));
+    // Cap at 300s.
+    assert_eq!(release_backoff_delay(7), Duration::from_secs(300));
+    assert_eq!(release_backoff_delay(20), Duration::from_secs(300));
+}
+
+#[silo::test]
+fn jitter_backoff_is_deterministic_and_within_10pct() {
+    let shard_id = ShardId::new();
+    let base = Duration::from_secs(60);
+    let jittered_a = jitter_backoff(base, &shard_id);
+    let jittered_b = jitter_backoff(base, &shard_id);
+    // Determinism: same input → same output (DST-friendly).
+    assert_eq!(jittered_a, jittered_b);
+    // Bounded: jitter is non-negative and at most 10% of base.
+    assert!(jittered_a >= base);
+    assert!(jittered_a <= base + Duration::from_secs(6));
 }
 
 // --- ShardOwnerMap tests ---

--- a/tests/etcd_coordination_tests.rs
+++ b/tests/etcd_coordination_tests.rs
@@ -3723,13 +3723,9 @@ fn restore_dir_tree_writable(path: &std::path::Path) {
     }
 }
 
-/// If factory.close() fails during a normal release, the guard should keep retrying
-/// and the ownership key should persist in etcd until close succeeds.
-///
-/// With slatedb's current close semantics, a timed-out close internally marks the DB
-/// as closed. On the guard's next retry cycle, factory.close() detects the
-/// "already closed" state and treats it as a successful close. The shard is then
-/// released normally. This verifies the graceful recovery path.
+/// If factory.close() fails during a normal release, the guard should keep ownership
+/// and retry with backoff. Once the underlying issue is resolved, a subsequent
+/// force_reopen + close cycle drains the WAL and the ownership key is removed from etcd.
 #[silo::test(flavor = "multi_thread", worker_threads = 2)]
 async fn etcd_shard_close_failure_keeps_ownership() {
     let prefix = unique_prefix();
@@ -3777,26 +3773,54 @@ async fn etcd_shard_close_failure_keeps_ownership() {
     guard.ctx.set_desired(false).await;
     guard.ctx.notify.notify_one();
 
-    // The first close attempt will time out (3s) because the directory is read-only
-    // and slatedb's retrying_object_store retries indefinitely. After the timeout,
-    // the guard reverts to Held and retries. On the second attempt, slatedb reports
-    // the DB as already closed (it internally closed during the timeout), and
-    // factory.close() treats this as success.
-    //
-    // Wait for the shard to be fully released after the close timeout + retry cycle.
-    let released = wait_until(Duration::from_secs(15), || async {
+    // The first close attempt times out (3s) because the directory is read-only and
+    // slatedb's retrying_object_store retries indefinitely. The guard records a
+    // release failure (release_attempts >= 1) and reverts to Held with backoff.
+    let release_failed = wait_until(Duration::from_secs(10), || async {
+        let st = guard.ctx.state.lock().await;
+        st.has_token() && st.release_attempts >= 1
+    })
+    .await;
+    assert!(
+        release_failed,
+        "guard should record a failed release attempt and keep ownership"
+    );
+    assert!(
+        owned.lock().await.contains(&shard_id),
+        "shard should remain in owned set while close keeps failing"
+    );
+
+    // Verify the owner key still exists in etcd (lease retained on close failure)
+    let owner_key = silo::coordination::keys::shard_owner_key(&prefix, &shard_id);
+    let resp = coord
+        .client()
+        .get(owner_key.as_bytes(), None)
+        .await
+        .expect("etcd get");
+    assert!(
+        !resp.kvs().is_empty(),
+        "owner key should persist in etcd while close is failing"
+    );
+
+    // Restore writability so the next retry's force_reopen + close can succeed.
+    restore_dir_tree_writable(&shard_data_path);
+
+    // Wait for the next backoff cycle to fire force_reopen + close. With a 5s
+    // initial backoff plus jitter and the close timeout, allow generous time.
+    let released = wait_until(Duration::from_secs(45), || async {
         let st = guard.ctx.state.lock().await;
         st.phase == ShardPhase::Idle && !st.has_token()
     })
     .await;
-    assert!(released, "guard should release after close retry succeeds");
+    assert!(
+        released,
+        "guard should release once close succeeds on retry"
+    );
     assert!(
         !owned.lock().await.contains(&shard_id),
-        "shard should be removed from owned set"
+        "shard should be removed from owned set after successful release"
     );
 
-    // Verify the owner key was cleaned up in etcd
-    let owner_key = silo::coordination::keys::shard_owner_key(&prefix, &shard_id);
     let resp = coord
         .client()
         .get(owner_key.as_bytes(), None)
@@ -3808,7 +3832,6 @@ async fn etcd_shard_close_failure_keeps_ownership() {
     );
 
     handle.abort();
-    restore_dir_tree_writable(&shard_data_path);
     let _ = std::fs::remove_dir_all(&tmpdir);
 }
 

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -82,6 +82,70 @@ async fn close_shard_after_open() {
     );
 }
 
+// --- force_reopen tests ---
+
+#[silo::test]
+async fn force_reopen_returns_fresh_instance_preserving_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory(&tmp);
+    let shard_id = ShardId::new();
+
+    let original = factory
+        .open(&shard_id, &ShardRange::full())
+        .await
+        .expect("open shard");
+
+    // Enqueue a job so we can verify WAL recovery preserves state.
+    original
+        .enqueue(
+            "test-tenant",
+            Some("job-fr-1".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"key": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue job");
+
+    let reopened = factory
+        .force_reopen(&shard_id, &ShardRange::full())
+        .await
+        .expect("force_reopen shard");
+
+    // The Arc returned must be a different allocation than the original —
+    // factory.force_reopen drops the cached entry and creates fresh.
+    assert!(
+        !Arc::ptr_eq(&original, &reopened),
+        "force_reopen should return a fresh JobStoreShard instance"
+    );
+
+    // Data must survive the re-open via WAL recovery.
+    let counters = reopened.get_counters().await.expect("get counters");
+    assert_eq!(counters.total_jobs, 1);
+    assert!(factory.owns_shard(&shard_id));
+}
+
+#[silo::test]
+async fn force_reopen_on_unopened_shard_creates_fresh() {
+    let tmp = tempfile::tempdir().unwrap();
+    let factory = make_fs_factory(&tmp);
+    let shard_id = ShardId::new();
+
+    // Shard was never opened — force_reopen should still produce a working shard.
+    let shard = factory
+        .force_reopen(&shard_id, &ShardRange::full())
+        .await
+        .expect("force_reopen un-opened shard");
+
+    let counters = shard.get_counters().await.expect("get counters");
+    assert_eq!(counters.total_jobs, 0);
+    assert!(factory.owns_shard(&shard_id));
+}
+
 // --- reset tests ---
 
 #[silo::test]

--- a/tests/k8s_coordination_tests.rs
+++ b/tests/k8s_coordination_tests.rs
@@ -5448,13 +5448,9 @@ fn restore_dir_tree_writable(path: &std::path::Path) {
     }
 }
 
-/// If factory.close() fails during a normal release, the guard should revert to Held
-/// and the lease should remain held in K8s, preventing another node from acquiring it.
-///
-/// With slatedb's current close semantics, a timed-out close internally marks the DB
-/// as closed. On the guard's next retry cycle, factory.close() detects the
-/// "already closed" state and treats it as a successful close. The shard is then
-/// released normally. This verifies the graceful recovery path.
+/// If factory.close() fails during a normal release, the guard should keep the lease
+/// and retry with backoff. Once the underlying issue is resolved, a subsequent
+/// force_reopen + close cycle drains the WAL and the lease is released.
 #[silo::test(flavor = "multi_thread", worker_threads = 2)]
 async fn k8s_shard_close_failure_keeps_lease() {
     let prefix = unique_prefix();
@@ -5505,21 +5501,35 @@ async fn k8s_shard_close_failure_keeps_lease() {
     guard.ctx.set_desired(false).await;
     guard.ctx.notify.notify_one();
 
-    // The first close attempt will time out (3s) because the directory is read-only
-    // and slatedb's retrying_object_store retries indefinitely. After the timeout,
-    // the guard reverts to Held and retries. On the second attempt, slatedb reports
-    // the DB as already closed, and factory.close() treats this as success.
-    //
-    // Wait for the shard to be fully released after the close timeout + retry cycle.
-    let released = wait_until(Duration::from_secs(15), || async {
+    // The first close attempt times out (3s) because the directory is read-only and
+    // slatedb's retrying_object_store retries indefinitely. The guard records a
+    // release failure (release_attempts >= 1) and reverts to Held with backoff.
+    let release_failed = wait_until(Duration::from_secs(10), || async {
+        let st = guard.ctx.state.lock().await;
+        st.has_token() && st.release_attempts >= 1 && owned.lock().await.contains(&shard_id)
+    })
+    .await;
+    assert!(
+        release_failed,
+        "guard should record a failed release attempt and keep the lease"
+    );
+
+    // Restore writability so the next retry's force_reopen + close can succeed.
+    restore_dir_tree_writable(&shard_data_path);
+
+    // Wait for the next backoff cycle to fire force_reopen + close. With a 5s
+    // initial backoff plus jitter and the close timeout, allow generous time.
+    let released = wait_until(Duration::from_secs(45), || async {
         let st = guard.ctx.state.lock().await;
         !st.has_token() && !owned.lock().await.contains(&shard_id)
     })
     .await;
-    assert!(released, "guard should release after close retry succeeds");
+    assert!(
+        released,
+        "guard should release once close succeeds on retry"
+    );
 
     handle.abort();
-    restore_dir_tree_writable(&shard_data_path);
     let _ = std::fs::remove_dir_all(&tmpdir);
 }
 

--- a/tests/turmoil_runner/helpers.rs
+++ b/tests/turmoil_runner/helpers.rs
@@ -897,6 +897,9 @@ pub struct ShardOwnershipTracker {
     /// acquired by another node, it is not considered split-brain since the crashed
     /// node is no longer running (even though it never emitted ShardReleased events).
     crashed_nodes: Mutex<HashSet<String>>,
+    /// Per-(node, shard) count of force-reopens after a failed close. Useful for
+    /// scenario tests that assert the retry path actually fired.
+    force_reopens: Mutex<HashMap<(String, String), u32>>,
 }
 
 impl ShardOwnershipTracker {
@@ -973,6 +976,44 @@ impl ShardOwnershipTracker {
             timestamp = timestamp,
             "shard_closed"
         );
+    }
+
+    /// Record that a node force-reopened a shard after a previous close failed.
+    /// A force-reopen invalidates any prior ShardClosed for the same (node, shard):
+    /// the shard is now back to "open" state and a fresh ShardClosed must precede
+    /// the next ShardReleased.
+    pub fn shard_force_reopened(&self, node_id: &str, shard_id: &str) {
+        let timestamp = self
+            .event_counter
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        let key = (node_id.to_string(), shard_id.to_string());
+        // Drop any stale "closed but not released" record — the close was
+        // invalidated by the re-open.
+        {
+            let mut pending = self.pending_closes.lock().unwrap();
+            pending.remove(&key);
+        }
+        {
+            let mut counts = self.force_reopens.lock().unwrap();
+            *counts.entry(key).or_insert(0) += 1;
+        }
+        tracing::trace!(
+            shard_id = %shard_id,
+            node_id = %node_id,
+            timestamp = timestamp,
+            "shard_force_reopened"
+        );
+    }
+
+    /// Get the number of force-reopens recorded for a (node, shard) pair.
+    #[allow(dead_code)]
+    pub fn force_reopen_count(&self, node_id: &str, shard_id: &str) -> u32 {
+        let counts = self.force_reopens.lock().unwrap();
+        counts
+            .get(&(node_id.to_string(), shard_id.to_string()))
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Record that a node released ownership of a shard.
@@ -1550,6 +1591,12 @@ impl InvariantTracker {
                     ref shard_id,
                 } => {
                     self.shards.shard_closed(node_id, shard_id);
+                }
+                DstEvent::ShardForceReopened {
+                    ref node_id,
+                    ref shard_id,
+                } => {
+                    self.shards.shard_force_reopened(node_id, shard_id);
                 }
                 DstEvent::ShardReleased {
                     ref node_id,


### PR DESCRIPTION
## Summary

When a pod's `factory.close()` hits its 30s timeout (e.g., hyperdisk-ha-backed WAL can't flush because object storage is unreachable), the shard lease is intentionally retained to prevent data loss. Previously the retry loop re-called `shard.close()` on the same half-closed SlateDB instance with no backoff — never made progress and could even silently release the lease via the `slatedb::ErrorKind::Closed` "treat as success" branch.

- New `factory.force_reopen(shard_id, range)` drops the cached entry, briefly drains the old shard, and re-opens fresh (SlateDB WAL recovery).
- Releasing branch in both etcd and k8s backends now applies exponential backoff (5s → 5min cap, deterministic per-shard jitter) and calls `force_reopen` before each close retry. Tracked as `release_attempts` + `next_release_attempt` on `ShardGuardState`; reset when `desired` flips back to true or release succeeds.
- New `ShardForceReopened` DST event; `ShardOwnershipTracker` sharpens close-before-release so a re-open invalidates the prior pending close.
- Alloy spec gains a `ShardCloseable` flag — `leaseReleaseStep` requires it, `closeAttemptFailedStep` clears it, `forceReopenStep` restores it. New asserts `closeableBeforeRelease` and `forceReopenPreservesLease` both verify UNSAT alongside the 24 existing checks.

## Test plan

- [x] `cargo check --features k8s,dst --all-targets` clean
- [x] `cargo fmt`
- [x] `factory_tests` (13/13, including 2 new `force_reopen` tests)
- [x] `coordination_mod_tests` (18/18, including 2 new backoff tests)
- [x] `cleanup_reacquire_tests` (10/10)
- [x] Library tests (4/4)
- [x] `alloy6 exec specs/coordination.als` — all 26 checks pass (9 example traces SAT, 24 existing assertions UNSAT, 2 new assertions UNSAT)
- [ ] `etcd_coordination_tests` — needs running etcd; verify locally with `process-compose up etcd`
- [ ] Manual smoke in process-compose: induce object-store unreachability, trigger ownership change, observe `force_reopen` retries with backoff in logs, restore object store, observe clean release