### PR TITLE
Add and use InstrumentedDb for automatic shard field logs

### DIFF
--- a/silo-compactor/src/worker.rs
+++ b/silo-compactor/src/worker.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use slatedb_common::metrics::DefaultMetricsRecorder;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{Instrument, info, info_span, warn};
 
 use crate::compaction_filter::CompletedJobCompactionFilterSupplier;
 use crate::config::CompactionFilterConfig;
@@ -242,9 +242,15 @@ async fn run_once(
         _ => None,
     };
 
+    // Run slatedb's compactor inside a span carrying the shard so its log-bridged
+    // events (e.g. "finished compaction" from slatedb::compactor_state) are tagged
+    // with the shard. Note: slatedb spawns internal tokio tasks that don't
+    // propagate the parent span, so logs emitted from those subtasks won't carry
+    // the shard field.
+    let run_span = info_span!("slatedb_compactor", shard = %shard_id);
     let mut run_task = tokio::spawn({
         let compactor = compactor.clone();
-        async move { compactor.run().await }
+        async move { compactor.run().await }.instrument(run_span)
     });
 
     let result = tokio::select! {

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -45,6 +45,8 @@ use futures::StreamExt;
 use slatedb::config::WriteOptions;
 use slatedb::{Db, DbIterator, WriteBatch};
 
+use crate::instrumented_db::InstrumentedDb;
+
 use crate::job_store_shard::counters::encode_counter;
 use crate::job_store_shard::helpers::WriteBatcher;
 
@@ -660,7 +662,7 @@ impl ConcurrencyManager {
     /// Then enters an event-driven loop, woken by `request_grant` calls.
     pub fn start_grant_scanner(
         self: &Arc<Self>,
-        db: Arc<Db>,
+        db: Arc<InstrumentedDb>,
         brokers: Arc<TaskBrokerRegistry>,
         range: ShardRange,
     ) {
@@ -713,7 +715,7 @@ impl ConcurrencyManager {
     ///
     /// This is used at grant-scanner startup and by the shard's periodic
     /// reconciliation task to self-heal from missed notifications.
-    pub async fn reconcile_pending_requests(&self, db: &Db, range: &ShardRange) {
+    pub async fn reconcile_pending_requests(&self, db: &InstrumentedDb, range: &ShardRange) {
         let start = concurrency_requests_prefix();
         let end = end_bound(&start);
         let mut iter = match db
@@ -778,7 +780,7 @@ impl ConcurrencyManager {
     /// request queue is exhausted.
     pub(crate) async fn process_grants(
         &self,
-        db: &Db,
+        db: &InstrumentedDb,
         range: &ShardRange,
         tenant: &str,
         queue: &str,

--- a/src/instrumented_db.rs
+++ b/src/instrumented_db.rs
@@ -1,0 +1,89 @@
+//! [`InstrumentedDb`] — `slatedb::Db` wrapper that attaches a per-shard tracing
+//! span to every write operation it performs.
+//!
+//! `slatedb` logs through the `log` crate, which `tracing-subscriber` bridges
+//! into tracing events. Bridged events inherit whatever span is active on the
+//! current task when they fire. This wrapper makes sure that any silo code
+//! awaiting `db.write` / `db.put` / `db.merge` / `db.delete` does so under the
+//! shard span, so log lines like the backpressure warnings from
+//! `slatedb::db` are tagged with the shard.
+//!
+//! The wrapper derefs to `&Db`, so reads and other passthrough calls keep
+//! working without modification (they don't typically log).
+use std::ops::Deref;
+use std::sync::Arc;
+
+use slatedb::bytes::Bytes;
+use slatedb::{Db, WriteBatch, WriteHandle};
+use tracing::{Instrument, Span};
+
+pub struct InstrumentedDb {
+    inner: Arc<Db>,
+    span: Span,
+}
+
+impl InstrumentedDb {
+    pub fn new(inner: Arc<Db>, span: Span) -> Arc<Self> {
+        Arc::new(Self { inner, span })
+    }
+
+    pub fn inner(&self) -> &Arc<Db> {
+        &self.inner
+    }
+
+    pub async fn write(&self, batch: WriteBatch) -> Result<WriteHandle, slatedb::Error> {
+        self.inner.write(batch).instrument(self.span.clone()).await
+    }
+
+    pub async fn put<K, V>(&self, key: K, value: V) -> Result<WriteHandle, slatedb::Error>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        self.inner
+            .put(key, value)
+            .instrument(self.span.clone())
+            .await
+    }
+
+    pub async fn merge<K, V>(&self, key: K, value: V) -> Result<WriteHandle, slatedb::Error>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        self.inner
+            .merge(key, value)
+            .instrument(self.span.clone())
+            .await
+    }
+
+    pub async fn delete<K: AsRef<[u8]>>(&self, key: K) -> Result<WriteHandle, slatedb::Error> {
+        self.inner.delete(key).instrument(self.span.clone()).await
+    }
+
+    pub async fn close(&self) -> Result<(), slatedb::Error> {
+        self.inner.close().instrument(self.span.clone()).await
+    }
+
+    pub async fn flush(&self) -> Result<(), slatedb::Error> {
+        self.inner.flush().instrument(self.span.clone()).await
+    }
+
+    /// Return the value associated with `key` if present. Reads don't usually
+    /// log, but we still pin the span so any future trace/debug events bridged
+    /// from slatedb's read path inherit shard context.
+    pub async fn get<K: AsRef<[u8]> + Send>(
+        &self,
+        key: K,
+    ) -> Result<Option<Bytes>, slatedb::Error> {
+        self.inner.get(key).instrument(self.span.clone()).await
+    }
+}
+
+impl Deref for InstrumentedDb {
+    type Target = Db;
+
+    fn deref(&self) -> &Db {
+        &self.inner
+    }
+}

--- a/src/instrumented_db.rs
+++ b/src/instrumented_db.rs
@@ -14,6 +14,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use slatedb::bytes::Bytes;
+use slatedb::config::WriteOptions;
 use slatedb::{Db, WriteBatch, WriteHandle};
 use tracing::{Instrument, Span};
 
@@ -33,6 +34,17 @@ impl InstrumentedDb {
 
     pub async fn write(&self, batch: WriteBatch) -> Result<WriteHandle, slatedb::Error> {
         self.inner.write(batch).instrument(self.span.clone()).await
+    }
+
+    pub async fn write_with_options(
+        &self,
+        batch: WriteBatch,
+        options: &WriteOptions,
+    ) -> Result<WriteHandle, slatedb::Error> {
+        self.inner
+            .write_with_options(batch, options)
+            .instrument(self.span.clone())
+            .await
     }
 
     pub async fn put<K, V>(&self, key: K, value: V) -> Result<WriteHandle, slatedb::Error>

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -28,6 +28,7 @@ impl JobStoreShard {
     ///
     /// Uses a transaction with optimistic concurrency control to detect if the job state
     /// changes during the cancellation flow. Retries automatically on conflict.
+    #[tracing::instrument(skip_all, fields(shard = %self.name))]
     pub async fn cancel_job(&self, tenant: &str, id: &str) -> Result<(), JobStoreShardError> {
         retry_on_txn_conflict("cancel_job", || self.cancel_job_inner(tenant, id)).await
     }

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -89,6 +89,7 @@ impl JobStoreShard {
     /// When no ID is provided (auto-generated UUID), uses a faster WriteBatch path
     /// since UUID collisions are not a concern.
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip_all, fields(shard = %self.name))]
     pub async fn enqueue(
         &self,
         tenant: &str,

--- a/src/job_store_shard/expedite.rs
+++ b/src/job_store_shard/expedite.rs
@@ -44,6 +44,7 @@ impl JobStoreShard {
     /// - Returns error if the task is already ready to run (in buffer) or running (has lease)
     ///
     /// Uses a transaction with optimistic concurrency control to detect if the job state changes during the expedite flow. Retries automatically on conflict.
+    #[tracing::instrument(skip_all, fields(shard = %self.name))]
     pub async fn expedite_job(&self, tenant: &str, id: &str) -> Result<(), JobStoreShardError> {
         retry_on_txn_conflict("expedite_job", || self.expedite_job_inner(tenant, id)).await
     }

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -88,6 +88,7 @@ impl JobStoreShard {
     /// Import a batch of jobs, returning per-job results.
     /// Each job is imported independently; failures don't affect other jobs in the batch.
     /// Returns an error if any job in the batch already exists and is currently Running.
+    #[tracing::instrument(skip_all, fields(shard = %self.name))]
     pub async fn import_jobs(
         &self,
         tenant: &str,

--- a/src/job_store_shard/lease_task.rs
+++ b/src/job_store_shard/lease_task.rs
@@ -50,6 +50,7 @@ impl JobStoreShard {
     /// Uses a transaction with optimistic concurrency control to atomically
     /// read the job state, delete the pending task, create a lease, and
     /// update the status.
+    #[tracing::instrument(skip_all, fields(shard = %self.name))]
     pub async fn lease_task(
         &self,
         tenant: &str,

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -38,6 +38,9 @@ use std::sync::OnceLock;
 use std::time::Duration;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
+use tracing::info_span;
+
+use crate::instrumented_db::InstrumentedDb;
 
 use crate::codec::CodecError;
 use crate::concurrency::ConcurrencyManager;
@@ -99,7 +102,7 @@ pub struct DequeueResult {
 /// Represents a single shard of the system. Owns the SlateDB instance.
 pub struct JobStoreShard {
     pub(crate) name: String,
-    pub(crate) db: Arc<Db>,
+    pub(crate) db: Arc<InstrumentedDb>,
     pub(crate) brokers: Arc<TaskBrokerRegistry>,
     pub(crate) concurrency: Arc<ConcurrencyManager>,
     #[cfg(feature = "server")]
@@ -368,8 +371,9 @@ impl JobStoreShard {
             db_builder = db_builder.with_db_cache(Arc::new(cache));
         }
 
+        let shard_span = info_span!("shard", shard = %name);
         let db = db_builder.build().await?;
-        let db = Arc::new(db);
+        let db = InstrumentedDb::new(Arc::new(db), shard_span);
         let concurrency = Arc::new(ConcurrencyManager::new(metrics.clone()));
 
         // Note: concurrency counts are hydrated lazily on first access to each queue.
@@ -382,8 +386,14 @@ impl JobStoreShard {
             range.clone(),
         );
 
-        // Start the grant scanner after both ConcurrencyManager and TaskBrokerRegistry are ready
-        concurrency.start_grant_scanner(Arc::clone(&db), Arc::clone(&brokers), range.clone());
+        // Start the grant scanner after both ConcurrencyManager and TaskBrokerRegistry are ready.
+        // The grant scanner takes a raw `Arc<Db>` (no shard instrumentation) — its own
+        // logging path doesn't need it.
+        concurrency.start_grant_scanner(
+            Arc::clone(db.inner()),
+            Arc::clone(&brokers),
+            range.clone(),
+        );
 
         let shard = Arc::new(Self {
             name,

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -387,13 +387,8 @@ impl JobStoreShard {
         );
 
         // Start the grant scanner after both ConcurrencyManager and TaskBrokerRegistry are ready.
-        // The grant scanner takes a raw `Arc<Db>` (no shard instrumentation) — its own
-        // logging path doesn't need it.
-        concurrency.start_grant_scanner(
-            Arc::clone(db.inner()),
-            Arc::clone(&brokers),
-            range.clone(),
-        );
+        // It takes the instrumented db so its writes are tagged with the shard span too.
+        concurrency.start_grant_scanner(Arc::clone(&db), Arc::clone(&brokers), range.clone());
 
         let shard = Arc::new(Self {
             name,

--- a/src/job_store_shard/restart.rs
+++ b/src/job_store_shard/restart.rs
@@ -55,6 +55,7 @@ impl JobStoreShard {
     ///
     /// Uses a transaction with optimistic concurrency control to detect if the job state
     /// changes during the restart flow. Retries automatically on conflict.
+    #[tracing::instrument(skip_all, fields(shard = %self.name))]
     pub async fn restart_job(&self, tenant: &str, id: &str) -> Result<(), JobStoreShardError> {
         retry_on_txn_conflict("restart_job", || self.restart_job_inner(tenant, id)).await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod factory;
 pub mod grpc_trace;
 pub mod gubernator;
 pub mod heap_profile;
+pub mod instrumented_db;
 pub mod job;
 pub mod job_attempt;
 pub mod job_store_shard;

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -8,7 +8,9 @@ use std::time::Duration;
 
 use crossbeam_skiplist::SkipMap;
 use dashmap::DashMap;
-use slatedb::{Db, WriteBatch};
+use slatedb::WriteBatch;
+
+use crate::instrumented_db::InstrumentedDb;
 use tokio::sync::Notify;
 
 use crate::codec::{DecodedTask, decode_task_validated};
@@ -37,7 +39,7 @@ pub struct TaskBroker {
     // The task group this broker is responsible for
     task_group: String,
     // The SlateDB database to read tasks from
-    db: Arc<Db>,
+    db: Arc<InstrumentedDb>,
     // The buffer of tasks read out of the DB and ready to be claimed by a dequeue-ing worker
     buffer: Arc<SkipMap<Vec<u8>, BrokerTask>>,
     // The set of tasks already read out of the DB and claimed by a worker but not yet durably leased. Required so that the scanner doesn't re-add tasks that are in the middle of being dequeued to the buffer.
@@ -73,7 +75,7 @@ impl TaskBroker {
 
     fn new(
         task_group: String,
-        db: Arc<Db>,
+        db: Arc<InstrumentedDb>,
         shard_name: String,
         metrics: Option<Metrics>,
         range: ShardRange,
@@ -493,7 +495,7 @@ impl Drop for TaskBroker {
 /// Registry of per-task-group brokers. Lazily creates a broker for each task group
 /// on first access, scoping each broker's DB scan to its task group's key range.
 pub struct TaskBrokerRegistry {
-    db: Arc<Db>,
+    db: Arc<InstrumentedDb>,
     shard_name: String,
     metrics: Option<Metrics>,
     range: ShardRange,
@@ -502,7 +504,7 @@ pub struct TaskBrokerRegistry {
 
 impl TaskBrokerRegistry {
     pub fn new(
-        db: Arc<Db>,
+        db: Arc<InstrumentedDb>,
         shard_name: String,
         metrics: Option<Metrics>,
         range: ShardRange,


### PR DESCRIPTION
## Summary

Slatedb logs through the `log` crate, which `tracing-subscriber` bridges into tracing events that inherit whatever span is active on the polling task. Without a shard-scoped span around our slatedb calls, lines like `unflushed memtable size exceeds max_unflushed_bytes. applying backpressure` and `db closed` show up unattributed in multi-shard processes.

This PR attaches a shard tracing context to slatedb work in three places:

- **silo-compactor** (`silo-compactor/src/worker.rs`) wraps the spawned `compactor.run()` future in a `slatedb_compactor{shard}` span so the standalone compactor's bridged log events carry the shard id (e.g. `slatedb::compactor_state_protocols: creating new compactions file`).
- **silo** introduces an `InstrumentedDb` newtype around `Arc<Db>` (`src/instrumented_db.rs`) that attaches a shard span to direct write/put/merge/delete/close/flush/get/write_with_options calls. Existing call sites keep `self.db.write(...)` style — inherent methods on the wrapper take precedence over slatedb's via `Deref<Target=Db>`. Reads pass through to slatedb's `Db` via `Deref` and don't need instrumentation.
- The shard-mutation entry points on `JobStoreShard` (`enqueue`, `cancel_job`, `expedite_job`, `restart_job`, `import_jobs`, `lease_task`) get `#[tracing::instrument(skip_all, fields(shard))]` so the transaction-based write paths (`db.begin` + `txn.commit`) — which bypass the wrapper — still emit slatedb events under a shard span.
- `start_grant_scanner` / `reconcile_pending_requests` / `process_grants` in `src/concurrency.rs` now take `Arc<InstrumentedDb>` / `&InstrumentedDb` so the grant scanner's commit batches (`write_with_options`) also pick up the shard span.

## Verified in dev

After the change (ANSI stripped):

```
INFO slatedb_compactor{shard=410c97a4-...}: slatedb::compactor_state_protocols: creating new compactions file [compactor_epoch=0]
INFO shard.acquire:shard: slatedb::db: db closed shard_id=410c97a4-... shard=410c97a4-...
WARN grpc_request:enqueue: slatedb::db: unflushed memtable size exceeds max_unflushed_bytes... rpc.method=Enqueue shard=410c97a4-...
```

## Caveat

Slatedb spawns its own internal tokio tasks via `JoinSet::spawn_on`, which does **not** propagate the parent span. Logs emitted from those subtasks will not carry the shard tag without a slatedb-side change. The most prominent example is the `slatedb::compactor_state: finished compaction` log, which fires from inside `MessageDispatcher` running `CompactorEventHandler::handle` — verified locally that this specific line still has no shard. Tagging it would require a slatedb fork (e.g. `#[instrument(fields(shard))]` on the dispatcher and threading a shard label through `CompactorBuilder`).

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo fmt --all`
- [x] Verified in dev: silo-compactor, silo `db closed`, silo backpressure WARN under load all carry the shard
- [x] Verified the slatedb-internal-spawn caveat is real and called out