### PR TITLE
Enable tokio-console in production silo build for staging testing

### DIFF
--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -45,6 +45,9 @@
         # based unwinding, which requires the compiler to actually preserve them
         CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";  # Better inlining visibility
         RUSTFLAGS = "--cfg tokio_unstable --cfg tokio_taskdump -C force-frame-pointers=yes";
+        # Enable tokio-console in production so staging deployments expose the
+        # console_subscriber gRPC endpoint for live runtime inspection.
+        cargoExtraArgs = "--features tokio-console";
       };
       
       # Build dependencies separately for caching


### PR DESCRIPTION
## Summary
- Adds `cargoExtraArgs = "--features tokio-console"` to the crane `commonArgs` in `nix/modules/rust.nix`, so the production `silo` package (and the `silo-docker` image built from it) ships with `console_subscriber` baked in.
- Pairs with the existing `--cfg tokio_unstable --cfg tokio_taskdump` RUSTFLAGS that were already in `commonArgs`.
- Intended for staging deployments so we can attach `tokio-console` to a running silo pod and inspect the runtime live. Revert (or gate) before promoting to prod proper.

## Test plan
- [x] `cargo check -p silo --features tokio-console --bin silo`
- [x] `cargo fmt --all -- --check`
- [ ] Build `silo-docker` via the staging pipeline and confirm the resulting binary exposes the console gRPC endpoint when `TOKIO_CONSOLE_BIND` is set on the pod
- [ ] `tokio-console http://<pod>:6669` connects and shows tasks