### PR TITLE
Scope reset_shards to locally-owned shards to fix multi-node fencing flake

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1509,27 +1509,43 @@ impl Silo for SiloService {
             ));
         }
 
-        // Use the coordinator's shard map as the source of truth for which shards
-        // should exist, not just what's currently in the factory. This catches cases
-        // where shards failed to open during startup (e.g., due to path configuration
-        // errors) but are still listed in the shard map.
+        // Only reset shards this node owns. In a multi-node cluster, resetting a
+        // shard owned by another node would wipe its object-store data and bump
+        // the manifest epoch, fencing the owner's `l0_manifest_writer` task and
+        // permanently closing its slatedb instance. The TS test client calls
+        // `resetShards` against every server, so each owner resets its own shards.
         let shard_map = self
             .coordinator
             .get_shard_map()
             .await
             .map_err(|e| Status::internal(format!("failed to get shard map: {}", e)))?;
+        let owned_ids: std::collections::HashSet<_> = self
+            .coordinator
+            .base()
+            .owned
+            .lock()
+            .await
+            .iter()
+            .copied()
+            .collect();
+        let local_shards: Vec<_> = shard_map
+            .shards()
+            .iter()
+            .filter(|info| owned_ids.contains(&info.id))
+            .cloned()
+            .collect();
 
         let mut reset_count = 0u32;
-        for shard_info in shard_map.shards() {
+        for shard_info in &local_shards {
             let shard_id = shard_info.id;
             let range = match self.factory.get(&shard_id) {
                 Some(shard) => shard.get_range(),
                 None => {
-                    // Shard is in the shard map but not in the factory - this means it
-                    // failed to open during startup. Try to open it now.
+                    // Shard is owned but not in the factory - this means it failed
+                    // to open during startup. Try to open it now.
                     tracing::warn!(
                         shard = %shard_id,
-                        "shard not found in factory during reset, attempting to open it"
+                        "owned shard not found in factory during reset, attempting to open it"
                     );
                     shard_info.range.clone()
                 }
@@ -1554,13 +1570,13 @@ impl Silo for SiloService {
         // which improves diagnostic logging in shard_with_redirect().
         {
             let mut owned = self.coordinator.base().owned.lock().await;
-            for shard_info in shard_map.shards() {
+            for shard_info in &local_shards {
                 owned.insert(shard_info.id);
             }
         }
 
-        // Verify all shards are accessible after reset
-        for shard_info in shard_map.shards() {
+        // Verify all locally-owned shards are accessible after reset
+        for shard_info in &local_shards {
             if self.factory.get(&shard_info.id).is_none() {
                 return Err(Status::internal(format!(
                     "shard {} not accessible after reset - this is a bug",

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -2576,8 +2576,8 @@ export class SiloGRPCClient {
         return;
       }
 
-      // Reset on each unique server sequentially to avoid SlateDB conflicts
-      // when nodes share the same underlying object storage
+      // Each server only resets its own locally-owned shards, so we must call
+      // every node in the cluster to cover the full shard map.
       for (const addr of servers) {
         const conn = this._getOrCreateConnection(addr);
         const call = conn.client.resetShards({}, this._rpcOptions());


### PR DESCRIPTION
## Summary

The dev-mode `ResetShards` RPC was iterating the full shard map and calling `factory.reset()` for every shard — including ones owned by other nodes. In a multi-node cluster (the TS worker-integration tests run against `silo-1` + `silo-2` with 8 shards split between them), that meant a single `client.resetShards()` call from a test's `beforeEach`:

1. Wiped the object-store data for shards owned by the *other* node, and
2. Opened a fresh slatedb locally, bumping the manifest epoch and **fencing the real owner's `l0_manifest_writer` task**.

SlateDB's dispatcher labels every non-Ok run result as "background task panicked unexpectedly" and then marks the DB permanently closed. So subsequent operations routed to the fenced node failed with `Closed error: background task panicked. name=`l0_manifest_writer`` — confusingly worded, but `error=Fenced, panic=None` in the actual log line — which is exactly the flake seen in [run 25606422471](https://github.com/gadget-inc/silo/actions/runs/25606422471/job/75169012806).

This change scopes the server-side reset to shards present in `coordinator.base().owned`. The TS client already loops over every server it has seen in the topology when calling `resetShards`, so the per-node scoping still gives full-cluster coverage — without one node's reset trampling another node's data.

Single-node tests (`NoneCoordinator`) own the entire shard map, so their behavior is unchanged. All 8 `grpc_server_reset_shards_*` tests still pass.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets` (no new warnings on touched files)
- [x] `cargo fmt`
- [x] `cargo test -p silo --test grpc_misc_tests reset_shards` (8/8 pass)
- [ ] Verify TS worker-integration suite no longer flakes on the `floating concurrency limit refresh` block in CI