### PR TITLE
Enable tokio-console feature in silo-debug build

### DIFF
--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -62,6 +62,11 @@
         strictDeps = true;
         nativeBuildInputs = [ pkgs.protobuf pkgs.flatbuffers ];
         CARGO_PROFILE = "dev";
+        # Enable the embedded console-subscriber server so the dev image's
+        # tokio-console CLI can attach to a running silo. Requires
+        # `--cfg tokio_unstable` to compile against tokio's unstable APIs.
+        cargoExtraArgs = "--features tokio-console";
+        RUSTFLAGS = "--cfg tokio_unstable";
         # Disable fortify hardening so jemalloc's configure script can build
         # its strerror_r feature test. Nix's default _FORTIFY_SOURCE=2 + cargo's
         # debug -O0 + jemalloc's -Werror combine into a hard error in glibc's


### PR DESCRIPTION
## Summary
- Compile the `silo-debug` binary with `--features tokio-console` and `--cfg tokio_unstable` so the embedded `console-subscriber` server starts at runtime.
- The dev image already ships the `tokio-console` CLI (`nix/modules/docker.nix:67`), but until now the bundled binary didn't have the feature enabled, so attaching the CLI was a no-op.

## Test plan
- [ ] `nix build .#silo-debug -L` succeeds
- [ ] `nix build .#silo-docker-dev -L` succeeds
- [ ] In the dev image, run silo and confirm `tokio-console` can attach (default port 6669)