### PR TITLE
Label silo_concurrency_tickets_granted_total by grant path

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -531,6 +531,9 @@ impl ConcurrencyManager {
                 relative_attempt_number,
                 task_group,
             )?;
+            if let Some(ref m) = self.metrics {
+                m.record_concurrency_ticket_granted("immediate_grant");
+            }
             Ok(Some(RequestTicketOutcome::GrantedImmediately {
                 task_id: task_id.to_string(),
                 queue: queue.clone(),
@@ -1130,7 +1133,7 @@ impl ConcurrencyManager {
 
             if let Some(ref m) = self.metrics {
                 for _ in 0..grants.len() {
-                    m.record_concurrency_ticket_granted();
+                    m.record_concurrency_ticket_granted("scanned_grant");
                 }
             }
 

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -532,7 +532,7 @@ impl ConcurrencyManager {
                 task_group,
             )?;
             if let Some(ref m) = self.metrics {
-                m.record_concurrency_ticket_granted("immediate_grant");
+                m.record_concurrency_tickets_granted(crate::metrics::GrantPath::Immediate, 1);
             }
             Ok(Some(RequestTicketOutcome::GrantedImmediately {
                 task_id: task_id.to_string(),
@@ -1132,9 +1132,10 @@ impl ConcurrencyManager {
             }
 
             if let Some(ref m) = self.metrics {
-                for _ in 0..grants.len() {
-                    m.record_concurrency_ticket_granted("scanned_grant");
-                }
+                m.record_concurrency_tickets_granted(
+                    crate::metrics::GrantPath::Scanned,
+                    grants.len() as u64,
+                );
             }
 
             total_granted += grants.len();

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -452,7 +452,7 @@ impl JobStoreShard {
 
                 // Record concurrency ticket metric and ready-to-start latency
                 if let Some(ref m) = self.metrics {
-                    m.record_concurrency_ticket_granted();
+                    m.record_concurrency_ticket_granted("scanned_grant");
                     if let Some(parsed) = parse_task_key(task_key) {
                         let latency_ms = (now_ms - parsed.start_time_ms as i64).max(0) as f64;
                         m.record_ready_to_start_latency_ms(self.name(), req_task_group, latency_ms);

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -452,7 +452,7 @@ impl JobStoreShard {
 
                 // Record concurrency ticket metric and ready-to-start latency
                 if let Some(ref m) = self.metrics {
-                    m.record_concurrency_ticket_granted("scanned_grant");
+                    m.record_concurrency_tickets_granted(crate::metrics::GrantPath::Scanned, 1);
                     if let Some(parsed) = parse_task_key(task_key) {
                         let latency_ms = (now_ms - parsed.start_time_ms as i64).max(0) as f64;
                         m.record_ready_to_start_latency_ms(self.name(), req_task_group, latency_ms);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -68,6 +68,27 @@ const OS_REQUEST_COUNT: &str = "slatedb.object_store.request_count";
 const OS_ERROR_COUNT: &str = "slatedb.object_store.error_count";
 const OS_REQUEST_DURATION_SECONDS: &str = "slatedb.object_store.request_duration_seconds";
 
+/// Code path that produced a concurrency ticket grant. Becomes the `path`
+/// label on `silo_concurrency_tickets_granted_total`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GrantPath {
+    /// Synchronous enqueue path where `try_reserve` finds capacity and a
+    /// holder is created right away (no request queue round-trip).
+    Immediate,
+    /// Async grant scanner or dequeue ticket-request processing path that
+    /// drains queued ticket requests as capacity becomes available.
+    Scanned,
+}
+
+impl GrantPath {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GrantPath::Immediate => "immediate",
+            GrantPath::Scanned => "scanned",
+        }
+    }
+}
+
 /// Silo metrics handle containing all metric instruments.
 #[derive(Clone)]
 pub struct Metrics {
@@ -394,16 +415,14 @@ impl Metrics {
             .inc();
     }
 
-    /// Record a concurrency ticket being granted.
-    ///
-    /// `granted` labels the code path that produced the grant: `immediate_grant`
-    /// for the synchronous enqueue path that observes capacity via `try_reserve`,
-    /// and `scanned_grant` for the async grant scanner / dequeue ticket-request
-    /// processing path that drains queued requests.
-    pub fn record_concurrency_ticket_granted(&self, granted: &str) {
+    /// Record `n` concurrency tickets being granted via `path`.
+    pub fn record_concurrency_tickets_granted(&self, path: GrantPath, n: u64) {
+        if n == 0 {
+            return;
+        }
         self.concurrency_tickets_granted
-            .with_label_values(&[granted])
-            .inc();
+            .with_label_values(&[path.as_str()])
+            .inc_by(n as f64);
     }
 
     /// Update SlateDB storage metrics from a shard's StatRegistry.
@@ -1133,7 +1152,7 @@ pub fn init() -> anyhow::Result<Metrics> {
                 "silo_concurrency_tickets_granted_total",
                 "Total number of concurrency tickets granted, labelled by grant path",
             ),
-            &["granted"],
+            &["path"],
         )?,
     );
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,8 +31,8 @@ use std::task::{Context, Poll};
 
 use axum::{Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
 use prometheus::{
-    Counter, CounterVec, Encoder, Gauge, GaugeVec, HistogramOpts, HistogramVec, Opts, Registry,
-    TextEncoder, core::Collector,
+    CounterVec, Encoder, Gauge, GaugeVec, HistogramOpts, HistogramVec, Opts, Registry, TextEncoder,
+    core::Collector,
 };
 use slatedb_common::metrics::{DefaultMetricsRecorder, LATENCY_BOUNDARIES, MetricValue};
 use tokio::sync::broadcast;
@@ -107,7 +107,7 @@ pub struct Metrics {
     lease_reaper_errors_total: CounterVec,
 
     // Concurrency metrics
-    concurrency_tickets_granted: Counter,
+    concurrency_tickets_granted: CounterVec,
 
     // SlateDB watcher metrics (driven by Db::subscribe)
     slatedb_durable_seq: GaugeVec,
@@ -395,8 +395,15 @@ impl Metrics {
     }
 
     /// Record a concurrency ticket being granted.
-    pub fn record_concurrency_ticket_granted(&self) {
-        self.concurrency_tickets_granted.inc();
+    ///
+    /// `granted` labels the code path that produced the grant: `immediate_grant`
+    /// for the synchronous enqueue path that observes capacity via `try_reserve`,
+    /// and `scanned_grant` for the async grant scanner / dequeue ticket-request
+    /// processing path that drains queued requests.
+    pub fn record_concurrency_ticket_granted(&self, granted: &str) {
+        self.concurrency_tickets_granted
+            .with_label_values(&[granted])
+            .inc();
     }
 
     /// Update SlateDB storage metrics from a shard's StatRegistry.
@@ -1121,9 +1128,12 @@ pub fn init() -> anyhow::Result<Metrics> {
     // Concurrency metrics
     let concurrency_tickets_granted = register(
         &registry,
-        Counter::new(
-            "silo_concurrency_tickets_granted_total",
-            "Total number of concurrency tickets granted",
+        CounterVec::new(
+            Opts::new(
+                "silo_concurrency_tickets_granted_total",
+                "Total number of concurrency tickets granted, labelled by grant path",
+            ),
+            &["granted"],
         )?,
     );
 

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -1769,7 +1769,9 @@ async fn grant_scanner_records_concurrency_ticket_granted_metric() {
         holder_tasks.push(tasks[0].attempt().task_id().to_string());
     }
 
-    let baseline = read_concurrency_tickets_granted(&metrics);
+    let baseline_scanned = read_concurrency_tickets_granted_for(&metrics, Some("scanned_grant"));
+    let baseline_immediate =
+        read_concurrency_tickets_granted_for(&metrics, Some("immediate_grant"));
 
     // Enqueue 3 more jobs that will queue as concurrency requests (queue is full).
     for i in 0..3 {
@@ -1801,18 +1803,104 @@ async fn grant_scanner_records_concurrency_ticket_granted_metric() {
     let granted = shard.process_concurrency_grants(tenant, queue, 2).await;
     assert_eq!(granted.len(), 2, "should grant 2 of the 3 waiters");
 
-    let after = read_concurrency_tickets_granted(&metrics);
+    let after_scanned = read_concurrency_tickets_granted_for(&metrics, Some("scanned_grant"));
+    let after_immediate = read_concurrency_tickets_granted_for(&metrics, Some("immediate_grant"));
     assert_eq!(
-        after - baseline,
+        after_scanned - baseline_scanned,
         2.0,
-        "process_grants must increment the counter once per granted ticket"
+        "process_grants must increment the scanned_grant counter once per granted ticket"
+    );
+    assert_eq!(
+        after_immediate - baseline_immediate,
+        0.0,
+        "process_grants must not touch the immediate_grant counter"
+    );
+}
+
+/// Tests that the immediate-grant enqueue path (where `try_reserve` finds capacity
+/// and `handle_enqueue` skips the request queue) increments
+/// `silo_concurrency_tickets_granted_total{granted="immediate_grant"}` once per
+/// granted enqueue, and does not bleed into the `scanned_grant` counter.
+#[silo::test]
+async fn immediate_enqueue_records_concurrency_ticket_granted_metric() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let queue = "immediate-metric-q";
+    let tenant = "immediate-metric-tenant";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: 3,
+    });
+
+    let baseline_immediate =
+        read_concurrency_tickets_granted_for(&metrics, Some("immediate_grant"));
+    let baseline_scanned = read_concurrency_tickets_granted_for(&metrics, Some("scanned_grant"));
+
+    // 3 enqueues into a queue with capacity=3 should all hit the immediate-grant
+    // path (try_reserve succeeds for each).
+    for i in 0..3 {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("immediate-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+
+    let after_immediate = read_concurrency_tickets_granted_for(&metrics, Some("immediate_grant"));
+    let after_scanned = read_concurrency_tickets_granted_for(&metrics, Some("scanned_grant"));
+
+    assert_eq!(
+        after_immediate - baseline_immediate,
+        3.0,
+        "immediate-grant enqueue path must increment the immediate_grant counter once per grant"
+    );
+    assert_eq!(
+        after_scanned - baseline_scanned,
+        0.0,
+        "immediate-grant enqueue path must not touch the scanned_grant counter"
+    );
+
+    // A 4th enqueue exceeds capacity and goes through the request queue, so the
+    // immediate_grant counter should not advance.
+    shard
+        .enqueue(
+            tenant,
+            Some("waiter".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .unwrap();
+
+    let final_immediate = read_concurrency_tickets_granted_for(&metrics, Some("immediate_grant"));
+    assert_eq!(
+        final_immediate - after_immediate,
+        0.0,
+        "an at-capacity enqueue must not increment the immediate_grant counter"
     );
 }
 
 /// Read the current value of the `silo_concurrency_tickets_granted_total` counter
-/// out of the Prometheus registry. The counter is unlabelled, so we just sum the
-/// single sample.
-fn read_concurrency_tickets_granted(metrics: &silo::metrics::Metrics) -> f64 {
+/// for a specific `granted` label value, or summed across all values when `granted`
+/// is `None`.
+fn read_concurrency_tickets_granted_for(
+    metrics: &silo::metrics::Metrics,
+    granted: Option<&str>,
+) -> f64 {
     metrics
         .registry()
         .gather()
@@ -1821,6 +1909,13 @@ fn read_concurrency_tickets_granted(metrics: &silo::metrics::Metrics) -> f64 {
         .map(|f| {
             f.get_metric()
                 .iter()
+                .filter(|m| match granted {
+                    None => true,
+                    Some(want) => m
+                        .get_label()
+                        .iter()
+                        .any(|l| l.get_name() == "granted" && l.get_value() == want),
+                })
                 .map(|m| m.get_counter().get_value())
                 .sum()
         })

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -1769,9 +1769,10 @@ async fn grant_scanner_records_concurrency_ticket_granted_metric() {
         holder_tasks.push(tasks[0].attempt().task_id().to_string());
     }
 
-    let baseline_scanned = read_concurrency_tickets_granted_for(&metrics, Some("scanned_grant"));
+    let baseline_scanned =
+        read_concurrency_tickets_granted_for(&metrics, Some(silo::metrics::GrantPath::Scanned));
     let baseline_immediate =
-        read_concurrency_tickets_granted_for(&metrics, Some("immediate_grant"));
+        read_concurrency_tickets_granted_for(&metrics, Some(silo::metrics::GrantPath::Immediate));
 
     // Enqueue 3 more jobs that will queue as concurrency requests (queue is full).
     for i in 0..3 {
@@ -1803,24 +1804,26 @@ async fn grant_scanner_records_concurrency_ticket_granted_metric() {
     let granted = shard.process_concurrency_grants(tenant, queue, 2).await;
     assert_eq!(granted.len(), 2, "should grant 2 of the 3 waiters");
 
-    let after_scanned = read_concurrency_tickets_granted_for(&metrics, Some("scanned_grant"));
-    let after_immediate = read_concurrency_tickets_granted_for(&metrics, Some("immediate_grant"));
+    let after_scanned =
+        read_concurrency_tickets_granted_for(&metrics, Some(silo::metrics::GrantPath::Scanned));
+    let after_immediate =
+        read_concurrency_tickets_granted_for(&metrics, Some(silo::metrics::GrantPath::Immediate));
     assert_eq!(
         after_scanned - baseline_scanned,
         2.0,
-        "process_grants must increment the scanned_grant counter once per granted ticket"
+        "process_grants must increment the scanned-path counter once per granted ticket"
     );
     assert_eq!(
         after_immediate - baseline_immediate,
         0.0,
-        "process_grants must not touch the immediate_grant counter"
+        "process_grants must not touch the immediate-path counter"
     );
 }
 
 /// Tests that the immediate-grant enqueue path (where `try_reserve` finds capacity
 /// and `handle_enqueue` skips the request queue) increments
-/// `silo_concurrency_tickets_granted_total{granted="immediate_grant"}` once per
-/// granted enqueue, and does not bleed into the `scanned_grant` counter.
+/// `silo_concurrency_tickets_granted_total{path="immediate"}` once per granted
+/// enqueue, and does not bleed into the `path="scanned"` series.
 #[silo::test]
 async fn immediate_enqueue_records_concurrency_ticket_granted_metric() {
     let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
@@ -1833,8 +1836,9 @@ async fn immediate_enqueue_records_concurrency_ticket_granted_metric() {
     });
 
     let baseline_immediate =
-        read_concurrency_tickets_granted_for(&metrics, Some("immediate_grant"));
-    let baseline_scanned = read_concurrency_tickets_granted_for(&metrics, Some("scanned_grant"));
+        read_concurrency_tickets_granted_for(&metrics, Some(silo::metrics::GrantPath::Immediate));
+    let baseline_scanned =
+        read_concurrency_tickets_granted_for(&metrics, Some(silo::metrics::GrantPath::Scanned));
 
     // 3 enqueues into a queue with capacity=3 should all hit the immediate-grant
     // path (try_reserve succeeds for each).
@@ -1855,22 +1859,24 @@ async fn immediate_enqueue_records_concurrency_ticket_granted_metric() {
             .unwrap();
     }
 
-    let after_immediate = read_concurrency_tickets_granted_for(&metrics, Some("immediate_grant"));
-    let after_scanned = read_concurrency_tickets_granted_for(&metrics, Some("scanned_grant"));
+    let after_immediate =
+        read_concurrency_tickets_granted_for(&metrics, Some(silo::metrics::GrantPath::Immediate));
+    let after_scanned =
+        read_concurrency_tickets_granted_for(&metrics, Some(silo::metrics::GrantPath::Scanned));
 
     assert_eq!(
         after_immediate - baseline_immediate,
         3.0,
-        "immediate-grant enqueue path must increment the immediate_grant counter once per grant"
+        "immediate-grant enqueue path must increment the immediate-path counter once per grant"
     );
     assert_eq!(
         after_scanned - baseline_scanned,
         0.0,
-        "immediate-grant enqueue path must not touch the scanned_grant counter"
+        "immediate-grant enqueue path must not touch the scanned-path counter"
     );
 
     // A 4th enqueue exceeds capacity and goes through the request queue, so the
-    // immediate_grant counter should not advance.
+    // immediate-path counter should not advance.
     shard
         .enqueue(
             tenant,
@@ -1886,20 +1892,21 @@ async fn immediate_enqueue_records_concurrency_ticket_granted_metric() {
         .await
         .unwrap();
 
-    let final_immediate = read_concurrency_tickets_granted_for(&metrics, Some("immediate_grant"));
+    let final_immediate =
+        read_concurrency_tickets_granted_for(&metrics, Some(silo::metrics::GrantPath::Immediate));
     assert_eq!(
         final_immediate - after_immediate,
         0.0,
-        "an at-capacity enqueue must not increment the immediate_grant counter"
+        "an at-capacity enqueue must not increment the immediate-path counter"
     );
 }
 
 /// Read the current value of the `silo_concurrency_tickets_granted_total` counter
-/// for a specific `granted` label value, or summed across all values when `granted`
+/// for a specific `path` label value, or summed across all values when `path`
 /// is `None`.
 fn read_concurrency_tickets_granted_for(
     metrics: &silo::metrics::Metrics,
-    granted: Option<&str>,
+    path: Option<silo::metrics::GrantPath>,
 ) -> f64 {
     metrics
         .registry()
@@ -1909,12 +1916,12 @@ fn read_concurrency_tickets_granted_for(
         .map(|f| {
             f.get_metric()
                 .iter()
-                .filter(|m| match granted {
+                .filter(|m| match path {
                     None => true,
                     Some(want) => m
                         .get_label()
                         .iter()
-                        .any(|l| l.get_name() == "granted" && l.get_value() == want),
+                        .any(|l| l.get_name() == "path" && l.get_value() == want.as_str()),
                 })
                 .map(|m| m.get_counter().get_value())
                 .sum()

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -240,10 +240,9 @@ async fn test_metrics_all_recording_methods() {
     metrics.inc_task_leases_active("0", "default");
     metrics.dec_task_leases_active("0", "default");
 
-    // record_concurrency_ticket_granted
-    metrics.record_concurrency_ticket_granted("immediate_grant");
-    metrics.record_concurrency_ticket_granted("scanned_grant");
-    metrics.record_concurrency_ticket_granted("scanned_grant");
+    // record_concurrency_tickets_granted
+    metrics.record_concurrency_tickets_granted(silo::metrics::GrantPath::Immediate, 1);
+    metrics.record_concurrency_tickets_granted(silo::metrics::GrantPath::Scanned, 2);
 
     // set_coordination_shards_open
     metrics.set_coordination_shards_open(5);
@@ -350,13 +349,13 @@ async fn test_metrics_all_recording_methods() {
 
     // Verify concurrency tickets granted, labelled by grant path
     assert!(
-        body_str.contains("silo_concurrency_tickets_granted_total{granted=\"immediate_grant\"} 1"),
-        "immediate_grant concurrency ticket should be 1, body: {}",
+        body_str.contains("silo_concurrency_tickets_granted_total{path=\"immediate\"} 1"),
+        "immediate-path concurrency ticket should be 1, body: {}",
         body_str
     );
     assert!(
-        body_str.contains("silo_concurrency_tickets_granted_total{granted=\"scanned_grant\"} 2"),
-        "scanned_grant concurrency tickets should be 2, body: {}",
+        body_str.contains("silo_concurrency_tickets_granted_total{path=\"scanned\"} 2"),
+        "scanned-path concurrency tickets should be 2, body: {}",
         body_str
     );
 

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -241,7 +241,9 @@ async fn test_metrics_all_recording_methods() {
     metrics.dec_task_leases_active("0", "default");
 
     // record_concurrency_ticket_granted
-    metrics.record_concurrency_ticket_granted();
+    metrics.record_concurrency_ticket_granted("immediate_grant");
+    metrics.record_concurrency_ticket_granted("scanned_grant");
+    metrics.record_concurrency_ticket_granted("scanned_grant");
 
     // set_coordination_shards_open
     metrics.set_coordination_shards_open(5);
@@ -346,10 +348,16 @@ async fn test_metrics_all_recording_methods() {
         leases_line
     );
 
-    // Verify concurrency tickets granted
+    // Verify concurrency tickets granted, labelled by grant path
     assert!(
-        body_str.contains("silo_concurrency_tickets_granted_total 1"),
-        "concurrency tickets granted should be 1"
+        body_str.contains("silo_concurrency_tickets_granted_total{granted=\"immediate_grant\"} 1"),
+        "immediate_grant concurrency ticket should be 1, body: {}",
+        body_str
+    );
+    assert!(
+        body_str.contains("silo_concurrency_tickets_granted_total{granted=\"scanned_grant\"} 2"),
+        "scanned_grant concurrency tickets should be 2, body: {}",
+        body_str
     );
 
     // Verify coordination shards open


### PR DESCRIPTION
## Summary

- Splits the unlabelled `silo_concurrency_tickets_granted_total` counter into a `CounterVec` keyed by a new `granted` label.
- `granted="scanned_grant"` covers the async grant scanner and the dequeue path that drains queued `RequestTicket` tasks (the previous default behavior).
- `granted="immediate_grant"` covers the synchronous enqueue path in `ConcurrencyManager::handle_enqueue` where `try_reserve` finds capacity and a holder is created right away. This path was previously not recorded at all, so the counter only reflected delayed grants — this closes that observability gap.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --tests`
- [x] `cargo clippy --tests --all-targets` (no new warnings in touched files)
- [x] `cargo test --test metrics_tests` — updated `test_metrics_all_recording_methods` to record both label values and assert each label's count separately.
- [x] `cargo test --test job_store_shard_concurrency_tests grant_scanner_records_concurrency_ticket_granted_metric immediate_enqueue_records_concurrency_ticket_granted_metric` — existing scanner test now asserts only the `scanned_grant` series moves; new `immediate_enqueue_records_concurrency_ticket_granted_metric` test exercises 3 in-capacity enqueues + 1 over-capacity enqueue and asserts only the `immediate_grant` series moves (and only by 3).