### PR TITLE
Route all shard slatedb calls through InstrumentedDb

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"5e9361ba-29fe-4811-8a2b-047578cc5bf7","pid":22983,"procStart":"Mon May 11 01:57:04 2026","acquiredAt":1778467330975}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"5e9361ba-29fe-4811-8a2b-047578cc5bf7","pid":22983,"procStart":"Mon May 11 01:57:04 2026","acquiredAt":1778467330975}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ AGENTS.md
 tests/turmoil/AGENTS.md
 # end lnai-generated
 profiles/
+.claude/scheduled_tasks.lock

--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -284,6 +284,7 @@ async fn generate_golden_dataset(tenant_sizes: &[(String, usize)]) -> GoldenShar
     };
     let checkpoint = shard
         .db()
+        .inner()
         .create_checkpoint(slatedb::config::CheckpointScope::All, &checkpoint_options)
         .await
         .expect("create checkpoint");

--- a/src/bin/silo-sim.rs
+++ b/src/bin/silo-sim.rs
@@ -76,7 +76,10 @@ fn unique_prefix() -> String {
 /// the actual concurrency-holder prefix is 0x09). That made the simulator's
 /// holder/lease/request invariants vacuous. Always pass the binary prefix from
 /// `keys::*_prefix()`.
-async fn count_with_binary_prefix(db: &slatedb::Db, prefix: &[u8]) -> usize {
+async fn count_with_binary_prefix(
+    db: &silo::instrumented_db::InstrumentedDb,
+    prefix: &[u8],
+) -> usize {
     let start: Vec<u8> = prefix.to_vec();
     let end: Vec<u8> = keys::end_bound(prefix);
     let mut iter = db.scan::<Vec<u8>, _>(start..end).await.expect("scan");

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -42,8 +42,8 @@ use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;
 
+use slatedb::WriteBatch;
 use slatedb::config::WriteOptions;
-use slatedb::{Db, DbIterator, WriteBatch};
 
 use crate::instrumented_db::InstrumentedDb;
 
@@ -156,7 +156,7 @@ impl ConcurrencyCounts {
     /// Uses the per-queue prefix for efficient scanning of only the relevant holders. The `range` parameter filters holders to only load those for tenants within the shard's range. This is critical after shard splits - both child shards clone the same holder records, and without filtering, both would think they own the same concurrency tickets, leading to limit violations.
     pub async fn hydrate_queue(
         &self,
-        db: &Db,
+        db: &InstrumentedDb,
         range: &ShardRange,
         tenant: &str,
         queue: &str,
@@ -166,7 +166,7 @@ impl ConcurrencyCounts {
         // Scan holders for this specific tenant/queue using the queue prefix
         let start = concurrency_holders_queue_prefix(tenant, queue);
         let end = end_bound(&start);
-        let mut iter: DbIterator = db
+        let mut iter = db
             .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
             .await?;
 
@@ -218,7 +218,7 @@ impl ConcurrencyCounts {
     /// Fast path: if already hydrated, return immediately.
     pub async fn ensure_hydrated(
         &self,
-        db: &Db,
+        db: &InstrumentedDb,
         range: &ShardRange,
         tenant: &str,
         queue: &str,
@@ -246,7 +246,7 @@ impl ConcurrencyCounts {
     #[allow(clippy::too_many_arguments)]
     pub async fn try_reserve(
         &self,
-        db: &Db,
+        db: &InstrumentedDb,
         range: &ShardRange,
         tenant: &str,
         queue: &str,
@@ -445,7 +445,7 @@ impl ConcurrencyManager {
     }
 
     async fn resolve_queue_capacity(
-        db: &Db,
+        db: &InstrumentedDb,
         tenant: &str,
         queue: &str,
         view: &JobView,
@@ -482,7 +482,7 @@ impl ConcurrencyManager {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn handle_enqueue<W: WriteBatcher>(
         &self,
-        db: &Db,
+        db: &InstrumentedDb,
         range: &ShardRange,
         writer: &mut W,
         tenant: &str,
@@ -595,7 +595,7 @@ impl ConcurrencyManager {
     #[allow(clippy::too_many_arguments)]
     pub async fn process_ticket_request_task(
         &self,
-        db: &Db,
+        db: &InstrumentedDb,
         range: &ShardRange,
         batch: &mut WriteBatch,
         task_key: &[u8],

--- a/src/instrumented_db.rs
+++ b/src/instrumented_db.rs
@@ -1,21 +1,27 @@
 //! [`InstrumentedDb`] — `slatedb::Db` wrapper that attaches a per-shard tracing
-//! span to every write operation it performs.
+//! span to every operation it performs.
 //!
 //! `slatedb` logs through the `log` crate, which `tracing-subscriber` bridges
 //! into tracing events. Bridged events inherit whatever span is active on the
 //! current task when they fire. This wrapper makes sure that any silo code
-//! awaiting `db.write` / `db.put` / `db.merge` / `db.delete` does so under the
-//! shard span, so log lines like the backpressure warnings from
-//! `slatedb::db` are tagged with the shard.
+//! awaiting a slatedb operation does so under the shard span, so log lines
+//! like the backpressure warnings from `slatedb::db` are tagged with the
+//! shard.
 //!
-//! The wrapper derefs to `&Db`, so reads and other passthrough calls keep
-//! working without modification (they don't typically log).
-use std::ops::Deref;
+//! Shard-scoped slatedb operations must go through `InstrumentedDb`,
+//! [`InstrumentedDbIterator`], or [`InstrumentedDbTransaction`]. The
+//! `inner()` accessor is an escape hatch reserved for non-shard-scoped work
+//! (factory operations on closed parents, status watchers, metrics readers).
+//!
+//! `InstrumentedDb` deliberately does not implement `Deref<Target = Db>`. If a
+//! method you need isn't here, add a wrapper rather than reaching for
+//! `inner()` — Deref is exactly what caused the past coverage gaps.
+use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use slatedb::bytes::Bytes;
-use slatedb::config::WriteOptions;
-use slatedb::{Db, WriteBatch, WriteHandle};
+use slatedb::config::{FlushOptions, ScanOptions, WriteOptions};
+use slatedb::{Db, DbIterator, DbTransaction, IsolationLevel, KeyValue, WriteBatch, WriteHandle};
 use tracing::{Instrument, Span};
 
 pub struct InstrumentedDb {
@@ -28,8 +34,15 @@ impl InstrumentedDb {
         Arc::new(Self { inner, span })
     }
 
+    /// Escape hatch for non-shard-scoped consumers (factory ops, status
+    /// watchers, metrics readers). Do not use for shard-scoped reads/writes —
+    /// add a wrapped method instead.
     pub fn inner(&self) -> &Arc<Db> {
         &self.inner
+    }
+
+    pub fn span(&self) -> &Span {
+        &self.span
     }
 
     pub async fn write(&self, batch: WriteBatch) -> Result<WriteHandle, slatedb::Error> {
@@ -81,21 +94,155 @@ impl InstrumentedDb {
         self.inner.flush().instrument(self.span.clone()).await
     }
 
-    /// Return the value associated with `key` if present. Reads don't usually
-    /// log, but we still pin the span so any future trace/debug events bridged
-    /// from slatedb's read path inherit shard context.
+    pub async fn flush_with_options(&self, options: FlushOptions) -> Result<(), slatedb::Error> {
+        self.inner
+            .flush_with_options(options)
+            .instrument(self.span.clone())
+            .await
+    }
+
     pub async fn get<K: AsRef<[u8]> + Send>(
         &self,
         key: K,
     ) -> Result<Option<Bytes>, slatedb::Error> {
         self.inner.get(key).instrument(self.span.clone()).await
     }
+
+    pub async fn scan<K, T>(&self, range: T) -> Result<InstrumentedDbIterator, slatedb::Error>
+    where
+        K: AsRef<[u8]> + Send,
+        T: RangeBounds<K> + Send,
+    {
+        let inner = self.inner.scan(range).instrument(self.span.clone()).await?;
+        Ok(InstrumentedDbIterator {
+            inner,
+            span: self.span.clone(),
+        })
+    }
+
+    pub async fn scan_with_options<K, T>(
+        &self,
+        range: T,
+        options: &ScanOptions,
+    ) -> Result<InstrumentedDbIterator, slatedb::Error>
+    where
+        K: AsRef<[u8]> + Send,
+        T: RangeBounds<K> + Send,
+    {
+        let inner = self
+            .inner
+            .scan_with_options(range, options)
+            .instrument(self.span.clone())
+            .await?;
+        Ok(InstrumentedDbIterator {
+            inner,
+            span: self.span.clone(),
+        })
+    }
+
+    pub async fn begin(
+        &self,
+        isolation_level: IsolationLevel,
+    ) -> Result<InstrumentedDbTransaction, slatedb::Error> {
+        let inner = self
+            .inner
+            .begin(isolation_level)
+            .instrument(self.span.clone())
+            .await?;
+        Ok(InstrumentedDbTransaction {
+            inner,
+            span: self.span.clone(),
+        })
+    }
 }
 
-impl Deref for InstrumentedDb {
-    type Target = Db;
+/// Wraps a [`slatedb::DbIterator`] so that `.next()` runs under the shard span.
+pub struct InstrumentedDbIterator {
+    inner: DbIterator,
+    span: Span,
+}
 
-    fn deref(&self) -> &Db {
-        &self.inner
+impl InstrumentedDbIterator {
+    pub async fn next(&mut self) -> Result<Option<KeyValue>, slatedb::Error> {
+        self.inner.next().instrument(self.span.clone()).await
+    }
+}
+
+/// Wraps a [`slatedb::DbTransaction`] so that every method runs under the shard
+/// span. Sync methods (`put`/`delete`/`merge`/`unmark_write`) enter the span
+/// for the duration of the call so any synchronous `log!` emissions inherit it.
+pub struct InstrumentedDbTransaction {
+    inner: DbTransaction,
+    span: Span,
+}
+
+impl InstrumentedDbTransaction {
+    pub fn span(&self) -> &Span {
+        &self.span
+    }
+
+    pub async fn get<K: AsRef<[u8]> + Send>(
+        &self,
+        key: K,
+    ) -> Result<Option<Bytes>, slatedb::Error> {
+        self.inner.get(key).instrument(self.span.clone()).await
+    }
+
+    pub async fn scan<K, T>(&self, range: T) -> Result<InstrumentedDbIterator, slatedb::Error>
+    where
+        K: AsRef<[u8]> + Send,
+        T: RangeBounds<K> + Send,
+    {
+        let inner = self.inner.scan(range).instrument(self.span.clone()).await?;
+        Ok(InstrumentedDbIterator {
+            inner,
+            span: self.span.clone(),
+        })
+    }
+
+    pub fn put<K, V>(&self, key: K, value: V) -> Result<(), slatedb::Error>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        let _g = self.span.enter();
+        self.inner.put(key, value)
+    }
+
+    pub fn delete<K: AsRef<[u8]>>(&self, key: K) -> Result<(), slatedb::Error> {
+        let _g = self.span.enter();
+        self.inner.delete(key)
+    }
+
+    pub fn merge<K, V>(&self, key: K, value: V) -> Result<(), slatedb::Error>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        let _g = self.span.enter();
+        self.inner.merge(key, value)
+    }
+
+    pub fn unmark_write<K, I>(&self, keys: I) -> Result<(), slatedb::Error>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
+    {
+        let _g = self.span.enter();
+        self.inner.unmark_write(keys)
+    }
+
+    pub async fn commit(self) -> Result<Option<WriteHandle>, slatedb::Error> {
+        self.inner.commit().instrument(self.span).await
+    }
+
+    pub async fn commit_with_options(
+        self,
+        options: &WriteOptions,
+    ) -> Result<Option<WriteHandle>, slatedb::Error> {
+        self.inner
+            .commit_with_options(options)
+            .instrument(self.span)
+            .await
     }
 }

--- a/src/instrumented_db.rs
+++ b/src/instrumented_db.rs
@@ -41,10 +41,6 @@ impl InstrumentedDb {
         &self.inner
     }
 
-    pub fn span(&self) -> &Span {
-        &self.span
-    }
-
     pub async fn write(&self, batch: WriteBatch) -> Result<WriteHandle, slatedb::Error> {
         self.inner.write(batch).instrument(self.span.clone()).await
     }
@@ -177,10 +173,6 @@ pub struct InstrumentedDbTransaction {
 }
 
 impl InstrumentedDbTransaction {
-    pub fn span(&self) -> &Span {
-        &self.span
-    }
-
     pub async fn get<K: AsRef<[u8]> + Send>(
         &self,
         key: K,

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -1,6 +1,6 @@
 //! Job cancellation operations.
 
-use slatedb::{DbIterator, IsolationLevel};
+use slatedb::IsolationLevel;
 
 use crate::codec::{decode_cancellation_at_ms, decode_task, encode_job_cancellation};
 use crate::job::{JobCancellation, JobStatus, JobStatusKind, JobView, Limit};
@@ -218,7 +218,7 @@ impl JobStoreShard {
     #[expect(clippy::too_many_arguments)]
     pub(crate) async fn delete_concurrency_requests_for_job(
         &self,
-        txn: &slatedb::DbTransaction,
+        txn: &crate::instrumented_db::InstrumentedDbTransaction,
         tenant: &str,
         job_id: &str,
         limits: &[Limit],
@@ -267,7 +267,7 @@ impl JobStoreShard {
     #[expect(clippy::too_many_arguments)]
     async fn delete_concurrency_requests_with_prefix(
         &self,
-        txn: &slatedb::DbTransaction,
+        txn: &crate::instrumented_db::InstrumentedDbTransaction,
         tenant: &str,
         job_id: &str,
         queue_key: &str,
@@ -284,7 +284,7 @@ impl JobStoreShard {
             attempt_number,
         );
         let end = end_bound(&prefix);
-        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(prefix..end).await?;
+        let mut iter = self.db.scan::<Vec<u8>, _>(prefix..end).await?;
 
         let mut deleted_count: i64 = 0;
         while let Some(kv) = iter.next().await? {

--- a/src/job_store_shard/counters.rs
+++ b/src/job_store_shard/counters.rs
@@ -226,7 +226,6 @@ impl JobStoreShard {
         use crate::keys::{
             end_bound, parse_tenant_status_counter_key, tenant_status_counter_prefix,
         };
-        use slatedb::DbIterator;
 
         let (start, end) = tenant_range
             .as_ref()
@@ -243,7 +242,7 @@ impl JobStoreShard {
 
         let range = self.get_range();
 
-        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
         let mut results = Vec::new();
 
         while let Some(kv) = iter.next().await? {

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -1,7 +1,7 @@
 //! Task dequeue and processing operations.
 
+use slatedb::WriteBatch;
 use slatedb::config::WriteOptions;
-use slatedb::{DbIterator, WriteBatch};
 
 use crate::codec::{DecodedTask, decode_task, encode_attempt, encode_lease};
 use crate::concurrency::RequestTicketTaskOutcome;
@@ -387,7 +387,7 @@ impl JobStoreShard {
         let outcome = self
             .concurrency
             .process_ticket_request_task(
-                &self.db,
+                self.db.as_ref(),
                 shard_range,
                 &mut state.batch,
                 task_key,
@@ -822,7 +822,7 @@ impl JobStoreShard {
         // Scan tasks under tasks/{task_group}/ using binary storekey encoding
         let start = crate::keys::task_group_prefix(task_group);
         let end = crate::keys::end_bound(&start);
-        let mut iter: DbIterator = self
+        let mut iter = self
             .db
             .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
             .await?;

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -466,7 +466,7 @@ impl JobStoreShard {
                     let outcome = self
                         .concurrency
                         .handle_enqueue(
-                            &self.db,
+                            self.db.as_ref(),
                             &self.get_range(),
                             writer,
                             tenant,
@@ -523,7 +523,7 @@ impl JobStoreShard {
                     let outcome = self
                         .concurrency
                         .handle_enqueue(
-                            &self.db,
+                            self.db.as_ref(),
                             &self.get_range(),
                             writer,
                             tenant,

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -1,6 +1,6 @@
 //! Floating concurrency limit operations.
 
-use slatedb::{DbIterator, WriteBatch};
+use slatedb::WriteBatch;
 use uuid::Uuid;
 
 use crate::codec::{
@@ -44,7 +44,7 @@ impl JobStoreShard {
     ) -> Result<bool, JobStoreShardError> {
         let start = concurrency_request_prefix(tenant, queue_key);
         let end = end_bound(&start);
-        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
         Ok(iter.next().await?.is_some())
     }
 

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -1,9 +1,10 @@
 //! Helper functions shared across job_store_shard submodules.
+use slatedb::WriteBatch;
 use slatedb::bytes::Bytes;
-use slatedb::{Db, DbTransaction, WriteBatch};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::codec::encode_task;
+use crate::instrumented_db::{InstrumentedDb, InstrumentedDbTransaction};
 use crate::job::JobStatus;
 use crate::job_store_shard::JobStoreShardError;
 use crate::keys::task_key;
@@ -55,12 +56,12 @@ pub(crate) trait WriteBatcher {
 ///
 /// This combines a database reference for reads with a write batch for writes, allowing batch-based code paths to use the same trait as transaction-based ones.
 pub(crate) struct DbWriteBatcher<'a> {
-    pub db: &'a Db,
+    pub db: &'a InstrumentedDb,
     pub batch: &'a mut WriteBatch,
 }
 
 impl<'a> DbWriteBatcher<'a> {
-    pub fn new(db: &'a Db, batch: &'a mut WriteBatch) -> Self {
+    pub fn new(db: &'a InstrumentedDb, batch: &'a mut WriteBatch) -> Self {
         Self { db, batch }
     }
 }
@@ -94,12 +95,12 @@ impl WriteBatcher for DbWriteBatcher<'_> {
     }
 }
 
-/// Wrapper around `&DbTransaction` that implements `WriteBatcher`.
+/// Wrapper around `&InstrumentedDbTransaction` that implements `WriteBatcher`.
 ///
-/// This wrapper is needed because `DbTransaction` methods take `&self` (interior mutability)
+/// This wrapper is needed because transaction methods take `&self` (interior mutability)
 /// while `WriteBatch` methods take `&mut self`. The wrapper allows us to have a uniform
 /// `&mut self` interface in the `WriteBatcher` trait.
-pub(crate) struct TxnWriter<'a>(pub &'a DbTransaction);
+pub(crate) struct TxnWriter<'a>(pub &'a InstrumentedDbTransaction);
 
 impl WriteBatcher for TxnWriter<'_> {
     fn put<K: AsRef<[u8]>, V: AsRef<[u8]>>(

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -335,7 +335,7 @@ impl JobStoreShard {
         &self,
         tenant: &str,
         params: &ImportJobParams,
-        txn: slatedb::DbTransaction,
+        txn: crate::instrumented_db::InstrumentedDbTransaction,
         existing_job: JobView,
         now_ms: i64,
     ) -> Result<JobStatusKind, JobStoreShardError> {

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -1,7 +1,7 @@
 //! Lease management: heartbeat, outcome reporting, and expired lease reaping.
 
+use slatedb::WriteBatch;
 use slatedb::config::WriteOptions;
-use slatedb::{DbIterator, WriteBatch};
 use uuid::Uuid;
 
 use crate::codec::{
@@ -366,7 +366,7 @@ impl JobStoreShard {
         // Scan all lease keys using the binary prefix
         let start = crate::keys::leases_prefix();
         let end = crate::keys::end_bound(&start);
-        let mut iter: DbIterator = self
+        let mut iter = self
             .db
             .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
             .await?;
@@ -546,7 +546,7 @@ impl JobStoreShard {
     ) -> Result<usize, JobStoreShardError> {
         let start = concurrency_holders_tenant_prefix(tenant);
         let end = end_bound(&start);
-        let mut iter: DbIterator = self
+        let mut iter = self
             .db
             .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
             .await?;

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -30,7 +30,6 @@ use helpers::DbWriteBatcher;
 use helpers::WriteBatcher;
 pub use helpers::now_epoch_ms;
 
-use slatedb::Db;
 use slatedb_common::metrics::DefaultMetricsRecorder;
 use std::sync::Arc;
 #[cfg(feature = "server")]
@@ -542,7 +541,7 @@ impl JobStoreShard {
         };
         let shard_name = self.name.clone();
         let cancellation = self.cancellation.clone();
-        let mut rx = self.db.subscribe();
+        let mut rx = self.db.inner().subscribe();
 
         tokio::spawn(async move {
             // Emit initial values so gauges aren't empty until the first
@@ -697,7 +696,7 @@ impl JobStoreShard {
         });
     }
 
-    pub fn db(&self) -> &Db {
+    pub fn db(&self) -> &InstrumentedDb {
         &self.db
     }
 
@@ -936,12 +935,10 @@ impl JobStoreShard {
         tenant: &str,
         job_id: &str,
     ) -> Result<Vec<JobAttemptView>, JobStoreShardError> {
-        use slatedb::DbIterator;
-
         let start = crate::keys::attempt_prefix(tenant, job_id);
         let end = crate::keys::end_bound(&start);
 
-        let mut iter: DbIterator = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
         let mut attempts = Vec::new();
 
         while let Some(kv) = iter.next().await? {

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -37,7 +37,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
-use tracing::info_span;
+use tracing::{Instrument, info_span};
 
 use crate::instrumented_db::InstrumentedDb;
 
@@ -371,7 +371,7 @@ impl JobStoreShard {
         }
 
         let shard_span = info_span!("shard", shard = %name);
-        let db = db_builder.build().await?;
+        let db = db_builder.build().instrument(shard_span.clone()).await?;
         let db = InstrumentedDb::new(Arc::new(db), shard_span);
         let concurrency = Arc::new(ConcurrencyManager::new(metrics.clone()));
 

--- a/src/job_store_shard/scan.rs
+++ b/src/job_store_shard/scan.rs
@@ -2,8 +2,7 @@
 
 use std::ops::ControlFlow;
 
-use slatedb::Db;
-
+use crate::instrumented_db::InstrumentedDb;
 use crate::job::JobStatusKind;
 use crate::job::{JobStatus, JobView};
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
@@ -22,7 +21,7 @@ use crate::keys::{
 /// - `ControlFlow::Continue(None)` to skip the entry
 /// - `ControlFlow::Break(())` to stop iteration early
 async fn scan_collect<T>(
-    db: &Db,
+    db: &InstrumentedDb,
     start: Vec<u8>,
     end: Vec<u8>,
     limit: Option<usize>,

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -6,7 +6,7 @@ use silo::job_attempt::{AttemptOutcome, AttemptStatus};
 use silo::keys::{concurrency_holder_key, concurrency_request_key};
 use silo::retry::RetryPolicy;
 use silo::task::{ConcurrencyAction, LeaseRecord, Task};
-use slatedb::{DbIterator, WriteBatch};
+use slatedb::WriteBatch;
 
 use test_helpers::*;
 
@@ -1807,7 +1807,7 @@ async fn concurrency_no_overgrant_with_lazy_hydration() {
     // Verify we have 2 holders in DB (the original ones)
     let start = silo::keys::concurrency_holders_queue_prefix("-", &queue);
     let end = silo::keys::end_bound(&start);
-    let mut iter: DbIterator = shard2
+    let mut iter = shard2
         .db()
         .scan::<Vec<u8>, _>(start..end)
         .await

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -2186,7 +2186,6 @@ async fn verify_metadata_prefix_explain_plan() {
 use silo::keys::{
     ParsedMetadataIndexKey, end_bound, idx_metadata_key_only_prefix, parse_metadata_index_key,
 };
-use slatedb::DbIterator;
 
 /// Collect all metadata index entries (0x04) for a given tenant and key.
 async fn collect_metadata_index_entries(
@@ -2196,7 +2195,7 @@ async fn collect_metadata_index_entries(
 ) -> Vec<ParsedMetadataIndexKey> {
     let start = idx_metadata_key_only_prefix(tenant, key);
     let end = end_bound(&start);
-    let mut iter: DbIterator = shard.db().scan::<Vec<u8>, _>(start..end).await.unwrap();
+    let mut iter = shard.db().scan::<Vec<u8>, _>(start..end).await.unwrap();
     let mut out = Vec::new();
     loop {
         let maybe = iter.next().await.unwrap();

--- a/tests/query_waiting_tests.rs
+++ b/tests/query_waiting_tests.rs
@@ -11,7 +11,6 @@ use silo::keys::{
 };
 use silo::query::ShardQueryEngine;
 use silo::retry::RetryPolicy;
-use slatedb::DbIterator;
 use test_helpers::*;
 
 // Helper to extract string column values from batches
@@ -94,7 +93,7 @@ async fn collect_index_entries(
 ) -> Vec<ParsedStatusTimeIndexKey> {
     let start = idx_status_time_prefix(tenant, status);
     let end = end_bound(&start);
-    let mut iter: DbIterator = shard.db().scan::<Vec<u8>, _>(start..end).await.unwrap();
+    let mut iter = shard.db().scan::<Vec<u8>, _>(start..end).await.unwrap();
     let mut out = Vec::new();
     loop {
         let maybe = iter.next().await.unwrap();
@@ -110,7 +109,7 @@ async fn collect_index_entries(
 async fn collect_all_index_entries(shard: &JobStoreShard) -> Vec<ParsedStatusTimeIndexKey> {
     let start = vec![0x03u8];
     let end = end_bound(&start);
-    let mut iter: DbIterator = shard.db().scan::<Vec<u8>, _>(start..end).await.unwrap();
+    let mut iter = shard.db().scan::<Vec<u8>, _>(start..end).await.unwrap();
     let mut out = Vec::new();
     loop {
         let maybe = iter.next().await.unwrap();

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code)]
 
 use silo::gubernator::{MockGubernatorClient, RateLimitClient};
+use silo::instrumented_db::InstrumentedDb;
 use silo::job_store_shard::{JobStoreShard, OpenShardOptions};
 use silo::settings::{Backend, DatabaseConfig};
 use silo::shard_range::ShardRange;
 use silo::storage::resolve_object_store;
-use slatedb::{Db, DbIterator};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -207,47 +207,50 @@ pub fn now_ms() -> i64 {
         .as_millis() as i64
 }
 
-pub async fn first_kv_with_prefix(db: &Db, prefix: &str) -> Option<(String, bytes::Bytes)> {
+pub async fn first_kv_with_prefix(
+    db: &InstrumentedDb,
+    prefix: &str,
+) -> Option<(String, bytes::Bytes)> {
     let start: Vec<u8> = prefix.as_bytes().to_vec();
     let mut end: Vec<u8> = prefix.to_string().into_bytes();
     end.push(0xFF);
-    let mut iter: DbIterator = db.scan::<Vec<u8>, _>(start..=end).await.ok()?;
+    let mut iter = db.scan::<Vec<u8>, _>(start..=end).await.ok()?;
     let first = iter.next().await.ok()?;
     first.map(|kv| (String::from_utf8_lossy(&kv.key).to_string(), kv.value))
 }
 
 /// Get first key/value with a binary prefix (for storekey-encoded keys).
 pub async fn first_kv_with_binary_prefix(
-    db: &Db,
+    db: &InstrumentedDb,
     prefix: &[u8],
 ) -> Option<(Vec<u8>, bytes::Bytes)> {
     let start = prefix.to_vec();
     let end = silo::keys::end_bound(&start);
-    let mut iter: DbIterator = db.scan::<Vec<u8>, _>(start..end).await.ok()?;
+    let mut iter = db.scan::<Vec<u8>, _>(start..end).await.ok()?;
     let first = iter.next().await.ok()?;
     first.map(|kv| (kv.key.to_vec(), kv.value))
 }
 
 /// Get first task key/value (0x05 prefix).
-pub async fn first_task_kv(db: &Db) -> Option<(Vec<u8>, bytes::Bytes)> {
+pub async fn first_task_kv(db: &InstrumentedDb) -> Option<(Vec<u8>, bytes::Bytes)> {
     first_kv_with_binary_prefix(db, &silo::keys::tasks_prefix()).await
 }
 
 /// Get first lease key/value (0x06 prefix).
-pub async fn first_lease_kv(db: &Db) -> Option<(Vec<u8>, bytes::Bytes)> {
+pub async fn first_lease_kv(db: &InstrumentedDb) -> Option<(Vec<u8>, bytes::Bytes)> {
     first_kv_with_binary_prefix(db, &silo::keys::leases_prefix()).await
 }
 
 /// Get first concurrency request key/value (0x08 prefix).
-pub async fn first_concurrency_request_kv(db: &Db) -> Option<(Vec<u8>, bytes::Bytes)> {
+pub async fn first_concurrency_request_kv(db: &InstrumentedDb) -> Option<(Vec<u8>, bytes::Bytes)> {
     first_kv_with_binary_prefix(db, &silo::keys::concurrency_requests_prefix()).await
 }
 
-pub async fn count_tasks_before(db: &Db, cutoff_ms: i64) -> usize {
+pub async fn count_tasks_before(db: &InstrumentedDb, cutoff_ms: i64) -> usize {
     let start: Vec<u8> = b"tasks/".to_vec();
     let mut end: Vec<u8> = b"tasks/".to_vec();
     end.push(0xFF);
-    let mut iter: DbIterator = db.scan::<Vec<u8>, _>(start..=end).await.unwrap();
+    let mut iter = db.scan::<Vec<u8>, _>(start..=end).await.unwrap();
     let mut count = 0usize;
     loop {
         let maybe = iter.next().await.unwrap();
@@ -262,11 +265,11 @@ pub async fn count_tasks_before(db: &Db, cutoff_ms: i64) -> usize {
     count
 }
 
-pub async fn count_with_prefix(db: &Db, prefix: &str) -> usize {
+pub async fn count_with_prefix(db: &InstrumentedDb, prefix: &str) -> usize {
     let start: Vec<u8> = prefix.as_bytes().to_vec();
     let mut end: Vec<u8> = prefix.to_string().into_bytes();
     end.push(0xFF);
-    let mut iter: DbIterator = db.scan::<Vec<u8>, _>(start..=end).await.unwrap();
+    let mut iter = db.scan::<Vec<u8>, _>(start..=end).await.unwrap();
     let mut count = 0usize;
     loop {
         let maybe = iter.next().await.unwrap();
@@ -279,10 +282,10 @@ pub async fn count_with_prefix(db: &Db, prefix: &str) -> usize {
 }
 
 /// Count keys with a binary prefix (for use with storekey-encoded keys).
-pub async fn count_with_binary_prefix(db: &Db, prefix: &[u8]) -> usize {
+pub async fn count_with_binary_prefix(db: &InstrumentedDb, prefix: &[u8]) -> usize {
     let start = prefix.to_vec();
     let end = silo::keys::end_bound(&start);
-    let mut iter: DbIterator = db.scan::<Vec<u8>, _>(start..end).await.unwrap();
+    let mut iter = db.scan::<Vec<u8>, _>(start..end).await.unwrap();
     let mut count = 0usize;
     loop {
         let maybe = iter.next().await.unwrap();
@@ -295,47 +298,47 @@ pub async fn count_with_binary_prefix(db: &Db, prefix: &[u8]) -> usize {
 }
 
 /// Count job info keys (0x01 prefix).
-pub async fn count_job_info_keys(db: &Db) -> usize {
+pub async fn count_job_info_keys(db: &InstrumentedDb) -> usize {
     count_with_binary_prefix(db, &silo::keys::jobs_prefix()).await
 }
 
 /// Count job info keys for a specific tenant.
-pub async fn count_job_info_keys_for_tenant(db: &Db, tenant: &str) -> usize {
+pub async fn count_job_info_keys_for_tenant(db: &InstrumentedDb, tenant: &str) -> usize {
     count_with_binary_prefix(db, &silo::keys::job_info_prefix(tenant)).await
 }
 
 /// Count job status keys (0x02 prefix).
-pub async fn count_job_status_keys(db: &Db) -> usize {
+pub async fn count_job_status_keys(db: &InstrumentedDb) -> usize {
     count_with_binary_prefix(db, &[0x02]).await
 }
 
 /// Count status/time index keys (0x03 prefix).
-pub async fn count_status_time_index_keys(db: &Db) -> usize {
+pub async fn count_status_time_index_keys(db: &InstrumentedDb) -> usize {
     count_with_binary_prefix(db, &[0x03]).await
 }
 
 /// Count task keys (0x05 prefix).
-pub async fn count_task_keys(db: &Db) -> usize {
+pub async fn count_task_keys(db: &InstrumentedDb) -> usize {
     count_with_binary_prefix(db, &silo::keys::tasks_prefix()).await
 }
 
 /// Count lease keys (0x06 prefix).
-pub async fn count_lease_keys(db: &Db) -> usize {
+pub async fn count_lease_keys(db: &InstrumentedDb) -> usize {
     count_with_binary_prefix(db, &silo::keys::leases_prefix()).await
 }
 
 /// Count concurrency request keys (0x08 prefix).
-pub async fn count_concurrency_requests(db: &Db) -> usize {
+pub async fn count_concurrency_requests(db: &InstrumentedDb) -> usize {
     count_with_binary_prefix(db, &silo::keys::concurrency_requests_prefix()).await
 }
 
 /// Count concurrency holder keys (0x09 prefix).
-pub async fn count_concurrency_holders(db: &Db) -> usize {
+pub async fn count_concurrency_holders(db: &InstrumentedDb) -> usize {
     count_with_binary_prefix(db, &silo::keys::concurrency_holders_prefix()).await
 }
 
 /// Count concurrency holder keys for a specific tenant.
-pub async fn count_concurrency_holders_for_tenant(db: &Db, tenant: &str) -> usize {
+pub async fn count_concurrency_holders_for_tenant(db: &InstrumentedDb, tenant: &str) -> usize {
     count_with_binary_prefix(db, &silo::keys::concurrency_holders_tenant_prefix(tenant)).await
 }
 


### PR DESCRIPTION
## Summary
- Drop `Deref<Target = Db>` on `InstrumentedDb` so the compiler enforces that every shard-scoped slatedb call goes through the wrapper. Previously, `Deref` let calls silently fall through to the raw `Db`, which is how transactions, scans, and `flush_with_options` ended up uninstrumented.
- Add wrappers for the previously uncovered surface: `scan`, `scan_with_options`, `flush_with_options`, `begin`, plus two new types — `InstrumentedDbIterator` (wraps `DbIterator::next`) and `InstrumentedDbTransaction` (wraps every method used by callers, with a `span.enter()` guard around the sync `put`/`delete`/`merge`/`unmark_write` so any synchronous `log!` they emit inherits the shard).
- Migrate every shard-scoped call site. `inner()` stays as a documented escape hatch and is used in two places: `job_store_shard/mod.rs` (the `DbStatus` `subscribe()` watcher — non-shard-scoped status changes) and `benches/bench_helpers.rs` (`create_checkpoint` during bench setup — admin op, not a shard read/write).
- Instrument the `db_builder.build()` call in `job_store_shard/mod.rs` with the shard span, so slatedb logs emitted during shard open (manifest reads, WAL replay, cache warmup) also carry `shard=<uuid>` — previously the build future ran outside the span.
- `factory.rs` continues to use `slatedb::DbBuilder` / `slatedb::admin::Admin` / `slatedb::config::*` for admin/checkpoint operations on closed parent shards during split. `storage.rs` references `slatedb::Db::resolve_object_store`, a static URL parser, not a database operation. Both are non-shard-scoped and intentionally not wrapped.

## Verification

After this change, the only places that name the bare `slatedb::Db` type in `src/` are `instrumented_db.rs` (the wrapper itself and its module-level doc-comment). Concretely:

```
$ rg 'slatedb::Db\b' src/
src/instrumented_db.rs://! [`InstrumentedDb`] — `slatedb::Db` wrapper that attaches a per-shard tracing
```

`factory.rs` and `storage.rs` reach into other parts of the `slatedb` namespace (`DbBuilder`, `admin::Admin`, `config::*`, `Db::resolve_object_store`) but no longer hold an instance of the bare `Db` type. All log lines slatedb bridges through the `log` crate during shard open and during reads/writes/transactions/scans now carry the `shard=<uuid>` field.

## Test plan
- [x] `cargo build --all-targets` clean
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --lib --bins --all-features -- -D warnings`
- [x] Local test runs: `concurrency_tests`, `query_tests`, `query_waiting_tests`, `concurrent_grant_race_tests`, `floating_concurrency_tests`, `job_store_shard_concurrency_tests`, `job_store_shard_retry_tests`, `split_aware_processing_tests`, `factory_tests`, `cleanup_reacquire_tests`, `compact_shard_tests`, `concurrency_counts_tests`, `grpc_enqueue_tests`, `grpc_query_tests` — all green (250+ tests)
- [ ] CI green