### PR TITLE
Gate tokio_taskdump rustflag to Linux only

### DIFF
--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -44,7 +44,10 @@
         # Enable frame pointers for profiling support - pprof uses frame-pointer
         # based unwinding, which requires the compiler to actually preserve them
         CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";  # Better inlining visibility
-        RUSTFLAGS = "--cfg tokio_unstable --cfg tokio_taskdump -C force-frame-pointers=yes";
+        # tokio_taskdump only compiles on Linux (x86_64/aarch64); gate it so
+        # macOS/aarch64-darwin consumers of this flake (e.g. siloctl in gadget's
+        # development flake) can build.
+        RUSTFLAGS = "--cfg tokio_unstable ${lib.optionalString pkgs.stdenv.isLinux "--cfg tokio_taskdump "}-C force-frame-pointers=yes";
       };
       
       # Build dependencies separately for caching


### PR DESCRIPTION
## Summary
- `nix/modules/rust.nix` unconditionally passed `--cfg tokio_taskdump` in `RUSTFLAGS`, which activates tokio's taskdump module. That module only compiles on Linux (x86_64/aarch64), breaking macOS consumers of this flake — notably `siloctl` pulled in via gadget's `development/flake.nix` (where most engineers are on `aarch64-darwin`).
- The Rust source already gates `dump_tasks` behind `#[cfg(all(tokio_unstable, tokio_taskdump, target_os = "linux", ...))]` with a `Status::unimplemented` fallback (`src/server.rs:1961-2002`), so dropping the cfg on Darwin is a no-op at the source level — the RPC simply returns `unimplemented` there, as it already does for any non-Linux build.
- Fix wraps the cfg in `lib.optionalString pkgs.stdenv.isLinux` so Linux builds are unchanged while Darwin builds drop just that one cfg.

## Test plan
- [ ] `nix build .#siloctl` on `aarch64-darwin` succeeds (previously failed in tokio's taskdump module).
- [ ] `nix build .#silo` on `x86_64-linux` still includes taskdump support — verify the `dump_tasks` RPC returns task traces rather than `unimplemented`.
- [ ] After merge, bump the silo rev pin in `gadget/development/flake.nix` to pick up the fix.