### PR TITLE
Tag silo_concurrency_tickets_granted_total with shard label

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -380,6 +380,9 @@ pub struct CachedQueueLimit {
 /// This eliminates the race condition where concurrent `release_and_grant_next` calls
 /// would both scan and grant the same pending request.
 pub struct ConcurrencyManager {
+    /// Name of the shard this manager belongs to. Used as the `shard` label
+    /// on per-shard metrics emitted from the grant paths.
+    shard: String,
     counts: ConcurrencyCounts,
     /// Pending grant counts per queue. Key: concurrency_counts_key(tenant, queue).
     /// Value: (tenant, queue, count). Lock held only briefly for increment/drain.
@@ -393,15 +396,10 @@ pub struct ConcurrencyManager {
     metrics: Option<Metrics>,
 }
 
-impl Default for ConcurrencyManager {
-    fn default() -> Self {
-        Self::new(None)
-    }
-}
-
 impl ConcurrencyManager {
-    pub fn new(metrics: Option<Metrics>) -> Self {
+    pub fn new(shard: impl Into<String>, metrics: Option<Metrics>) -> Self {
         Self {
+            shard: shard.into(),
             counts: ConcurrencyCounts::new(),
             pending_grants: Mutex::new(BTreeMap::new()),
             grant_notify: tokio::sync::Notify::new(),
@@ -532,7 +530,11 @@ impl ConcurrencyManager {
                 task_group,
             )?;
             if let Some(ref m) = self.metrics {
-                m.record_concurrency_tickets_granted(crate::metrics::GrantPath::Immediate, 1);
+                m.record_concurrency_tickets_granted(
+                    &self.shard,
+                    crate::metrics::GrantPath::Immediate,
+                    1,
+                );
             }
             Ok(Some(RequestTicketOutcome::GrantedImmediately {
                 task_id: task_id.to_string(),
@@ -1133,6 +1135,7 @@ impl ConcurrencyManager {
 
             if let Some(ref m) = self.metrics {
                 m.record_concurrency_tickets_granted(
+                    &self.shard,
                     crate::metrics::GrantPath::Scanned,
                     grants.len() as u64,
                 );

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -452,7 +452,11 @@ impl JobStoreShard {
 
                 // Record concurrency ticket metric and ready-to-start latency
                 if let Some(ref m) = self.metrics {
-                    m.record_concurrency_tickets_granted(crate::metrics::GrantPath::Scanned, 1);
+                    m.record_concurrency_tickets_granted(
+                        self.name(),
+                        crate::metrics::GrantPath::Scanned,
+                        1,
+                    );
                     if let Some(parsed) = parse_task_key(task_key) {
                         let latency_ms = (now_ms - parsed.start_time_ms as i64).max(0) as f64;
                         m.record_ready_to_start_latency_ms(self.name(), req_task_group, latency_ms);

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -373,7 +373,7 @@ impl JobStoreShard {
         let shard_span = info_span!("shard", shard = %name);
         let db = db_builder.build().instrument(shard_span.clone()).await?;
         let db = InstrumentedDb::new(Arc::new(db), shard_span);
-        let concurrency = Arc::new(ConcurrencyManager::new(metrics.clone()));
+        let concurrency = Arc::new(ConcurrencyManager::new(name.clone(), metrics.clone()));
 
         // Note: concurrency counts are hydrated lazily on first access to each queue.
         // This avoids blocking shard startup while scanning potentially large holder sets.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -415,13 +415,13 @@ impl Metrics {
             .inc();
     }
 
-    /// Record `n` concurrency tickets being granted via `path`.
-    pub fn record_concurrency_tickets_granted(&self, path: GrantPath, n: u64) {
+    /// Record `n` concurrency tickets being granted via `path` on `shard`.
+    pub fn record_concurrency_tickets_granted(&self, shard: &str, path: GrantPath, n: u64) {
         if n == 0 {
             return;
         }
         self.concurrency_tickets_granted
-            .with_label_values(&[path.as_str()])
+            .with_label_values(&[shard, path.as_str()])
             .inc_by(n as f64);
     }
 
@@ -1150,9 +1150,9 @@ pub fn init() -> anyhow::Result<Metrics> {
         CounterVec::new(
             Opts::new(
                 "silo_concurrency_tickets_granted_total",
-                "Total number of concurrency tickets granted, labelled by grant path",
+                "Total number of concurrency tickets granted, labelled by shard and grant path",
             ),
-            &["path"],
+            &["shard", "path"],
         )?,
     );
 

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -241,8 +241,8 @@ async fn test_metrics_all_recording_methods() {
     metrics.dec_task_leases_active("0", "default");
 
     // record_concurrency_tickets_granted
-    metrics.record_concurrency_tickets_granted(silo::metrics::GrantPath::Immediate, 1);
-    metrics.record_concurrency_tickets_granted(silo::metrics::GrantPath::Scanned, 2);
+    metrics.record_concurrency_tickets_granted("0", silo::metrics::GrantPath::Immediate, 1);
+    metrics.record_concurrency_tickets_granted("0", silo::metrics::GrantPath::Scanned, 2);
 
     // set_coordination_shards_open
     metrics.set_coordination_shards_open(5);
@@ -347,14 +347,16 @@ async fn test_metrics_all_recording_methods() {
         leases_line
     );
 
-    // Verify concurrency tickets granted, labelled by grant path
+    // Verify concurrency tickets granted, labelled by shard and grant path.
+    // Prometheus exposition renders labels in alphabetical order.
     assert!(
-        body_str.contains("silo_concurrency_tickets_granted_total{path=\"immediate\"} 1"),
+        body_str
+            .contains("silo_concurrency_tickets_granted_total{path=\"immediate\",shard=\"0\"} 1"),
         "immediate-path concurrency ticket should be 1, body: {}",
         body_str
     );
     assert!(
-        body_str.contains("silo_concurrency_tickets_granted_total{path=\"scanned\"} 2"),
+        body_str.contains("silo_concurrency_tickets_granted_total{path=\"scanned\",shard=\"0\"} 2"),
         "scanned-path concurrency tickets should be 2, body: {}",
         body_str
     );


### PR DESCRIPTION
## Summary
- Add a `shard` label to `silo_concurrency_tickets_granted_total` so grant activity can be attributed per shard instead of aggregating across all shards owned by a process.
- Plumb the shard name through `ConcurrencyManager::new` (it's per-shard already) and pass it from both grant call sites in `src/concurrency.rs` plus the dequeue-path grant in `src/job_store_shard/dequeue.rs`.
- The Prometheus exposition now reads e.g. `silo_concurrency_tickets_granted_total{path="immediate",shard="0"}`.

## Test plan
- [x] `nix develop -c cargo check --tests`
- [x] `nix develop -c cargo clippy --lib -- -D warnings`
- [x] `nix develop -c cargo test --test metrics_tests` — exposition now includes the shard label for both paths.
- [x] `nix develop -c cargo test --test job_store_shard_concurrency_tests` — 23 passed.