### PR TITLE
Adding a %shard% prefix for the local object cache

### DIFF
--- a/docs/src/content/docs/guides/deployment.mdx
+++ b/docs/src/content/docs/guides/deployment.mdx
@@ -80,14 +80,14 @@ backend = "gcs"
 path = "gs://my-bucket/silo/%shard%"
 
 [database.slatedb.object_store_cache_options]
-root_folder = "/var/silo-cache"
+root_folder = "/var/silo-cache/%shard%"
 max_cache_size_bytes = 17179869184  # 16 GB
 cache_puts = true
 ```
 
 The cache is enabled when `root_folder` is set. Key options:
 
-- **`root_folder`**: Path to the local directory where cached data is stored. Must be set to enable the cache.
+- **`root_folder`**: Path to the local directory where cached data is stored. Must be set to enable the cache. Supports the same `%shard%` and `{shard}` placeholders as `[database].path`.
 - **`max_cache_size_bytes`**: Maximum total size of the cache on disk. When exceeded, older entries are evicted.
 - **`cache_puts`**: When `true`, data written to object storage is also written to the local cache, warming it for subsequent reads.
 

--- a/docs/src/content/docs/reference/server-configuration.mdx
+++ b/docs/src/content/docs/reference/server-configuration.mdx
@@ -280,7 +280,7 @@ You can specify only the SlateDB options you want to customize—unspecified opt
 flush_interval = "1ms"
 
 [database.slatedb.object_store_cache_options]
-root_folder = "/var/silo-cache"
+root_folder = "/var/silo-cache/%shard%"
 cache_puts = true
 ```
 

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -91,6 +91,35 @@ pub struct OpenShardOptions {
     pub enable_counter_reconciliation: bool,
 }
 
+fn expand_slatedb_settings_for_shard(
+    mut settings: slatedb::config::Settings,
+    shard_name: &str,
+) -> slatedb::config::Settings {
+    expand_shard_placeholder_in_path(
+        &mut settings.object_store_cache_options.root_folder,
+        shard_name,
+    );
+    settings
+}
+
+fn expand_shard_placeholder_in_path(path: &mut Option<std::path::PathBuf>, shard_name: &str) {
+    let Some(path) = path.as_mut() else {
+        return;
+    };
+    let Some(path_str) = path.to_str() else {
+        return;
+    };
+    if !path_str.contains("%shard%") && !path_str.contains("{shard}") {
+        return;
+    }
+
+    *path = std::path::PathBuf::from(
+        path_str
+            .replace("%shard%", shard_name)
+            .replace("{shard}", shard_name),
+    );
+}
+
 /// Result of a dequeue operation - contains both job tasks and floating limit refresh tasks
 #[derive(Debug, Default)]
 pub struct DequeueResult {
@@ -339,7 +368,8 @@ impl JobStoreShard {
         // Note: The merge_operator field in settings is ignored because we already
         // set it above via with_merge_operator() for counter support
         if let Some(settings) = slatedb_settings {
-            db_builder = db_builder.with_settings(settings);
+            db_builder =
+                db_builder.with_settings(expand_slatedb_settings_for_shard(settings, &name));
         }
 
         // Apply custom in-memory cache sizes if specified
@@ -1024,5 +1054,64 @@ impl JobStoreShard {
         self.db.write(batch).await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand_slatedb_settings_for_shard;
+
+    #[test]
+    fn expands_shard_placeholder_in_slatedb_cache_root_folder() {
+        let settings = slatedb::config::Settings {
+            object_store_cache_options: slatedb::config::ObjectStoreCacheOptions {
+                root_folder: Some("/var/silo-cache/%shard%".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let settings = expand_slatedb_settings_for_shard(settings, "shard-123");
+
+        assert_eq!(
+            settings.object_store_cache_options.root_folder.as_deref(),
+            Some(std::path::Path::new("/var/silo-cache/shard-123"))
+        );
+    }
+
+    #[test]
+    fn expands_braced_shard_placeholder_in_slatedb_cache_root_folder() {
+        let settings = slatedb::config::Settings {
+            object_store_cache_options: slatedb::config::ObjectStoreCacheOptions {
+                root_folder: Some("/var/silo-cache/{shard}".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let settings = expand_slatedb_settings_for_shard(settings, "shard-123");
+
+        assert_eq!(
+            settings.object_store_cache_options.root_folder.as_deref(),
+            Some(std::path::Path::new("/var/silo-cache/shard-123"))
+        );
+    }
+
+    #[test]
+    fn leaves_slatedb_cache_root_folder_without_placeholder_unchanged() {
+        let settings = slatedb::config::Settings {
+            object_store_cache_options: slatedb::config::ObjectStoreCacheOptions {
+                root_folder: Some("/var/silo-cache".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let settings = expand_slatedb_settings_for_shard(settings, "shard-123");
+
+        assert_eq!(
+            settings.object_store_cache_options.root_folder.as_deref(),
+            Some(std::path::Path::new("/var/silo-cache"))
+        );
     }
 }


### PR DESCRIPTION
Eventhough the object cache uses the path of an object in it, this will allow the cache to be deleted safely on clean up of a shard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only affects SlateDB initialization by expanding `%shard%`/`{shard}` in the local object-store cache `root_folder`, leaving existing paths unchanged when no placeholder is present.
> 
> **Overview**
> Updates SlateDB object-store cache configuration to support per-shard cache directories by expanding `%shard%`/`{shard}` placeholders in `object_store_cache_options.root_folder` when opening a `JobStoreShard`.
> 
> Docs are updated to recommend `root_folder = "/var/silo-cache/%shard%"` and to note placeholder support, and unit tests are added to validate placeholder expansion and the no-placeholder case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78d0f693df9ae7c7260f7c37454c3a088b14f3a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->