### PR TITLE
Add task_group label to silo_polls_total and silo_poll_duration_seconds

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -358,15 +358,17 @@ impl Metrics {
             .set(count as f64);
     }
 
-    /// Record a poll (lease_tasks call) for a shard.
-    pub fn record_poll(&self, shard: &str) {
-        self.polls_total.with_label_values(&[shard]).inc();
+    /// Record a poll (lease_tasks call) for a shard/task_group.
+    pub fn record_poll(&self, shard: &str, task_group: &str) {
+        self.polls_total
+            .with_label_values(&[shard, task_group])
+            .inc();
     }
 
-    /// Record poll duration (time to service a lease_tasks call for a shard) in seconds.
-    pub fn record_poll_duration(&self, shard: &str, duration_secs: f64) {
+    /// Record poll duration (time to service a lease_tasks call for a shard/task_group) in seconds.
+    pub fn record_poll_duration(&self, shard: &str, task_group: &str, duration_secs: f64) {
         self.poll_duration
-            .with_label_values(&[shard])
+            .with_label_values(&[shard, task_group])
             .observe(duration_secs);
     }
 
@@ -1057,9 +1059,9 @@ pub fn init() -> anyhow::Result<Metrics> {
         CounterVec::new(
             Opts::new(
                 "silo_polls_total",
-                "Total number of lease_tasks polls received per shard",
+                "Total number of lease_tasks polls received per shard/task_group",
             ),
-            &["shard"],
+            &["shard", "task_group"],
         )?,
     );
 
@@ -1068,10 +1070,10 @@ pub fn init() -> anyhow::Result<Metrics> {
         HistogramVec::new(
             HistogramOpts::new(
                 "silo_poll_duration_seconds",
-                "Duration of lease_tasks poll per shard in seconds",
+                "Duration of lease_tasks poll per shard/task_group in seconds",
             )
             .buckets(LATENCY_BUCKETS.to_vec()),
-            &["shard"],
+            &["shard", "task_group"],
         )?,
     );
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1139,8 +1139,12 @@ impl Silo for SiloService {
             let now_ms = crate::job_store_shard::now_epoch_ms();
 
             if let Some(ref m) = self.metrics {
-                m.record_poll(&shard_str);
-                m.record_poll_duration(&shard_str, poll_start.elapsed().as_secs_f64());
+                m.record_poll(&shard_str, &r.task_group);
+                m.record_poll_duration(
+                    &shard_str,
+                    &r.task_group,
+                    poll_start.elapsed().as_secs_f64(),
+                );
             }
 
             for lt in result.tasks {


### PR DESCRIPTION
## Summary
- Adds a `task_group` label to `silo_polls_total` and `silo_poll_duration_seconds`. `task_group` is a required field on `LeaseTasksRequest` and is already in scope at the call site, so this is just plumbing through what's already known.
- Matches the labeling on `silo_jobs_dequeued_total`, which means you can finally do per-`task_group` "polls vs. dequeues" / empty-poll panels — useful for diagnosing "why didn't this group get a lease?" on the dashboards.

## Test plan
- [x] `cargo check --all-targets` clean
- [x] `cargo fmt`
- [ ] Confirm in staging Grafana that the new label appears on `silo_polls_total` and `silo_poll_duration_seconds`