### PR TITLE
Expose jemalloc stats and process collector as Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,7 +2367,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.59.0",
 ]
 
@@ -3456,6 +3456,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -4355,6 +4361,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.9.4",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.9.4",
+ "hex",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4363,8 +4392,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs",
  "protobuf",
  "thiserror 1.0.69",
 ]
@@ -4897,6 +4928,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -4904,7 +4948,7 @@ dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.0",
 ]
 
@@ -5808,7 +5852,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tracing-opentelemetry = "0.27"
 opentelemetry = { version = "0.26" }
 opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.26", features = ["http-json", "trace"] }
-prometheus = "0.13"
+prometheus = { version = "0.13", features = ["process"] }
 usdt = "0.6.0"
 tempfile = "3"
 async-trait = "0.1"
@@ -89,8 +89,8 @@ rand = "0.9"
 datafusion-sql = { version = "50", optional = true }
 hostname = "0.4"
 pprof = { version = "0.15", features = ["prost-codec", "frame-pointer"] }
-tikv-jemallocator = { version = "0.6", features = ["profiling"] }
-tikv-jemalloc-ctl = { version = "0.6", features = ["profiling"] }
+tikv-jemallocator = { version = "0.6", features = ["profiling", "stats"] }
+tikv-jemalloc-ctl = { version = "0.6", features = ["profiling", "stats"] }
 flate2 = "1"
 urlencoding = "2"
 storekey = { version = "0.11", features = ["storekey-derive"] }

--- a/src/jemalloc_metrics.rs
+++ b/src/jemalloc_metrics.rs
@@ -8,8 +8,6 @@
 //! Jemalloc caches stats per "epoch" — `epoch::advance()` must be called
 //! before reading or the values are stale.
 
-#![cfg(unix)]
-
 use std::time::Duration;
 
 use prometheus::{Gauge, Registry, core::Collector};

--- a/src/jemalloc_metrics.rs
+++ b/src/jemalloc_metrics.rs
@@ -1,0 +1,130 @@
+//! Jemalloc allocator stats exposed through the Prometheus registry.
+//!
+//! Surfaces the five canonical jemalloc memory counters so we can tell whether
+//! the gap between live data and process RSS is purgeable retained pages
+//! (`retained`), genuinely live allocations (`allocated`), or non-jemalloc
+//! mmaps (RSS far above `mapped`).
+//!
+//! Jemalloc caches stats per "epoch" — `epoch::advance()` must be called
+//! before reading or the values are stale.
+
+#![cfg(unix)]
+
+use std::time::Duration;
+
+use prometheus::{Gauge, Registry, core::Collector};
+use tikv_jemalloc_ctl::{epoch, stats};
+use tokio::sync::broadcast;
+use tracing::debug;
+
+#[derive(Clone)]
+pub struct JemallocMetrics {
+    allocated: Gauge,
+    active: Gauge,
+    resident: Gauge,
+    retained: Gauge,
+    mapped: Gauge,
+}
+
+impl JemallocMetrics {
+    pub fn register(registry: &Registry) -> anyhow::Result<Self> {
+        let allocated = register(
+            registry,
+            Gauge::new(
+                "silo_jemalloc_allocated_bytes",
+                "Bytes allocated by the application (stats.allocated).",
+            )?,
+        );
+        let active = register(
+            registry,
+            Gauge::new(
+                "silo_jemalloc_active_bytes",
+                "Bytes in active pages allocated by the application (stats.active).",
+            )?,
+        );
+        let resident = register(
+            registry,
+            Gauge::new(
+                "silo_jemalloc_resident_bytes",
+                "Bytes in physically resident data pages (stats.resident).",
+            )?,
+        );
+        let retained = register(
+            registry,
+            Gauge::new(
+                "silo_jemalloc_retained_bytes",
+                "Bytes retained by jemalloc but not mapped (stats.retained, purgeable).",
+            )?,
+        );
+        let mapped = register(
+            registry,
+            Gauge::new(
+                "silo_jemalloc_mapped_bytes",
+                "Bytes in mapped chunks (stats.mapped).",
+            )?,
+        );
+        Ok(Self {
+            allocated,
+            active,
+            resident,
+            retained,
+            mapped,
+        })
+    }
+
+    pub fn scrape(&self) {
+        if let Err(e) = epoch::advance() {
+            debug!(error = %e, "jemalloc epoch advance failed");
+            return;
+        }
+        if let Ok(v) = stats::allocated::read() {
+            self.allocated.set(v as f64);
+        }
+        if let Ok(v) = stats::active::read() {
+            self.active.set(v as f64);
+        }
+        if let Ok(v) = stats::resident::read() {
+            self.resident.set(v as f64);
+        }
+        if let Ok(v) = stats::retained::read() {
+            self.retained.set(v as f64);
+        }
+        if let Ok(v) = stats::mapped::read() {
+            self.mapped.set(v as f64);
+        }
+    }
+}
+
+fn register<C: Collector + Clone + 'static>(registry: &Registry, metric: C) -> C {
+    if let Err(e) = registry.register(Box::new(metric.clone())) {
+        tracing::warn!(error = %e, "failed to register jemalloc metric");
+    }
+    metric
+}
+
+pub async fn run_scraper(
+    metrics: JemallocMetrics,
+    interval: Duration,
+    mut shutdown: broadcast::Receiver<()>,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    debug!(
+        interval_ms = interval.as_millis() as u64,
+        "jemalloc metrics scraper started"
+    );
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.recv() => {
+                debug!("jemalloc metrics scraper shutting down");
+                break;
+            }
+            _ = ticker.tick() => {
+                metrics.scrape();
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub mod grpc_trace;
 pub mod gubernator;
 pub mod heap_profile;
 pub mod instrumented_db;
+#[cfg(unix)]
+pub mod jemalloc_metrics;
 pub mod job;
 pub mod job_attempt;
 pub mod job_store_shard;

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,19 @@ async fn main() -> anyhow::Result<()> {
         ))
     });
 
+    // Periodic jemalloc stats scrape: lets us distinguish purgeable retained
+    // pages from genuinely live allocations vs non-jemalloc mmaps.
+    #[cfg(unix)]
+    let _jemalloc_metrics_handle = metrics.as_ref().map(|m| {
+        let jm = m.jemalloc.clone();
+        let shutdown = shutdown_tx.subscribe();
+        tokio::spawn(silo::jemalloc_metrics::run_scraper(
+            jm,
+            Duration::from_secs(1),
+            shutdown,
+        ))
+    });
+
     // Log server startup with all enabled endpoints
     let webui_addr_str = if cfg.webui.enabled {
         Some(cfg.webui.addr.as_str())

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -145,6 +145,10 @@ pub struct Metrics {
     /// Tokio runtime metrics (worker busy time, queue depths, mean poll time)
     /// driven by a periodic scraper spawned in `main.rs`.
     pub tokio_runtime: crate::tokio_runtime_metrics::TokioRuntimeMetrics,
+
+    /// Jemalloc allocator stats driven by a periodic scraper spawned in `main.rs`.
+    #[cfg(unix)]
+    pub jemalloc: crate::jemalloc_metrics::JemallocMetrics,
 }
 
 /// SlateDB per-shard metric instruments plus the previous-value map needed
@@ -897,6 +901,16 @@ fn register<C: Collector + Clone + 'static>(registry: &Registry, metric: C) -> C
 pub fn init() -> anyhow::Result<Metrics> {
     let registry = Registry::new();
 
+    // Process-level metrics (RSS, VSZ, FDs, CPU). Linux-only because the
+    // prometheus crate's ProcessCollector reads /proc.
+    #[cfg(target_os = "linux")]
+    {
+        let pc = prometheus::process_collector::ProcessCollector::for_self();
+        if let Err(e) = registry.register(Box::new(pc)) {
+            tracing::warn!(error = %e, "failed to register process collector");
+        }
+    }
+
     // Job metrics
     let jobs_enqueued = register(
         &registry,
@@ -1227,6 +1241,8 @@ pub fn init() -> anyhow::Result<Metrics> {
 
     let slatedb = SlatedbShardMetrics::register(&registry, "silo_")?;
     let tokio_runtime = crate::tokio_runtime_metrics::TokioRuntimeMetrics::register(&registry)?;
+    #[cfg(unix)]
+    let jemalloc = crate::jemalloc_metrics::JemallocMetrics::register(&registry)?;
 
     Ok(Metrics {
         registry: Arc::new(registry),
@@ -1262,6 +1278,8 @@ pub fn init() -> anyhow::Result<Metrics> {
         slatedb_manifest_checkpoints_count,
         slatedb,
         tokio_runtime,
+        #[cfg(unix)]
+        jemalloc,
     })
 }
 


### PR DESCRIPTION
## Summary
- Adds five `silo_jemalloc_*_bytes` gauges (`allocated`, `active`, `resident`, `retained`, `mapped`) sourced from `tikv-jemalloc-ctl`, driven by a 1 s background scraper that mirrors the existing `tokio_runtime_metrics` pattern. Calling `epoch::advance()` before each read keeps the values fresh.
- Registers the `prometheus` crate's built-in `ProcessCollector` under `cfg(target_os = "linux")`, exposing `process_resident_memory_bytes`, `process_virtual_memory_bytes`, `process_cpu_seconds_total`, `process_open_fds`, `process_start_time_seconds`.
- Together these let us tell whether RSS growth is jemalloc retained pages (purgeable), genuinely live allocations, or non-jemalloc mmaps (e.g. cached object store file mappings) by comparing `process_resident_memory_bytes` against `silo_jemalloc_mapped_bytes` and the `resident - allocated` gap against `retained`.

## Test plan
- [x] `nix develop -c cargo build --bin silo` succeeds
- [x] `nix develop -c cargo check --bin silo --all-features` succeeds
- [ ] Deploy to staging, curl `/metrics` and confirm `silo_jemalloc_*_bytes` (five gauges, non-zero) and `process_*` series appear
- [ ] Spot-check that `silo_jemalloc_resident_bytes - silo_jemalloc_allocated_bytes` is roughly `silo_jemalloc_retained_bytes` under steady state