### PR TITLE
Drop lg_prof_sample from compiled-in MALLOC_CONF

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ union MallocConfPtr {
 }
 
 #[cfg(unix)]
-const MALLOC_CONF_STR: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
+const MALLOC_CONF_STR: &[u8] = b"prof:true,prof_active:false\0";
 
 // This build keeps jemalloc's default `_rjem_` prefixing. If we switch to
 // `unprefixed_malloc_on_supported_platforms` later, this export should change


### PR DESCRIPTION
## Summary
- Remove the hardcoded `lg_prof_sample:19` from the compiled-in jemalloc `MALLOC_CONF`
- The sample rate will be set via the `MALLOC_CONF` env var at deploy time instead, so it can be tuned per deployment without rebuilding

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo clippy --lib` passes
- [ ] Confirm `MALLOC_CONF=lg_prof_sample:N` (or equivalent) is wired up in the deployment env to retain the previous sampling behaviour