### PR TITLE
Jitter the concurrency reconcile task's first tick per shard

### DIFF
--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -618,6 +618,33 @@ impl JobStoreShard {
         let reconcile_interval = self.concurrency_reconcile_interval;
 
         tokio::spawn(async move {
+            // Deterministic jitter based on shard name so that many shards
+            // opened simultaneously in one process don't all scan the
+            // CONCURRENCY_REQUESTS prefix at the same instant.
+            let interval_ms = reconcile_interval.as_millis() as u64;
+            let jitter_ms = if interval_ms > 0 {
+                let mut h: u64 = 1469598103934665603;
+                for b in shard_name.as_bytes() {
+                    h ^= *b as u64;
+                    h = h.wrapping_mul(1099511628211);
+                }
+                h % interval_ms
+            } else {
+                0
+            };
+
+            tokio::select! {
+                biased;
+                _ = tokio::time::sleep(Duration::from_millis(jitter_ms)) => {}
+                _ = cancellation.cancelled() => {
+                    tracing::debug!(
+                        shard = %shard_name,
+                        "stopping periodic concurrency reconciliation before first tick (shard closing)"
+                    );
+                    return;
+                }
+            }
+
             let mut interval = tokio::time::interval(reconcile_interval);
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 


### PR DESCRIPTION
## Summary
- When many shards open at once in one process, all their `CONCURRENCY_REQUESTS` prefix scans fire in lockstep on the configured interval, spiking object-store reads on the same wall-clock instant.
- Sleep a shard-name-deterministic jitter in `[0, reconcile_interval)` before the first tick of the concurrency reconcile task, then proceed on the normal interval. This mirrors the pattern already used by `spawn_counter_reconcile_task`.
- Deterministic (FNV-1a over `shard_name`), so simulation tests stay reproducible.

## Test plan
- [x] `cargo fmt`
- [x] `cargo check`
- [x] `cargo clippy --lib -- -D warnings` (pre-existing clippy errors in `tests/etcd_coordination_tests.rs` are untouched and unrelated)