### PR TITLE
Add reconcile_pending_requests memory + scan metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
             runner: blacksmith-8vcpu-ubuntu-2404
             nix_system: x86_64-linux
           - platform: arm64
-            runner: blacksmith-8vcpu-ubuntu-2404-arm
+            runner: blacksmith-16vcpu-ubuntu-2404-arm
             nix_system: aarch64-linux
     runs-on: ${{ matrix.runner }}
     permissions:

--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -613,6 +613,9 @@ pub async fn clone_golden_shard(
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS,
             ),
             enable_counter_reconciliation: false,
+            background_task_gate: Arc::new(tokio::sync::Semaphore::new(
+                silo::settings::DEFAULT_BACKGROUND_TASK_CONCURRENCY,
+            )),
         },
         ShardRange::full(),
     )

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -164,6 +164,14 @@ const STATUS_LOOKUP_CONCURRENCY: usize = 64;
 /// the requested count.
 const MAX_GRANTS_PER_PASS: usize = 256;
 
+/// Number of keys `reconcile_pending_requests` scans through one open
+/// iterator before dropping it and reopening at the next key. Caps the
+/// SST iterator's live heap residency (decoded index entries plus the
+/// buffered data block) so a shard with a very large `CONCURRENCY_REQUESTS`
+/// prefix doesn't accumulate iterator state proportional to the full
+/// prefix size before the sweep finishes.
+const RECONCILE_REOPEN_AFTER: u32 = 4_096;
+
 /// Result of attempting to enqueue a job with concurrency limits
 #[derive(Debug)]
 pub enum RequestTicketOutcome {
@@ -782,56 +790,89 @@ impl ConcurrencyManager {
         let probe = ReconcileMemProbe::start();
         let t0 = std::time::Instant::now();
 
-        let start = concurrency_requests_prefix();
-        let end = end_bound(&start);
-        // Reconciliation is a one-shot cold sweep over the full shard prefix on
-        // a slow cadence; pinning the touched SST blocks into the cache (which
-        // [`crate::scan_options`] does) inflates RSS without any hit-rate gain.
-        let mut iter = match db
-            .scan_with_options::<Vec<u8>, _>(start..end, &crate::cold_scan_options())
-            .await
-        {
-            Ok(i) => i,
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "grant scanner: failed to scan requests during reconciliation"
-                );
-                return;
-            }
-        };
+        let prefix = concurrency_requests_prefix();
+        let end = end_bound(&prefix);
 
         // Count pending requests per (tenant, queue)
         let mut queue_counts: BTreeMap<Vec<u8>, (String, String, u32)> = BTreeMap::new();
         let mut keys_scanned: u64 = 0;
-        loop {
-            let kv = match iter.next().await {
-                Ok(Some(kv)) => kv,
-                Ok(None) => break,
+
+        // Drop+reopen pacing: every `RECONCILE_REOPEN_AFTER` keys we drop the
+        // iterator and reopen it just past the last key. This bounds the live
+        // SST iterator state (decoded index entries + buffered data blocks)
+        // across the full sweep — the failure mode without this is that a
+        // shard with millions of pending requests pulls the entire prefix's
+        // worth of SST blocks into the iterator's heap residency before the
+        // sweep finishes.
+        //
+        // The reconcile scan is also a cold sweep, so reopening pays only the
+        // SST index decode cost; data blocks aren't cached either way (see
+        // `cold_scan_options`).
+        let mut next_start: Vec<u8> = prefix;
+        'outer: loop {
+            let mut iter = match db
+                .scan_with_options::<Vec<u8>, _>(
+                    next_start.clone()..end.clone(),
+                    &crate::cold_scan_options(),
+                )
+                .await
+            {
+                Ok(i) => i,
                 Err(e) => {
                     tracing::warn!(
                         error = %e,
-                        "grant scanner: reconciliation scan iteration error"
+                        "grant scanner: failed to scan requests during reconciliation"
                     );
-                    break;
+                    return;
                 }
             };
-            keys_scanned += 1;
 
-            let Some(parsed) = parse_concurrency_request_key(&kv.key) else {
-                continue;
-            };
+            let mut keys_this_pass: u32 = 0;
+            // Loop until the iterator is exhausted (break 'outer) or we hit
+            // the per-pass cap (continue 'outer to reopen at the next key).
+            loop {
+                let kv = match iter.next().await {
+                    Ok(Some(kv)) => kv,
+                    Ok(None) => break 'outer,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "grant scanner: reconciliation scan iteration error"
+                        );
+                        break 'outer;
+                    }
+                };
+                keys_scanned += 1;
+                keys_this_pass += 1;
 
-            // Only process requests for tenants in our range
-            if !range.contains_tenant(&parsed.tenant) {
-                continue;
+                if let Some(parsed) = parse_concurrency_request_key(&kv.key) {
+                    // Only process requests for tenants in our range
+                    if range.contains_tenant(&parsed.tenant) {
+                        let key = concurrency_counts_key(&parsed.tenant, &parsed.queue);
+                        let entry = queue_counts
+                            .entry(key)
+                            .or_insert_with(|| (parsed.tenant.clone(), parsed.queue.clone(), 0));
+                        entry.2 += 1;
+                    }
+                }
+
+                if keys_this_pass >= RECONCILE_REOPEN_AFTER {
+                    // Advance past this key. Appending a zero byte yields the
+                    // lexicographically next key, which is the smallest key
+                    // the next half-open scan must include. Drop the iterator
+                    // first so the buffered SST blocks and index entries it
+                    // holds are released before the next pass opens fresh
+                    // ones. Yield to the runtime to avoid starving other
+                    // shard tasks if the entire pass ran without awaiting on
+                    // I/O (block cache hits, in-memtable reads).
+                    let mut next = kv.key.to_vec();
+                    next.push(0);
+                    drop(iter);
+                    next_start = next;
+                    tokio::task::yield_now().await;
+                    continue 'outer;
+                }
             }
-
-            let key = concurrency_counts_key(&parsed.tenant, &parsed.queue);
-            let entry = queue_counts
-                .entry(key)
-                .or_insert_with(|| (parsed.tenant.clone(), parsed.queue.clone(), 0));
-            entry.2 += 1;
         }
 
         let queues_found = queue_counts.len() as u64;

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -68,22 +68,35 @@ use crate::shard_range::ShardRange;
 use crate::task::{ConcurrencyAction, HolderRecord, Task};
 use crate::task_broker::TaskBrokerRegistry;
 
-/// Probe for capturing jemalloc allocated/resident deltas across a code region.
+/// Probe for capturing the *peak* jemalloc allocated/resident growth across a
+/// code region with multiple natural sample points.
 ///
-/// `start()` records the current allocated/resident counters (after advancing
-/// the jemalloc stats epoch), and `finish()` re-reads them and returns the
-/// signed deltas. On non-unix or when jemalloc isn't built in, both values
-/// come back as zero.
+/// `start()` records the baseline counters. `observe()` re-reads the counters
+/// and updates the running max of `current - baseline`. `finish()` returns
+/// the peak deltas seen across all `observe()` calls.
 ///
-/// Note: jemalloc's `stats.*` counters are process-global, so concurrent work
-/// on other tasks bleeds into the delta. The delta is still useful as a
-/// directional signal when this scan dominates the shard's work during its
-/// run, and the histogram aggregates across many samples.
+/// This shape matters because the thing we want to size is *in-flight*
+/// allocations (e.g. an SST iterator's buffered blocks), not lasting growth.
+/// A naive before/after probe would miss everything the iterator allocated
+/// and freed before `finish()` — `stats::allocated` is current, not peak. By
+/// `observe()`-ing at each iterator drop point (after `RECONCILE_REOPEN_AFTER`
+/// keys), we capture the iterator's working set right before it's released.
+///
+/// `stats::resident` is sticky — jemalloc keeps physical pages around after
+/// `free` for arena reuse — so it grows monotonically over a region but is
+/// noisier and process-global. The peak metric on resident is roughly the
+/// high-water mark of physical pages this scan caused jemalloc to map.
+///
+/// On non-unix or when jemalloc isn't built in, all values are zero.
 struct ReconcileMemProbe {
     #[cfg(unix)]
-    allocated_before: i64,
+    allocated_baseline: i64,
     #[cfg(unix)]
-    resident_before: i64,
+    resident_baseline: i64,
+    #[cfg(unix)]
+    peak_allocated_delta: i64,
+    #[cfg(unix)]
+    peak_resident_delta: i64,
 }
 
 impl ReconcileMemProbe {
@@ -95,11 +108,14 @@ impl ReconcileMemProbe {
             // advance. If the call fails, we still capture whatever the cache
             // holds — the delta is a relative measure.
             let _ = tikv_jemalloc_ctl::epoch::advance();
-            let allocated_before = tikv_jemalloc_ctl::stats::allocated::read().unwrap_or(0) as i64;
-            let resident_before = tikv_jemalloc_ctl::stats::resident::read().unwrap_or(0) as i64;
+            let allocated_baseline =
+                tikv_jemalloc_ctl::stats::allocated::read().unwrap_or(0) as i64;
+            let resident_baseline = tikv_jemalloc_ctl::stats::resident::read().unwrap_or(0) as i64;
             Self {
-                allocated_before,
-                resident_before,
+                allocated_baseline,
+                resident_baseline,
+                peak_allocated_delta: 0,
+                peak_resident_delta: 0,
             }
         }
         #[cfg(not(unix))]
@@ -108,16 +124,30 @@ impl ReconcileMemProbe {
         }
     }
 
-    fn finish(self) -> (i64, i64) {
+    /// Sample the current counters and update the peak deltas. Cheap enough
+    /// to call at each reopen point (every few thousand keys); too expensive
+    /// to call per-key (`epoch::advance` triggers a per-arena stats refresh).
+    fn observe(&mut self) {
         #[cfg(unix)]
         {
             let _ = tikv_jemalloc_ctl::epoch::advance();
-            let allocated_after = tikv_jemalloc_ctl::stats::allocated::read().unwrap_or(0) as i64;
-            let resident_after = tikv_jemalloc_ctl::stats::resident::read().unwrap_or(0) as i64;
-            (
-                allocated_after - self.allocated_before,
-                resident_after - self.resident_before,
-            )
+            let allocated_now = tikv_jemalloc_ctl::stats::allocated::read().unwrap_or(0) as i64;
+            let resident_now = tikv_jemalloc_ctl::stats::resident::read().unwrap_or(0) as i64;
+            let allocated_delta = allocated_now - self.allocated_baseline;
+            let resident_delta = resident_now - self.resident_baseline;
+            if allocated_delta > self.peak_allocated_delta {
+                self.peak_allocated_delta = allocated_delta;
+            }
+            if resident_delta > self.peak_resident_delta {
+                self.peak_resident_delta = resident_delta;
+            }
+        }
+    }
+
+    fn finish(self) -> (i64, i64) {
+        #[cfg(unix)]
+        {
+            (self.peak_allocated_delta, self.peak_resident_delta)
         }
         #[cfg(not(unix))]
         {
@@ -787,7 +817,7 @@ impl ConcurrencyManager {
     /// This is used at grant-scanner startup and by the shard's periodic
     /// reconciliation task to self-heal from missed notifications.
     pub async fn reconcile_pending_requests(&self, db: &InstrumentedDb, range: &ShardRange) {
-        let probe = ReconcileMemProbe::start();
+        let mut probe = ReconcileMemProbe::start();
         let t0 = std::time::Instant::now();
 
         let prefix = concurrency_requests_prefix();
@@ -833,8 +863,15 @@ impl ConcurrencyManager {
             loop {
                 let kv = match iter.next().await {
                     Ok(Some(kv)) => kv,
-                    Ok(None) => break 'outer,
+                    Ok(None) => {
+                        // Sample peak memory before the iterator is dropped
+                        // at the end of this scope so we capture whatever
+                        // working set it built up on this final pass.
+                        probe.observe();
+                        break 'outer;
+                    }
                     Err(e) => {
+                        probe.observe();
                         tracing::warn!(
                             error = %e,
                             "grant scanner: reconciliation scan iteration error"
@@ -857,6 +894,12 @@ impl ConcurrencyManager {
                 }
 
                 if keys_this_pass >= RECONCILE_REOPEN_AFTER {
+                    // Sample peak memory *before* the iterator is dropped:
+                    // its in-flight buffered SST blocks and decoded index
+                    // entries are what we're trying to size, and they're
+                    // gone once we drop it.
+                    probe.observe();
+
                     // Advance past this key. Appending a zero byte yields the
                     // lexicographically next key, which is the smallest key
                     // the next half-open scan must include. Drop the iterator

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -68,6 +68,64 @@ use crate::shard_range::ShardRange;
 use crate::task::{ConcurrencyAction, HolderRecord, Task};
 use crate::task_broker::TaskBrokerRegistry;
 
+/// Probe for capturing jemalloc allocated/resident deltas across a code region.
+///
+/// `start()` records the current allocated/resident counters (after advancing
+/// the jemalloc stats epoch), and `finish()` re-reads them and returns the
+/// signed deltas. On non-unix or when jemalloc isn't built in, both values
+/// come back as zero.
+///
+/// Note: jemalloc's `stats.*` counters are process-global, so concurrent work
+/// on other tasks bleeds into the delta. The delta is still useful as a
+/// directional signal when this scan dominates the shard's work during its
+/// run, and the histogram aggregates across many samples.
+struct ReconcileMemProbe {
+    #[cfg(unix)]
+    allocated_before: i64,
+    #[cfg(unix)]
+    resident_before: i64,
+}
+
+impl ReconcileMemProbe {
+    fn start() -> Self {
+        #[cfg(unix)]
+        {
+            // Advance the jemalloc stats epoch so the subsequent reads return
+            // current values rather than the cached snapshot from the last
+            // advance. If the call fails, we still capture whatever the cache
+            // holds — the delta is a relative measure.
+            let _ = tikv_jemalloc_ctl::epoch::advance();
+            let allocated_before = tikv_jemalloc_ctl::stats::allocated::read().unwrap_or(0) as i64;
+            let resident_before = tikv_jemalloc_ctl::stats::resident::read().unwrap_or(0) as i64;
+            Self {
+                allocated_before,
+                resident_before,
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            Self {}
+        }
+    }
+
+    fn finish(self) -> (i64, i64) {
+        #[cfg(unix)]
+        {
+            let _ = tikv_jemalloc_ctl::epoch::advance();
+            let allocated_after = tikv_jemalloc_ctl::stats::allocated::read().unwrap_or(0) as i64;
+            let resident_after = tikv_jemalloc_ctl::stats::resident::read().unwrap_or(0) as i64;
+            (
+                allocated_after - self.allocated_before,
+                resident_after - self.resident_before,
+            )
+        }
+        #[cfg(not(unix))]
+        {
+            (0, 0)
+        }
+    }
+}
+
 /// Error type for concurrency operations that can fail due to storage or encoding errors.
 #[derive(Debug, thiserror::Error)]
 pub enum ConcurrencyError {
@@ -721,10 +779,16 @@ impl ConcurrencyManager {
     /// This is used at grant-scanner startup and by the shard's periodic
     /// reconciliation task to self-heal from missed notifications.
     pub async fn reconcile_pending_requests(&self, db: &InstrumentedDb, range: &ShardRange) {
+        let probe = ReconcileMemProbe::start();
+        let t0 = std::time::Instant::now();
+
         let start = concurrency_requests_prefix();
         let end = end_bound(&start);
+        // Reconciliation is a one-shot cold sweep over the full shard prefix on
+        // a slow cadence; pinning the touched SST blocks into the cache (which
+        // [`crate::scan_options`] does) inflates RSS without any hit-rate gain.
         let mut iter = match db
-            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::cold_scan_options())
             .await
         {
             Ok(i) => i,
@@ -739,6 +803,7 @@ impl ConcurrencyManager {
 
         // Count pending requests per (tenant, queue)
         let mut queue_counts: BTreeMap<Vec<u8>, (String, String, u32)> = BTreeMap::new();
+        let mut keys_scanned: u64 = 0;
         loop {
             let kv = match iter.next().await {
                 Ok(Some(kv)) => kv,
@@ -751,6 +816,7 @@ impl ConcurrencyManager {
                     break;
                 }
             };
+            keys_scanned += 1;
 
             let Some(parsed) = parse_concurrency_request_key(&kv.key) else {
                 continue;
@@ -768,9 +834,23 @@ impl ConcurrencyManager {
             entry.2 += 1;
         }
 
+        let queues_found = queue_counts.len() as u64;
+
         // Trigger grants for each queue with pending requests
         for (_key, (tenant, queue, count)) in queue_counts {
             self.request_grant_count(&tenant, &queue, count);
+        }
+
+        if let Some(ref m) = self.metrics {
+            let (allocated_delta, resident_delta) = probe.finish();
+            m.record_concurrency_reconcile(
+                &self.shard,
+                t0.elapsed().as_secs_f64(),
+                keys_scanned,
+                queues_found,
+                allocated_delta,
+                resident_delta,
+            );
         }
     }
 

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -850,7 +850,7 @@ impl ConcurrencyManager {
             let mut iter = match db
                 .scan_with_options::<Vec<u8>, _>(
                     next_start.clone()..end.clone(),
-                    &crate::scan_options(),
+                    &crate::cold_scan_options(),
                 )
                 .await
             {

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -766,12 +766,23 @@ impl ConcurrencyManager {
         db: Arc<InstrumentedDb>,
         brokers: Arc<TaskBrokerRegistry>,
         range: ShardRange,
+        background_task_gate: Arc<tokio::sync::Semaphore>,
     ) {
         self.grant_running.store(true, Ordering::SeqCst);
         let mgr = Arc::clone(self);
         tokio::spawn(async move {
-            // Startup: scan for existing pending requests
-            mgr.reconcile_pending_requests(&db, &range).await;
+            // Startup: scan for existing pending requests. Acquire a permit
+            // from the process-wide gate first so a node hosting many shards
+            // doesn't fan out N startup scans at once.
+            match background_task_gate.acquire().await {
+                Ok(_permit) => {
+                    mgr.reconcile_pending_requests(&db, &range).await;
+                }
+                Err(_) => {
+                    // Semaphore closed before startup reconcile ran.
+                    return;
+                }
+            }
 
             loop {
                 mgr.grant_notify.notified().await;
@@ -834,16 +845,12 @@ impl ConcurrencyManager {
         // shard with millions of pending requests pulls the entire prefix's
         // worth of SST blocks into the iterator's heap residency before the
         // sweep finishes.
-        //
-        // The reconcile scan is also a cold sweep, so reopening pays only the
-        // SST index decode cost; data blocks aren't cached either way (see
-        // `cold_scan_options`).
         let mut next_start: Vec<u8> = prefix;
         'outer: loop {
             let mut iter = match db
                 .scan_with_options::<Vec<u8>, _>(
                     next_start.clone()..end.clone(),
-                    &crate::cold_scan_options(),
+                    &crate::scan_options(),
                 )
                 .await
             {

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -962,6 +962,11 @@ impl ConcurrencyManager {
         queue: &str,
         count: u32,
     ) -> Vec<String> {
+        let t0 = std::time::Instant::now();
+        let mut passes: u64 = 0;
+        let mut keys_scanned: u64 = 0;
+        let mut stale_deleted_total: u64 = 0;
+
         if let Err(e) = self.counts.ensure_hydrated(db, range, tenant, queue).await {
             tracing::warn!(
                 error = %e,
@@ -969,6 +974,15 @@ impl ConcurrencyManager {
                 queue = %queue,
                 "grant scanner: failed to hydrate queue"
             );
+            if let Some(ref m) = self.metrics {
+                m.record_concurrency_process_grants(
+                    &self.shard,
+                    t0.elapsed().as_secs_f64(),
+                    passes,
+                    keys_scanned,
+                    stale_deleted_total,
+                );
+            }
             return Vec::new();
         }
 
@@ -984,6 +998,15 @@ impl ConcurrencyManager {
             Ok(i) => i,
             Err(e) => {
                 tracing::warn!(error = %e, "grant scanner: failed to scan requests");
+                if let Some(ref m) = self.metrics {
+                    m.record_concurrency_process_grants(
+                        &self.shard,
+                        t0.elapsed().as_secs_f64(),
+                        passes,
+                        keys_scanned,
+                        stale_deleted_total,
+                    );
+                }
                 return Vec::new();
             }
         };
@@ -1014,6 +1037,7 @@ impl ConcurrencyManager {
         // so a large accumulated `count` is drained over multiple bounded passes
         // rather than one unbounded one.
         while total_granted < count as usize && !iter_exhausted && !capacity_exhausted {
+            passes += 1;
             let needed = (count as usize - total_granted).min(MAX_GRANTS_PER_PASS);
 
             let mut batch = WriteBatch::new();
@@ -1035,6 +1059,7 @@ impl ConcurrencyManager {
                         break;
                     }
                 };
+                keys_scanned += 1;
 
                 let parsed_req = parse_concurrency_request_key(&kv.key);
 
@@ -1292,8 +1317,21 @@ impl ConcurrencyManager {
                     prior_grants = total_granted,
                     "grant scanner: batch write failed, rolled back this pass's reservations"
                 );
+                if let Some(ref m) = self.metrics {
+                    m.record_concurrency_process_grants(
+                        &self.shard,
+                        t0.elapsed().as_secs_f64(),
+                        passes,
+                        keys_scanned,
+                        stale_deleted_total,
+                    );
+                }
                 return all_granted_groups;
             }
+            // Only count stale deletions after the batch successfully commits;
+            // a failed commit leaves the stale rows in the DB so we'll see them
+            // again next pass.
+            stale_deleted_total += stale_and_corrupt_count as u64;
 
             for (request_id, task_group) in &grants {
                 tracing::debug!(
@@ -1314,6 +1352,16 @@ impl ConcurrencyManager {
 
             total_granted += grants.len();
             all_granted_groups.extend(grants.into_iter().map(|(_, tg)| tg));
+        }
+
+        if let Some(ref m) = self.metrics {
+            m.record_concurrency_process_grants(
+                &self.shard,
+                t0.elapsed().as_secs_f64(),
+                passes,
+                keys_scanned,
+                stale_deleted_total,
+            );
         }
 
         all_granted_groups

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -66,6 +66,13 @@ pub struct ShardFactory {
 }
 
 impl ShardFactory {
+    /// Build a factory from a validated template.
+    ///
+    /// Callers are expected to have run `DatabaseTemplate::validate()` already
+    /// (e.g. via `AppConfig::load`), which rejects
+    /// `background_task_concurrency == 0`. The `.max(1)` below is defense-in-
+    /// depth: if a caller bypasses validation, the gate falls back to one
+    /// permit instead of deadlocking on `acquire`.
     pub fn new(
         template: DatabaseTemplate,
         rate_limiter: Arc<dyn RateLimitClient>,

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
-use tokio::sync::OnceCell;
+use tokio::sync::{OnceCell, Semaphore};
 
 use crate::gubernator::RateLimitClient;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError, OpenShardOptions};
@@ -59,6 +59,10 @@ pub struct ShardFactory {
     rate_limiter: Arc<dyn RateLimitClient>,
     metrics: Option<Metrics>,
     close_timeout: Duration,
+    /// Process-global cap on heavy background scan concurrency. Shared with
+    /// every shard opened by this factory and with the lease reaper loop that
+    /// iterates shards. See `DatabaseTemplate::background_task_concurrency`.
+    background_task_gate: Arc<Semaphore>,
 }
 
 impl ShardFactory {
@@ -67,12 +71,15 @@ impl ShardFactory {
         rate_limiter: Arc<dyn RateLimitClient>,
         metrics: Option<Metrics>,
     ) -> Self {
+        let background_task_gate =
+            Arc::new(Semaphore::new(template.background_task_concurrency.max(1)));
         Self {
             instances: DashMap::new(),
             template,
             rate_limiter,
             metrics,
             close_timeout: DEFAULT_CLOSE_TIMEOUT,
+            background_task_gate,
         }
     }
 
@@ -84,17 +91,26 @@ impl ShardFactory {
     pub fn new_noop() -> Self {
         use crate::gubernator::NullGubernatorClient;
 
+        let template = DatabaseTemplate {
+            path: "/noop".to_string(),
+            apply_wal_on_close: false,
+            ..Default::default()
+        };
+        let background_task_gate =
+            Arc::new(Semaphore::new(template.background_task_concurrency.max(1)));
         Self {
             instances: DashMap::new(),
-            template: DatabaseTemplate {
-                path: "/noop".to_string(),
-                apply_wal_on_close: false,
-                ..Default::default()
-            },
+            template,
             rate_limiter: NullGubernatorClient::new(),
             metrics: None,
             close_timeout: DEFAULT_CLOSE_TIMEOUT,
+            background_task_gate,
         }
+    }
+
+    /// Process-global semaphore that caps concurrent heavy background scans.
+    pub fn background_task_gate(&self) -> &Arc<Semaphore> {
+        &self.background_task_gate
     }
 
     /// Set the timeout for shard close operations.
@@ -146,6 +162,7 @@ impl ShardFactory {
         let template = &self.template;
         let rate_limiter = Arc::clone(&self.rate_limiter);
         let metrics = self.metrics.clone();
+        let background_task_gate = Arc::clone(&self.background_task_gate);
 
         entry
             .get_or_try_init(|| async {
@@ -192,6 +209,7 @@ impl ShardFactory {
                             template.concurrency_reconcile_interval_ms.max(1),
                         ),
                         enable_counter_reconciliation: template.enable_counter_reconciliation,
+                        background_task_gate: Arc::clone(&background_task_gate),
                     },
                     range.clone(),
                 )

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -287,6 +287,8 @@ impl JobStoreShard {
         metrics: Option<Metrics>,
         range: ShardRange,
     ) -> Result<Arc<Self>, JobStoreShardError> {
+        cfg.validate()
+            .map_err(JobStoreShardError::InvalidArgument)?;
         let resolved = resolve_object_store(&cfg.backend, &cfg.path)?;
 
         // Configure separate WAL object store if specified, and track for cleanup on close

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -36,6 +36,7 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
 use thiserror::Error;
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info_span};
 
@@ -89,6 +90,12 @@ pub struct OpenShardOptions {
     /// standalone compactor dropping terminal job rows; deployments that run
     /// the standalone compactor enable it. Defaults to off.
     pub enable_counter_reconciliation: bool,
+    /// Process-global cap on heavy background scan concurrency. Acquired
+    /// before reconcile_pending_requests, the counter reconciler, and the
+    /// lease reaper's per-shard scan, so the number of live SST iterators
+    /// across all shards is bounded. A single semaphore instance is shared
+    /// across all shards in the same factory.
+    pub background_task_gate: Arc<Semaphore>,
 }
 
 fn expand_slatedb_settings_for_shard(
@@ -142,6 +149,9 @@ pub struct JobStoreShard {
     pub(crate) metrics: Option<Metrics>,
     /// Interval for periodic concurrency request reconciliation.
     concurrency_reconcile_interval: Duration,
+    /// Process-global cap on heavy background scan concurrency. See
+    /// [`OpenShardOptions::background_task_gate`].
+    pub(crate) background_task_gate: Arc<Semaphore>,
     /// Cancellation token for background tasks like cleanup.
     /// Signaled when the shard is closing.
     cancellation: CancellationToken,
@@ -300,6 +310,8 @@ impl JobStoreShard {
         // Use SlateDB settings if configured
         let slatedb_settings = cfg.slatedb.clone();
 
+        let background_task_gate = Arc::new(Semaphore::new(cfg.background_task_concurrency.max(1)));
+
         Self::open_with_resolved_store(
             cfg.name.clone(),
             &resolved.canonical_path,
@@ -315,6 +327,7 @@ impl JobStoreShard {
                     crate::settings::DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS.max(1),
                 ),
                 enable_counter_reconciliation: cfg.enable_counter_reconciliation,
+                background_task_gate,
             },
             range,
         )
@@ -352,6 +365,7 @@ impl JobStoreShard {
             metrics,
             concurrency_reconcile_interval,
             enable_counter_reconciliation,
+            background_task_gate,
         } = options;
 
         let slatedb_metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
@@ -417,7 +431,12 @@ impl JobStoreShard {
 
         // Start the grant scanner after both ConcurrencyManager and TaskBrokerRegistry are ready.
         // It takes the instrumented db so its writes are tagged with the shard span too.
-        concurrency.start_grant_scanner(Arc::clone(&db), Arc::clone(&brokers), range.clone());
+        concurrency.start_grant_scanner(
+            Arc::clone(&db),
+            Arc::clone(&brokers),
+            range.clone(),
+            Arc::clone(&background_task_gate),
+        );
 
         let shard = Arc::new(Self {
             name,
@@ -430,6 +449,7 @@ impl JobStoreShard {
             wal_close_config,
             metrics,
             concurrency_reconcile_interval,
+            background_task_gate,
             cancellation: CancellationToken::new(),
             store,
             db_path: db_path.to_string(),
@@ -652,6 +672,12 @@ impl JobStoreShard {
                 tokio::select! {
                     biased;
                     _ = interval.tick() => {
+                        // Cap how many shards can be running this scan
+                        // concurrently across the whole process.
+                        let Ok(_permit) = shard.background_task_gate.acquire().await else {
+                            // Semaphore closed — process shutting down.
+                            break;
+                        };
                         shard
                             .concurrency
                             .reconcile_pending_requests(shard.db.as_ref(), &range)
@@ -723,6 +749,14 @@ impl JobStoreShard {
                 tokio::select! {
                     biased;
                     _ = interval.tick() => {
+                        // Cap how many shards can be running this scan
+                        // concurrently across the whole process. This task's
+                        // scan is the heaviest in silo (full JOB_INFO +
+                        // JOB_STATUS sweep), so the gate matters most here.
+                        let Ok(_permit) = shard.background_task_gate.acquire().await else {
+                            // Semaphore closed — process shutting down.
+                            break;
+                        };
                         let summary = shard.reconcile_counters(&range).await;
                         if summary.failed > 0 {
                             tracing::warn!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,3 +90,12 @@ pub static rjem_malloc_conf: Option<&'static std::ffi::c_char> = Some(unsafe {
 pub fn scan_options() -> slatedb::config::ScanOptions {
     slatedb::config::ScanOptions::default().with_cache_blocks(true)
 }
+
+/// Scan options for one-shot cold sweeps (e.g. periodic reconciliation).
+///
+/// Unlike [`scan_options`], these scans walk a large shard-wide prefix on a
+/// slow cadence and never revisit the same blocks soon after. Pinning the
+/// touched SST blocks into the cache bloats RSS for no hit-rate benefit.
+pub fn cold_scan_options() -> slatedb::config::ScanOptions {
+    slatedb::config::ScanOptions::default().with_cache_blocks(false)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,3 +90,12 @@ pub static rjem_malloc_conf: Option<&'static std::ffi::c_char> = Some(unsafe {
 pub fn scan_options() -> slatedb::config::ScanOptions {
     slatedb::config::ScanOptions::default().with_cache_blocks(true)
 }
+
+/// Scan options for one-shot cold sweeps (e.g. periodic reconciliation).
+///
+/// Unlike [`scan_options`], these scans walk a large shard-wide prefix on a
+/// slow cadence and never revisit the same blocks soon after. Pinning the
+/// touched SST blocks into the cache bloats RSS without any hit-rate gain.
+pub fn cold_scan_options() -> slatedb::config::ScanOptions {
+    slatedb::config::ScanOptions::default().with_cache_blocks(false)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,12 +90,3 @@ pub static rjem_malloc_conf: Option<&'static std::ffi::c_char> = Some(unsafe {
 pub fn scan_options() -> slatedb::config::ScanOptions {
     slatedb::config::ScanOptions::default().with_cache_blocks(true)
 }
-
-/// Scan options for one-shot cold sweeps (e.g. periodic reconciliation).
-///
-/// Unlike [`scan_options`], these scans walk a large shard-wide prefix on a
-/// slow cadence and never revisit the same blocks soon after. Pinning the
-/// touched SST blocks into the cache bloats RSS for no hit-rate benefit.
-pub fn cold_scan_options() -> slatedb::config::ScanOptions {
-    slatedb::config::ScanOptions::default().with_cache_blocks(false)
-}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -55,6 +55,34 @@ const WAIT_TIME_BUCKETS: &[f64] = &[
     0.001, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0, 1800.0, 3600.0,
 ];
 
+/// Histogram buckets for "items counted" in a reconcile sweep (keys scanned,
+/// queues with pending requests). Exponential, covers up to ~10M.
+const RECONCILE_ITEMS_BUCKETS: &[f64] = &[
+    1.0,
+    10.0,
+    100.0,
+    1_000.0,
+    10_000.0,
+    100_000.0,
+    1_000_000.0,
+    10_000_000.0,
+];
+
+/// Histogram buckets for memory-delta observations in bytes (jemalloc
+/// allocated/resident bytes before vs after a reconcile sweep). Exponential
+/// from 1KiB up to 4GiB.
+const RECONCILE_BYTES_BUCKETS: &[f64] = &[
+    1_024.0,
+    16_384.0,
+    262_144.0,
+    1_048_576.0,     // 1 MiB
+    16_777_216.0,    // 16 MiB
+    134_217_728.0,   // 128 MiB
+    536_870_912.0,   // 512 MiB
+    2_147_483_648.0, // 2 GiB
+    4_294_967_296.0, // 4 GiB
+];
+
 /// Histogram buckets for ready-to-start latency (in milliseconds)
 const READY_TO_START_LATENCY_MS_BUCKETS: &[f64] = &[
     1.0, 10.0, 50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 30000.0, 60000.0, 300000.0, 600000.0,
@@ -129,6 +157,12 @@ pub struct Metrics {
 
     // Concurrency metrics
     concurrency_tickets_granted: CounterVec,
+    concurrency_reconcile_duration: HistogramVec,
+    concurrency_reconcile_keys_scanned: HistogramVec,
+    concurrency_reconcile_queues_found: HistogramVec,
+    concurrency_reconcile_allocated_delta_bytes: HistogramVec,
+    concurrency_reconcile_resident_delta_bytes: HistogramVec,
+    concurrency_reconcile_total: CounterVec,
 
     // SlateDB watcher metrics (driven by Db::subscribe)
     slatedb_durable_seq: GaugeVec,
@@ -429,6 +463,44 @@ impl Metrics {
         self.concurrency_tickets_granted
             .with_label_values(&[shard, path.as_str()])
             .inc_by(n as f64);
+    }
+
+    /// Record one pass of `ConcurrencyManager::reconcile_pending_requests`.
+    ///
+    /// `allocated_delta` and `resident_delta` are jemalloc deltas (after - before)
+    /// captured around the scan. They are process-global, so concurrent work on
+    /// other shards bleeds in — but a sustained spike here when reconcile is the
+    /// dominant work isolates whether this scan is the OOM source.
+    pub fn record_concurrency_reconcile(
+        &self,
+        shard: &str,
+        duration_secs: f64,
+        keys_scanned: u64,
+        queues_found: u64,
+        allocated_delta_bytes: i64,
+        resident_delta_bytes: i64,
+    ) {
+        self.concurrency_reconcile_total
+            .with_label_values(&[shard])
+            .inc();
+        self.concurrency_reconcile_duration
+            .with_label_values(&[shard])
+            .observe(duration_secs);
+        self.concurrency_reconcile_keys_scanned
+            .with_label_values(&[shard])
+            .observe(keys_scanned as f64);
+        self.concurrency_reconcile_queues_found
+            .with_label_values(&[shard])
+            .observe(queues_found as f64);
+        // Clamp negative deltas to zero: histograms only meaningfully capture
+        // growth, and negatives mean other code freed more than reconcile
+        // allocated during the window (still useful as the bottom bucket).
+        self.concurrency_reconcile_allocated_delta_bytes
+            .with_label_values(&[shard])
+            .observe(allocated_delta_bytes.max(0) as f64);
+        self.concurrency_reconcile_resident_delta_bytes
+            .with_label_values(&[shard])
+            .observe(resident_delta_bytes.max(0) as f64);
     }
 
     /// Update SlateDB storage metrics from a shard's StatRegistry.
@@ -1172,6 +1244,77 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let concurrency_reconcile_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_concurrency_reconcile_total",
+                "Total number of reconcile_pending_requests sweeps per shard",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_reconcile_duration = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_concurrency_reconcile_duration_seconds",
+                "Wall time of reconcile_pending_requests sweeps per shard",
+            )
+            .buckets(SCAN_DURATION_BUCKETS.to_vec()),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_reconcile_keys_scanned = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_concurrency_reconcile_keys_scanned",
+                "Number of CONCURRENCY_REQUESTS keys read during a reconcile sweep",
+            )
+            .buckets(RECONCILE_ITEMS_BUCKETS.to_vec()),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_reconcile_queues_found = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_concurrency_reconcile_queues_found",
+                "Number of distinct (tenant, queue) pairs with pending requests in a reconcile sweep",
+            )
+            .buckets(RECONCILE_ITEMS_BUCKETS.to_vec()),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_reconcile_allocated_delta_bytes = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_concurrency_reconcile_allocated_delta_bytes",
+                "Process-global jemalloc stats.allocated delta (after - before) across a reconcile sweep",
+            )
+            .buckets(RECONCILE_BYTES_BUCKETS.to_vec()),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_reconcile_resident_delta_bytes = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_concurrency_reconcile_resident_delta_bytes",
+                "Process-global jemalloc stats.resident delta (after - before) across a reconcile sweep",
+            )
+            .buckets(RECONCILE_BYTES_BUCKETS.to_vec()),
+            &["shard"],
+        )?,
+    );
+
     // SlateDB watcher metrics (driven by Db::subscribe)
     let slatedb_durable_seq = register(
         &registry,
@@ -1270,6 +1413,12 @@ pub fn init() -> anyhow::Result<Metrics> {
         lease_reaper_leases_reaped_total,
         lease_reaper_errors_total,
         concurrency_tickets_granted,
+        concurrency_reconcile_duration,
+        concurrency_reconcile_keys_scanned,
+        concurrency_reconcile_queues_found,
+        concurrency_reconcile_allocated_delta_bytes,
+        concurrency_reconcile_resident_delta_bytes,
+        concurrency_reconcile_total,
         slatedb_durable_seq,
         slatedb_manifest_revisions,
         slatedb_manifest_last_l0_seq,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -163,6 +163,11 @@ pub struct Metrics {
     concurrency_reconcile_peak_allocated_bytes: HistogramVec,
     concurrency_reconcile_peak_resident_bytes: HistogramVec,
     concurrency_reconcile_total: CounterVec,
+    concurrency_process_grants_total: CounterVec,
+    concurrency_process_grants_passes_total: CounterVec,
+    concurrency_process_grants_stale_total: CounterVec,
+    concurrency_process_grants_duration: HistogramVec,
+    concurrency_process_grants_keys_scanned: HistogramVec,
 
     // SlateDB watcher metrics (driven by Db::subscribe)
     slatedb_durable_seq: GaugeVec,
@@ -503,6 +508,39 @@ impl Metrics {
         self.concurrency_reconcile_peak_resident_bytes
             .with_label_values(&[shard])
             .observe(peak_resident_bytes.max(0) as f64);
+    }
+
+    /// Record one invocation of `ConcurrencyManager::process_grants`.
+    ///
+    /// `passes` is the number of scan→validate→commit passes the call ran
+    /// (the outer `while total_granted < count` loop). `keys_scanned` is the
+    /// total number of CONCURRENCY_REQUESTS rows pulled from the iterator
+    /// across all passes; `stale_deleted` counts request rows deleted for
+    /// being malformed, of an unknown variant, or pointing at a job whose
+    /// status has moved past the request's attempt.
+    pub fn record_concurrency_process_grants(
+        &self,
+        shard: &str,
+        duration_secs: f64,
+        passes: u64,
+        keys_scanned: u64,
+        stale_deleted: u64,
+    ) {
+        self.concurrency_process_grants_total
+            .with_label_values(&[shard])
+            .inc();
+        self.concurrency_process_grants_passes_total
+            .with_label_values(&[shard])
+            .inc_by(passes as f64);
+        self.concurrency_process_grants_stale_total
+            .with_label_values(&[shard])
+            .inc_by(stale_deleted as f64);
+        self.concurrency_process_grants_duration
+            .with_label_values(&[shard])
+            .observe(duration_secs);
+        self.concurrency_process_grants_keys_scanned
+            .with_label_values(&[shard])
+            .observe(keys_scanned as f64);
     }
 
     /// Update SlateDB storage metrics from a shard's StatRegistry.
@@ -1317,6 +1355,63 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let concurrency_process_grants_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_concurrency_process_grants_total",
+                "Total number of process_grants invocations per shard (each invocation drains pending requests for a single (tenant, queue))",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_process_grants_passes_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_concurrency_process_grants_passes_total",
+                "Total number of scan->validate->commit passes across all process_grants invocations per shard",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_process_grants_stale_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_concurrency_process_grants_stale_total",
+                "Total number of request rows deleted by process_grants for being malformed, of unknown variant, or for a non-current job attempt",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_process_grants_duration = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_concurrency_process_grants_duration_seconds",
+                "Wall time of process_grants invocations per shard",
+            )
+            .buckets(SCAN_DURATION_BUCKETS.to_vec()),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_process_grants_keys_scanned = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_concurrency_process_grants_keys_scanned",
+                "Number of CONCURRENCY_REQUESTS keys read by a single process_grants invocation across all passes",
+            )
+            .buckets(RECONCILE_ITEMS_BUCKETS.to_vec()),
+            &["shard"],
+        )?,
+    );
+
     // SlateDB watcher metrics (driven by Db::subscribe)
     let slatedb_durable_seq = register(
         &registry,
@@ -1421,6 +1516,11 @@ pub fn init() -> anyhow::Result<Metrics> {
         concurrency_reconcile_peak_allocated_bytes,
         concurrency_reconcile_peak_resident_bytes,
         concurrency_reconcile_total,
+        concurrency_process_grants_total,
+        concurrency_process_grants_passes_total,
+        concurrency_process_grants_stale_total,
+        concurrency_process_grants_duration,
+        concurrency_process_grants_keys_scanned,
         slatedb_durable_seq,
         slatedb_manifest_revisions,
         slatedb_manifest_last_l0_seq,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -160,8 +160,8 @@ pub struct Metrics {
     concurrency_reconcile_duration: HistogramVec,
     concurrency_reconcile_keys_scanned: HistogramVec,
     concurrency_reconcile_queues_found: HistogramVec,
-    concurrency_reconcile_allocated_delta_bytes: HistogramVec,
-    concurrency_reconcile_resident_delta_bytes: HistogramVec,
+    concurrency_reconcile_peak_allocated_bytes: HistogramVec,
+    concurrency_reconcile_peak_resident_bytes: HistogramVec,
     concurrency_reconcile_total: CounterVec,
 
     // SlateDB watcher metrics (driven by Db::subscribe)
@@ -467,18 +467,20 @@ impl Metrics {
 
     /// Record one pass of `ConcurrencyManager::reconcile_pending_requests`.
     ///
-    /// `allocated_delta` and `resident_delta` are jemalloc deltas (after - before)
-    /// captured around the scan. They are process-global, so concurrent work on
-    /// other shards bleeds in — but a sustained spike here when reconcile is the
-    /// dominant work isolates whether this scan is the OOM source.
+    /// `peak_allocated_bytes` / `peak_resident_bytes` are the maximum
+    /// `current - baseline` deltas observed across the sweep (sampled at each
+    /// iterator-drop point, when the SST iterator's working set is fully
+    /// realized). They are process-global, so concurrent work on other shards
+    /// bleeds in — but a sustained spike here when reconcile is the dominant
+    /// work isolates whether this scan is the OOM source.
     pub fn record_concurrency_reconcile(
         &self,
         shard: &str,
         duration_secs: f64,
         keys_scanned: u64,
         queues_found: u64,
-        allocated_delta_bytes: i64,
-        resident_delta_bytes: i64,
+        peak_allocated_bytes: i64,
+        peak_resident_bytes: i64,
     ) {
         self.concurrency_reconcile_total
             .with_label_values(&[shard])
@@ -492,15 +494,15 @@ impl Metrics {
         self.concurrency_reconcile_queues_found
             .with_label_values(&[shard])
             .observe(queues_found as f64);
-        // Clamp negative deltas to zero: histograms only meaningfully capture
-        // growth, and negatives mean other code freed more than reconcile
-        // allocated during the window (still useful as the bottom bucket).
-        self.concurrency_reconcile_allocated_delta_bytes
+        // Clamp negative peaks to zero: the peak tracker only updates on
+        // growth, but if jemalloc's stats epoch lands awkwardly the baseline
+        // can exceed every sample. Negatives aren't meaningful for a peak.
+        self.concurrency_reconcile_peak_allocated_bytes
             .with_label_values(&[shard])
-            .observe(allocated_delta_bytes.max(0) as f64);
-        self.concurrency_reconcile_resident_delta_bytes
+            .observe(peak_allocated_bytes.max(0) as f64);
+        self.concurrency_reconcile_peak_resident_bytes
             .with_label_values(&[shard])
-            .observe(resident_delta_bytes.max(0) as f64);
+            .observe(peak_resident_bytes.max(0) as f64);
     }
 
     /// Update SlateDB storage metrics from a shard's StatRegistry.
@@ -1291,24 +1293,24 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
-    let concurrency_reconcile_allocated_delta_bytes = register(
+    let concurrency_reconcile_peak_allocated_bytes = register(
         &registry,
         HistogramVec::new(
             HistogramOpts::new(
-                "silo_concurrency_reconcile_allocated_delta_bytes",
-                "Process-global jemalloc stats.allocated delta (after - before) across a reconcile sweep",
+                "silo_concurrency_reconcile_peak_allocated_bytes",
+                "Peak in-flight jemalloc stats.allocated growth observed during a reconcile sweep (sampled at each iterator-drop point so SST iterator working sets are captured before they're freed)",
             )
             .buckets(RECONCILE_BYTES_BUCKETS.to_vec()),
             &["shard"],
         )?,
     );
 
-    let concurrency_reconcile_resident_delta_bytes = register(
+    let concurrency_reconcile_peak_resident_bytes = register(
         &registry,
         HistogramVec::new(
             HistogramOpts::new(
-                "silo_concurrency_reconcile_resident_delta_bytes",
-                "Process-global jemalloc stats.resident delta (after - before) across a reconcile sweep",
+                "silo_concurrency_reconcile_peak_resident_bytes",
+                "Peak jemalloc stats.resident growth observed during a reconcile sweep (high-water mark of resident pages caused by the scan; sticky relative to allocated)",
             )
             .buckets(RECONCILE_BYTES_BUCKETS.to_vec()),
             &["shard"],
@@ -1416,8 +1418,8 @@ pub fn init() -> anyhow::Result<Metrics> {
         concurrency_reconcile_duration,
         concurrency_reconcile_keys_scanned,
         concurrency_reconcile_queues_found,
-        concurrency_reconcile_allocated_delta_bytes,
-        concurrency_reconcile_resident_delta_bytes,
+        concurrency_reconcile_peak_allocated_bytes,
+        concurrency_reconcile_peak_resident_bytes,
         concurrency_reconcile_total,
         slatedb_durable_seq,
         slatedb_manifest_revisions,

--- a/src/server.rs
+++ b/src/server.rs
@@ -2110,8 +2110,16 @@ where
                         m.set_coordination_shards_open(instances.len() as u64);
                     }
 
-                    // Use default tenant "-" for system-level reaping
+                    // Use default tenant "-" for system-level reaping. Acquire
+                    // a permit from the process-global gate before each shard's
+                    // reap so the reaper can't fan out N concurrent lease-prefix
+                    // scans (or run alongside N reconcile/counter passes).
+                    let gate = reaper_factory.background_task_gate();
                     for (shard_id, shard) in instances.iter() {
+                        let Ok(_permit) = gate.acquire().await else {
+                            // Semaphore closed — process shutting down.
+                            break;
+                        };
                         let reap_start = std::time::Instant::now();
                         let result = shard.reap_expired_leases("-").await;
                         let shard_label = shard_id.to_string();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -272,6 +272,25 @@ impl Default for DatabaseTemplate {
     }
 }
 
+impl DatabaseTemplate {
+    /// Validate fields that have no sensible "zero" interpretation.
+    ///
+    /// `background_task_concurrency = 0` would create a `Semaphore` with no
+    /// permits, deadlocking every gated background task. Reject at parse
+    /// time so the failure is loud instead of silent. The constructors
+    /// downstream still floor at 1 as defense-in-depth, but no production
+    /// configuration should rely on that.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.background_task_concurrency == 0 {
+            return Err(
+                "database.background_task_concurrency must be >= 1 (got 0); use a positive value to cap heavy background scan parallelism"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
 /// Configuration for SlateDB's in-memory caches.
 ///
 /// SlateDB maintains two separate in-memory caches:
@@ -553,6 +572,19 @@ impl Default for DatabaseConfig {
     }
 }
 
+impl DatabaseConfig {
+    /// See [`DatabaseTemplate::validate`] for the rationale.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.background_task_concurrency == 0 {
+            return Err(
+                "database.background_task_concurrency must be >= 1 (got 0); use a positive value to cap heavy background scan parallelism"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum Backend {
@@ -682,6 +714,9 @@ impl AppConfig {
                 // This allows using ${VAR} or ${VAR:-default} syntax in config values.
                 let expanded = expand_env_vars(&data);
                 let cfg: Self = toml::from_str(&expanded)?;
+                cfg.database
+                    .validate()
+                    .map_err(|e| anyhow::anyhow!("invalid config: {e}"))?;
                 Ok(cfg)
             }
             None => Ok(default),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -193,6 +193,17 @@ fn default_enable_counter_reconciliation() -> bool {
     false
 }
 
+/// Default cap on how many heavy background scan tasks can run
+/// concurrently across the process (per shard reconcile_pending_requests,
+/// per shard counter reconciliation, and the global lease reaper as it
+/// walks each shard). Sized so a single host hosting many shards can't
+/// fan out all of them onto SST iterators at the same moment and OOM.
+pub const DEFAULT_BACKGROUND_TASK_CONCURRENCY: usize = 4;
+
+fn default_background_task_concurrency() -> usize {
+    DEFAULT_BACKGROUND_TASK_CONCURRENCY
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseTemplate {
     pub backend: Backend,
@@ -236,6 +247,13 @@ pub struct DatabaseTemplate {
     /// (512 MB for block cache, 128 MB for meta cache).
     #[serde(default)]
     pub memory_cache: Option<MemoryCacheConfig>,
+    /// Maximum number of heavy background scan tasks that may run
+    /// concurrently across the entire process. Gates per-shard
+    /// `reconcile_pending_requests`, per-shard counter reconciliation,
+    /// and the global lease reaper's per-shard scans. Caps the number of
+    /// SST iterators that can be live at once across all shards.
+    #[serde(default = "default_background_task_concurrency")]
+    pub background_task_concurrency: usize,
 }
 
 impl Default for DatabaseTemplate {
@@ -249,6 +267,7 @@ impl Default for DatabaseTemplate {
             enable_counter_reconciliation: default_enable_counter_reconciliation(),
             slatedb: None,
             memory_cache: None,
+            background_task_concurrency: default_background_task_concurrency(),
         }
     }
 }
@@ -512,6 +531,10 @@ pub struct DatabaseConfig {
     /// (512 MB for block cache, 128 MB for meta cache).
     #[serde(default)]
     pub memory_cache: Option<MemoryCacheConfig>,
+    /// Maximum number of heavy background scan tasks that may run
+    /// concurrently. See `DatabaseTemplate::background_task_concurrency`.
+    #[serde(default = "default_background_task_concurrency")]
+    pub background_task_concurrency: usize,
 }
 
 impl Default for DatabaseConfig {
@@ -525,6 +548,7 @@ impl Default for DatabaseConfig {
             enable_counter_reconciliation: default_enable_counter_reconciliation(),
             slatedb: None,
             memory_cache: None,
+            background_task_concurrency: default_background_task_concurrency(),
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -176,7 +176,7 @@ fn default_apply_wal_on_close() -> bool {
     true
 }
 
-pub const DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS: u64 = 5000;
+pub const DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS: u64 = 10_000;
 
 fn default_concurrency_reconcile_interval_ms() -> u64 {
     DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -597,6 +597,28 @@ enable_counter_reconciliation = true
     assert!(cfg.database.enable_counter_reconciliation);
 }
 
+#[silo::test]
+fn app_config_load_rejects_zero_background_task_concurrency() {
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    std::fs::write(
+        tmp.path(),
+        r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+background_task_concurrency = 0
+"#,
+    )
+    .expect("write");
+
+    let err = silo::settings::AppConfig::load(Some(tmp.path())).expect_err("expected rejection");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("background_task_concurrency"),
+        "error should mention the field; got: {msg}"
+    );
+}
+
 /// Guards against the manual `Default` impl on `DatabaseTemplate` drifting away
 /// from the serde defaults. If a future field is added with a `#[serde(default)]`
 /// but is not mirrored in the `Default` impl (or vice versa), this fails.

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -553,7 +553,7 @@ path = "/tmp/silo-%shard%"
     // slatedb should be None when not specified
     assert!(cfg.database.slatedb.is_none());
     assert_eq!(
-        cfg.database.concurrency_reconcile_interval_ms, 5000,
+        cfg.database.concurrency_reconcile_interval_ms, 10_000,
         "missing concurrency_reconcile_interval_ms should use default"
     );
 }

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -103,6 +103,9 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             metrics: None,
             concurrency_reconcile_interval: Duration::from_millis(interval_ms.max(1)),
             enable_counter_reconciliation: false,
+            background_task_gate: std::sync::Arc::new(tokio::sync::Semaphore::new(
+                silo::settings::DEFAULT_BACKGROUND_TASK_CONCURRENCY,
+            )),
         },
         ShardRange::full(),
     )


### PR DESCRIPTION
## Summary

- Wraps the periodic `ConcurrencyManager::reconcile_pending_requests` sweep with a jemalloc `stats.allocated` / `stats.resident` delta probe and exposes 6 new Prometheus series (`silo_concurrency_reconcile_*`): total, duration, keys_scanned, queues_found, allocated_delta_bytes, resident_delta_bytes — labelled by shard.
- Adds `crate::cold_scan_options()` (block-cache off) and switches the reconcile scan to it. Pinning the touched SST blocks into the cache for this slow-cadence shard-wide sweep was inflating RSS without any hit-rate gain.

## Motivation

Heap profiles in prod consistently show `Sst iterators` dominating, which lines up with the unbounded scan over `CONCURRENCY_REQUESTS` that this task does every 5s per shard. Before doing a bigger refactor (per-tenant ranges or yield-and-reopen pacing), get hard metrics on how much each pass actually allocates so we know we're looking at the right code.

## Test plan

- [ ] cargo check (clean locally)
- [ ] cargo clippy --lib (clean locally; existing test-file warnings are pre-existing on main)
- [ ] Deploy to staging and confirm the new histograms populate
- [ ] Verify `silo_concurrency_reconcile_allocated_delta_bytes` correlates with RSS growth bursts