### PR TITLE
Disable in-memory cache for full table scans

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -724,7 +724,7 @@ impl ConcurrencyManager {
         let start = concurrency_requests_prefix();
         let end = end_bound(&start);
         let mut iter = match db
-            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options_uncached())
             .await
         {
             Ok(i) => i,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,3 +90,11 @@ pub static rjem_malloc_conf: Option<&'static std::ffi::c_char> = Some(unsafe {
 pub fn scan_options() -> slatedb::config::ScanOptions {
     slatedb::config::ScanOptions::default().with_cache_blocks(true)
 }
+
+/// Variant of [`scan_options`] for full-prefix / one-shot scans where the
+/// scanned data is unlikely to be re-read soon. Disables block caching to
+/// avoid evicting hot blocks used by short-range scans on the steady-state
+/// path.
+pub fn scan_options_uncached() -> slatedb::config::ScanOptions {
+    scan_options().with_cache_blocks(false)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low functional risk since it only changes SlateDB scan caching behavior, but it could affect grant-scanner reconciliation performance (CPU vs cache churn) under load.
> 
> **Overview**
> Introduces `scan_options_uncached()` (disables `cache_blocks`) for full-prefix/one-shot scans to reduce eviction of hot blocks used by steady-state short-range scans.
> 
> Updates the concurrency grant scanner’s `reconcile_pending_requests` full-prefix scan to use the uncached options, aiming to avoid in-memory cache pollution during startup/periodic reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc7a1b410309beb285b1c4f777d92b7fca19ed75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->