### PR TITLE
Adding some metrics to see the size of concurrency caches

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -356,6 +356,32 @@ impl ConcurrencyCounts {
         let key = concurrency_counts_key(tenant, queue);
         h.get(&key).map(|s| s.len()).unwrap_or(0)
     }
+
+    /// Snapshot the sizes of the in-memory holders cache for metrics reporting.
+    pub fn cache_stats(&self) -> ConcurrencyCacheStats {
+        let (queue_count, total_holders) = {
+            let h = self.holders.lock().unwrap();
+            let total: usize = h.values().map(|s| s.len()).sum();
+            (h.len(), total)
+        };
+        let hydrated_queue_count = self.hydrated_queues.lock().unwrap().len();
+        ConcurrencyCacheStats {
+            total_holders,
+            queue_count,
+            hydrated_queue_count,
+        }
+    }
+}
+
+/// Snapshot of the in-memory concurrency holders cache for metrics reporting.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConcurrencyCacheStats {
+    /// Total number of holder entries across all tracked queues.
+    pub total_holders: usize,
+    /// Number of (tenant, queue) pairs currently tracked in the holders map.
+    pub queue_count: usize,
+    /// Number of (tenant, queue) pairs that have been hydrated from durable storage.
+    pub hydrated_queue_count: usize,
 }
 
 /// The type of concurrency limit for a queue.
@@ -411,6 +437,11 @@ impl ConcurrencyManager {
 
     pub fn counts(&self) -> &ConcurrencyCounts {
         &self.counts
+    }
+
+    /// Snapshot the sizes of the in-memory concurrency caches for metrics reporting.
+    pub fn cache_stats(&self) -> ConcurrencyCacheStats {
+        self.counts.cache_stats()
     }
 
     /// Cache the resolved concurrency limit for a queue. Called during enqueue and grant_next

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -766,6 +766,11 @@ impl JobStoreShard {
     pub fn broker_buffer_len(&self) -> usize {
         self.brokers.buffer_len()
     }
+
+    /// Snapshot the sizes of the in-memory concurrency holders cache.
+    pub fn concurrency_cache_stats(&self) -> crate::concurrency::ConcurrencyCacheStats {
+        self.concurrency.cache_stats()
+    }
     /// Get the SlateDB metrics registry for this shard.
     /// Use this to collect storage-level statistics for observability.
     pub fn slatedb_metrics_recorder(&self) -> &Arc<DefaultMetricsRecorder> {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -129,6 +129,9 @@ pub struct Metrics {
 
     // Concurrency metrics
     concurrency_tickets_granted: CounterVec,
+    concurrency_holders_cache_holders: GaugeVec,
+    concurrency_holders_cache_queues: GaugeVec,
+    concurrency_holders_cache_hydrated_queues: GaugeVec,
 
     // SlateDB watcher metrics (driven by Db::subscribe)
     slatedb_durable_seq: GaugeVec,
@@ -429,6 +432,23 @@ impl Metrics {
         self.concurrency_tickets_granted
             .with_label_values(&[shard, path.as_str()])
             .inc_by(n as f64);
+    }
+
+    /// Update the in-memory concurrency holders cache size gauges for a shard.
+    pub fn set_concurrency_holders_cache_stats(
+        &self,
+        shard: &str,
+        stats: crate::concurrency::ConcurrencyCacheStats,
+    ) {
+        self.concurrency_holders_cache_holders
+            .with_label_values(&[shard])
+            .set(stats.total_holders as f64);
+        self.concurrency_holders_cache_queues
+            .with_label_values(&[shard])
+            .set(stats.queue_count as f64);
+        self.concurrency_holders_cache_hydrated_queues
+            .with_label_values(&[shard])
+            .set(stats.hydrated_queue_count as f64);
     }
 
     /// Update SlateDB storage metrics from a shard's StatRegistry.
@@ -1172,6 +1192,39 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let concurrency_holders_cache_holders = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_concurrency_holders_cache_holders",
+                "Total number of holder entries in the in-memory concurrency holders cache",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_holders_cache_queues = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_concurrency_holders_cache_queues",
+                "Number of (tenant, queue) pairs tracked in the in-memory concurrency holders cache",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_holders_cache_hydrated_queues = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_concurrency_holders_cache_hydrated_queues",
+                "Number of (tenant, queue) pairs hydrated from durable storage into the concurrency holders cache",
+            ),
+            &["shard"],
+        )?,
+    );
+
     // SlateDB watcher metrics (driven by Db::subscribe)
     let slatedb_durable_seq = register(
         &registry,
@@ -1270,6 +1323,9 @@ pub fn init() -> anyhow::Result<Metrics> {
         lease_reaper_leases_reaped_total,
         lease_reaper_errors_total,
         concurrency_tickets_granted,
+        concurrency_holders_cache_holders,
+        concurrency_holders_cache_queues,
+        concurrency_holders_cache_hydrated_queues,
         slatedb_durable_seq,
         slatedb_manifest_revisions,
         slatedb_manifest_last_l0_seq,

--- a/src/server.rs
+++ b/src/server.rs
@@ -2158,8 +2158,13 @@ where
                 _ = interval.tick() => {
                     if let Some(ref m) = metrics_for_scrape {
                         for (shard_id, shard) in metrics_factory.instances().iter() {
+                            let shard_label = shard_id.to_string();
                             let recorder = shard.slatedb_metrics_recorder();
-                            m.update_slatedb_stats(&shard_id.to_string(), recorder);
+                            m.update_slatedb_stats(&shard_label, recorder);
+                            m.set_concurrency_holders_cache_stats(
+                                &shard_label,
+                                shard.concurrency_cache_stats(),
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk observability-only change that adds new Prometheus gauges and a periodic scrape; no concurrency-control logic or persistence behavior is modified.
> 
> **Overview**
> Adds per-shard Prometheus gauges to report the in-memory concurrency holders cache size (total holder entries, tracked queues, and hydrated queues).
> 
> Implements `cache_stats`/`ConcurrencyCacheStats` in the concurrency layer, exposes it via `JobStoreShard`, and updates `server.rs`’s 1s metrics scrape loop to publish these new gauges alongside existing SlateDB stats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe846e05649a60e48cdf5c776915cf793aa689e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->