### PR TITLE
Hydrate all queues at startup

### DIFF
--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -613,6 +613,7 @@ pub async fn clone_golden_shard(
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS,
             ),
             enable_counter_reconciliation: false,
+            hydrate_all_at_startup: false,
         },
         ShardRange::full(),
     )

--- a/specs/job_shard.als
+++ b/specs/job_shard.als
@@ -379,6 +379,31 @@ pred queueHasCapacity[q: Queue, t: Time] {
     no holdersAt[q, t]
 }
 
+-- ============================================================================
+-- Startup Hydration
+-- ============================================================================
+-- At process startup, the in-memory holders cache is populated by scanning
+-- every holder record in durable storage. Queues with zero holders at startup
+-- are deliberately omitted from the cache to avoid wasted work. The set
+-- `hydratedQueues` models that choice: it contains exactly the queues that
+-- had >=1 holder at the initial time `first`.
+
+/** Queues eagerly hydrated from durable storage at startup. */
+fun hydratedQueues: set Queue {
+    { q: Queue | some holdersAt[q, first] }
+}
+
+/** A queue is "observed" at t iff a holder or a request mentions it at t. */
+pred queueObservedAt[q: Queue, t: Time] {
+    some holdersAt[q, t] or some requestsAt[q, t]
+}
+
+/** First time the queue is observed across the whole trace. */
+pred queueFirstObservedAt[q: Queue, t: Time] {
+    queueObservedAt[q, t]
+    no tp: Time | lt[tp, t] and queueObservedAt[q, tp]
+}
+
 /** Check if a task holds all required queues for its job */
 pred taskHoldsAllQueues[tid: TaskId, j: Job, t: Time] {
     all q: jobQueues[j] | some h: TicketHolder | h.th_task = tid and h.th_queue = q and h.th_time = t
@@ -2123,6 +2148,26 @@ assert grantedMeansNoRequest {
 }
 
 /**
+ * Safety claim for the "skip empty queues at startup" optimization.
+ *
+ * Whenever we observe a queue at runtime that is NOT in `hydratedQueues`
+ * (i.e., we omitted it at startup because it had zero holders), at least one
+ * of the following holds:
+ *   (a) this is the very first time the queue is observed in the trace, OR
+ *   (b) the queue had zero holders at startup.
+ *
+ * Clause (b) is true by construction of `hydratedQueues`, so the assertion is
+ * provable. It is included as an explicit safety claim that documents the
+ * engineering invariant: a cache miss for an omitted queue can never surprise
+ * us with a "ghost" holder we forgot about.
+ */
+assert omittedQueuesAreSafe {
+    all q: Queue, t: Time |
+        (q not in hydratedQueues and queueObservedAt[q, t]) implies
+            (queueFirstObservedAt[q, t] or no holdersAt[q, first])
+}
+
+/**
  * Expedite doesn't change job status.
  * After expediting, the job remains in the same status (Scheduled).
  * See: [SILO-EXP-2] pre: not terminal, so status must be Scheduled or Running.
@@ -3249,6 +3294,12 @@ check grantedMeansNoRequest for 4 but 2 Job, 2 Worker, 3 TaskId, 4 Attempt, 8 Ti
     4 JobQueueRequirement, 8 TicketRequest, 8 TicketHolder
 
 check noHoldersForTerminal for 4 but 2 Job, 2 Worker, 3 TaskId, 4 Attempt, 8 Time, 2 Queue,
+    16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease,
+    6 DbCheckRateLimitTask, 6 BufferedCheckRateLimitTask,
+    8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 12 JobCancelled,
+    4 JobQueueRequirement, 8 TicketRequest, 8 TicketHolder
+
+check omittedQueuesAreSafe for 4 but 2 Job, 2 Worker, 3 TaskId, 4 Attempt, 8 Time, 2 Queue,
     16 JobState, 24 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease,
     6 DbCheckRateLimitTask, 6 BufferedCheckRateLimitTask,
     8 AttemptExists, 8 JobExists, 4 JobAttemptRelation, 12 JobCancelled,

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -37,7 +37,6 @@
 //!   this also catches any stale cancelled requests.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -197,15 +196,6 @@ fn queue_key(tenant: &str, queue: &str) -> QueueKey {
     (Arc::from(tenant), Arc::from(queue))
 }
 
-/// Reads `SILO_HYDRATE_ALL` once per process. When set to `1`, callers eagerly
-/// scan all queues at startup and treat `ensure_hydrated` misses as empty
-/// queues (`Hydrated` with no holders). When unset or any other value, the
-/// normal singleflighted JIT path runs on each miss.
-pub fn eager_hydration_enabled() -> bool {
-    static CACHED: OnceLock<bool> = OnceLock::new();
-    *CACHED.get_or_init(|| matches!(std::env::var("SILO_HYDRATE_ALL").as_deref(), Ok("1")))
-}
-
 /// In-memory counts for concurrency holders.
 ///
 /// Backed by a `DashMap` so each call serializes only on its shard's lock
@@ -219,6 +209,11 @@ pub fn eager_hydration_enabled() -> bool {
 /// lock. All such scopes in this file are explicit `{ ... }` blocks.
 pub struct ConcurrencyCounts {
     queues: Arc<DashMap<QueueKey, QueueEntry>>,
+    /// When `true`, `ensure_hydrated` treats `NotHydrated` misses as
+    /// already-hydrated empty queues — startup `hydrate_all` is expected to
+    /// have already scanned every non-empty queue. When `false`, the
+    /// singleflighted per-queue scan runs on miss.
+    hydrate_all_at_startup: bool,
 }
 
 impl Default for ConcurrencyCounts {
@@ -228,9 +223,17 @@ impl Default for ConcurrencyCounts {
 }
 
 impl ConcurrencyCounts {
+    /// JIT-hydration ConcurrencyCounts. Used by unit tests that don't go
+    /// through a real shard open; production code goes through
+    /// [`ConcurrencyCounts::with_config`].
     pub fn new() -> Self {
+        Self::with_config(false)
+    }
+
+    pub fn with_config(hydrate_all_at_startup: bool) -> Self {
         Self {
             queues: Arc::new(DashMap::new()),
+            hydrate_all_at_startup,
         }
     }
 
@@ -314,7 +317,7 @@ impl ConcurrencyCounts {
     /// scan future, store it on the entry, spawn a detached driver to keep
     /// it making progress regardless of caller cancellation, and await.
     ///
-    /// When `SILO_HYDRATE_ALL=1`, `hydrate_all` has already loaded every
+    /// When `hydrate_all_at_startup` is set, `hydrate_all` has already loaded every
     /// non-empty queue at startup, so a `NotHydrated` miss here is a queue
     /// with zero durable holders. We flip it to `Hydrated` in place rather
     /// than scanning durable storage again.
@@ -336,7 +339,7 @@ impl ConcurrencyCounts {
             match &entry.state {
                 HydrationState::Hydrated => HydrateAction::Done,
                 HydrationState::Hydrating(fut) => HydrateAction::Wait(fut.clone()),
-                HydrationState::NotHydrated if eager_hydration_enabled() => {
+                HydrationState::NotHydrated if self.hydrate_all_at_startup => {
                     // Startup `hydrate_all` already scanned every non-empty
                     // queue, so a miss is an empty queue. Skip the per-queue
                     // scan and treat as hydrated.
@@ -648,10 +651,14 @@ pub struct ConcurrencyManager {
 }
 
 impl ConcurrencyManager {
-    pub fn new(shard: impl Into<String>, metrics: Option<Metrics>) -> Self {
+    pub fn new(
+        shard: impl Into<String>,
+        metrics: Option<Metrics>,
+        hydrate_all_at_startup: bool,
+    ) -> Self {
         Self {
             shard: shard.into(),
-            counts: ConcurrencyCounts::new(),
+            counts: ConcurrencyCounts::with_config(hydrate_all_at_startup),
             pending_grants: Mutex::new(BTreeMap::new()),
             grant_notify: tokio::sync::Notify::new(),
             grant_running: AtomicBool::new(false),

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -37,6 +37,7 @@
 //!   this also catches any stale cancelled requests.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -196,6 +197,15 @@ fn queue_key(tenant: &str, queue: &str) -> QueueKey {
     (Arc::from(tenant), Arc::from(queue))
 }
 
+/// Reads `SILO_HYDRATE_ALL` once per process. When set to `1`, callers eagerly
+/// scan all queues at startup and treat `ensure_hydrated` misses as empty
+/// queues (`Hydrated` with no holders). When unset or any other value, the
+/// normal singleflighted JIT path runs on each miss.
+pub fn eager_hydration_enabled() -> bool {
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| matches!(std::env::var("SILO_HYDRATE_ALL").as_deref(), Ok("1")))
+}
+
 /// In-memory counts for concurrency holders.
 ///
 /// Backed by a `DashMap` so each call serializes only on its shard's lock
@@ -303,6 +313,11 @@ impl ConcurrencyCounts {
     /// Slow path: if a scan is in flight, await it; otherwise build a new
     /// scan future, store it on the entry, spawn a detached driver to keep
     /// it making progress regardless of caller cancellation, and await.
+    ///
+    /// When `SILO_HYDRATE_ALL=1`, `hydrate_all` has already loaded every
+    /// non-empty queue at startup, so a `NotHydrated` miss here is a queue
+    /// with zero durable holders. We flip it to `Hydrated` in place rather
+    /// than scanning durable storage again.
     pub async fn ensure_hydrated(
         &self,
         db: &Arc<InstrumentedDb>,
@@ -321,6 +336,13 @@ impl ConcurrencyCounts {
             match &entry.state {
                 HydrationState::Hydrated => HydrateAction::Done,
                 HydrationState::Hydrating(fut) => HydrateAction::Wait(fut.clone()),
+                HydrationState::NotHydrated if eager_hydration_enabled() => {
+                    // Startup `hydrate_all` already scanned every non-empty
+                    // queue, so a miss is an empty queue. Skip the per-queue
+                    // scan and treat as hydrated.
+                    entry.state = HydrationState::Hydrated;
+                    HydrateAction::Done
+                }
                 HydrationState::NotHydrated => {
                     let fut = build_hydrate_future(
                         Arc::clone(&self.queues),

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -258,6 +258,7 @@ impl ConcurrencyCounts {
         db: &InstrumentedDb,
         range: &ShardRange,
     ) -> Result<(), slatedb::Error> {
+        let started_at = std::time::Instant::now();
         let start = concurrency_holders_prefix();
         let end = end_bound(&start);
         let mut iter = db
@@ -304,6 +305,7 @@ impl ConcurrencyCounts {
         tracing::info!(
             queues = queue_count,
             holders = holder_count,
+            elapsed_ms = started_at.elapsed().as_millis() as u64,
             "hydrated concurrency holders cache at startup"
         );
         Ok(())

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -61,10 +61,11 @@ use crate::dst_events::{self, DstEvent};
 use crate::job::{ConcurrencyLimit, JobStatusKind, JobView, Limit};
 use crate::job_store_shard::helpers::decode_job_status_owned;
 use crate::keys::{
-    concurrency_counts_key, concurrency_holder_key, concurrency_holders_queue_prefix,
-    concurrency_request_key, concurrency_request_prefix, concurrency_requester_counter_key,
-    concurrency_requests_prefix, end_bound, floating_limit_state_key, job_status_key,
-    parse_concurrency_holder_key, parse_concurrency_request_key, task_key,
+    concurrency_counts_key, concurrency_holder_key, concurrency_holders_prefix,
+    concurrency_holders_queue_prefix, concurrency_request_key, concurrency_request_prefix,
+    concurrency_requester_counter_key, concurrency_requests_prefix, end_bound,
+    floating_limit_state_key, job_status_key, parse_concurrency_holder_key,
+    parse_concurrency_request_key, task_key,
 };
 use crate::metrics::Metrics;
 use crate::shard_range::ShardRange;
@@ -221,6 +222,137 @@ impl ConcurrencyCounts {
         Self {
             queues: Arc::new(DashMap::new()),
         }
+    }
+
+    /// Hydrate a specific queue's concurrency holder state from durable storage.
+    ///
+    /// Uses the per-queue prefix for efficient scanning of only the relevant holders. The `range` parameter filters holders to only load those for tenants within the shard's range. This is critical after shard splits - both child shards clone the same holder records, and without filtering, both would think they own the same concurrency tickets, leading to limit violations.
+    pub async fn hydrate_queue(
+        &self,
+        db: &InstrumentedDb,
+        range: &ShardRange,
+        tenant: &str,
+        queue: &str,
+    ) -> Result<(), slatedb::Error> {
+        let key = concurrency_counts_key(tenant, queue);
+
+        // Scan holders for this specific tenant/queue using the queue prefix
+        let start = concurrency_holders_queue_prefix(tenant, queue);
+        let end = end_bound(&start);
+        let mut iter = db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
+
+        let mut task_ids = Vec::new();
+        loop {
+            let maybe = iter.next().await?;
+            let Some(kv) = maybe else { break };
+
+            // Parse holder key to extract tenant, queue, task_id
+            let Some(parsed) = parse_concurrency_holder_key(&kv.key) else {
+                continue;
+            };
+
+            // Filter by shard range - only hydrate holders for tenants in this shard
+            if !range.contains_tenant(&parsed.tenant) {
+                tracing::debug!(
+                    tenant = %parsed.tenant,
+                    queue = %parsed.queue,
+                    task = %parsed.task_id,
+                    range = %range,
+                    "skipping holder outside shard range during queue hydration"
+                );
+                continue;
+            }
+
+            task_ids.push(parsed.task_id);
+        }
+
+        // Update holders map
+        {
+            let mut h = self.holders.lock().unwrap();
+            let set = h.entry(key.clone()).or_default();
+            for task_id in task_ids {
+                set.insert(task_id);
+            }
+        }
+
+        // Mark queue as hydrated
+        {
+            let mut hydrated = self.hydrated_queues.lock().unwrap();
+            hydrated.insert(key);
+        }
+
+        Ok(())
+    }
+
+    /// Eagerly hydrate every (tenant, queue) pair that has at least one
+    /// in-range holder in durable storage. Called once at shard startup so
+    /// that `try_reserve` and the grant scanner observe accurate capacity
+    /// from the very first operation.
+    ///
+    /// Queues with zero holders are deliberately skipped — they don't appear
+    /// in the scan, so they're never inserted into `holders` or
+    /// `hydrated_queues`. The lazy `ensure_hydrated` path remains responsible
+    /// for them: when such a queue is first encountered after startup, the
+    /// per-queue scan correctly finds zero durable holders (see the
+    /// `omittedQueuesAreSafe` assertion in specs/job_shard.als).
+    ///
+    /// The `range` parameter filters holders to only those for tenants within
+    /// the shard's range. This is critical after shard splits — both child
+    /// shards may see the same holder records in durable storage but only one
+    /// of them owns each tenant.
+    pub async fn hydrate_all(
+        &self,
+        db: &InstrumentedDb,
+        range: &ShardRange,
+    ) -> Result<(), slatedb::Error> {
+        let start = concurrency_holders_prefix();
+        let end = end_bound(&start);
+        let mut iter = db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
+
+        // Group task_ids by composite key. BTreeMap gives deterministic
+        // iteration order for DST reproducibility.
+        let mut grouped: BTreeMap<Vec<u8>, HashSet<String>> = BTreeMap::new();
+        loop {
+            let Some(kv) = iter.next().await? else { break };
+            let Some(parsed) = parse_concurrency_holder_key(&kv.key) else {
+                continue;
+            };
+            if !range.contains_tenant(&parsed.tenant) {
+                tracing::debug!(
+                    tenant = %parsed.tenant,
+                    queue = %parsed.queue,
+                    task = %parsed.task_id,
+                    range = %range,
+                    "skipping holder outside shard range during startup hydration"
+                );
+                continue;
+            }
+            let key = concurrency_counts_key(&parsed.tenant, &parsed.queue);
+            grouped.entry(key).or_default().insert(parsed.task_id);
+        }
+
+        let queue_count = grouped.len();
+        let holder_count: usize = grouped.values().map(|s| s.len()).sum();
+
+        {
+            let mut h = self.holders.lock().unwrap();
+            let mut hydrated = self.hydrated_queues.lock().unwrap();
+            for (key, set) in grouped {
+                h.insert(key.clone(), set);
+                hydrated.insert(key);
+            }
+        }
+
+        tracing::info!(
+            queues = queue_count,
+            holders = holder_count,
+            "hydrated concurrency holders cache at startup"
+        );
+        Ok(())
     }
 
     /// Ensure a queue is hydrated before checking capacity.

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -224,68 +224,6 @@ impl ConcurrencyCounts {
         }
     }
 
-    /// Hydrate a specific queue's concurrency holder state from durable storage.
-    ///
-    /// Uses the per-queue prefix for efficient scanning of only the relevant holders. The `range` parameter filters holders to only load those for tenants within the shard's range. This is critical after shard splits - both child shards clone the same holder records, and without filtering, both would think they own the same concurrency tickets, leading to limit violations.
-    pub async fn hydrate_queue(
-        &self,
-        db: &InstrumentedDb,
-        range: &ShardRange,
-        tenant: &str,
-        queue: &str,
-    ) -> Result<(), slatedb::Error> {
-        let key = concurrency_counts_key(tenant, queue);
-
-        // Scan holders for this specific tenant/queue using the queue prefix
-        let start = concurrency_holders_queue_prefix(tenant, queue);
-        let end = end_bound(&start);
-        let mut iter = db
-            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
-            .await?;
-
-        let mut task_ids = Vec::new();
-        loop {
-            let maybe = iter.next().await?;
-            let Some(kv) = maybe else { break };
-
-            // Parse holder key to extract tenant, queue, task_id
-            let Some(parsed) = parse_concurrency_holder_key(&kv.key) else {
-                continue;
-            };
-
-            // Filter by shard range - only hydrate holders for tenants in this shard
-            if !range.contains_tenant(&parsed.tenant) {
-                tracing::debug!(
-                    tenant = %parsed.tenant,
-                    queue = %parsed.queue,
-                    task = %parsed.task_id,
-                    range = %range,
-                    "skipping holder outside shard range during queue hydration"
-                );
-                continue;
-            }
-
-            task_ids.push(parsed.task_id);
-        }
-
-        // Update holders map
-        {
-            let mut h = self.holders.lock().unwrap();
-            let set = h.entry(key.clone()).or_default();
-            for task_id in task_ids {
-                set.insert(task_id);
-            }
-        }
-
-        // Mark queue as hydrated
-        {
-            let mut hydrated = self.hydrated_queues.lock().unwrap();
-            hydrated.insert(key);
-        }
-
-        Ok(())
-    }
-
     /// Eagerly hydrate every (tenant, queue) pair that has at least one
     /// in-range holder in durable storage. Called once at shard startup so
     /// that `try_reserve` and the grant scanner observe accurate capacity
@@ -315,7 +253,7 @@ impl ConcurrencyCounts {
 
         // Group task_ids by composite key. BTreeMap gives deterministic
         // iteration order for DST reproducibility.
-        let mut grouped: BTreeMap<Vec<u8>, HashSet<String>> = BTreeMap::new();
+        let mut grouped: BTreeMap<QueueKey, HashSet<String>> = BTreeMap::new();
         loop {
             let Some(kv) = iter.next().await? else { break };
             let Some(parsed) = parse_concurrency_holder_key(&kv.key) else {
@@ -331,20 +269,23 @@ impl ConcurrencyCounts {
                 );
                 continue;
             }
-            let key = concurrency_counts_key(&parsed.tenant, &parsed.queue);
+            let key = queue_key(&parsed.tenant, &parsed.queue);
             grouped.entry(key).or_default().insert(parsed.task_id);
         }
 
         let queue_count = grouped.len();
         let holder_count: usize = grouped.values().map(|s| s.len()).sum();
 
-        {
-            let mut h = self.holders.lock().unwrap();
-            let mut hydrated = self.hydrated_queues.lock().unwrap();
-            for (key, set) in grouped {
-                h.insert(key.clone(), set);
-                hydrated.insert(key);
+        // DashMap shards are per-key, so we acquire each entry's guard
+        // individually and drop it at the end of the iteration. Called once
+        // at startup before workers run, so no concurrent `ensure_hydrated`
+        // can race here.
+        for (key, set) in grouped {
+            let mut entry = self.queues.entry(key).or_insert_with(QueueEntry::new);
+            for task_id in set {
+                entry.holders.insert(task_id);
             }
+            entry.state = HydrationState::Hydrated;
         }
 
         tracing::info!(

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -192,6 +192,7 @@ impl ShardFactory {
                             template.concurrency_reconcile_interval_ms.max(1),
                         ),
                         enable_counter_reconciliation: template.enable_counter_reconciliation,
+                        hydrate_all_at_startup: template.hydrate_all_at_startup,
                     },
                     range.clone(),
                 )

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -89,6 +89,15 @@ pub struct OpenShardOptions {
     /// standalone compactor dropping terminal job rows; deployments that run
     /// the standalone compactor enable it. Defaults to off.
     pub enable_counter_reconciliation: bool,
+    /// When true, scan every concurrency holder into the in-memory cache
+    /// before opening the shard for ticket granting, and treat
+    /// `ensure_hydrated` misses thereafter as empty queues. When false, no
+    /// startup scan runs and the singleflighted per-queue `ensure_hydrated`
+    /// path hydrates each queue lazily on first access.
+    ///
+    /// Populated from `DatabaseConfig::hydrate_all_at_startup` /
+    /// `DatabaseTemplate::hydrate_all_at_startup`; tests set it explicitly.
+    pub hydrate_all_at_startup: bool,
 }
 
 fn expand_slatedb_settings_for_shard(
@@ -327,6 +336,7 @@ impl JobStoreShard {
                     crate::settings::DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS.max(1),
                 ),
                 enable_counter_reconciliation: cfg.enable_counter_reconciliation,
+                hydrate_all_at_startup: cfg.hydrate_all_at_startup,
             },
             range,
         )
@@ -364,6 +374,7 @@ impl JobStoreShard {
             metrics,
             concurrency_reconcile_interval,
             enable_counter_reconciliation,
+            hydrate_all_at_startup,
         } = options;
 
         let slatedb_metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
@@ -415,7 +426,11 @@ impl JobStoreShard {
         let shard_span = info_span!("shard", shard = %name);
         let db = db_builder.build().instrument(shard_span.clone()).await?;
         let db = InstrumentedDb::new(Arc::new(db), shard_span);
-        let concurrency = Arc::new(ConcurrencyManager::new(name.clone(), metrics.clone()));
+        let concurrency = Arc::new(ConcurrencyManager::new(
+            name.clone(),
+            metrics.clone(),
+            hydrate_all_at_startup,
+        ));
 
         // Eagerly hydrate the in-memory holders cache from durable storage so
         // that try_reserve and the grant scanner observe accurate capacity
@@ -423,9 +438,10 @@ impl JobStoreShard {
         // when eager mode is enabled, `ensure_hydrated` treats such misses as
         // empty hydrated queues (see omittedQueuesAreSafe in specs/job_shard.als).
         //
-        // Gated by `SILO_HYDRATE_ALL=1`. Unset / `0` falls back to the
-        // singleflighted JIT path on first access.
-        if crate::concurrency::eager_hydration_enabled() {
+        // Controlled by `hydrate_all_at_startup`. When false, the
+        // singleflighted JIT `ensure_hydrated` path covers each queue on
+        // first access.
+        if hydrate_all_at_startup {
             concurrency.counts().hydrate_all(&db, &range).await?;
         }
 

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -417,8 +417,12 @@ impl JobStoreShard {
         let db = InstrumentedDb::new(Arc::new(db), shard_span);
         let concurrency = Arc::new(ConcurrencyManager::new(name.clone(), metrics.clone()));
 
-        // Note: concurrency counts are hydrated lazily on first access to each queue.
-        // This avoids blocking shard startup while scanning potentially large holder sets.
+        // Eagerly hydrate the in-memory holders cache from durable storage so
+        // that try_reserve and the grant scanner observe accurate capacity
+        // from the first operation. Queues with zero holders are skipped —
+        // the lazy ensure_hydrated path remains the fallback for queues first
+        // seen after startup (see omittedQueuesAreSafe in specs/job_shard.als).
+        concurrency.counts().hydrate_all(&db, &range).await?;
 
         let brokers = TaskBrokerRegistry::new(
             Arc::clone(&db),
@@ -782,6 +786,12 @@ impl JobStoreShard {
     /// Snapshot the sizes of the in-memory concurrency holders cache.
     pub fn concurrency_cache_stats(&self) -> crate::concurrency::ConcurrencyCacheStats {
         self.concurrency.cache_stats()
+    }
+
+    /// Holder count tracked in the in-memory concurrency cache for a specific
+    /// (tenant, queue). Useful for tests and ad-hoc debugging.
+    pub fn concurrency_holder_count(&self, tenant: &str, queue: &str) -> usize {
+        self.concurrency.counts().holder_count(tenant, queue)
     }
     /// Get the SlateDB metrics registry for this shard.
     /// Use this to collect storage-level statistics for observability.

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -420,9 +420,14 @@ impl JobStoreShard {
         // Eagerly hydrate the in-memory holders cache from durable storage so
         // that try_reserve and the grant scanner observe accurate capacity
         // from the first operation. Queues with zero holders are skipped —
-        // the lazy ensure_hydrated path remains the fallback for queues first
-        // seen after startup (see omittedQueuesAreSafe in specs/job_shard.als).
-        concurrency.counts().hydrate_all(&db, &range).await?;
+        // when eager mode is enabled, `ensure_hydrated` treats such misses as
+        // empty hydrated queues (see omittedQueuesAreSafe in specs/job_shard.als).
+        //
+        // Gated by `SILO_HYDRATE_ALL=1`. Unset / `0` falls back to the
+        // singleflighted JIT path on first access.
+        if crate::concurrency::eager_hydration_enabled() {
+            concurrency.counts().hydrate_all(&db, &range).await?;
+        }
 
         let brokers = TaskBrokerRegistry::new(
             Arc::clone(&db),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -193,6 +193,10 @@ fn default_enable_counter_reconciliation() -> bool {
     false
 }
 
+fn default_hydrate_all_at_startup() -> bool {
+    false
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseTemplate {
     pub backend: Backend,
@@ -224,6 +228,13 @@ pub struct DatabaseTemplate {
     /// are unaffected. Defaults to false (reconciliation disabled).
     #[serde(default = "default_enable_counter_reconciliation")]
     pub enable_counter_reconciliation: bool,
+    /// When true, scan every concurrency holder into the in-memory cache before
+    /// the shard accepts traffic, and treat later `ensure_hydrated` misses as
+    /// empty queues. When false, no startup scan runs and the singleflighted
+    /// per-queue `ensure_hydrated` path hydrates each queue lazily on first
+    /// access. Defaults to false.
+    #[serde(default = "default_hydrate_all_at_startup")]
+    pub hydrate_all_at_startup: bool,
     /// Optional SlateDB-specific settings for tuning database performance.
     /// If not specified, SlateDB defaults are used. When partially specified,
     /// unspecified fields use SlateDB defaults.
@@ -247,6 +258,7 @@ impl Default for DatabaseTemplate {
             apply_wal_on_close: default_apply_wal_on_close(),
             concurrency_reconcile_interval_ms: default_concurrency_reconcile_interval_ms(),
             enable_counter_reconciliation: default_enable_counter_reconciliation(),
+            hydrate_all_at_startup: default_hydrate_all_at_startup(),
             slatedb: None,
             memory_cache: None,
         }
@@ -500,6 +512,11 @@ pub struct DatabaseConfig {
     /// See `DatabaseTemplate::enable_counter_reconciliation` for details.
     #[serde(default = "default_enable_counter_reconciliation")]
     pub enable_counter_reconciliation: bool,
+    /// When true, eagerly scan every concurrency holder into the in-memory
+    /// cache at startup. See `DatabaseTemplate::hydrate_all_at_startup` for
+    /// details. Defaults to false.
+    #[serde(default = "default_hydrate_all_at_startup")]
+    pub hydrate_all_at_startup: bool,
     /// Optional SlateDB-specific settings for tuning database performance.
     /// If not specified, SlateDB defaults are used. When partially specified,
     /// unspecified fields use SlateDB defaults.
@@ -523,6 +540,7 @@ impl Default for DatabaseConfig {
             wal: None,
             apply_wal_on_close: default_apply_wal_on_close(),
             enable_counter_reconciliation: default_enable_counter_reconciliation(),
+            hydrate_all_at_startup: default_hydrate_all_at_startup(),
             slatedb: None,
             memory_cache: None,
         }

--- a/tests/startup_hydration_tests.rs
+++ b/tests/startup_hydration_tests.rs
@@ -1,0 +1,167 @@
+//! Tests for eager hydration of the concurrency holders cache at shard startup.
+//!
+//! `JobStoreShard::new` scans every concurrency holder record in durable storage
+//! into `ConcurrencyCounts` so that the first `try_reserve` and grant scanner
+//! tick see accurate capacity. Queues with zero holders are skipped — the lazy
+//! `ensure_hydrated` path remains the fallback for queues first observed after
+//! startup (see `omittedQueuesAreSafe` in specs/job_shard.als).
+
+mod test_helpers;
+
+use silo::codec::encode_holder;
+use silo::gubernator::MockGubernatorClient;
+use silo::keys::concurrency_holder_key;
+use silo::settings::{Backend, DatabaseConfig};
+use silo::shard_range::{ShardRange, hash_tenant};
+use silo::task::HolderRecord;
+
+use test_helpers::*;
+
+fn fresh_holder() -> Vec<u8> {
+    encode_holder(&HolderRecord {
+        granted_at_ms: now_ms(),
+    })
+}
+
+fn fs_config(path: &std::path::Path) -> DatabaseConfig {
+    DatabaseConfig {
+        name: "test".to_string(),
+        backend: Backend::Fs,
+        path: path.to_string_lossy().to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        ..Default::default()
+    }
+}
+
+/// Eager hydration: holders that exist in durable storage are loaded into the
+/// in-memory cache before `open` returns, across multiple (tenant, queue)
+/// pairs.
+#[silo::test]
+async fn eager_hydration_loads_existing_holders_at_startup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = fs_config(tmp.path());
+    let rate_limiter = MockGubernatorClient::new_arc();
+
+    // Phase 1: open a shard and plant holders for two queues under one tenant
+    // and a third queue under a different tenant.
+    let shard1 = silo::job_store_shard::JobStoreShard::open(
+        &cfg,
+        rate_limiter.clone(),
+        None,
+        ShardRange::full(),
+    )
+    .await
+    .expect("open shard1");
+
+    let holder = fresh_holder();
+    for (tenant, queue, task) in [
+        ("tenant-a", "queue-1", "task-1"),
+        ("tenant-a", "queue-1", "task-2"),
+        ("tenant-a", "queue-2", "task-3"),
+        ("tenant-b", "queue-1", "task-4"),
+    ] {
+        shard1
+            .db()
+            .put(&concurrency_holder_key(tenant, queue, task), &holder)
+            .await
+            .expect("plant holder");
+    }
+    shard1.db().flush().await.expect("flush");
+    shard1.close().await.expect("close");
+
+    // Phase 2: reopen — eager hydration must populate the cache from the
+    // holders we just planted.
+    let shard2 =
+        silo::job_store_shard::JobStoreShard::open(&cfg, rate_limiter, None, ShardRange::full())
+            .await
+            .expect("open shard2");
+
+    assert_eq!(shard2.concurrency_holder_count("tenant-a", "queue-1"), 2);
+    assert_eq!(shard2.concurrency_holder_count("tenant-a", "queue-2"), 1);
+    assert_eq!(shard2.concurrency_holder_count("tenant-b", "queue-1"), 1);
+    // Queue never seen before stays at zero — and (per the omittedQueuesAreSafe
+    // invariant) lazy hydration would still find zero if it ran.
+    assert_eq!(shard2.concurrency_holder_count("tenant-a", "never-seen"), 0);
+
+    shard2.close().await.expect("close");
+}
+
+/// A freshly opened shard with no holders has an empty cache — zero-holder
+/// queues are skipped, including the case where there are no queues at all.
+#[silo::test]
+async fn eager_hydration_is_a_noop_when_no_holders_exist() {
+    let (_tmp, shard) = open_temp_shard().await;
+    assert_eq!(shard.concurrency_holder_count("any-tenant", "any-queue"), 0);
+}
+
+/// After a shard split, both child shards see the same holder records in
+/// durable storage but each must only hydrate the tenants in its own range.
+#[silo::test]
+async fn eager_hydration_filters_by_shard_range() {
+    // Find two tenant IDs whose hashes land in different halves of the hash
+    // space so we can build a range that contains one and excludes the other.
+    let (lo_tenant, hi_tenant) = {
+        let mut lo: Option<String> = None;
+        let mut hi: Option<String> = None;
+        for i in 0..512u32 {
+            let name = format!("tenant-{i}");
+            let h = hash_tenant(&name);
+            if h.as_str() < "8" && lo.is_none() {
+                lo = Some(name);
+            } else if h.as_str() >= "8" && hi.is_none() {
+                hi = Some(name);
+            }
+            if lo.is_some() && hi.is_some() {
+                break;
+            }
+        }
+        (lo.expect("low-hash tenant"), hi.expect("high-hash tenant"))
+    };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = fs_config(tmp.path());
+    let rate_limiter = MockGubernatorClient::new_arc();
+
+    // Plant holders for both tenants under the full range.
+    let shard1 = silo::job_store_shard::JobStoreShard::open(
+        &cfg,
+        rate_limiter.clone(),
+        None,
+        ShardRange::full(),
+    )
+    .await
+    .expect("open shard1");
+
+    let holder = fresh_holder();
+    shard1
+        .db()
+        .put(&concurrency_holder_key(&lo_tenant, "q", "t-lo"), &holder)
+        .await
+        .expect("plant lo holder");
+    shard1
+        .db()
+        .put(&concurrency_holder_key(&hi_tenant, "q", "t-hi"), &holder)
+        .await
+        .expect("plant hi holder");
+    shard1.db().flush().await.expect("flush");
+    shard1.close().await.expect("close shard1");
+
+    // Reopen with a range that only contains the low-hash tenant. The high-hash
+    // tenant's holder must be filtered out during startup hydration.
+    let half_range = ShardRange::new("", "8");
+    assert!(half_range.contains_tenant(&lo_tenant));
+    assert!(!half_range.contains_tenant(&hi_tenant));
+
+    let shard2 = silo::job_store_shard::JobStoreShard::open(&cfg, rate_limiter, None, half_range)
+        .await
+        .expect("open shard2");
+
+    assert_eq!(shard2.concurrency_holder_count(&lo_tenant, "q"), 1);
+    assert_eq!(
+        shard2.concurrency_holder_count(&hi_tenant, "q"),
+        0,
+        "out-of-range holder must not appear in the cache"
+    );
+
+    shard2.close().await.expect("close shard2");
+}

--- a/tests/startup_hydration_tests.rs
+++ b/tests/startup_hydration_tests.rs
@@ -91,10 +91,22 @@ async fn eager_hydration_loads_existing_holders_at_startup() {
 
 /// A freshly opened shard with no holders has an empty cache — zero-holder
 /// queues are skipped, including the case where there are no queues at all.
+/// Uses `fs_config` (eager mode enabled) so this actually exercises the
+/// `hydrate_all` path on an empty shard.
 #[silo::test]
 async fn eager_hydration_is_a_noop_when_no_holders_exist() {
-    let (_tmp, shard) = open_temp_shard().await;
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = fs_config(tmp.path());
+    let rate_limiter = MockGubernatorClient::new_arc();
+
+    let shard =
+        silo::job_store_shard::JobStoreShard::open(&cfg, rate_limiter, None, ShardRange::full())
+            .await
+            .expect("open shard");
+
     assert_eq!(shard.concurrency_holder_count("any-tenant", "any-queue"), 0);
+
+    shard.close().await.expect("close");
 }
 
 /// After a shard split, both child shards see the same holder records in

--- a/tests/startup_hydration_tests.rs
+++ b/tests/startup_hydration_tests.rs
@@ -29,6 +29,9 @@ fn fs_config(path: &std::path::Path) -> DatabaseConfig {
         backend: Backend::Fs,
         path: path.to_string_lossy().to_string(),
         slatedb: Some(fast_flush_slatedb_settings()),
+        // These tests exercise the eager startup-hydration path, so opt in
+        // explicitly here regardless of the global default.
+        hydrate_all_at_startup: true,
         ..Default::default()
     }
 }

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -103,6 +103,7 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             metrics: None,
             concurrency_reconcile_interval: Duration::from_millis(interval_ms.max(1)),
             enable_counter_reconciliation: false,
+            hydrate_all_at_startup: false,
         },
         ShardRange::full(),
     )


### PR DESCRIPTION
This is now blocking at startup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an optional blocking startup scan of durable concurrency holder records and changes cache hydration behavior, which can affect shard startup latency and ticket-grant correctness if misconfigured. Also touches shard-opening/config plumbing and introduces new tests/spec assertions, but behind a default-off flag.
> 
> **Overview**
> Adds an opt-in `hydrate_all_at_startup` mode that **eagerly scans all durable concurrency holder records during shard open** and pre-populates the in-memory holders cache, instead of relying solely on per-queue lazy hydration.
> 
> Threads this flag through `DatabaseConfig`/`DatabaseTemplate`, shard factory/open options, and `ConcurrencyManager`/`ConcurrencyCounts`; when enabled, `ensure_hydrated` treats missing queues as already-hydrated empties to avoid extra scans. Updates the Alloy spec with a startup-hydration model + `omittedQueuesAreSafe` assertion, and adds `startup_hydration_tests` to validate loading, empty-shard no-op, and shard-range filtering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2262099e6cb1b0259d627f493b50c44d195dca47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->