### PR TITLE
silo-bench: read SILO_AUTH_TOKEN for gRPC auth

### DIFF
--- a/src/bin/silo-bench.rs
+++ b/src/bin/silo-bench.rs
@@ -10,12 +10,12 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use clap::Parser;
 use rand::Rng;
+use silo::cluster_client::ClientConfig;
 use silo::pb::report_outcome_request::Outcome;
 use silo::pb::{
     ConcurrencyLimit, EnqueueRequest, LeaseTasksRequest, Limit, ReportOutcomeRequest,
     SerializedBytes, serialized_bytes,
 };
-use silo::cluster_client::ClientConfig;
 use silo::routing_client::RoutingClient;
 use silo::settings::LogFormat;
 use silo::trace;

--- a/src/bin/silo-bench.rs
+++ b/src/bin/silo-bench.rs
@@ -15,6 +15,7 @@ use silo::pb::{
     ConcurrencyLimit, EnqueueRequest, LeaseTasksRequest, Limit, ReportOutcomeRequest,
     SerializedBytes, serialized_bytes,
 };
+use silo::cluster_client::ClientConfig;
 use silo::routing_client::RoutingClient;
 use silo::settings::LogFormat;
 use silo::trace;
@@ -77,6 +78,11 @@ struct Args {
     /// Enable structured JSON logging
     #[arg(long)]
     structured_logging: bool,
+
+    /// Bearer token for gRPC authentication.
+    /// Can also be set via SILO_AUTH_TOKEN environment variable.
+    #[arg(long, env = "SILO_AUTH_TOKEN")]
+    auth_token: Option<String>,
 }
 
 fn now_ms() -> i64 {
@@ -606,7 +612,11 @@ async fn main() -> anyhow::Result<()> {
 
     // Discover cluster topology and create shared client
     info!("Discovering cluster topology...");
-    let client = RoutingClient::discover(&args.address).await?;
+    let client_config = ClientConfig {
+        auth_token: args.auth_token.clone(),
+        ..ClientConfig::default()
+    };
+    let client = RoutingClient::discover_with_config(&args.address, client_config).await?;
 
     let topo = client.topology();
     info!(


### PR DESCRIPTION
## Summary
- Add `--auth-token` flag to `silo-bench` with `SILO_AUTH_TOKEN` env fallback (clap `env = ...`).
- Switch from `RoutingClient::discover` to `RoutingClient::discover_with_config` so the token flows through `ClientConfig` into the gRPC `AuthInterceptor` on every connection.

Without this, `silo-bench` can't talk to an auth-enabled cluster — it had no plumbing for the bearer token at all.

## Test plan
- [ ] `cargo check --bin silo-bench` (already verified locally)
- [ ] Run `silo-bench` against an auth-enabled silo with `SILO_AUTH_TOKEN=…` set and confirm it discovers topology and runs (no `Unauthenticated`).
- [ ] Run against an auth-disabled silo with the env unset and confirm it still works.