### PR TITLE
Upgrade slatedb to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5407,8 +5407,8 @@ dependencies = [
  "serde_json",
  "silo-macros",
  "siloctl",
- "slatedb 0.13.0",
- "slatedb-common 0.13.0",
+ "slatedb",
+ "slatedb-common",
  "storekey",
  "tempfile",
  "thiserror 1.0.69",
@@ -5474,8 +5474,8 @@ dependencies = [
  "serde",
  "serde_json",
  "silo",
- "slatedb 0.12.0",
- "slatedb-common 0.12.0",
+ "slatedb",
+ "slatedb-common",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -5533,52 +5533,6 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slatedb"
-version = "0.12.0"
-source = "git+https://github.com/slatedb/slatedb?rev=a0524976466c9a320106351b092c6c1ca00e4c52#a0524976466c9a320106351b092c6c1ca00e4c52"
-dependencies = [
- "async-channel",
- "async-trait",
- "atomic",
- "backon",
- "bitflags 2.9.4",
- "bytes",
- "chrono",
- "crc32fast",
- "crossbeam-skiplist",
- "dotenvy",
- "duration-str",
- "fail-parallel",
- "figment",
- "flatbuffers",
- "foyer",
- "futures",
- "log",
- "lru",
- "object_store",
- "once_cell",
- "ouroboros",
- "parking_lot",
- "rand 0.9.2",
- "rand_xoshiro",
- "serde",
- "serde_json",
- "siphasher",
- "slatedb-common 0.12.0",
- "slatedb-txn-obj 0.12.0",
- "sysinfo",
- "thiserror 1.0.69",
- "thread_local",
- "tokio",
- "tokio-util",
- "tracing",
- "ulid",
- "url",
- "uuid",
- "walkdir",
-]
-
-[[package]]
-name = "slatedb"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "286ec5657d17f3ba70c060becd57a5550ad43973b8480811ad27d3fa4d620a49"
@@ -5610,8 +5564,8 @@ dependencies = [
  "serde",
  "serde_json",
  "siphasher",
- "slatedb-common 0.13.0",
- "slatedb-txn-obj 0.13.0",
+ "slatedb-common",
+ "slatedb-txn-obj",
  "sysinfo",
  "thiserror 1.0.69",
  "thread_local",
@@ -5622,17 +5576,6 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
-]
-
-[[package]]
-name = "slatedb-common"
-version = "0.12.0"
-source = "git+https://github.com/slatedb/slatedb?rev=a0524976466c9a320106351b092c6c1ca00e4c52#a0524976466c9a320106351b092c6c1ca00e4c52"
-dependencies = [
- "chrono",
- "log",
- "serde",
- "tokio",
 ]
 
 [[package]]
@@ -5649,21 +5592,6 @@ dependencies = [
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.12.0"
-source = "git+https://github.com/slatedb/slatedb?rev=a0524976466c9a320106351b092c6c1ca00e4c52#a0524976466c9a320106351b092c6c1ca00e4c52"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures",
- "log",
- "object_store",
- "slatedb-common 0.12.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "slatedb-txn-obj"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9bd80ee7b7f7da1fd4ada17fcf6ee564e76af71254e8189e68bf497856557aa"
@@ -5674,7 +5602,7 @@ dependencies = [
  "futures",
  "log",
  "object_store",
- "slatedb-common 0.13.0",
+ "slatedb-common",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4448,7 +4448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4481,7 +4481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4936,7 +4936,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5407,8 +5407,8 @@ dependencies = [
  "serde_json",
  "silo-macros",
  "siloctl",
- "slatedb",
- "slatedb-common",
+ "slatedb 0.13.0",
+ "slatedb-common 0.13.0",
  "storekey",
  "tempfile",
  "thiserror 1.0.69",
@@ -5474,8 +5474,8 @@ dependencies = [
  "serde",
  "serde_json",
  "silo",
- "slatedb",
- "slatedb-common",
+ "slatedb 0.12.0",
+ "slatedb-common 0.12.0",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -5563,8 +5563,55 @@ dependencies = [
  "serde",
  "serde_json",
  "siphasher",
- "slatedb-common",
- "slatedb-txn-obj",
+ "slatedb-common 0.12.0",
+ "slatedb-txn-obj 0.12.0",
+ "sysinfo",
+ "thiserror 1.0.69",
+ "thread_local",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ulid",
+ "url",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "slatedb"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286ec5657d17f3ba70c060becd57a5550ad43973b8480811ad27d3fa4d620a49"
+dependencies = [
+ "async-channel",
+ "async-trait",
+ "atomic",
+ "backon",
+ "bitflags 2.9.4",
+ "bytes",
+ "chrono",
+ "crc32fast",
+ "crossbeam-skiplist",
+ "dotenvy",
+ "duration-str",
+ "fail-parallel",
+ "figment",
+ "flatbuffers",
+ "foyer",
+ "futures",
+ "log",
+ "lru",
+ "object_store",
+ "once_cell",
+ "ouroboros",
+ "parking_lot",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "slatedb-common 0.13.0",
+ "slatedb-txn-obj 0.13.0",
  "sysinfo",
  "thiserror 1.0.69",
  "thread_local",
@@ -5589,6 +5636,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "slatedb-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9caca0e37a5bc4c65c61143cdd9674faa6b9f69f76a02e1edc94d8e2a6da414a"
+dependencies = [
+ "chrono",
+ "log",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "slatedb-txn-obj"
 version = "0.12.0"
 source = "git+https://github.com/slatedb/slatedb?rev=a0524976466c9a320106351b092c6c1ca00e4c52#a0524976466c9a320106351b092c6c1ca00e4c52"
@@ -5599,7 +5658,23 @@ dependencies = [
  "futures",
  "log",
  "object_store",
- "slatedb-common",
+ "slatedb-common 0.12.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slatedb-txn-obj"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9bd80ee7b7f7da1fd4ada17fcf6ee564e76af71254e8189e68bf497856557aa"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "log",
+ "object_store",
+ "slatedb-common 0.13.0",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ version = "0.3.0"
 [dependencies]
 clap = { version = "4.3.14", features = ["derive", "env"] }
 futures = "0.3"
-slatedb = "0.12"
-slatedb-common = "0.12"
+slatedb = "0.13"
+slatedb-common = "0.13"
 object_store = { version = "0.12", features = ["gcp"] }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,11 +125,6 @@ http-body-util = "0.1"
 tonic-build = "0.12"
 protoc-bin-vendored = "3.0"
 
-[patch.crates-io]
-slatedb = { git = "https://github.com/slatedb/slatedb", rev = "a0524976466c9a320106351b092c6c1ca00e4c52" }
-slatedb-common = { git = "https://github.com/slatedb/slatedb", rev = "a0524976466c9a320106351b092c6c1ca00e4c52" }
-slatedb-txn-obj = { git = "https://github.com/slatedb/slatedb", rev = "a0524976466c9a320106351b092c6c1ca00e4c52" }
-
 [profile.release]
 debug = 1     # debug info with line tables only for profiling
 strip = false # do not strip symbols for profiling

--- a/silo-compactor/Cargo.toml
+++ b/silo-compactor/Cargo.toml
@@ -9,8 +9,8 @@ name = "silo-compactor"
 path = "src/main.rs"
 
 [dependencies]
-slatedb = { version = "0.12", features = ["compaction_filters"] }
-slatedb-common = "0.12"
+slatedb = { version = "0.13", features = ["compaction_filters"] }
+slatedb-common = "0.13"
 object_store = { version = "0.12", features = ["gcp"] }
 prometheus = "0.13"
 

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1372,6 +1372,7 @@ impl ConcurrencyManager {
                     batch,
                     &WriteOptions {
                         await_durable: true,
+                        ..Default::default()
                     },
                 )
                 .await

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -220,6 +220,7 @@ impl JobStoreShard {
                         state.batch,
                         &WriteOptions {
                             await_durable: true,
+                            ..Default::default()
                         },
                     )
                     .await

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -184,6 +184,7 @@ impl JobStoreShard {
                 batch,
                 &WriteOptions {
                     await_durable: true,
+                    ..Default::default()
                 },
             )
             .await
@@ -287,6 +288,7 @@ impl JobStoreShard {
         if let Err(e) = txn
             .commit_with_options(&WriteOptions {
                 await_durable: true,
+                ..Default::default()
             })
             .await
         {

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -302,6 +302,7 @@ impl JobStoreShard {
         if let Err(e) = txn
             .commit_with_options(&WriteOptions {
                 await_durable: true,
+                ..Default::default()
             })
             .await
         {
@@ -687,6 +688,7 @@ impl JobStoreShard {
         if let Err(e) = txn
             .commit_with_options(&WriteOptions {
                 await_durable: true,
+                ..Default::default()
             })
             .await
         {

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -72,6 +72,7 @@ impl JobStoreShard {
                 batch,
                 &WriteOptions {
                     await_durable: true,
+                    ..Default::default()
                 },
             )
             .await?;
@@ -316,6 +317,7 @@ impl JobStoreShard {
                 batch,
                 &WriteOptions {
                     await_durable: true,
+                    ..Default::default()
                 },
             )
             .await
@@ -574,6 +576,7 @@ impl JobStoreShard {
                 batch,
                 &WriteOptions {
                     await_durable: true,
+                    ..Default::default()
                 },
             )
             .await?;

--- a/src/job_store_shard/lease_task.rs
+++ b/src/job_store_shard/lease_task.rs
@@ -215,6 +215,7 @@ impl JobStoreShard {
         // Commit the transaction with durable writes
         txn.commit_with_options(&WriteOptions {
             await_durable: true,
+            ..Default::default()
         })
         .await?;
 

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -502,7 +502,6 @@ flush_interval = "50ms"
 manifest_poll_interval = "1s"
 manifest_update_timeout = "300s"
 min_filter_keys = 1000
-filter_bits_per_key = 10
 l0_sst_size_bytes = 33554432
 l0_max_ssts = 4
 max_unflushed_bytes = 536870912
@@ -767,10 +766,6 @@ cache_puts = true
     assert_eq!(
         slatedb_settings.l0_max_ssts, defaults.l0_max_ssts,
         "l0_max_ssts should use default"
-    );
-    assert_eq!(
-        slatedb_settings.filter_bits_per_key, defaults.filter_bits_per_key,
-        "filter_bits_per_key should use default"
     );
     assert_eq!(
         slatedb_settings.object_store_cache_options.part_size_bytes,


### PR DESCRIPTION
## Summary
- Bump `slatedb` and `slatedb-common` from 0.12 to 0.13 in Cargo.toml

has this important patch: https://github.com/slatedb/slatedb/pull/1639



## Test plan
- [ ] CI is green