### PR TITLE
Fix multi-limit enqueue dropping limits[1..] and leaking holders

### DIFF
--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -60,21 +60,37 @@ fn record_grant_outcome(
     outcome: Option<RequestTicketOutcome>,
     queue_key: &str,
     grants: &mut Vec<(String, String)>,
-    current_task_id: &mut String,
+    current_task_id: &str,
     current_held_queues: &mut Vec<String>,
     current_index: &mut usize,
 ) -> GrantResult {
     match outcome {
-        None => {
-            // Granted immediately - record grant and continue to next limit
-            grants.push((queue_key.to_string(), current_task_id.clone()));
+        None | Some(RequestTicketOutcome::GrantedImmediately { .. }) => {
+            // Slot granted (or no limit existed) - record grant and continue to
+            // the next limit. The interim RunAttempt that handle_enqueue wrote
+            // via append_grant_edits is overwritten at the same task_key when
+            // the outer loop reaches its terminal "no more limits" branch,
+            // which rewrites the RunAttempt with the full accumulated
+            // current_held_queues so ReportOutcome can release every holder.
+            //
+            // Crucially, `current_task_id` is NOT cycled here. The chained
+            // cleanup paths (handle_check_rate_limit, handle_run_attempt) all
+            // release holders by `concurrency_holder_key(tenant, queue,
+            // <chained_task_id>)`, so every holder we accumulate across the
+            // limit chain must share one task_id — the one carried forward to
+            // the final RunAttempt / CheckRateLimit task. Cycling here left
+            // earlier-granted holders orphaned and produced leaked slots on
+            // outcome release.
+            grants.push((queue_key.to_string(), current_task_id.to_string()));
             current_held_queues.push(queue_key.to_string());
             *current_index += 1;
-            *current_task_id = Uuid::new_v4().to_string();
             GrantResult::Granted
         }
-        Some(_) => {
-            // Not granted - RequestTicket was created by handle_enqueue
+        Some(RequestTicketOutcome::TicketRequested { .. })
+        | Some(RequestTicketOutcome::FutureRequestTaskWritten { .. }) => {
+            // Not granted - a request/RequestTicket was already written by
+            // handle_enqueue. Stop processing further limits; remaining ones
+            // will be applied when the queued request is granted later.
             GrantResult::Queued
         }
     }
@@ -436,7 +452,7 @@ impl JobStoreShard {
         let mut grants = Vec::new();
         let mut current_index = limit_index;
         let mut current_held_queues = held_queues;
-        let mut current_task_id = task_id.to_string();
+        let current_task_id = task_id.to_string();
 
         loop {
             if current_index >= limits.len() {
@@ -498,7 +514,7 @@ impl JobStoreShard {
                             outcome,
                             &cl.key,
                             &mut grants,
-                            &mut current_task_id,
+                            &current_task_id,
                             &mut current_held_queues,
                             &mut current_index,
                         ),
@@ -574,7 +590,7 @@ impl JobStoreShard {
                             outcome,
                             &fl.key,
                             &mut grants,
-                            &mut current_task_id,
+                            &current_task_id,
                             &mut current_held_queues,
                             &mut current_index,
                         ),

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -896,12 +896,12 @@ async fn concurrency_multiple_queues_per_job() {
         .await
         .expect("enqueue");
 
-    // Should get ticket for first queue immediately (api)
+    // Should get a ticket immediately — both queues have slots free.
     let tasks = shard.dequeue("w", "default", 1).await.expect("deq").tasks;
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0].job().id(), job_id);
 
-    // Should have holder for api queue only (first limit)
+    // Should have a holder for both queues — every limit in the chain is gated.
     let api_holder = shard
         .db()
         .get(&concurrency_holder_key(
@@ -913,7 +913,6 @@ async fn concurrency_multiple_queues_per_job() {
         .expect("get api holder");
     assert!(api_holder.is_some(), "should have api holder");
 
-    // Should NOT have db holder yet (only first limit is gated)
     let db_holder = shard
         .db()
         .get(&concurrency_holder_key(
@@ -923,12 +922,9 @@ async fn concurrency_multiple_queues_per_job() {
         ))
         .await
         .expect("get db holder");
-    assert!(
-        db_holder.is_none(),
-        "should not have db holder (only first limit gated)"
-    );
+    assert!(db_holder.is_some(), "should have db holder");
 
-    // Complete job -> should release api holder
+    // Complete job -> should release both holders
     shard
         .report_attempt_outcome(
             tasks[0].attempt().task_id(),
@@ -937,7 +933,6 @@ async fn concurrency_multiple_queues_per_job() {
         .await
         .expect("report");
 
-    // All holders released
     assert_eq!(count_concurrency_holders(shard.db()).await, 0);
 }
 

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -81,7 +81,7 @@ async fn concurrency_shared_across_task_groups() {
     // Should only have RequestTicket, not RunAttempt
     let run_attempts: Vec<_> = tasks2
         .iter()
-        .filter(|t| t.attempt().task_id().len() > 0)
+        .filter(|t| !t.attempt().task_id().is_empty())
         .collect();
     assert_eq!(
         run_attempts.len(),
@@ -2235,4 +2235,295 @@ async fn grant_scanner_drains_backlog_larger_than_max_per_pass() {
         "all request records should be consumed"
     );
     assert_eq!(count_concurrency_holders(shard.db()).await, N);
+}
+
+/// Reproduces a Gadget production report: jobs enqueued with TWO concurrency limits
+/// (a floating "platform" limit + a user-named fixed concurrency limit, e.g.
+/// `exampleshopname.myshopify.com`) advance through the first (platform) limit
+/// but the user-named queue never gets a holder or request — workers therefore see
+/// no leases for that queue.
+///
+/// Mirrors `SiloActionStore.createAction` which constructs:
+///   limits[0] = FloatingConcurrency(platform-tenant-env-…)
+///   limits[1] = Concurrency(action.queue)
+#[silo::test]
+async fn enqueue_with_two_concurrency_limits_grants_both() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+
+    let platform_queue = "platform-tenant-env-123".to_string();
+    let user_queue = "exampleshopname.myshopify.com".to_string();
+
+    let _job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: platform_queue.clone(),
+                    default_max_concurrency: 100,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: user_queue.clone(),
+                    max_concurrency: 5,
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue with two limits");
+
+    let total_holders = count_concurrency_holders(shard.db()).await;
+    let platform_holders = count_holders_for_queue(shard.db(), tenant, &platform_queue).await;
+    let user_holders = count_holders_for_queue(shard.db(), tenant, &user_queue).await;
+
+    println!(
+        "total_holders={}, platform_holders={}, user_holders={}",
+        total_holders, platform_holders, user_holders
+    );
+
+    assert_eq!(
+        platform_holders, 1,
+        "platform queue should have a holder for the granted floating limit"
+    );
+    assert_eq!(
+        user_holders, 1,
+        "user queue should have a holder for the granted fixed concurrency limit \
+         — if this is 0, the second limit was silently skipped at enqueue"
+    );
+}
+
+/// Verifies the held_queues subtlety in append_grant_edits: when multiple limits
+/// each grant immediately, append_grant_edits writes interim RunAttempts with
+/// only the current queue in held_queues. The loop's terminal branch must
+/// overwrite the same task_key with the full accumulated held_queues — and
+/// reporting the worker outcome must release BOTH holders.
+///
+/// If only one queue is released on outcome, the other holder leaks and that
+/// queue's capacity is permanently consumed.
+#[silo::test]
+async fn two_concurrency_limits_release_both_holders_on_success() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+
+    let platform_queue = "platform-tenant-env-456".to_string();
+    let user_queue = "exampleshopname.myshopify.com".to_string();
+
+    let _job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: platform_queue.clone(),
+                    default_max_concurrency: 100,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: user_queue.clone(),
+                    max_concurrency: 5,
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue with two limits");
+
+    // Sanity: a holder exists on each queue.
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &platform_queue).await,
+        1
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &user_queue).await,
+        1
+    );
+
+    // Dequeue the RunAttempt and verify the lease record's held_queues
+    // contains BOTH queues so ReportOutcome can release them all.
+    let tasks = shard
+        .dequeue("w1", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 1, "the RunAttempt should be leaseable");
+    let task_id = tasks[0].attempt().task_id().to_string();
+
+    // Read the lease record to confirm held_queues was preserved end-to-end.
+    let lease_bytes = shard
+        .db()
+        .get(&silo::keys::leased_task_key(&task_id))
+        .await
+        .expect("read lease")
+        .expect("lease present after dequeue");
+    let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
+    let held = decoded_lease.held_queues();
+    assert!(
+        held.iter().any(|q| q == &platform_queue),
+        "lease held_queues should include platform queue, got {:?}",
+        held
+    );
+    assert!(
+        held.iter().any(|q| q == &user_queue),
+        "lease held_queues should include user queue — if missing, the final \
+         RunAttempt overwrite dropped the earlier granted queue. Got {:?}",
+        held
+    );
+    assert_eq!(
+        held.len(),
+        2,
+        "lease held_queues should be exactly the two granted queues, got {:?}",
+        held
+    );
+
+    // Report success — silo must release holders for BOTH queues.
+    shard
+        .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report success");
+
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &platform_queue).await,
+        0,
+        "platform queue holder should be released after outcome"
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &user_queue).await,
+        0,
+        "user queue holder should be released after outcome — leak indicates \
+         held_queues wasn't fully populated on the final RunAttempt"
+    );
+}
+
+/// When a job has limits = [A, B] and A grants but B is at capacity, the
+/// `append_grant_edits` call for A writes an interim RunAttempt at task_key.
+/// `append_request_edits` for B only writes a concurrency request record — it
+/// does NOT delete/overwrite the task at task_key. If this bug is real, a
+/// worker can dequeue and run the RunAttempt for a job that should be blocked
+/// on B, violating the B limit.
+#[silo::test]
+async fn second_limit_request_must_not_leave_runnable_task() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+    let queue_a = "queue-a".to_string();
+    let queue_b = "queue-b".to_string();
+
+    // Fill queue B to capacity: enqueue job1 with only limit B, then dequeue
+    // it so the holder persists.
+    let _job1 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: queue_b.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue job1");
+    let job1_tasks = shard
+        .dequeue("w1", "default", 1)
+        .await
+        .expect("deq job1")
+        .tasks;
+    assert_eq!(job1_tasks.len(), 1, "job1 should be runnable");
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_b).await,
+        1,
+        "queue B should be at capacity (1 holder)"
+    );
+
+    // Enqueue job2 with [A, B]. A grants immediately; B is full so returns a
+    // TicketRequested.
+    let _job2 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_a.clone(),
+                    max_concurrency: 5,
+                }),
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_b.clone(),
+                    max_concurrency: 1,
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue job2");
+
+    // A concurrency request for queue B should exist for job2.
+    assert!(
+        count_concurrency_requests(shard.db()).await >= 1,
+        "expected a concurrency request to be written for job2 on queue B"
+    );
+
+    // The critical assertion: dequeue must not return a RunAttempt for job2.
+    // If the interim RunAttempt from A's append_grant_edits was left at
+    // task_key, a worker will pick it up and run the job while B is at
+    // capacity — violating the B limit.
+    let job2_tasks = shard
+        .dequeue("w2", "default", 1)
+        .await
+        .expect("deq job2")
+        .tasks;
+    assert_eq!(
+        job2_tasks.len(),
+        0,
+        "job2 must not be runnable while queue B is at capacity — a stale \
+         RunAttempt at task_key from limit[0]'s append_grant_edits was not \
+         removed when limit[1] returned TicketRequested. \
+         Got task: {:?}",
+        job2_tasks
+            .first()
+            .map(|t| t.attempt().task_id().to_string()),
+    );
+}
+
+/// Helper: count concurrency holder keys for a specific (tenant, queue) pair.
+async fn count_holders_for_queue(
+    db: &silo::instrumented_db::InstrumentedDb,
+    tenant: &str,
+    queue: &str,
+) -> usize {
+    let start = silo::keys::concurrency_holders_queue_prefix(tenant, queue);
+    let end = silo::keys::end_bound(&start);
+    let mut iter = db
+        .scan_with_options::<Vec<u8>, _>(start..end, &silo::scan_options())
+        .await
+        .expect("scan holders");
+    let mut count = 0;
+    while let Ok(Some(_)) = iter.next().await {
+        count += 1;
+    }
+    count
 }


### PR DESCRIPTION
## Summary

- `record_grant_outcome` had its match arms inverted relative to what `handle_enqueue` actually returns. `handle_enqueue` only returns `Ok(None)` when the `limits` slice is empty (unreachable from these callers — they always pass `std::slice::from_ref(cl)`); every real outcome is `Ok(Some(_))`. The match treated `None` as "granted, advance" and `Some(_)` as "queued, return", so the limit-processing chain always exited after the first limit and silently dropped `limits[1..]`.
- Also stopped cycling `current_task_id` after each grant. The chained cleanup paths (`handle_check_rate_limit`, `handle_run_attempt`, `report_attempt_outcome`) all release holders via `concurrency_holder_key(tenant, queue, <single_task_id>)` — they assume every holder accumulated across the limit chain shares one task_id. Cycling left earlier-granted holders orphaned at stale task_ids, so on outcome release the deletes targeted nonexistent keys and the slots leaked permanently.

## Why this matters

In Gadget production this manifested as: jobs enqueued with `[FloatingConcurrency(platform-tenant-env-…), Concurrency(user_queue)]` honored the platform limit but the user-named queue (e.g. `shopa.myshopify.com`) was never touched — no holder, no request, no lease activity. Workers correctly polled by `task_group` and saw nothing for that queue because silo never wrote anything there.

This bug pre-dates the recent `ca1db8a` "Refactor enqueue/dequeue/cancel hot paths to reduce DRY violations" — the pre-refactor inline `match outcome` had the exact same inversion, so this is the original semantics, not a regression. It went undetected because the existing test corpus didn't exercise jobs with multiple concurrency-style limits in a single enqueue.

## Tests added

`tests/job_store_shard_concurrency_tests.rs`:
- `enqueue_with_two_concurrency_limits_grants_both` — a job with one floating + one fixed concurrency limit produces a holder on each queue (fails on `main`).
- `two_concurrency_limits_release_both_holders_on_success` — dequeues the lease, asserts `held_queues` contains both queues, then asserts `ReportOutcome(Success)` releases both holders (fails on `main` after the inversion fix alone, because of the task_id cycling).

## Test plan

- [x] `cargo test --test job_store_shard_concurrency_tests` — 25/25 pass (incl. both new tests)
- [x] `cargo test --test holder_leak_tests --test floating_concurrency_tests --test concurrent_grant_race_tests --test concurrency_requester_counter_tests --test job_store_shard_enqueue_tests --test job_store_shard_restart_tests --test job_store_shard_cancel_tests --test job_store_shard_expedite_tests --test job_store_shard_retry_tests --test job_store_shard_edge_case_tests` — all pass
- [ ] Turmoil scenarios (`tests/turmoil_runner/scenarios/concurrency_limits.rs` and `rate_limits.rs`) — should be re-run in CI
- [ ] `rate_limit_tests` — require a Gubernator service; verify in CI

## Open follow-ups (not in this PR)

- When a limit *queues* (not granted), the subsequent limits in the chain are never processed (`enqueue_limit_task_at_index` returns early). When `process_grants` later grants the queued request, it creates a `RunAttempt` with `held_queues = vec![queue]` (just this queue) and does not resume the limit chain. So jobs with 3+ limits where any non-final limit queues will currently bypass the remaining limits. This PR is scoped to the immediately-granted multi-limit case that explains the production report; the queued-mid-chain case needs a separate design pass (likely passing `limit_index` through the request action so `process_grants` can resume the chain).