### PR TITLE
Plumb held_queues + limit_index through queued concurrency requests

### DIFF
--- a/schema/internal_storage.fbs
+++ b/schema/internal_storage.fbs
@@ -129,7 +129,6 @@ table ResumeAfterConcurrencyGrant {
   task_group: string;
   held_queues: [HeldQueue];
   limit_index: uint32;
-  start_at_ms: int64;
   priority: ubyte;
 }
 

--- a/schema/internal_storage.fbs
+++ b/schema/internal_storage.fbs
@@ -31,6 +31,15 @@ table KeyValuePair {
   value: string;
 }
 
+// Pair of (queue, task_id) identifying a concurrency holder created during the
+// limit chain. Each chain accumulates one HeldQueue per granted limit; the
+// task_id is the request_id that created the holder, used at release time to
+// look up `concurrency_holder_key(tenant, queue, task_id)`.
+table HeldQueue {
+  queue: string;
+  task_id: string;
+}
+
 table RetryPolicy {
   retry_count: uint32;
   initial_interval_ms: int64;
@@ -74,7 +83,7 @@ table RunAttempt {
   job_id: string;
   attempt_number: uint32;
   relative_attempt_number: uint32;
-  held_queues: [string];
+  held_queues: [HeldQueue];
   task_group: string;
 }
 
@@ -88,6 +97,9 @@ table RequestTicket {
   relative_attempt_number: uint32;
   request_id: string;
   task_group: string;
+  held_queues: [HeldQueue];
+  limit_index: uint32;
+  total_limits: uint32;
 }
 
 table CheckRateLimit {
@@ -101,8 +113,24 @@ table CheckRateLimit {
   retry_count: uint32;
   started_at_ms: int64;
   priority: ubyte;
-  held_queues: [string];
+  held_queues: [HeldQueue];
   task_group: string;
+}
+
+// Internal task variant: resume the limit chain after a queued ticket request
+// was granted by `process_grants`. Encodes everything needed to call back into
+// `enqueue_limit_task_at_index` to walk any remaining limits.
+table ResumeAfterConcurrencyGrant {
+  request_id: string;
+  tenant: string;
+  job_id: string;
+  attempt_number: uint32;
+  relative_attempt_number: uint32;
+  task_group: string;
+  held_queues: [HeldQueue];
+  limit_index: uint32;
+  start_at_ms: int64;
+  priority: ubyte;
 }
 
 table RefreshFloatingLimit {
@@ -120,6 +148,7 @@ union TaskVariant {
   RequestTicket,
   CheckRateLimit,
   RefreshFloatingLimit,
+  ResumeAfterConcurrencyGrant,
 }
 
 table Task {
@@ -237,6 +266,9 @@ table EnqueueTask {
   attempt_number: uint32;
   relative_attempt_number: uint32;
   task_group: string;
+  held_queues: [HeldQueue];
+  limit_index: uint32;
+  total_limits: uint32;
 }
 
 union ConcurrencyActionVariant {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -4,7 +4,9 @@ use flatbuffers::FlatBufferBuilder;
 use crate::fb::silo::fb;
 use crate::job::{FloatingLimitState, JobCancellation, JobInfo, JobStatus, JobStatusKind, Limit};
 use crate::job_attempt::{AttemptStatus, JobAttempt};
-use crate::task::{ConcurrencyAction, GubernatorRateLimitData, HolderRecord, LeaseRecord, Task};
+use crate::task::{
+    ConcurrencyAction, GubernatorRateLimitData, HeldQueue, HolderRecord, LeaseRecord, Task,
+};
 
 /// Error type for codec operations
 #[derive(Debug, Clone, thiserror::Error)]
@@ -44,6 +46,44 @@ fn build_kv_pair_offsets<'a, A: flatbuffers::Allocator + 'a>(
         .collect()
 }
 
+/// Build a vector of HeldQueue offsets.
+fn build_held_queue_offsets<'a, A: flatbuffers::Allocator + 'a>(
+    builder: &mut FlatBufferBuilder<'a, A>,
+    held: &[HeldQueue],
+) -> flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<fb::HeldQueue<'a>>>>
+{
+    let offsets: Vec<_> = held
+        .iter()
+        .map(|hq| {
+            let queue = builder.create_string(&hq.queue);
+            let task_id = builder.create_string(&hq.task_id);
+            fb::HeldQueue::create(
+                builder,
+                &fb::HeldQueueArgs {
+                    queue: Some(queue),
+                    task_id: Some(task_id),
+                },
+            )
+        })
+        .collect();
+    builder.create_vector(&offsets)
+}
+
+/// Decode a flatbuffer `[HeldQueue]` vector into an owned `Vec<HeldQueue>`.
+fn fb_held_queues_to_owned(
+    held: Option<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<fb::HeldQueue<'_>>>>,
+) -> Vec<HeldQueue> {
+    held.map(|v| {
+        v.iter()
+            .map(|hq| HeldQueue {
+                queue: hq.queue().unwrap_or_default().to_string(),
+                task_id: hq.task_id().unwrap_or_default().to_string(),
+            })
+            .collect()
+    })
+    .unwrap_or_default()
+}
+
 /// Build a Task union (TaskVariant) into the builder. Returns (type, offset).
 fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
     builder: &mut FlatBufferBuilder<'a, A>,
@@ -65,11 +105,7 @@ fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
             let id = builder.create_string(id);
             let tenant = builder.create_string(tenant);
             let job_id = builder.create_string(job_id);
-            let hq: Vec<_> = held_queues
-                .iter()
-                .map(|s| builder.create_string(s))
-                .collect();
-            let held_queues = builder.create_vector(&hq);
+            let held_queues = build_held_queue_offsets(builder, held_queues);
             let task_group = builder.create_string(task_group);
             let ra = fb::RunAttempt::create(
                 builder,
@@ -95,12 +131,16 @@ fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
             relative_attempt_number,
             request_id,
             task_group,
+            held_queues,
+            limit_index,
+            total_limits,
         } => {
             let queue = builder.create_string(queue);
             let tenant = builder.create_string(tenant);
             let job_id = builder.create_string(job_id);
             let request_id = builder.create_string(request_id);
             let task_group = builder.create_string(task_group);
+            let held_queues = build_held_queue_offsets(builder, held_queues);
             let rt = fb::RequestTicket::create(
                 builder,
                 &fb::RequestTicketArgs {
@@ -113,6 +153,9 @@ fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
                     relative_attempt_number: *relative_attempt_number,
                     request_id: Some(request_id),
                     task_group: Some(task_group),
+                    held_queues: Some(held_queues),
+                    limit_index: *limit_index,
+                    total_limits: *total_limits,
                 },
             );
             (fb::TaskVariant::RequestTicket, rt.as_union_value())
@@ -152,11 +195,7 @@ fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
                     retry_max_retries: rate_limit.retry_max_retries,
                 },
             );
-            let hq: Vec<_> = held_queues
-                .iter()
-                .map(|s| builder.create_string(s))
-                .collect();
-            let held_queues = builder.create_vector(&hq);
+            let held_queues = build_held_queue_offsets(builder, held_queues);
             let task_group = builder.create_string(task_group);
             let crl = fb::CheckRateLimit::create(
                 builder,
@@ -205,6 +244,43 @@ fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
                 },
             );
             (fb::TaskVariant::RefreshFloatingLimit, rfl.as_union_value())
+        }
+        Task::ResumeAfterConcurrencyGrant {
+            request_id,
+            tenant,
+            job_id,
+            attempt_number,
+            relative_attempt_number,
+            task_group,
+            held_queues,
+            limit_index,
+            start_at_ms,
+            priority,
+        } => {
+            let request_id = builder.create_string(request_id);
+            let tenant = builder.create_string(tenant);
+            let job_id = builder.create_string(job_id);
+            let task_group = builder.create_string(task_group);
+            let held_queues = build_held_queue_offsets(builder, held_queues);
+            let rg = fb::ResumeAfterConcurrencyGrant::create(
+                builder,
+                &fb::ResumeAfterConcurrencyGrantArgs {
+                    request_id: Some(request_id),
+                    tenant: Some(tenant),
+                    job_id: Some(job_id),
+                    attempt_number: *attempt_number,
+                    relative_attempt_number: *relative_attempt_number,
+                    task_group: Some(task_group),
+                    held_queues: Some(held_queues),
+                    limit_index: *limit_index,
+                    start_at_ms: *start_at_ms,
+                    priority: *priority,
+                },
+            );
+            (
+                fb::TaskVariant::ResumeAfterConcurrencyGrant,
+                rg.as_union_value(),
+            )
         }
     }
 }
@@ -474,9 +550,13 @@ pub fn encode_concurrency_action(action: &ConcurrencyAction) -> Vec<u8> {
             attempt_number,
             relative_attempt_number,
             task_group,
+            held_queues,
+            limit_index,
+            total_limits,
         } => {
             let job_id = builder.create_string(job_id);
             let task_group = builder.create_string(task_group);
+            let held_queues = build_held_queue_offsets(&mut builder, held_queues);
             let et = fb::EnqueueTask::create(
                 &mut builder,
                 &fb::EnqueueTaskArgs {
@@ -486,6 +566,9 @@ pub fn encode_concurrency_action(action: &ConcurrencyAction) -> Vec<u8> {
                     attempt_number: *attempt_number,
                     relative_attempt_number: *relative_attempt_number,
                     task_group: Some(task_group),
+                    held_queues: Some(held_queues),
+                    limit_index: *limit_index,
+                    total_limits: *total_limits,
                 },
             );
             let root = fb::ConcurrencyAction::create(
@@ -572,10 +655,7 @@ fn task_from_fb_variant(
                 job_id: ra.job_id().unwrap_or_default().to_string(),
                 attempt_number: ra.attempt_number(),
                 relative_attempt_number: ra.relative_attempt_number(),
-                held_queues: ra
-                    .held_queues()
-                    .map(|v| v.iter().map(|s| s.to_string()).collect())
-                    .unwrap_or_default(),
+                held_queues: fb_held_queues_to_owned(ra.held_queues()),
                 task_group: ra.task_group().unwrap_or_default().to_string(),
             })
         }
@@ -591,6 +671,9 @@ fn task_from_fb_variant(
                 relative_attempt_number: rt.relative_attempt_number(),
                 request_id: rt.request_id().unwrap_or_default().to_string(),
                 task_group: rt.task_group().unwrap_or_default().to_string(),
+                held_queues: fb_held_queues_to_owned(rt.held_queues()),
+                limit_index: rt.limit_index(),
+                total_limits: rt.total_limits(),
             })
         }
         fb::TaskVariant::CheckRateLimit => {
@@ -621,10 +704,7 @@ fn task_from_fb_variant(
                 retry_count: crl.retry_count(),
                 started_at_ms: crl.started_at_ms(),
                 priority: crl.priority(),
-                held_queues: crl
-                    .held_queues()
-                    .map(|v| v.iter().map(|s| s.to_string()).collect())
-                    .unwrap_or_default(),
+                held_queues: fb_held_queues_to_owned(crl.held_queues()),
                 task_group: crl.task_group().unwrap_or_default().to_string(),
             })
         }
@@ -638,6 +718,21 @@ fn task_from_fb_variant(
                 last_refreshed_at_ms: rfl.last_refreshed_at_ms(),
                 metadata: fb_kv_pairs_to_owned(rfl.metadata()),
                 task_group: rfl.task_group().unwrap_or_default().to_string(),
+            })
+        }
+        fb::TaskVariant::ResumeAfterConcurrencyGrant => {
+            let rg = unsafe { fb::ResumeAfterConcurrencyGrant::init_from_table(table) };
+            Ok(Task::ResumeAfterConcurrencyGrant {
+                request_id: rg.request_id().unwrap_or_default().to_string(),
+                tenant: rg.tenant().unwrap_or_default().to_string(),
+                job_id: rg.job_id().unwrap_or_default().to_string(),
+                attempt_number: rg.attempt_number(),
+                relative_attempt_number: rg.relative_attempt_number(),
+                task_group: rg.task_group().unwrap_or_default().to_string(),
+                held_queues: fb_held_queues_to_owned(rg.held_queues()),
+                limit_index: rg.limit_index(),
+                start_at_ms: rg.start_at_ms(),
+                priority: rg.priority(),
             })
         }
         _ => Err(CodecError::Flatbuffer(format!(
@@ -759,6 +854,7 @@ impl DecodedTask {
             RequestTicket => variant_as_request_ticket,
             CheckRateLimit => variant_as_check_rate_limit,
             RefreshFloatingLimit => variant_as_refresh_floating_limit,
+            ResumeAfterConcurrencyGrant => variant_as_resume_after_concurrency_grant,
         )
     }
 
@@ -768,6 +864,7 @@ impl DecodedTask {
             RequestTicket => variant_as_request_ticket,
             CheckRateLimit => variant_as_check_rate_limit,
             RefreshFloatingLimit => variant_as_refresh_floating_limit,
+            ResumeAfterConcurrencyGrant => variant_as_resume_after_concurrency_grant,
         )
     }
 
@@ -785,6 +882,10 @@ impl DecodedTask {
 
     pub fn as_refresh_floating_limit(&self) -> Option<fb::RefreshFloatingLimit<'_>> {
         self.fb().variant_as_refresh_floating_limit()
+    }
+
+    pub fn as_resume_after_concurrency_grant(&self) -> Option<fb::ResumeAfterConcurrencyGrant<'_>> {
+        self.fb().variant_as_resume_after_concurrency_grant()
     }
 
     /// Materialize a fully-owned Task from the FlatBuffer data.
@@ -860,6 +961,7 @@ impl DecodedLease {
             RequestTicket => task_as_request_ticket,
             CheckRateLimit => task_as_check_rate_limit,
             RefreshFloatingLimit => task_as_refresh_floating_limit,
+            ResumeAfterConcurrencyGrant => task_as_resume_after_concurrency_grant,
         )
     }
 
@@ -868,6 +970,7 @@ impl DecodedLease {
             RunAttempt => task_as_run_attempt,
             RequestTicket => task_as_request_ticket,
             CheckRateLimit => task_as_check_rate_limit,
+            ResumeAfterConcurrencyGrant => task_as_resume_after_concurrency_grant,
         )
     }
 
@@ -876,6 +979,7 @@ impl DecodedLease {
             RunAttempt => task_as_run_attempt,
             RequestTicket => task_as_request_ticket,
             CheckRateLimit => task_as_check_rate_limit,
+            ResumeAfterConcurrencyGrant => task_as_resume_after_concurrency_grant,
         )
     }
 
@@ -884,6 +988,7 @@ impl DecodedLease {
             RunAttempt => task_as_run_attempt,
             RequestTicket => task_as_request_ticket,
             CheckRateLimit => task_as_check_rate_limit,
+            ResumeAfterConcurrencyGrant => task_as_resume_after_concurrency_grant,
         )
     }
 
@@ -901,19 +1006,15 @@ impl DecodedLease {
         }
     }
 
-    pub fn held_queues(&self) -> Vec<String> {
+    pub fn held_queues(&self) -> Vec<HeldQueue> {
         let lr = self.fb();
         match lr.task_type() {
-            fb::TaskVariant::RunAttempt => lr
-                .task_as_run_attempt()
-                .and_then(|r| r.held_queues())
-                .map(|v| v.iter().map(|s| s.to_string()).collect())
-                .unwrap_or_default(),
-            fb::TaskVariant::CheckRateLimit => lr
-                .task_as_check_rate_limit()
-                .and_then(|r| r.held_queues())
-                .map(|v| v.iter().map(|s| s.to_string()).collect())
-                .unwrap_or_default(),
+            fb::TaskVariant::RunAttempt => {
+                fb_held_queues_to_owned(lr.task_as_run_attempt().and_then(|r| r.held_queues()))
+            }
+            fb::TaskVariant::CheckRateLimit => {
+                fb_held_queues_to_owned(lr.task_as_check_rate_limit().and_then(|r| r.held_queues()))
+            }
             _ => Vec::new(),
         }
     }
@@ -923,6 +1024,7 @@ impl DecodedLease {
             RunAttempt => task_as_run_attempt,
             RequestTicket => task_as_request_ticket,
             CheckRateLimit => task_as_check_rate_limit,
+            ResumeAfterConcurrencyGrant => task_as_resume_after_concurrency_grant,
             RefreshFloatingLimit => task_as_refresh_floating_limit,
         )
     }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -254,7 +254,6 @@ fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
             task_group,
             held_queues,
             limit_index,
-            start_at_ms,
             priority,
         } => {
             let request_id = builder.create_string(request_id);
@@ -273,7 +272,6 @@ fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
                     task_group: Some(task_group),
                     held_queues: Some(held_queues),
                     limit_index: *limit_index,
-                    start_at_ms: *start_at_ms,
                     priority: *priority,
                 },
             );
@@ -731,7 +729,6 @@ fn task_from_fb_variant(
                 task_group: rg.task_group().unwrap_or_default().to_string(),
                 held_queues: fb_held_queues_to_owned(rg.held_queues()),
                 limit_index: rg.limit_index(),
-                start_at_ms: rg.start_at_ms(),
                 priority: rg.priority(),
             })
         }

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -69,7 +69,7 @@ use crate::keys::{
 };
 use crate::metrics::Metrics;
 use crate::shard_range::ShardRange;
-use crate::task::{ConcurrencyAction, HolderRecord, Task};
+use crate::task::{ConcurrencyAction, HeldQueue, HolderRecord, Task};
 use crate::task_broker::TaskBrokerRegistry;
 
 /// Error type for concurrency operations that can fail due to storage or encoding errors.
@@ -759,6 +759,9 @@ impl ConcurrencyManager {
         attempt_number: u32,
         relative_attempt_number: u32,
         skip_try_reserve: bool,
+        held_queues_so_far: &[HeldQueue],
+        limit_index_in_order: u32,
+        total_limits: u32,
     ) -> Result<Option<RequestTicketOutcome>, ConcurrencyError> {
         // Only gate on the first limit (if any)
         let Some(limit) = limits.first() else {
@@ -793,6 +796,7 @@ impl ConcurrencyManager {
                 attempt_number,
                 relative_attempt_number,
                 task_group,
+                held_queues_so_far,
             )?;
             if let Some(ref m) = self.metrics {
                 m.record_concurrency_tickets_granted(
@@ -819,6 +823,9 @@ impl ConcurrencyManager {
                 attempt_number,
                 relative_attempt_number,
                 task_group,
+                held_queues_so_far,
+                limit_index_in_order,
+                total_limits,
             )?;
             Ok(Some(RequestTicketOutcome::TicketRequested {
                 queue: queue.clone(),
@@ -837,6 +844,9 @@ impl ConcurrencyManager {
                 relative_attempt_number,
                 request_id: request_id.clone(),
                 task_group: task_group.to_string(),
+                held_queues: held_queues_so_far.to_vec(),
+                limit_index: limit_index_in_order,
+                total_limits,
             };
             let ticket_value = encode_task(&ticket);
             writer.put(
@@ -1091,6 +1101,9 @@ impl ConcurrencyManager {
             start_time_ms: i64,
             priority: u8,
             task_group: String,
+            held_queues: Vec<HeldQueue>,
+            limit_index: u32,
+            total_limits: u32,
         }
 
         let mut max_concurrency: Option<(usize, ConcurrencyLimitType)> = None;
@@ -1201,6 +1214,18 @@ impl ConcurrencyManager {
                     };
                 }
 
+                let held_queues: Vec<HeldQueue> = et
+                    .held_queues()
+                    .map(|v| {
+                        v.iter()
+                            .map(|hq| HeldQueue {
+                                queue: hq.queue().unwrap_or_default().to_string(),
+                                task_id: hq.task_id().unwrap_or_default().to_string(),
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
                 scanned.push(ScannedRequest {
                     request_key: kv.key.to_vec(),
                     request_id,
@@ -1210,6 +1235,9 @@ impl ConcurrencyManager {
                     start_time_ms,
                     priority: et.priority(),
                     task_group: et.task_group().unwrap_or_default().to_string(),
+                    held_queues,
+                    limit_index: et.limit_index(),
+                    total_limits: et.total_limits(),
                 });
             }
 
@@ -1325,16 +1353,49 @@ impl ConcurrencyManager {
                     &holder_val,
                 );
 
-                // [SILO-GRANT-4] Create RunAttempt task
-                let tval = encode_task(&Task::RunAttempt {
-                    id: req.request_id.clone(),
-                    tenant: tenant.to_string(),
-                    job_id: req.job_id.clone(),
-                    attempt_number: req.attempt_number,
-                    relative_attempt_number: req.relative_attempt_number,
-                    held_queues: vec![queue.to_string()],
-                    task_group: req.task_group.clone(),
+                // Append the just-granted queue to the chain's held_queues,
+                // paired with the request_id that created its holder.
+                let mut held_queues: Vec<HeldQueue> = req.held_queues.clone();
+                held_queues.push(HeldQueue {
+                    queue: queue.to_string(),
+                    task_id: req.request_id.clone(),
                 });
+
+                let next_index = req.limit_index.saturating_add(1);
+                let task = if next_index >= req.total_limits {
+                    // Terminal: this was the last limit. Write the RunAttempt
+                    // with the full accumulated held_queues so report_outcome
+                    // can release every holder.
+                    // [SILO-GRANT-4]
+                    Task::RunAttempt {
+                        id: req.request_id.clone(),
+                        tenant: tenant.to_string(),
+                        job_id: req.job_id.clone(),
+                        attempt_number: req.attempt_number,
+                        relative_attempt_number: req.relative_attempt_number,
+                        held_queues,
+                        task_group: req.task_group.clone(),
+                    }
+                } else {
+                    // More limits remain: write a resume task that
+                    // `handle_resume_after_grant` will dispatch back into
+                    // `enqueue_limit_task_at_index`, mirroring how
+                    // `handle_check_rate_limit` resumes after a rate-limit
+                    // check passes.
+                    Task::ResumeAfterConcurrencyGrant {
+                        request_id: req.request_id.clone(),
+                        tenant: tenant.to_string(),
+                        job_id: req.job_id.clone(),
+                        attempt_number: req.attempt_number,
+                        relative_attempt_number: req.relative_attempt_number,
+                        task_group: req.task_group.clone(),
+                        held_queues,
+                        limit_index: next_index,
+                        start_at_ms: req.start_time_ms,
+                        priority: req.priority,
+                    }
+                };
+                let tval = encode_task(&task);
                 batch.put(
                     task_key(
                         &req.task_group,
@@ -1430,6 +1491,7 @@ fn append_grant_edits<W: WriteBatcher>(
     attempt_number: u32,
     relative_attempt_number: u32,
     task_group: &str,
+    held_queues_so_far: &[HeldQueue],
 ) -> Result<(), ConcurrencyError> {
     let holder = HolderRecord {
         granted_at_ms: now_ms,
@@ -1437,13 +1499,25 @@ fn append_grant_edits<W: WriteBatcher>(
     let holder_val = encode_holder(&holder);
     writer.put(concurrency_holder_key(tenant, queue, task_id), &holder_val)?;
 
+    // The interim RunAttempt holds the accumulated `held_queues_so_far` plus
+    // the just-granted queue (paired with `task_id`, which is the request_id
+    // that created the holder). It is either (a) overwritten in the terminal
+    // branch of `enqueue_limit_task_at_index` with the full accumulated
+    // `held_queues`, or (b) deleted by the `queued_with_request && !grants.is_empty()`
+    // cleanup in `enqueue.rs` when a later limit queues. Neither path may
+    // bypass that cleanup — see #317.
+    let mut held_queues: Vec<HeldQueue> = held_queues_so_far.to_vec();
+    held_queues.push(HeldQueue {
+        queue: queue.to_string(),
+        task_id: task_id.to_string(),
+    });
     let task = Task::RunAttempt {
         id: task_id.to_string(),
         tenant: tenant.to_string(),
         job_id: job_id.to_string(),
         attempt_number,
         relative_attempt_number,
-        held_queues: vec![queue.to_string()],
+        held_queues,
         task_group: task_group.to_string(),
     };
     let task_value = encode_task(&task);
@@ -1466,6 +1540,9 @@ fn append_request_edits<W: WriteBatcher>(
     attempt_number: u32,
     relative_attempt_number: u32,
     task_group: &str,
+    held_queues_so_far: &[HeldQueue],
+    limit_index: u32,
+    total_limits: u32,
 ) -> Result<(), ConcurrencyError> {
     let action = ConcurrencyAction::EnqueueTask {
         start_time_ms,
@@ -1474,6 +1551,9 @@ fn append_request_edits<W: WriteBatcher>(
         attempt_number,
         relative_attempt_number,
         task_group: task_group.to_string(),
+        held_queues: held_queues_so_far.to_vec(),
+        limit_index,
+        total_limits,
     };
     let action_val = encode_concurrency_action(&action);
     let suffix = format!("{:08x}", rand::random::<u32>());

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1391,7 +1391,6 @@ impl ConcurrencyManager {
                         task_group: req.task_group.clone(),
                         held_queues,
                         limit_index: next_index,
-                        start_at_ms: req.start_time_ms,
                         priority: req.priority,
                     }
                 };

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -13,7 +13,7 @@ use crate::keys::{
     concurrency_holder_key, concurrency_request_job_prefix, concurrency_requester_counter_key,
     end_bound, job_cancelled_key, job_info_key, job_status_key, task_key,
 };
-use crate::task::Task;
+use crate::task::{HeldQueue, Task};
 
 impl JobStoreShard {
     /// Cancel a job by id. Prevents further execution and signals running workers to stop.
@@ -88,8 +88,7 @@ impl JobStoreShard {
         let was_scheduled = status.kind == JobStatusKind::Scheduled;
 
         // Track concurrency state for post-commit cleanup
-        let mut held_queues_to_release: Vec<String> = Vec::new();
-        let mut task_id_for_release: Option<String> = None;
+        let mut held_queues_to_release: Vec<HeldQueue> = Vec::new();
         let mut deleted_task_key: Option<Vec<u8>> = None;
 
         // [SILO-CXL-3] For Scheduled jobs, eagerly delete task and concurrency state
@@ -138,16 +137,18 @@ impl JobStoreShard {
 
                     match decoded {
                         Task::RunAttempt {
-                            id: tid,
+                            id: _tid,
                             held_queues,
                             ..
                         } => {
-                            // Delete concurrency holders for each held queue
-                            for queue in &held_queues {
-                                txn.delete(concurrency_holder_key(tenant, queue, &tid))?;
+                            // Delete concurrency holders for each held queue,
+                            // using the *creator's* task_id (stored on each
+                            // HeldQueue) rather than the RunAttempt's id —
+                            // resume-after-grant chains span multiple task_ids.
+                            for hq in &held_queues {
+                                txn.delete(concurrency_holder_key(tenant, &hq.queue, &hq.task_id))?;
                             }
                             if !held_queues.is_empty() {
-                                task_id_for_release = Some(tid);
                                 held_queues_to_release = held_queues;
                             }
                         }
@@ -195,15 +196,13 @@ impl JobStoreShard {
             self.brokers.evict_keys(std::slice::from_ref(key));
         }
 
-        // Release concurrency holders from in-memory counts and signal grant scanner
-        if !held_queues_to_release.is_empty() {
-            let finished_task_id = task_id_for_release.as_deref().unwrap_or_default();
-            for queue in &held_queues_to_release {
-                self.concurrency
-                    .counts()
-                    .atomic_release(tenant, queue, finished_task_id);
-                self.concurrency.request_grant(tenant, queue);
-            }
+        // Release concurrency holders from in-memory counts and signal grant scanner.
+        // Each HeldQueue carries the task_id its in-memory reservation was indexed by.
+        for hq in &held_queues_to_release {
+            self.concurrency
+                .counts()
+                .atomic_release(tenant, &hq.queue, &hq.task_id);
+            self.concurrency.request_grant(tenant, &hq.queue);
         }
 
         Ok(())

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -2,7 +2,9 @@
 
 use slatedb::IsolationLevel;
 
-use crate::codec::{decode_cancellation_at_ms, decode_task, encode_job_cancellation};
+use crate::codec::{
+    decode_cancellation_at_ms, decode_concurrency_action, decode_task, encode_job_cancellation,
+};
 use crate::job::{JobCancellation, JobStatus, JobStatusKind, JobView, Limit};
 use crate::job_store_shard::counters::encode_counter;
 use crate::job_store_shard::helpers::{
@@ -152,28 +154,67 @@ impl JobStoreShard {
                                 held_queues_to_release = held_queues;
                             }
                         }
-                        Task::RequestTicket { .. } => {
+                        Task::RequestTicket { held_queues, .. } => {
                             // FutureRequestTaskWritten case: the RequestTicket task IS the
-                            // pending request mechanism. Deleting the task is sufficient.
+                            // pending request mechanism, so deleting the task key cleans up
+                            // the request. Defensive: a queued chain may carry
+                            // `held_queues` from earlier limits — currently unreachable in
+                            // practice (the future-scheduled RequestTicket only writes from
+                            // the first limit, before any held_queues accumulate), but the
+                            // field is typed as a possibility so release them if present.
+                            for hq in &held_queues {
+                                txn.delete(concurrency_holder_key(tenant, &hq.queue, &hq.task_id))?;
+                            }
+                            if !held_queues.is_empty() {
+                                held_queues_to_release = held_queues;
+                            }
+                        }
+                        Task::ResumeAfterConcurrencyGrant { held_queues, .. } => {
+                            // Mid-chain resume task: release every accumulated holder
+                            // (under the request_id that created each row).
+                            for hq in &held_queues {
+                                txn.delete(concurrency_holder_key(tenant, &hq.queue, &hq.task_id))?;
+                            }
+                            if !held_queues.is_empty() {
+                                held_queues_to_release = held_queues;
+                            }
+                        }
+                        Task::CheckRateLimit { held_queues, .. } => {
+                            // Mid-chain rate-limit check: release any concurrency holders
+                            // accumulated from earlier limits in the chain.
+                            for hq in &held_queues {
+                                txn.delete(concurrency_holder_key(tenant, &hq.queue, &hq.task_id))?;
+                            }
+                            if !held_queues.is_empty() {
+                                held_queues_to_release = held_queues;
+                            }
                         }
                         _ => {
-                            // Other task types (CheckRateLimit, RefreshFloatingLimit, etc.)
+                            // Other task types (RefreshFloatingLimit, etc.)
                             // Just delete the task key above.
                         }
                     }
                 } else {
                     // No task found - check for TicketRequested case (request record
                     // exists but no task in DB queue). Scan for requests for this job.
-                    self.delete_concurrency_requests_for_job(
-                        &txn,
-                        tenant,
-                        id,
-                        &limits,
-                        attempt_number,
-                        start_time_ms,
-                        priority,
-                    )
-                    .await?;
+                    // Each ConcurrencyAction may carry held_queues from earlier-granted
+                    // limits in the chain — release those holders too, otherwise a
+                    // mid-chain cancel orphans the earlier-granted slots permanently.
+                    let mut from_requests = self
+                        .delete_concurrency_requests_for_job(
+                            &txn,
+                            tenant,
+                            id,
+                            &limits,
+                            attempt_number,
+                            start_time_ms,
+                            priority,
+                        )
+                        .await?;
+                    for hq in &from_requests {
+                        txn.delete(concurrency_holder_key(tenant, &hq.queue, &hq.task_id))?;
+                    }
+                    held_queues_to_release.append(&mut from_requests);
                 }
             }
         }
@@ -224,7 +265,11 @@ impl JobStoreShard {
         attempt_number: u32,
         start_time_ms: i64,
         priority: u8,
-    ) -> Result<(), JobStoreShardError> {
+    ) -> Result<Vec<HeldQueue>, JobStoreShardError> {
+        // Accumulate any held_queues carried by the deleted EnqueueTask actions.
+        // Mid-chain cancellations need to release earlier-granted holders that
+        // the request was carrying forward.
+        let mut collected_held_queues: Vec<HeldQueue> = Vec::new();
         for limit in limits {
             let queue_key = match limit {
                 Limit::Concurrency(cl) => &cl.key,
@@ -232,7 +277,7 @@ impl JobStoreShard {
                 Limit::RateLimit(_) => continue,
             };
 
-            let deleted = self
+            let (deleted, mut from_held) = self
                 .delete_concurrency_requests_with_prefix(
                     txn,
                     tenant,
@@ -243,26 +288,32 @@ impl JobStoreShard {
                     priority,
                 )
                 .await?;
+            collected_held_queues.append(&mut from_held);
 
             if !deleted {
                 // Fallback: try with start_time_ms=0 (immediate scheduling case)
-                self.delete_concurrency_requests_with_prefix(
-                    txn,
-                    tenant,
-                    job_id,
-                    queue_key,
-                    attempt_number,
-                    0,
-                    priority,
-                )
-                .await?;
+                let (_, mut from_held_fb) = self
+                    .delete_concurrency_requests_with_prefix(
+                        txn,
+                        tenant,
+                        job_id,
+                        queue_key,
+                        attempt_number,
+                        0,
+                        priority,
+                    )
+                    .await?;
+                collected_held_queues.append(&mut from_held_fb);
             }
         }
-        Ok(())
+        Ok(collected_held_queues)
     }
 
     /// Scan a narrow prefix for this job's concurrency requests and delete them.
-    /// Returns true if any requests were deleted.
+    /// Returns `(any_deleted, held_queues_collected)`: `any_deleted` controls the
+    /// caller's start_time_ms fallback, and `held_queues_collected` is the union
+    /// of `held_queues` carried by every deleted EnqueueTask — the caller releases
+    /// those holders.
     #[expect(clippy::too_many_arguments)]
     async fn delete_concurrency_requests_with_prefix(
         &self,
@@ -273,7 +324,7 @@ impl JobStoreShard {
         attempt_number: u32,
         start_time_ms: i64,
         priority: u8,
-    ) -> Result<bool, JobStoreShardError> {
+    ) -> Result<(bool, Vec<HeldQueue>), JobStoreShardError> {
         let prefix = concurrency_request_job_prefix(
             tenant,
             queue_key,
@@ -286,7 +337,22 @@ impl JobStoreShard {
         let mut iter = self.db.scan::<Vec<u8>, _>(prefix..end).await?;
 
         let mut deleted_count: i64 = 0;
+        let mut collected: Vec<HeldQueue> = Vec::new();
         while let Some(kv) = iter.next().await? {
+            // Decode the EnqueueTask before deleting so we can release any
+            // earlier-chain holders it carried forward. Malformed actions are
+            // still deleted to drain the queue, but their held_queues are lost.
+            if let Ok(decoded) = decode_concurrency_action(kv.value.clone())
+                && let Some(et) = decoded.fb().variant_as_enqueue_task()
+                && let Some(hq_vec) = et.held_queues()
+            {
+                for hq in hq_vec.iter() {
+                    collected.push(HeldQueue {
+                        queue: hq.queue().unwrap_or_default().to_string(),
+                        task_id: hq.task_id().unwrap_or_default().to_string(),
+                    });
+                }
+            }
             txn.delete(&kv.key)?;
             deleted_count += 1;
             tracing::debug!(
@@ -303,7 +369,7 @@ impl JobStoreShard {
             txn.unmark_write([counter_key.as_slice()])?;
         }
 
-        Ok(deleted_count > 0)
+        Ok((deleted_count > 0, collected))
     }
 
     /// Check if a job has been cancelled.

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -752,7 +752,6 @@ impl JobStoreShard {
             task_group,
             held_queues,
             limit_index,
-            start_at_ms,
             priority,
         } = decoded.to_task()?
         else {
@@ -801,16 +800,22 @@ impl JobStoreShard {
             }
         };
 
-        // IMPORTANT: pass `start_at_ms: now_ms` rather than the original
-        // `start_at_ms` decoded from the resume task. The original task at
-        // task_key(...,start_at_ms) was just ack_deleted, which installs a
-        // broker tombstone on that key for ~64 scan generations. If any
-        // subsequent chain step (a re-promoted request or another resume task)
-        // writes a fresh task at the SAME task_key, the broker scanner would
-        // suppress it. Using `now_ms` shifts every downstream task_key to a
-        // strictly-later timestamp, sidestepping the tombstone. This mirrors
-        // the start_at_ms = now_ms pattern in `handle_check_rate_limit`.
-        let _ = start_at_ms; // kept on the task for diagnostics/expedite paths
+        // IMPORTANT: pass `start_at_ms: now_ms` for downstream chain steps.
+        // The resume task at task_key(...,parsed_start_time) was just
+        // ack_deleted, which installs a broker tombstone on that key for ~64
+        // scan generations. If any subsequent chain step writes a fresh task
+        // at the SAME task_key, the broker scanner would suppress it. Using
+        // `now_ms` shifts every downstream task_key to a strictly-later
+        // timestamp, sidestepping the tombstone. This mirrors the
+        // `start_at_ms = now_ms` pattern in `handle_check_rate_limit`.
+        //
+        // TODO(metrics): this also means `ready_to_start_latency_ms` (emitted
+        // by `handle_run_attempt` from `parse_task_key(task_key).start_time_ms`)
+        // measures only from the last chain hop, not from the job's original
+        // schedule. Same limitation exists for the CheckRateLimit chain. A
+        // proper fix requires propagating an `original_start_at_ms` through
+        // every chain-task variant so the final lease can compute end-to-end
+        // latency.
         let chain = self
             .enqueue_limit_task_at_index(
                 &mut DbWriteBatcher::new(&self.db, &mut state.batch),

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -15,7 +15,7 @@ use crate::keys::{
     attempt_key, concurrency_holder_key, job_info_key, leased_task_key, parse_task_key,
 };
 use crate::shard_range::ShardRange;
-use crate::task::{DEFAULT_LEASE_MS, LeaseRecord, LeasedRefreshTask, LeasedTask, Task};
+use crate::task::{DEFAULT_LEASE_MS, HeldQueue, LeaseRecord, LeasedRefreshTask, LeasedTask, Task};
 use crate::task_broker::BrokerTask;
 
 /// Mutable accumulators for a single dequeue iteration.
@@ -171,6 +171,10 @@ impl JobStoreShard {
                             &mut state, &entry.key, decoded, worker_id, now_ms, expiry_ms,
                         )
                         .await?;
+                    }
+                    fb::TaskVariant::ResumeAfterConcurrencyGrant => {
+                        self.handle_resume_after_grant(&mut state, &entry.key, decoded, now_ms)
+                            .await?;
                     }
                     other => {
                         return Err(JobStoreShardError::Codec(format!(
@@ -370,6 +374,18 @@ impl JobStoreShard {
         let relative_attempt_number = rt.relative_attempt_number();
         let request_id = rt.request_id().unwrap_or_default();
         let req_task_group = rt.task_group().unwrap_or_default();
+        let prior_held_queues: Vec<HeldQueue> = rt
+            .held_queues()
+            .map(|v| {
+                v.iter()
+                    .map(|hq| HeldQueue {
+                        queue: hq.queue().unwrap_or_default().to_string(),
+                        task_id: hq.task_id().unwrap_or_default().to_string(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let limit_index_at_queue_time = rt.limit_index();
         state.processed_internal = true;
         let tenant = tenant.to_string();
 
@@ -409,60 +425,105 @@ impl JobStoreShard {
                     .grants_to_rollback
                     .push((tenant.clone(), queue.clone(), request_id.clone()));
 
-                // Create RunAttempt task for the lease (new Task, not a copy)
-                let run = Task::RunAttempt {
-                    id: request_id.clone(),
-                    tenant: tenant.clone(),
-                    job_id: job_id.to_string(),
-                    attempt_number,
-                    relative_attempt_number,
-                    held_queues: vec![queue],
-                    task_group: req_task_group.to_string(),
-                };
-
-                let attempt_val = self
-                    .write_lease_and_attempt(
-                        &mut state.batch,
-                        worker_id,
-                        &run,
-                        &request_id,
-                        &tenant,
-                        job_id,
-                        attempt_number,
-                        relative_attempt_number,
-                        now_ms,
-                        expiry_ms,
-                    )
-                    .await?;
-
+                // Resume the chain at limit_index + 1. The just-granted queue
+                // is appended to held_queues, paired with `request_id` (the
+                // task_id that created its holder in
+                // `process_ticket_request_task`). If the chain walks to a
+                // terminal RunAttempt, we lease it in this iteration without
+                // a re-read; otherwise the resume task takes over and the
+                // worker leases on a subsequent pass.
                 let view = job_view.ok_or_else(|| {
                     JobStoreShardError::Codec(format!(
                         "job view missing for granted ticket, job_id={}",
                         job_id
                     ))
                 })?;
-                state
-                    .pending_attempts
-                    .push((tenant.clone(), view, attempt_val));
-                state.ack_deleted(task_key);
+                let limits = view.limits();
+                let mut full_held_queues = prior_held_queues.clone();
+                full_held_queues.push(HeldQueue {
+                    queue: queue.clone(),
+                    task_id: request_id.clone(),
+                });
+                let resume_index = (limit_index_at_queue_time + 1) as usize;
 
-                // Track for DST event emission after commit
-                state
-                    .leased_tasks_for_dst
-                    .push((tenant, job_id.to_string(), request_id));
+                let chain = self
+                    .enqueue_limit_task_at_index(
+                        &mut DbWriteBatcher::new(&self.db, &mut state.batch),
+                        LimitTaskParams {
+                            tenant: &tenant,
+                            task_id: &request_id,
+                            job_id,
+                            attempt_number,
+                            relative_attempt_number,
+                            limit_index: resume_index,
+                            limits: &limits,
+                            priority: rt.priority(),
+                            start_at_ms: now_ms,
+                            now_ms,
+                            held_queues: full_held_queues,
+                            task_group: req_task_group,
+                            skip_try_reserve: false,
+                            inline_terminal: true,
+                        },
+                    )
+                    .await?;
 
-                // Record concurrency ticket metric and ready-to-start latency
-                if let Some(ref m) = self.metrics {
+                for (q, tid) in chain.grants {
+                    state.grants_to_rollback.push((tenant.clone(), q, tid));
+                }
+
+                if let Some(run_attempt) = chain.terminal_run_attempt {
+                    // Chain reached a terminal RunAttempt — lease it now so
+                    // the worker can pick it up in this dequeue pass.
+                    let attempt_val = self
+                        .write_lease_and_attempt(
+                            &mut state.batch,
+                            worker_id,
+                            &run_attempt,
+                            &request_id,
+                            &tenant,
+                            job_id,
+                            attempt_number,
+                            relative_attempt_number,
+                            now_ms,
+                            expiry_ms,
+                        )
+                        .await?;
+                    state
+                        .pending_attempts
+                        .push((tenant.clone(), view, attempt_val));
+
+                    // Track for DST event emission after commit
+                    state
+                        .leased_tasks_for_dst
+                        .push((tenant, job_id.to_string(), request_id));
+
+                    if let Some(ref m) = self.metrics {
+                        m.record_concurrency_tickets_granted(
+                            self.name(),
+                            crate::metrics::GrantPath::Scanned,
+                            1,
+                        );
+                        if let Some(parsed) = parse_task_key(task_key) {
+                            let latency_ms = (now_ms - parsed.start_time_ms as i64).max(0) as f64;
+                            m.record_ready_to_start_latency_ms(
+                                self.name(),
+                                req_task_group,
+                                latency_ms,
+                            );
+                        }
+                    }
+                } else if let Some(ref m) = self.metrics {
+                    // Chain wrote a follow-up task (CheckRateLimit or another
+                    // RequestTicket). Still record the grant, but no lease /
+                    // latency yet — the next stage will lease.
                     m.record_concurrency_tickets_granted(
                         self.name(),
                         crate::metrics::GrantPath::Scanned,
                         1,
                     );
-                    if let Some(parsed) = parse_task_key(task_key) {
-                        let latency_ms = (now_ms - parsed.start_time_ms as i64).max(0) as f64;
-                        m.record_ready_to_start_latency_ms(self.name(), req_task_group, latency_ms);
-                    }
                 }
+                state.ack_deleted(task_key);
             }
             RequestTicketTaskOutcome::Requested => {
                 // Release inflight only; task key remains in DB and must be eligible
@@ -470,7 +531,19 @@ impl JobStoreShard {
                 state.ack_release(task_key);
             }
             RequestTicketTaskOutcome::JobMissing => {
-                // process_ticket_request_task deleted the task key.
+                // process_ticket_request_task deleted the task key. Also
+                // release any holders from earlier limits in the chain — the
+                // job is gone so they're definitively orphaned.
+                for hq in &prior_held_queues {
+                    state
+                        .batch
+                        .delete(concurrency_holder_key(&tenant, &hq.queue, &hq.task_id));
+                    state.holder_releases.push((
+                        tenant.clone(),
+                        hq.queue.clone(),
+                        hq.task_id.clone(),
+                    ));
+                }
                 state.ack_deleted(task_key);
             }
         }
@@ -521,15 +594,14 @@ impl JobStoreShard {
                     // Drop the task and release any concurrency holders it
                     // carries from earlier chained limits. Symmetric with the
                     // missing-job_info path below and with handle_run_attempt.
-                    for q in held_queues.iter() {
-                        let queue = q.clone();
+                    for hq in held_queues.iter() {
                         state
                             .batch
-                            .delete(concurrency_holder_key(tenant, &queue, check_task_id));
+                            .delete(concurrency_holder_key(tenant, &hq.queue, &hq.task_id));
                         state.holder_releases.push((
                             tenant.to_string(),
-                            queue,
-                            check_task_id.to_string(),
+                            hq.queue.clone(),
+                            hq.task_id.clone(),
                         ));
                     }
                     return Ok(());
@@ -538,15 +610,14 @@ impl JobStoreShard {
             None => {
                 // Job missing — drop the task and release any concurrency
                 // holders it carries from earlier chained limits.
-                for q in held_queues.iter() {
-                    let queue = q.clone();
+                for hq in held_queues.iter() {
                     state
                         .batch
-                        .delete(concurrency_holder_key(tenant, &queue, check_task_id));
+                        .delete(concurrency_holder_key(tenant, &hq.queue, &hq.task_id));
                     state.holder_releases.push((
                         tenant.to_string(),
-                        queue,
-                        check_task_id.to_string(),
+                        hq.queue.clone(),
+                        hq.task_id.clone(),
                     ));
                 }
                 return Ok(());
@@ -559,7 +630,7 @@ impl JobStoreShard {
         match rate_limit_result {
             Ok(result) if result.under_limit => {
                 // Rate limit passed! Proceed to next limit or RunAttempt
-                let grants = self
+                let chain = self
                     .enqueue_limit_task_at_index(
                         &mut DbWriteBatcher::new(&self.db, &mut state.batch),
                         LimitTaskParams {
@@ -576,11 +647,12 @@ impl JobStoreShard {
                             held_queues: held_queues.clone(),
                             task_group: check_task_group,
                             skip_try_reserve: false,
+                            inline_terminal: false,
                         },
                     )
                     .await?;
                 // Track any immediate grants for rollback if DB write fails
-                for (queue, task_id) in grants {
+                for (queue, task_id) in chain.grants {
                     state
                         .grants_to_rollback
                         .push((tenant.clone(), queue, task_id));
@@ -600,15 +672,14 @@ impl JobStoreShard {
                     // carries from earlier chained limits. Without this, a
                     // stranded holder permanently consumes a slot for the
                     // queue.
-                    for q in held_queues.iter() {
-                        let queue = q.clone();
+                    for hq in held_queues.iter() {
                         state
                             .batch
-                            .delete(concurrency_holder_key(tenant, &queue, check_task_id));
+                            .delete(concurrency_holder_key(tenant, &hq.queue, &hq.task_id));
                         state.holder_releases.push((
                             tenant.to_string(),
-                            queue,
-                            check_task_id.to_string(),
+                            hq.queue.clone(),
+                            hq.task_id.clone(),
                         ));
                     }
                     return Ok(());
@@ -655,6 +726,117 @@ impl JobStoreShard {
                     check_task_group,
                 )?;
             }
+        }
+
+        Ok(())
+    }
+
+    /// Process a ResumeAfterConcurrencyGrant task: load the job's limits and
+    /// re-enter the limit chain at `limit_index`. Mirrors the pass-through path
+    /// in `handle_check_rate_limit` but skips the rate-limit call — the
+    /// previous limit was a concurrency limit that was already granted by
+    /// `process_grants` and recorded on `held_queues`.
+    async fn handle_resume_after_grant(
+        &self,
+        state: &mut DequeueIterationState,
+        task_key: &[u8],
+        decoded: &DecodedTask,
+        now_ms: i64,
+    ) -> Result<(), JobStoreShardError> {
+        let Task::ResumeAfterConcurrencyGrant {
+            request_id,
+            tenant,
+            job_id,
+            attempt_number,
+            relative_attempt_number,
+            task_group,
+            held_queues,
+            limit_index,
+            start_at_ms,
+            priority,
+        } = decoded.to_task()?
+        else {
+            return Err(JobStoreShardError::Codec(
+                "expected ResumeAfterConcurrencyGrant variant".to_string(),
+            ));
+        };
+
+        state.processed_internal = true;
+        state.batch.delete(task_key);
+        state.ack_deleted(task_key);
+
+        // Load job info to get the full limits list
+        let job_key = job_info_key(&tenant, &job_id);
+        let maybe_job = self.db.get(&job_key).await?;
+        let job_view = match maybe_job {
+            Some(bytes) => match JobView::new(bytes) {
+                Ok(v) => v,
+                Err(_) => {
+                    // Release every holder under its own task_id and exit.
+                    for hq in &held_queues {
+                        state
+                            .batch
+                            .delete(concurrency_holder_key(&tenant, &hq.queue, &hq.task_id));
+                        state.holder_releases.push((
+                            tenant.clone(),
+                            hq.queue.clone(),
+                            hq.task_id.clone(),
+                        ));
+                    }
+                    return Ok(());
+                }
+            },
+            None => {
+                for hq in &held_queues {
+                    state
+                        .batch
+                        .delete(concurrency_holder_key(&tenant, &hq.queue, &hq.task_id));
+                    state.holder_releases.push((
+                        tenant.clone(),
+                        hq.queue.clone(),
+                        hq.task_id.clone(),
+                    ));
+                }
+                return Ok(());
+            }
+        };
+
+        // IMPORTANT: pass `start_at_ms: now_ms` rather than the original
+        // `start_at_ms` decoded from the resume task. The original task at
+        // task_key(...,start_at_ms) was just ack_deleted, which installs a
+        // broker tombstone on that key for ~64 scan generations. If any
+        // subsequent chain step (a re-promoted request or another resume task)
+        // writes a fresh task at the SAME task_key, the broker scanner would
+        // suppress it. Using `now_ms` shifts every downstream task_key to a
+        // strictly-later timestamp, sidestepping the tombstone. This mirrors
+        // the start_at_ms = now_ms pattern in `handle_check_rate_limit`.
+        let _ = start_at_ms; // kept on the task for diagnostics/expedite paths
+        let chain = self
+            .enqueue_limit_task_at_index(
+                &mut DbWriteBatcher::new(&self.db, &mut state.batch),
+                LimitTaskParams {
+                    tenant: &tenant,
+                    task_id: &request_id,
+                    job_id: &job_id,
+                    attempt_number,
+                    relative_attempt_number,
+                    limit_index: limit_index as usize,
+                    limits: &job_view.limits(),
+                    priority,
+                    start_at_ms: now_ms,
+                    now_ms,
+                    held_queues,
+                    task_group: &task_group,
+                    skip_try_reserve: false,
+                    inline_terminal: false,
+                },
+            )
+            .await?;
+
+        for (queue, task_id) in chain.grants {
+            state
+                .grants_to_rollback
+                .push((tenant.clone(), queue, task_id));
         }
 
         Ok(())
@@ -734,14 +916,15 @@ impl JobStoreShard {
             state.batch.delete(task_key);
             state.ack_deleted(task_key);
             if let Some(held) = ra.held_queues() {
-                for q in held.iter() {
-                    let queue = q.to_string();
+                for hq in held.iter() {
+                    let queue = hq.queue().unwrap_or_default().to_string();
+                    let holder_task_id = hq.task_id().unwrap_or_default().to_string();
                     state
                         .batch
-                        .delete(concurrency_holder_key(tenant, &queue, task_id));
+                        .delete(concurrency_holder_key(tenant, &queue, &holder_task_id));
                     state
                         .holder_releases
-                        .push((tenant.to_string(), queue, task_id.to_string()));
+                        .push((tenant.to_string(), queue, holder_task_id));
                 }
             }
             tracing::warn!(

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -21,7 +21,7 @@ use crate::keys::{
     task_key, tenant_status_counter_key,
 };
 use crate::retry::RetryPolicy;
-use crate::task::{GubernatorRateLimitData, Task};
+use crate::task::{GubernatorRateLimitData, HeldQueue, Task};
 
 /// Parameters for creating limit-processing tasks.
 /// Bundles the many fields needed by `enqueue_limit_task_at_index` into a single struct.
@@ -36,13 +36,21 @@ pub(crate) struct LimitTaskParams<'a> {
     pub priority: u8,
     pub start_at_ms: i64,
     pub now_ms: i64,
-    pub held_queues: Vec<String>,
+    pub held_queues: Vec<HeldQueue>,
     pub task_group: &'a str,
     /// When true, skip try_reserve and always go through the request queue.
     /// Used for retry scheduling where the old holder is still in-memory (released post-commit).
     /// This matches the Alloy model's completeFailureRetryReleaseTicket which creates a
     /// TicketRequest, not an immediate holder.
     pub skip_try_reserve: bool,
+    /// When true and the chain reaches a terminal `Task::RunAttempt`, do NOT
+    /// write it to `task_key` in the DB — just return it on
+    /// `EnqueueChainResult::terminal_run_attempt` so the caller can lease it
+    /// in place. Set by `handle_request_ticket`'s grant path, which leases
+    /// the task within the same dequeue iteration and would otherwise leave a
+    /// stale RunAttempt at `task_key` that the broker can re-scan and grant a
+    /// second lease for the same job.
+    pub inline_terminal: bool,
 }
 
 /// Canonical processing order for a job's limits: Concurrency first, then
@@ -52,6 +60,14 @@ pub(crate) struct LimitTaskParams<'a> {
 /// strictly-tighter Concurrency limit blocks the job *before* it acquires a
 /// FloatingConcurrency slot — otherwise the FC grant produces a leasable
 /// `RunAttempt[FC]` that bypasses the still-full Concurrency limit.
+///
+/// IMPORTANT: This order is wire-format-load-bearing. The position within
+/// this canonical order is stored in `EnqueueTask.limit_index` and
+/// `RequestTicket.limit_index` so that promotion paths (the grant scanner,
+/// `handle_check_rate_limit`, `handle_resume_after_grant`) can pick up at
+/// `limit_index + 1`. Changing the sort key here would make in-flight
+/// requests resume at the wrong position; any change must either drain the
+/// pending request queue first or version-gate the encoding.
 pub(crate) fn limit_processing_order(limits: &[Limit]) -> Vec<usize> {
     let kind_rank = |i: usize| -> u8 {
         match &limits[i] {
@@ -73,6 +89,19 @@ enum GrantResult {
     Queued,
 }
 
+/// Result of `enqueue_limit_task_at_index`. The `grants` field is the
+/// (queue, task_id) pairs of in-memory reservations that need to be rolled
+/// back if the durable batch write fails. The `terminal_run_attempt` field
+/// is populated when the chain walked all the way to a terminal
+/// `Task::RunAttempt` write at the leasable task_key — the dequeue path
+/// uses this to hand the task to `write_lease_and_attempt` without an
+/// extra DB read. Other callers (`enqueue_batch`, retry scheduling, the
+/// rate-limit pass-through) can ignore it.
+pub(crate) struct EnqueueChainResult {
+    pub grants: Vec<(String, String)>,
+    pub terminal_run_attempt: Option<Task>,
+}
+
 /// Process the outcome of a `handle_enqueue` call, updating shared loop state.
 /// Returns `Granted` if the caller should continue to the next limit, or `Queued`
 /// if the caller should return early.
@@ -81,7 +110,7 @@ fn record_grant_outcome(
     queue_key: &str,
     grants: &mut Vec<(String, String)>,
     current_task_id: &str,
-    current_held_queues: &mut Vec<String>,
+    current_held_queues: &mut Vec<HeldQueue>,
     current_index: &mut usize,
 ) -> GrantResult {
     match outcome {
@@ -93,16 +122,19 @@ fn record_grant_outcome(
             // which rewrites the RunAttempt with the full accumulated
             // current_held_queues so ReportOutcome can release every holder.
             //
-            // Crucially, `current_task_id` is NOT cycled here. The chained
-            // cleanup paths (handle_check_rate_limit, handle_run_attempt) all
-            // release holders by `concurrency_holder_key(tenant, queue,
-            // <chained_task_id>)`, so every holder we accumulate across the
-            // limit chain must share one task_id — the one carried forward to
-            // the final RunAttempt / CheckRateLimit task. Cycling here left
-            // earlier-granted holders orphaned and produced leaked slots on
-            // outcome release.
+            // Each HeldQueue records the task_id that created its holder —
+            // that's what the release path uses to look up
+            // `concurrency_holder_key(tenant, queue, task_id)`. Within the
+            // initial-enqueue chain this happens to equal `current_task_id`,
+            // but pairing it explicitly removes the implicit invariant that
+            // every holder in a chain must share one task_id (the resume-
+            // after-grant path generates holders under request_ids that
+            // differ from the final RunAttempt's `id`).
             grants.push((queue_key.to_string(), current_task_id.to_string()));
-            current_held_queues.push(queue_key.to_string());
+            current_held_queues.push(HeldQueue {
+                queue: queue_key.to_string(),
+                task_id: current_task_id.to_string(),
+            });
             *current_index += 1;
             GrantResult::Granted
         }
@@ -388,25 +420,28 @@ impl JobStoreShard {
 
         Self::write_job_status_with_index(writer, tenant, job_id, job_status)?;
 
-        self.enqueue_limit_task_at_index(
-            writer,
-            LimitTaskParams {
-                tenant,
-                task_id: &first_task_id,
-                job_id,
-                attempt_number: 1,
-                relative_attempt_number: 1,
-                limit_index: 0,
-                limits: &job.limits,
-                priority,
-                start_at_ms,
-                now_ms,
-                held_queues: Vec::new(),
-                task_group,
-                skip_try_reserve: false,
-            },
-        )
-        .await
+        Ok(self
+            .enqueue_limit_task_at_index(
+                writer,
+                LimitTaskParams {
+                    tenant,
+                    task_id: &first_task_id,
+                    job_id,
+                    attempt_number: 1,
+                    relative_attempt_number: 1,
+                    limit_index: 0,
+                    limits: &job.limits,
+                    priority,
+                    start_at_ms,
+                    now_ms,
+                    held_queues: Vec::new(),
+                    task_group,
+                    skip_try_reserve: false,
+                    inline_terminal: false,
+                },
+            )
+            .await?
+            .grants)
     }
 
     /// Complete an enqueue after successful write/commit and DST event emission.
@@ -453,7 +488,7 @@ impl JobStoreShard {
         &self,
         writer: &mut W,
         params: LimitTaskParams<'_>,
-    ) -> Result<Vec<(String, String)>, JobStoreShardError> {
+    ) -> Result<EnqueueChainResult, JobStoreShardError> {
         let LimitTaskParams {
             tenant,
             task_id,
@@ -468,6 +503,7 @@ impl JobStoreShard {
             held_queues,
             task_group,
             skip_try_reserve,
+            inline_terminal,
         } = params;
         // Walk limits in the canonical processing order (see
         // `limit_processing_order`). `current_index` and the `limit_index`
@@ -475,6 +511,7 @@ impl JobStoreShard {
         // order function is deterministic on `limits`, so dequeue's
         // `limit_index + 1` continuation lands on the correct next entry.
         let order = limit_processing_order(limits);
+        let total_limits = limits.len() as u32;
         let mut grants = Vec::new();
         let mut current_index = limit_index;
         let mut current_held_queues = held_queues;
@@ -492,16 +529,24 @@ impl JobStoreShard {
                     held_queues: current_held_queues,
                     task_group: task_group.to_string(),
                 };
-                put_task(
-                    writer,
-                    task_group,
-                    start_at_ms,
-                    priority,
-                    job_id,
-                    attempt_number,
-                    &run_task,
-                )?;
-                return Ok(grants);
+                // Skip the DB put when the caller is going to lease the
+                // RunAttempt inline this iteration — otherwise the broker can
+                // re-scan it from `task_key` and hand out a second lease.
+                if !inline_terminal {
+                    put_task(
+                        writer,
+                        task_group,
+                        start_at_ms,
+                        priority,
+                        job_id,
+                        attempt_number,
+                        &run_task,
+                    )?;
+                }
+                return Ok(EnqueueChainResult {
+                    grants,
+                    terminal_run_attempt: Some(run_task),
+                });
             }
 
             match &limits[order[current_index]] {
@@ -524,6 +569,9 @@ impl JobStoreShard {
                             attempt_number,
                             relative_attempt_number,
                             skip_try_reserve,
+                            &current_held_queues,
+                            current_index as u32,
+                            total_limits,
                         )
                         .await?;
 
@@ -558,7 +606,10 @@ impl JobStoreShard {
                                 attempt_number,
                             ))?;
                         }
-                        return Ok(grants);
+                        return Ok(EnqueueChainResult {
+                            grants,
+                            terminal_run_attempt: None,
+                        });
                     }
                 }
 
@@ -593,6 +644,9 @@ impl JobStoreShard {
                             attempt_number,
                             relative_attempt_number,
                             skip_try_reserve,
+                            &current_held_queues,
+                            current_index as u32,
+                            total_limits,
                         )
                         .await?;
 
@@ -646,7 +700,10 @@ impl JobStoreShard {
                                 attempt_number,
                             ))?;
                         }
-                        return Ok(grants);
+                        return Ok(EnqueueChainResult {
+                            grants,
+                            terminal_run_attempt: None,
+                        });
                     }
                 }
 
@@ -675,7 +732,10 @@ impl JobStoreShard {
                         attempt_number,
                         &task,
                     )?;
-                    return Ok(grants);
+                    return Ok(EnqueueChainResult {
+                        grants,
+                        terminal_run_attempt: None,
+                    });
                 }
             }
         }

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -274,9 +274,11 @@ impl JobStoreShard {
                         held_queues: Vec::new(),
                         task_group: &params.task_group,
                         skip_try_reserve: false,
+                        inline_terminal: false,
                     },
                 )
-                .await?;
+                .await?
+                .grants;
         }
 
         // Include counters in the transaction (unmark_write excludes them from conflict detection)
@@ -542,7 +544,7 @@ impl JobStoreShard {
         let priority = existing_job.priority();
         let stored_limits = existing_job.limits();
         let mut matched_task_keys: Vec<Vec<u8>> = Vec::new();
-        let mut released_holders: Vec<(String, Vec<String>)> = Vec::new();
+        let mut released_holders: Vec<(String, Vec<crate::task::HeldQueue>)> = Vec::new();
 
         if old_status.kind == JobStatusKind::Scheduled {
             // O(1) task key reconstruction from status fields (same pattern as cancel/expedite/lease)
@@ -577,9 +579,12 @@ impl JobStoreShard {
                         held_queues,
                         ..
                     } => {
-                        // Delete concurrency holders for each held queue
-                        for queue in &held_queues {
-                            let holder_key = concurrency_holder_key(tenant, queue, &tid);
+                        // Delete concurrency holders for each held queue, using
+                        // the *creator's* task_id (stored on each HeldQueue) so
+                        // the resume-after-grant path's mixed-task_id chains
+                        // release correctly.
+                        for hq in &held_queues {
+                            let holder_key = concurrency_holder_key(tenant, &hq.queue, &hq.task_id);
                             txn.delete(&holder_key)?;
                         }
                         if !held_queues.is_empty() {
@@ -654,9 +659,11 @@ impl JobStoreShard {
                         held_queues: Vec::new(),
                         task_group: &task_group,
                         skip_try_reserve: false,
+                        inline_terminal: false,
                     },
                 )
-                .await?;
+                .await?
+                .grants;
         }
         // [SILO-REIMP-7] If terminal: status is terminal, no new tasks
 
@@ -709,12 +716,14 @@ impl JobStoreShard {
 
         // Release in-memory holders and immediately request grant scanning.
         // This avoids waiting for periodic reconciliation when slots free up.
-        for (finished_task_id, held_queues) in &released_holders {
-            for queue in held_queues {
+        // `finished_task_id` is no longer the in-memory key — each HeldQueue
+        // carries the task_id its holder was indexed by.
+        for (_finished_task_id, held_queues) in &released_holders {
+            for hq in held_queues {
                 self.concurrency
                     .counts()
-                    .atomic_release(tenant, queue, finished_task_id);
-                self.concurrency.request_grant(tenant, queue);
+                    .atomic_release(tenant, &hq.queue, &hq.task_id);
+                self.concurrency.request_grant(tenant, &hq.queue);
             }
         }
 

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -602,16 +602,29 @@ impl JobStoreShard {
                 // status-derived attempt/start fields (same approach as cancel).
                 // [SILO-REIMP-CONC-5] Scheduled old-state reimport performs targeted
                 // request-key cleanup for the old scheduled attempt.
-                self.delete_concurrency_requests_for_job(
-                    &txn,
-                    tenant,
-                    job_id,
-                    &stored_limits,
-                    attempt_number,
-                    start_time_ms,
-                    priority,
-                )
-                .await?;
+                // Mid-chain reimport: any held_queues carried on a pending
+                // EnqueueTask need to be released, otherwise reimport orphans
+                // earlier-granted holders.
+                let from_requests = self
+                    .delete_concurrency_requests_for_job(
+                        &txn,
+                        tenant,
+                        job_id,
+                        &stored_limits,
+                        attempt_number,
+                        start_time_ms,
+                        priority,
+                    )
+                    .await?;
+                if !from_requests.is_empty() {
+                    for hq in &from_requests {
+                        let holder_key = concurrency_holder_key(tenant, &hq.queue, &hq.task_id);
+                        txn.delete(&holder_key)?;
+                    }
+                    // Synthesize a "released" entry so the post-commit loop
+                    // drives atomic_release for each holder.
+                    released_holders.push((String::new(), from_requests));
+                }
             }
         }
 

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -241,9 +241,11 @@ impl JobStoreShard {
                                     held_queues: Vec::new(),
                                     task_group,
                                     skip_try_reserve: true,
+                                    inline_terminal: false,
                                 },
                             )
-                            .await?;
+                            .await?
+                            .grants;
 
                         // [SILO-RETRY-3] Set job status to Scheduled with next attempt time
                         let job_status =
@@ -282,9 +284,14 @@ impl JobStoreShard {
         }
 
         // [SILO-REL-1][SILO-RETRY-REL] Delete concurrency holders in the batch.
-        // In-memory release happens post-commit via atomic_release.
-        for queue in &held_queues_local {
-            batch.delete(concurrency_holder_key(&tenant, queue, task_id));
+        // In-memory release happens post-commit via atomic_release. Each
+        // HeldQueue carries the task_id of the request that *created* its
+        // holder — that's what `concurrency_holder_key` was indexed by. The
+        // lease's task_id is only correct for the initial-enqueue chain (where
+        // every holder shares one id); the resume-after-grant path produces
+        // chains whose holders span multiple task_ids.
+        for hq in &held_queues_local {
+            batch.delete(concurrency_holder_key(&tenant, &hq.queue, &hq.task_id));
         }
 
         // Two-phase DST events: emit before write for correct causal ordering,
@@ -333,10 +340,11 @@ impl JobStoreShard {
         dst_events::confirm_write(write_op);
 
         // Post-commit: release in-memory concurrency counts and signal grant scanner.
-        for queue in &held_queues_local {
+        for hq in &held_queues_local {
             let span = info_span!(
                 "concurrency.release",
-                queue = %queue,
+                queue = %hq.queue,
+                holder_task_id = %hq.task_id,
                 finished_task_id = %task_id
             );
             let _g = span.enter();
@@ -344,8 +352,8 @@ impl JobStoreShard {
 
             self.concurrency
                 .counts()
-                .atomic_release(&tenant, queue, task_id);
-            self.concurrency.request_grant(&tenant, queue);
+                .atomic_release(&tenant, &hq.queue, &hq.task_id);
+            self.concurrency.request_grant(&tenant, &hq.queue);
         }
         // If we scheduled a follow-up that is ready now, wake the scanner
         if let Some(nt) = followup_next_time

--- a/src/job_store_shard/rate_limit.rs
+++ b/src/job_store_shard/rate_limit.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 use crate::gubernator::{GubernatorError, RateLimitResult};
 use crate::job_store_shard::helpers::{WriteBatcher, put_task};
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
-use crate::task::{GubernatorRateLimitData, Task};
+use crate::task::{GubernatorRateLimitData, HeldQueue, Task};
 
 impl JobStoreShard {
     /// Schedule a rate limit check retry task
@@ -22,7 +22,7 @@ impl JobStoreShard {
         retry_count: u32,
         started_at_ms: i64,
         priority: u8,
-        held_queues: &[String],
+        held_queues: &[HeldQueue],
         retry_at_ms: i64,
         task_group: &str,
     ) -> Result<(), JobStoreShardError> {

--- a/src/task.rs
+++ b/src/task.rs
@@ -93,7 +93,6 @@ pub enum Task {
         task_group: String,
         held_queues: Vec<HeldQueue>,
         limit_index: u32,
-        start_at_ms: i64,
         priority: u8,
     },
     /// Worker task: refresh a floating concurrency limit's max concurrency value

--- a/src/task.rs
+++ b/src/task.rs
@@ -9,6 +9,17 @@ use crate::job_attempt::JobAttemptView;
 /// Default lease duration for dequeued tasks (milliseconds)
 pub const DEFAULT_LEASE_MS: i64 = 10_000;
 
+/// A concurrency holder accumulated by the limit chain: the queue whose holder
+/// was created and the task_id that created it. Stored on every task variant
+/// that participates in the chain so each holder can be released via
+/// `concurrency_holder_key(tenant, queue, task_id)` with the *creator's*
+/// task_id rather than the lease/RunAttempt task_id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeldQueue {
+    pub queue: String,
+    pub task_id: String,
+}
+
 /// A task is a unit of work that a worker needs to pickup and action to move the system forward.
 #[derive(Debug, Clone)]
 pub enum Task {
@@ -21,7 +32,7 @@ pub enum Task {
         attempt_number: u32,
         /// Attempt number within current run (resets to 1 on job restart)
         relative_attempt_number: u32,
-        held_queues: Vec<String>,
+        held_queues: Vec<HeldQueue>,
         task_group: String,
     },
     /// Internal: request a concurrency ticket for a queue at or after a specific time
@@ -37,6 +48,15 @@ pub enum Task {
         relative_attempt_number: u32,
         request_id: String,
         task_group: String,
+        /// Queues already held from earlier limits in the canonical-order chain
+        held_queues: Vec<HeldQueue>,
+        /// Position within the canonical limit-processing order at which this
+        /// RequestTicket was enqueued. On grant, the chain resumes at
+        /// `limit_index + 1`.
+        limit_index: u32,
+        /// Total number of limits in the job at queue-time, so the grant path
+        /// can decide terminal-vs-resume without re-reading job_info.
+        total_limits: u32,
     },
     /// Internal: check a Gubernator rate limit before proceeding
     CheckRateLimit {
@@ -58,8 +78,23 @@ pub enum Task {
         /// Priority for enqueueing subsequent tasks
         priority: u8,
         /// Queues already held from previous concurrency limits
-        held_queues: Vec<String>,
+        held_queues: Vec<HeldQueue>,
         task_group: String,
+    },
+    /// Internal: resume the limit chain after a queued concurrency ticket was
+    /// granted by `process_grants`. The granted queue has already been added
+    /// to `held_queues`; this task drives the chain forward at `limit_index`.
+    ResumeAfterConcurrencyGrant {
+        request_id: String,
+        tenant: String,
+        job_id: String,
+        attempt_number: u32,
+        relative_attempt_number: u32,
+        task_group: String,
+        held_queues: Vec<HeldQueue>,
+        limit_index: u32,
+        start_at_ms: i64,
+        priority: u8,
     },
     /// Worker task: refresh a floating concurrency limit's max concurrency value
     RefreshFloatingLimit {
@@ -81,6 +116,7 @@ impl Task {
             Task::RunAttempt { tenant, .. } => tenant,
             Task::RequestTicket { tenant, .. } => tenant,
             Task::CheckRateLimit { tenant, .. } => tenant,
+            Task::ResumeAfterConcurrencyGrant { tenant, .. } => tenant,
             Task::RefreshFloatingLimit { tenant, .. } => tenant,
         }
     }
@@ -149,6 +185,16 @@ pub enum ConcurrencyAction {
         /// Attempt number within current run (resets to 1 on job restart)
         relative_attempt_number: u32,
         task_group: String,
+        /// Queues already held from earlier limits in the canonical-order chain.
+        held_queues: Vec<HeldQueue>,
+        /// Position within the canonical limit-processing order at which this
+        /// request was enqueued. The grant path uses `limit_index + 1` as the
+        /// resume point.
+        limit_index: u32,
+        /// Total number of limits in the job at queue-time. The grant path
+        /// uses this to decide terminal-vs-resume without an extra job_info
+        /// lookup.
+        total_limits: u32,
     },
 }
 

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -7,7 +7,9 @@ use silo::codec::{
 };
 use silo::job::{FloatingLimitState, JobCancellation, JobInfo, JobStatus, JobStatusKind};
 use silo::job_attempt::{AttemptStatus, JobAttempt};
-use silo::task::{ConcurrencyAction, GubernatorRateLimitData, HolderRecord, LeaseRecord, Task};
+use silo::task::{
+    ConcurrencyAction, GubernatorRateLimitData, HeldQueue, HolderRecord, LeaseRecord, Task,
+};
 
 #[silo::test]
 fn test_task_roundtrip() {
@@ -17,7 +19,10 @@ fn test_task_roundtrip() {
         job_id: "job-1".to_string(),
         attempt_number: 1,
         relative_attempt_number: 1,
-        held_queues: vec!["queue-1".to_string()],
+        held_queues: vec![HeldQueue {
+            queue: "queue-1".to_string(),
+            task_id: "task-1".to_string(),
+        }],
         task_group: "default".to_string(),
     };
     let encoded = encode_task(&task);
@@ -37,7 +42,13 @@ fn test_task_roundtrip() {
             assert_eq!(job_id, "job-1");
             assert_eq!(attempt_number, 1);
             assert_eq!(relative_attempt_number, 1);
-            assert_eq!(held_queues, vec!["queue-1"]);
+            assert_eq!(
+                held_queues,
+                vec![HeldQueue {
+                    queue: "queue-1".to_string(),
+                    task_id: "task-1".to_string(),
+                }]
+            );
             assert_eq!(task_group, "default");
         }
         _ => panic!("unexpected task variant"),
@@ -124,6 +135,9 @@ fn test_concurrency_action_roundtrip() {
         attempt_number: 1,
         relative_attempt_number: 1,
         task_group: "default".to_string(),
+        held_queues: vec![],
+        limit_index: 0,
+        total_limits: 1,
     };
     let encoded = encode_concurrency_action(&action);
     let decoded = decode_concurrency_action(encoded).unwrap();
@@ -134,6 +148,8 @@ fn test_concurrency_action_roundtrip() {
     assert_eq!(et.attempt_number(), 1);
     assert_eq!(et.relative_attempt_number(), 1);
     assert_eq!(et.task_group().unwrap(), "default");
+    assert_eq!(et.limit_index(), 0);
+    assert_eq!(et.total_limits(), 1);
 }
 
 #[silo::test]
@@ -148,6 +164,9 @@ fn test_request_ticket_roundtrip() {
         relative_attempt_number: 1,
         request_id: "req-abc".to_string(),
         task_group: "fast".to_string(),
+        held_queues: vec![],
+        limit_index: 0,
+        total_limits: 1,
     };
     let encoded = encode_task(&task);
     let decoded = decode_task(&encoded).unwrap();
@@ -162,6 +181,9 @@ fn test_request_ticket_roundtrip() {
             relative_attempt_number,
             request_id,
             task_group,
+            held_queues: _,
+            limit_index: _,
+            total_limits: _,
         } => {
             assert_eq!(queue, "q1");
             assert_eq!(start_time_ms, 5000);
@@ -202,7 +224,16 @@ fn test_check_rate_limit_roundtrip() {
         retry_count: 1,
         started_at_ms: 9000,
         priority: 7,
-        held_queues: vec!["hq-1".to_string(), "hq-2".to_string()],
+        held_queues: vec![
+            HeldQueue {
+                queue: "hq-1".to_string(),
+                task_id: "task-99".to_string(),
+            },
+            HeldQueue {
+                queue: "hq-2".to_string(),
+                task_id: "task-99".to_string(),
+            },
+        ],
         task_group: "default".to_string(),
     };
     let encoded = encode_task(&task);
@@ -242,7 +273,19 @@ fn test_check_rate_limit_roundtrip() {
             assert_eq!(retry_count, 1);
             assert_eq!(started_at_ms, 9000);
             assert_eq!(priority, 7);
-            assert_eq!(held_queues, vec!["hq-1", "hq-2"]);
+            assert_eq!(
+                held_queues,
+                vec![
+                    HeldQueue {
+                        queue: "hq-1".to_string(),
+                        task_id: "task-99".to_string(),
+                    },
+                    HeldQueue {
+                        queue: "hq-2".to_string(),
+                        task_id: "task-99".to_string(),
+                    },
+                ]
+            );
             assert_eq!(task_group, "default");
         }
         _ => panic!("expected CheckRateLimit variant"),
@@ -375,7 +418,16 @@ fn test_decoded_lease_accessors_run_attempt() {
             job_id: "j1".to_string(),
             attempt_number: 3,
             relative_attempt_number: 2,
-            held_queues: vec!["q1".to_string(), "q2".to_string()],
+            held_queues: vec![
+                HeldQueue {
+                    queue: "q1".to_string(),
+                    task_id: "task-10".to_string(),
+                },
+                HeldQueue {
+                    queue: "q2".to_string(),
+                    task_id: "task-10".to_string(),
+                },
+            ],
             task_group: "grp".to_string(),
         },
         expiry_ms: 50000,
@@ -390,7 +442,19 @@ fn test_decoded_lease_accessors_run_attempt() {
     assert_eq!(decoded.job_id(), "j1");
     assert_eq!(decoded.attempt_number(), 3);
     assert_eq!(decoded.relative_attempt_number(), 2);
-    assert_eq!(decoded.held_queues(), vec!["q1", "q2"]);
+    assert_eq!(
+        decoded.held_queues(),
+        vec![
+            HeldQueue {
+                queue: "q1".to_string(),
+                task_id: "task-10".to_string(),
+            },
+            HeldQueue {
+                queue: "q2".to_string(),
+                task_id: "task-10".to_string(),
+            },
+        ]
+    );
     assert_eq!(decoded.task_group(), "grp");
     assert_eq!(decoded.task_id(), Some("task-10"));
 
@@ -429,7 +493,7 @@ fn test_decoded_lease_accessors_refresh_floating_limit() {
     assert_eq!(decoded.job_id(), "");
     assert_eq!(decoded.attempt_number(), 0);
     assert_eq!(decoded.relative_attempt_number(), 0);
-    assert_eq!(decoded.held_queues(), Vec::<String>::new());
+    assert_eq!(decoded.held_queues(), Vec::<HeldQueue>::new());
     assert_eq!(decoded.task_group(), "workers");
     assert_eq!(decoded.task_id(), None);
 
@@ -465,7 +529,16 @@ fn test_decoded_task_run_attempt() {
         job_id: "job-zc-1".to_string(),
         attempt_number: 5,
         relative_attempt_number: 3,
-        held_queues: vec!["q1".to_string(), "q2".to_string()],
+        held_queues: vec![
+            HeldQueue {
+                queue: "q1".to_string(),
+                task_id: "task-zc-1".to_string(),
+            },
+            HeldQueue {
+                queue: "q2".to_string(),
+                task_id: "task-zc-1".to_string(),
+            },
+        ],
         task_group: "default".to_string(),
     };
     let encoded = encode_task(&task);
@@ -504,6 +577,9 @@ fn test_decoded_task_request_ticket() {
         relative_attempt_number: 1,
         request_id: "req-rt".to_string(),
         task_group: "fast".to_string(),
+        held_queues: vec![],
+        limit_index: 0,
+        total_limits: 1,
     };
     let encoded = encode_task(&task);
     let decoded = decode_task_validated(encoded).unwrap();

--- a/tests/concurrency_requester_counter_tests.rs
+++ b/tests/concurrency_requester_counter_tests.rs
@@ -310,6 +310,9 @@ async fn inject_fake_request(
         attempt_number: attempt,
         relative_attempt_number: attempt,
         task_group: "default".to_string(),
+        held_queues: vec![],
+        limit_index: 0,
+        total_limits: 1,
     };
     let action_val = encode_concurrency_action(&action);
     db.put(&req_key, &action_val)

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -113,6 +113,7 @@ async fn concurrency_queues_when_full_and_grants_on_release() {
             }
             Task::RequestTicket { .. } => {}
             Task::CheckRateLimit { .. } => {}
+            Task::ResumeAfterConcurrencyGrant { .. } => {}
             Task::RefreshFloatingLimit { .. } => {}
         }
     }
@@ -175,6 +176,9 @@ async fn periodic_reconcile_grants_pending_request_without_signal() {
         attempt_number: 1,
         relative_attempt_number: 1,
         task_group: "default".to_string(),
+        held_queues: vec![],
+        limit_index: 0,
+        total_limits: 1,
     };
     let request_key = concurrency_request_key(tenant, &queue, now, 10, &job_id, 1, "manual");
     let request_value = encode_concurrency_action(&action);
@@ -616,6 +620,7 @@ async fn concurrent_enqueues_while_holding_dont_bypass_limit() {
             Task::RunAttempt { .. } => panic!("unexpected RunAttempt before release"),
             Task::RequestTicket { .. } => {}
             Task::CheckRateLimit { .. } => {}
+            Task::ResumeAfterConcurrencyGrant { .. } => {}
             Task::RefreshFloatingLimit { .. } => {}
         }
     }
@@ -718,6 +723,9 @@ async fn reap_marks_expired_lease_as_failed_and_enqueues_retry() {
         }
         Task::CheckRateLimit { .. } => {
             panic!("unexpected CheckRateLimit in tasks/ for this test")
+        }
+        Task::ResumeAfterConcurrencyGrant { .. } => {
+            panic!("unexpected ResumeAfterConcurrencyGrant in tasks/ for this test")
         }
         Task::RefreshFloatingLimit { .. } => {
             panic!("unexpected RefreshFloatingLimit in tasks/ for this test")

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -288,7 +288,10 @@ async fn check_rate_limit_max_retries_releases_held_queues() {
         retry_count: max_retries,
         started_at_ms: now_ms(),
         priority,
-        held_queues: vec![queue.to_string()],
+        held_queues: vec![silo::task::HeldQueue {
+            queue: queue.to_string(),
+            task_id: task_id.clone(),
+        }],
         task_group: task_group.to_string(),
     };
     let crl_key = task_key(task_group, now_ms(), priority, &job_id, attempt_number);
@@ -381,7 +384,10 @@ async fn check_rate_limit_missing_job_info_releases_held_queues() {
         retry_count: 0,
         started_at_ms: now_ms(),
         priority,
-        held_queues: vec![queue.to_string()],
+        held_queues: vec![silo::task::HeldQueue {
+            queue: queue.to_string(),
+            task_id: task_id.clone(),
+        }],
         task_group: task_group.to_string(),
     };
     let crl_key = task_key(task_group, now_ms(), priority, &job_id, attempt_number);

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -621,6 +621,7 @@ async fn concurrency_queues_when_full_and_grants_on_release() {
             }
             Task::RequestTicket { .. } => {}
             Task::CheckRateLimit { .. } => {}
+            Task::ResumeAfterConcurrencyGrant { .. } => {}
             Task::RefreshFloatingLimit { .. } => {}
         }
     }
@@ -969,6 +970,7 @@ async fn concurrent_enqueues_while_holding_dont_bypass_limit() {
             Task::RunAttempt { .. } => panic!("unexpected RunAttempt before release"),
             Task::RequestTicket { .. } => {}
             Task::CheckRateLimit { .. } => {}
+            Task::ResumeAfterConcurrencyGrant { .. } => {}
             Task::RefreshFloatingLimit { .. } => {}
         }
     }
@@ -1638,6 +1640,9 @@ async fn grant_scanner_skips_stale_requests_and_grants_valid_ones() {
             attempt_number: 1,
             relative_attempt_number: 1,
             task_group: "tg".to_string(),
+            held_queues: vec![],
+            limit_index: 0,
+            total_limits: 1,
         };
         let key = silo::keys::concurrency_request_key(
             tenant,
@@ -1699,6 +1704,9 @@ async fn grant_scanner_handles_all_stale_requests() {
             attempt_number: 1,
             relative_attempt_number: 1,
             task_group: "tg".to_string(),
+            held_queues: vec![],
+            limit_index: 0,
+            total_limits: 1,
         };
         let key = silo::keys::concurrency_request_key(
             tenant,
@@ -1994,6 +2002,9 @@ async fn grant_scanner_interleaved_stale_and_valid_requests() {
             attempt_number: 1,
             relative_attempt_number: 1,
             task_group: "tg".to_string(),
+            held_queues: vec![],
+            limit_index: 0,
+            total_limits: 1,
         };
         let key = silo::keys::concurrency_request_key(
             tenant,
@@ -2374,12 +2385,12 @@ async fn two_concurrency_limits_release_both_holders_on_success() {
     let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
     let held = decoded_lease.held_queues();
     assert!(
-        held.iter().any(|q| q == &platform_queue),
+        held.iter().any(|hq| hq.queue == platform_queue),
         "lease held_queues should include platform queue, got {:?}",
         held
     );
     assert!(
-        held.iter().any(|q| q == &user_queue),
+        held.iter().any(|hq| hq.queue == user_queue),
         "lease held_queues should include user queue — if missing, the final \
          RunAttempt overwrite dropped the earlier granted queue. Got {:?}",
         held
@@ -2506,6 +2517,453 @@ async fn second_limit_request_must_not_leave_runnable_task() {
         job2_tasks
             .first()
             .map(|t| t.attempt().task_id().to_string()),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Chain-of-limits regression tests for held_queues + bypass enforcement.
+//
+// PR #315 fixed multi-limit holder leaks at enqueue. PR #317 reordered
+// Concurrency before FloatingConcurrency so the common Gadget shape no
+// longer hit the latent grant-time leak. These tests cover the remaining
+// chain-time gaps that the resume-after-grant + per-queue task_id machinery
+// closes: holder preservation on grant-scanner promotion and enforcement
+// of limits-after-the-queued-one.
+// ---------------------------------------------------------------------------
+
+/// `[C1, C2]` where C1 grants immediately and C2 queues (other job holds C2).
+/// When the holder on C2 is freed, the promotion path must preserve the
+/// already-granted C1 holder AND enforce no bypass of any limit that follows
+/// C2 in the chain. Before the fix, `process_grants` wrote a RunAttempt with
+/// `held_queues = vec![C2]` only, orphaning the C1 holder; on report success
+/// the C1 slot leaked permanently.
+#[silo::test]
+async fn chain_c1_c2_promotion_preserves_prior_holder_and_releases_both() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue_c1 = "chain-c1-free".to_string();
+    let queue_c2 = "chain-c2-mutex".to_string();
+    let now = now_ms();
+
+    // Holder job for C2 — single-limit Concurrency with max=1, holds the slot.
+    let _holder_job = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "holder"})),
+            vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: queue_c2.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue holder");
+    let holder_tasks = shard
+        .dequeue("h", "default", 1)
+        .await
+        .expect("dequeue holder")
+        .tasks;
+    assert_eq!(holder_tasks.len(), 1);
+    let holder_task_id = holder_tasks[0].attempt().task_id().to_string();
+
+    // Target job — `[C1(free, max=5), C2(full, max=1)]`. C1 grants
+    // immediately, C2 queues. The interim RunAttempt is then dropped by
+    // PR #317's cleanup; the request record carries `held_queues = [{C1, T}]`.
+    let target_job = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "target"})),
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_c1.clone(),
+                    max_concurrency: 5,
+                }),
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_c2.clone(),
+                    max_concurrency: 1,
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue target");
+
+    // C1 has the target's holder; C2 has the holder job's holder.
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c1).await,
+        1
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c2).await,
+        1
+    );
+
+    // Free C2 by completing the holder job.
+    shard
+        .report_attempt_outcome(&holder_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report holder success");
+
+    // Poll for the target's RunAttempt to become dequeueable.
+    let target_tasks = poll_until(
+        || async {
+            shard
+                .dequeue("t", "default", 1)
+                .await
+                .expect("dq target")
+                .tasks
+        },
+        |t| !t.is_empty(),
+        5000,
+    )
+    .await;
+    assert_eq!(target_tasks.len(), 1, "target should become runnable");
+    assert_eq!(target_tasks[0].job().id(), target_job);
+    let target_task_id = target_tasks[0].attempt().task_id().to_string();
+
+    // Inspect the lease: held_queues must include BOTH C1 and C2.
+    let lease_bytes = shard
+        .db()
+        .get(&silo::keys::leased_task_key(&target_task_id))
+        .await
+        .expect("read lease")
+        .expect("lease present");
+    let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
+    let held = decoded_lease.held_queues();
+    assert!(
+        held.iter().any(|hq| hq.queue == queue_c1),
+        "lease must carry C1 holder; pre-fix the promotion path dropped it. \
+         Got {:?}",
+        held
+    );
+    assert!(
+        held.iter().any(|hq| hq.queue == queue_c2),
+        "lease must carry C2 holder (just-granted queue). Got {:?}",
+        held
+    );
+
+    // Report success — both holders must drop to zero.
+    shard
+        .report_attempt_outcome(&target_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report target success");
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c1).await,
+        0,
+        "C1 holder leaked: report_outcome only released the chained task_id, \
+         but the pre-fix held_queues dropped C1 entirely so its holder \
+         (under the original task_id) was never deleted"
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c2).await,
+        0,
+        "C2 holder should be released"
+    );
+}
+
+/// Three-limit chain `[C1, C2, C3]`. C1 grants, C2 queues (other job holds it).
+/// On C2's promotion the chain must continue at C3 — not bypass C3 by leasing
+/// a RunAttempt directly. Tests that the new `ResumeAfterConcurrencyGrant`
+/// task fires and chains through `enqueue_limit_task_at_index` to the next
+/// limit, which sees C3 is full and writes a request.
+#[silo::test]
+async fn chain_3_limits_middle_queue_does_not_bypass_later_limits() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue_c1 = "chain3-c1".to_string();
+    let queue_c2 = "chain3-c2".to_string();
+    let queue_c3 = "chain3-c3".to_string();
+    let now = now_ms();
+
+    // Block C2 with a holder job.
+    let _c2_holder = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "c2-holder"})),
+            vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: queue_c2.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue c2 holder");
+    let c2_holder_task = shard.dequeue("w", "default", 1).await.expect("dq").tasks;
+    let c2_holder_id = c2_holder_task[0].attempt().task_id().to_string();
+
+    // Block C3 with a holder job too.
+    let _c3_holder = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "c3-holder"})),
+            vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: queue_c3.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue c3 holder");
+    let c3_holder_task = shard.dequeue("w", "default", 1).await.expect("dq").tasks;
+    let c3_holder_id = c3_holder_task[0].attempt().task_id().to_string();
+
+    // Target: `[C1 free, C2 full, C3 full]`. C1 grants, C2 queues.
+    let target_job = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "target"})),
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_c1.clone(),
+                    max_concurrency: 5,
+                }),
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_c2.clone(),
+                    max_concurrency: 1,
+                }),
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_c3.clone(),
+                    max_concurrency: 1,
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue target");
+    let _ = target_job;
+
+    // Free C2 — target's chain should advance to C3 and queue there, NOT
+    // produce a leasable RunAttempt.
+    shard
+        .report_attempt_outcome(&c2_holder_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("release c2");
+
+    // Give the grant scanner and resume task a chance to settle.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // No runnable target task: it must still be blocked on C3.
+    let target_attempt = shard
+        .dequeue("worker", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert!(
+        target_attempt.is_empty(),
+        "target must remain blocked on C3 — bypass would yield {:?}",
+        target_attempt
+            .first()
+            .map(|t| t.attempt().task_id().to_string())
+    );
+
+    // Free C3 — chain completes, target becomes runnable.
+    shard
+        .report_attempt_outcome(&c3_holder_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("release c3");
+    let target_runs = poll_until(
+        || async {
+            shard
+                .dequeue("worker", "default", 1)
+                .await
+                .expect("dq")
+                .tasks
+        },
+        |t| !t.is_empty(),
+        5000,
+    )
+    .await;
+    assert_eq!(target_runs.len(), 1, "target should run after C3 frees");
+    let target_task_id = target_runs[0].attempt().task_id().to_string();
+
+    // Lease should carry all three holders, each under the right task_id.
+    let lease_bytes = shard
+        .db()
+        .get(&silo::keys::leased_task_key(&target_task_id))
+        .await
+        .expect("get lease")
+        .expect("lease present");
+    let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
+    let held = decoded_lease.held_queues();
+    assert!(held.iter().any(|hq| hq.queue == queue_c1));
+    assert!(held.iter().any(|hq| hq.queue == queue_c2));
+    assert!(held.iter().any(|hq| hq.queue == queue_c3));
+    assert_eq!(held.len(), 3, "all three queues expected; got {:?}", held);
+
+    // Report success — every holder must release.
+    shard
+        .report_attempt_outcome(&target_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report success");
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c1).await,
+        0
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c2).await,
+        0
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c3).await,
+        0
+    );
+}
+
+/// `[C(full), RateLimit]`. C queues. When C is freed, the resume path must
+/// hand off to the rate-limit branch — writing a `CheckRateLimit` task that
+/// carries the C holder with the request_id as its task_id. Tests the
+/// resume-after-grant → rate-limit handoff: this is the common Gadget shape
+/// when a tenant queue + an API rate limit are both configured.
+#[silo::test]
+async fn chain_concurrency_to_ratelimit_resumes_with_held_queue() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue_c = "chain-c-rl".to_string();
+    let now = now_ms();
+
+    // Holder job for the Concurrency limit.
+    let _c_holder = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "c-holder"})),
+            vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: queue_c.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue c-holder");
+    let c_holder_task = shard.dequeue("h", "default", 1).await.expect("dq").tasks;
+    let c_holder_id = c_holder_task[0].attempt().task_id().to_string();
+
+    // Target with `[C, RateLimit]`. Use a rate limit pointing at a name we
+    // won't actually call Gubernator for in this test (we tear down before).
+    // We're only interested in the structure: after C is freed, the chain
+    // must write a CheckRateLimit task — not a leasable RunAttempt.
+    let _target = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "target"})),
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_c.clone(),
+                    max_concurrency: 1,
+                }),
+                Limit::RateLimit(silo::job::GubernatorRateLimit {
+                    name: "test-rl".to_string(),
+                    unique_key: "chain-rl-key".to_string(),
+                    limit: 100,
+                    duration_ms: 60_000,
+                    hits: 1,
+                    algorithm: silo::job::GubernatorAlgorithm::TokenBucket,
+                    behavior: 0,
+                    retry_policy: silo::job::RateLimitRetryPolicy {
+                        initial_backoff_ms: 10,
+                        max_backoff_ms: 1000,
+                        backoff_multiplier: 2.0,
+                        max_retries: 3,
+                    },
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue target");
+
+    // Free C — the grant scanner promotes target's request. Because limits
+    // remain (the RateLimit at index 1), `process_grants` writes a
+    // `ResumeAfterConcurrencyGrant` at target's task_key carrying the
+    // just-granted C holder paired with the request_id. The resume task is
+    // the contract we care about here — the subsequent RateLimit walk goes
+    // through standard `enqueue_limit_task_at_index` machinery already
+    // covered by other tests.
+    shard
+        .report_attempt_outcome(&c_holder_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("release c");
+
+    let resume = poll_until(
+        || async {
+            let kv = first_task_kv(shard.db()).await;
+            kv.and_then(|(_, v)| decode_task(&v).ok())
+        },
+        |t| matches!(t, Some(Task::ResumeAfterConcurrencyGrant { .. })),
+        5000,
+    )
+    .await;
+    let task = resume.expect("expected resume task to be written");
+    let (held, req_id, lim_idx) = match task {
+        Task::ResumeAfterConcurrencyGrant {
+            held_queues,
+            request_id,
+            limit_index,
+            ..
+        } => (held_queues, request_id, limit_index),
+        other => panic!("expected ResumeAfterConcurrencyGrant, got {:?}", other),
+    };
+    assert_eq!(
+        lim_idx, 1,
+        "resume must continue at the RateLimit (index 1)"
+    );
+    assert_eq!(
+        held.len(),
+        1,
+        "resume must carry exactly the just-granted C holder; got {:?}",
+        held
+    );
+    assert_eq!(held[0].queue, queue_c);
+    assert_eq!(
+        held[0].task_id, req_id,
+        "the holder's task_id must match the resume's request_id — that's the \
+         task_id `process_ticket_request_task` / `process_grants` used when \
+         creating the holder, and the release path looks holders up by it."
+    );
+
+    // Sanity: the actual holder row in storage uses (queue, request_id) too.
+    let holder = shard
+        .db()
+        .get(&concurrency_holder_key(tenant, &queue_c, &req_id))
+        .await
+        .expect("read holder");
+    assert!(
+        holder.is_some(),
+        "holder for granted C ticket must be keyed by request_id"
     );
 }
 

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2671,6 +2671,169 @@ async fn chain_c1_c2_promotion_preserves_prior_holder_and_releases_both() {
     );
 }
 
+/// `[C, FC]` mixed-kind chain (the canonical Gadget shape post-PR #317
+/// reorder). C grants immediately; FC queues because another job is
+/// holding it. When the FC holder is released, the grant scanner must
+/// promote the target while preserving the C holder it already had.
+///
+/// `process_grants` doesn't differentiate fixed vs floating concurrency
+/// (it operates on the queue name + `held_queues` from the request, not
+/// on the limit kind), so the held_queues plumbing should work
+/// identically. This test locks that in and guards against future
+/// divergence.
+#[silo::test]
+async fn chain_c_then_fc_promotion_preserves_concurrency_holder() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue_c = "chain-c-fc-fixed".to_string();
+    let queue_fc = "chain-c-fc-floating".to_string();
+    let now = now_ms();
+
+    // Holder job for the FloatingConcurrency limit — single FC limit, max=1.
+    let _fc_holder = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "fc-holder"})),
+            vec![Limit::FloatingConcurrency(
+                silo::job::FloatingConcurrencyLimit {
+                    key: queue_fc.clone(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                },
+            )],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue fc holder");
+    let fc_holder_tasks = shard
+        .dequeue("h", "default", 1)
+        .await
+        .expect("dq fc holder")
+        .tasks;
+    assert_eq!(fc_holder_tasks.len(), 1);
+    let fc_holder_task_id = fc_holder_tasks[0].attempt().task_id().to_string();
+
+    // Target with `[C(free, max=5), FC(full, max=1)]`. With PR #317's
+    // reorder, C is processed first and grants immediately; FC then queues
+    // because the fc_holder occupies the FC slot.
+    let target_job = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "target"})),
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_c.clone(),
+                    max_concurrency: 5,
+                }),
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: queue_fc.clone(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue target");
+
+    // Sanity: C has target's holder; FC has the fc_holder's holder.
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c).await,
+        1,
+        "target should hold C immediately"
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_fc).await,
+        1,
+        "fc_holder should hold FC"
+    );
+
+    // Free FC by completing the fc_holder.
+    shard
+        .report_attempt_outcome(
+            &fc_holder_task_id,
+            AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("report fc_holder success");
+
+    // Target should now become runnable. The grant scanner promotes the
+    // queued FC request, and because total_limits == 2 and limit_index == 1
+    // (the FC position), next_index >= total_limits so a terminal RunAttempt
+    // is written directly — NOT a ResumeAfterConcurrencyGrant.
+    let target_tasks = poll_until(
+        || async {
+            shard
+                .dequeue("t", "default", 1)
+                .await
+                .expect("dq target")
+                .tasks
+        },
+        |t| !t.is_empty(),
+        5000,
+    )
+    .await;
+    assert_eq!(target_tasks.len(), 1, "target should become runnable");
+    assert_eq!(target_tasks[0].job().id(), target_job);
+    let target_task_id = target_tasks[0].attempt().task_id().to_string();
+
+    // Inspect the lease: held_queues must carry BOTH C and FC.
+    let lease_bytes = shard
+        .db()
+        .get(&silo::keys::leased_task_key(&target_task_id))
+        .await
+        .expect("read lease")
+        .expect("lease present");
+    let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
+    let held = decoded_lease.held_queues();
+    assert!(
+        held.iter().any(|hq| hq.queue == queue_c),
+        "lease must carry the C holder (preserved across FC promotion); got {:?}",
+        held
+    );
+    assert!(
+        held.iter().any(|hq| hq.queue == queue_fc),
+        "lease must carry the FC holder (just-granted); got {:?}",
+        held
+    );
+    assert_eq!(
+        held.len(),
+        2,
+        "exactly the two granted queues; got {:?}",
+        held
+    );
+
+    // Report success — both holders must release.
+    shard
+        .report_attempt_outcome(&target_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report target success");
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c).await,
+        0,
+        "C holder leaked: the [C, FC] promotion path dropped the pre-granted \
+         C holder, or release_outcome failed to find the C holder under the \
+         original target task_id"
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_fc).await,
+        0,
+        "FC holder should be released"
+    );
+}
+
 /// Three-limit chain `[C1, C2, C3]`. C1 grants, C2 queues (other job holds it).
 /// On C2's promotion the chain must continue at C3 — not bypass C3 by leasing
 /// a RunAttempt directly. Tests that the new `ResumeAfterConcurrencyGrant`

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2967,6 +2967,155 @@ async fn chain_concurrency_to_ratelimit_resumes_with_held_queue() {
     );
 }
 
+/// `[C1, C2]` chain cancelled mid-flight: C1 granted, C2 queued as a request.
+/// `cancel_job` must clean up the request AND release the C1 holder.
+#[silo::test]
+async fn cancel_mid_chain_releases_prior_holders() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue_c1 = "cancel-mid-c1".to_string();
+    let queue_c2 = "cancel-mid-c2".to_string();
+    let now = now_ms();
+
+    let _c2_holder = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "c2-holder"})),
+            vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: queue_c2.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue c2 holder");
+    let _ = shard.dequeue("h", "default", 1).await.expect("dq").tasks;
+
+    let target_job = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "target"})),
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_c1.clone(),
+                    max_concurrency: 5,
+                }),
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_c2.clone(),
+                    max_concurrency: 1,
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue target");
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c1).await,
+        1
+    );
+
+    shard
+        .cancel_job(tenant, &target_job)
+        .await
+        .expect("cancel target");
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c1).await,
+        0,
+        "C1 holder leaked on cancel-mid-chain"
+    );
+}
+
+/// JobMissing arrival in `handle_request_ticket`: synthesize a
+/// `Task::RequestTicket` with prior `held_queues`, plant the corresponding
+/// holder rows, then dequeue. The handler must take the JobMissing branch
+/// (the job_id doesn't exist) and clean up both the task and the prior
+/// holders. Currently, the future-scheduled RequestTicket only writes from
+/// the first limit (before any held_queues accumulate), but the field is
+/// typed as a possibility — this exercises the contract.
+#[silo::test]
+async fn handle_request_ticket_job_missing_releases_prior_held_queues() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue_c1 = "rt-jm-c1".to_string();
+    let queue_c2 = "rt-jm-c2".to_string();
+    let now = now_ms();
+
+    let fake_job_id = "rt-jm-ghost-job".to_string();
+    let request_id = "rt-jm-req-1".to_string();
+    let prior_task_id = "rt-jm-prior-task".to_string();
+
+    let holder = silo::task::HolderRecord { granted_at_ms: now };
+    shard
+        .db()
+        .put(
+            &silo::keys::concurrency_holder_key(tenant, &queue_c1, &prior_task_id),
+            &silo::codec::encode_holder(&holder),
+        )
+        .await
+        .expect("plant holder");
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c1).await,
+        1
+    );
+
+    let task = silo::task::Task::RequestTicket {
+        queue: queue_c2.clone(),
+        start_time_ms: now,
+        priority: 10,
+        tenant: tenant.to_string(),
+        job_id: fake_job_id.clone(),
+        attempt_number: 1,
+        relative_attempt_number: 1,
+        request_id: request_id.clone(),
+        task_group: "default".to_string(),
+        held_queues: vec![silo::task::HeldQueue {
+            queue: queue_c1.clone(),
+            task_id: prior_task_id.clone(),
+        }],
+        limit_index: 0,
+        total_limits: 2,
+    };
+    let planted_task_key = silo::keys::task_key("default", now, 10, &fake_job_id, 1);
+    shard
+        .db()
+        .put(&planted_task_key, &silo::codec::encode_task(&task))
+        .await
+        .expect("plant request ticket");
+    shard.db().flush().await.expect("flush");
+
+    // Drive the broker until the JobMissing branch processes the planted
+    // task. Returns no leasable tasks (job is gone). The prior C1 holder
+    // and the task_key must both be cleaned up.
+    let _ = poll_until(
+        || async {
+            let _ = shard.dequeue("w", "default", 5).await.expect("dq").tasks;
+            shard
+                .db()
+                .get(&planted_task_key)
+                .await
+                .expect("read task_key")
+        },
+        |r| r.is_none(),
+        5000,
+    )
+    .await;
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_c1).await,
+        0,
+        "prior chain holder leaked when handle_request_ticket hit JobMissing"
+    );
+}
+
 /// Helper: count concurrency holder keys for a specific (tenant, queue) pair.
 async fn count_holders_for_queue(
     db: &silo::instrumented_db::InstrumentedDb,

--- a/tests/job_store_shard_import_tests.rs
+++ b/tests/job_store_shard_import_tests.rs
@@ -3109,6 +3109,9 @@ async fn reimport_failed_to_scheduled_ignores_stale_concurrency_requests() {
         attempt_number: 1,
         relative_attempt_number: 1,
         task_group: "default".to_string(),
+        held_queues: vec![],
+        limit_index: 0,
+        total_limits: 1,
     };
     let stale_request_key = silo::keys::concurrency_request_key(
         "-",

--- a/tests/job_store_shard_retry_tests.rs
+++ b/tests/job_store_shard_retry_tests.rs
@@ -186,6 +186,9 @@ async fn error_with_retries_enqueues_next_attempt_until_limit() {
             Task::CheckRateLimit { .. } => {
                 panic!("unexpected CheckRateLimit in tasks/ for this test")
             }
+            Task::ResumeAfterConcurrencyGrant { .. } => {
+                panic!("unexpected ResumeAfterConcurrencyGrant in tasks/ for this test")
+            }
             Task::RefreshFloatingLimit { .. } => {
                 panic!("unexpected RefreshFloatingLimit in tasks/ for this test")
             }
@@ -220,6 +223,9 @@ async fn error_with_retries_enqueues_next_attempt_until_limit() {
             }
             Task::CheckRateLimit { .. } => {
                 panic!("unexpected CheckRateLimit in tasks/ for this test")
+            }
+            Task::ResumeAfterConcurrencyGrant { .. } => {
+                panic!("unexpected ResumeAfterConcurrencyGrant in tasks/ for this test")
             }
             Task::RefreshFloatingLimit { .. } => {
                 panic!("unexpected RefreshFloatingLimit in tasks/ for this test")
@@ -461,6 +467,9 @@ async fn retry_count_one_boundary_enqueues_attempt2_then_stops_on_second_error()
             panic!("unexpected RequestTicket in tasks/ for this test")
         }
         Task::CheckRateLimit { .. } => panic!("unexpected CheckRateLimit in tasks/ for this test"),
+        Task::ResumeAfterConcurrencyGrant { .. } => {
+            panic!("unexpected ResumeAfterConcurrencyGrant in tasks/ for this test")
+        }
         Task::RefreshFloatingLimit { .. } => {
             panic!("unexpected RefreshFloatingLimit in tasks/ for this test")
         }
@@ -1053,6 +1062,9 @@ async fn reap_marks_expired_lease_as_failed_and_enqueues_retry() {
             panic!("unexpected RequestTicket in tasks/ for this test")
         }
         Task::CheckRateLimit { .. } => panic!("unexpected CheckRateLimit in tasks/ for this test"),
+        Task::ResumeAfterConcurrencyGrant { .. } => {
+            panic!("unexpected ResumeAfterConcurrencyGrant in tasks/ for this test")
+        }
         Task::RefreshFloatingLimit { .. } => {
             panic!("unexpected RefreshFloatingLimit in tasks/ for this test")
         }


### PR DESCRIPTION
## Summary

PR #317's Concurrency-before-FloatingConcurrency reorder mitigated the common Gadget shape, but left a latent gap on any limit chain where an earlier limit grants and a later concurrency limit queues. On the queued-limit promotion path:

- The granted RunAttempt was built with `held_queues = [just-granted queue]` only, orphaning any earlier-accumulated holders → permanent leak on outcome release.
- The chain was never resumed, so any limit after the queued one was bypassed → RunAttempt became leasable while a downstream concurrency/rate limit was still full.

Both symptoms applied to `[C1, C2]` (C1 grants, C2 queues), `[C, FC]`, `[FC, FC]`, and any 3+ chain `[C1, C2, C3]` where a middle limit queued.

This change:

- Threads accumulated `held_queues` AND the canonical-order `limit_index` (+ `total_limits` for terminal-vs-resume decisions) through the queued `EnqueueTask` / `RequestTicket` encoding.
- Replaces `Vec<String>` held_queues with `Vec<HeldQueue { queue, task_id }>` so each holder is released under the task_id that *created* it, removing the implicit invariant that every holder in a chain shares one task_id (broken by the resume-after-grant path where the request_id differs from the final RunAttempt's id).
- Adds `Task::ResumeAfterConcurrencyGrant`. `process_grants` writes it when `limit_index + 1 < total_limits`; `handle_resume_after_grant` in dequeue drives the chain forward via the existing `enqueue_limit_task_at_index`.
- Updates `handle_request_ticket`'s grant path to also walk the chain, with `inline_terminal: true` so a terminal RunAttempt can be leased without leaving a stale DB task at task_key.

Release sites in `lease.rs`, `cancel.rs`, `dequeue.rs`, and `import.rs` now look up each holder via `concurrency_holder_key(tenant, &hq.queue, &hq.task_id)` so mixed-task_id chains release correctly. The `Vec<HeldQueue>` signature forces this change at every call site.

## Test plan

- [x] `cargo check --workspace --tests` clean
- [x] `cargo clippy --tests --no-deps` no new warnings
- [x] `cargo fmt` clean
- [x] New regression tests in `tests/job_store_shard_concurrency_tests.rs`:
  - `chain_c1_c2_promotion_preserves_prior_holder_and_releases_both` — `[C1, C2]` grant-then-queue: lease has both holders, both release on success.
  - `chain_3_limits_middle_queue_does_not_bypass_later_limits` — `[C1, C2, C3]` middle queues, frees through C2 then C3; verifies no bypass.
  - `chain_concurrency_to_ratelimit_resumes_with_held_queue` — `[C, RateLimit]` resume task carries the C holder paired with the request_id used to create the holder row.
- [x] Existing suites pass: `holder_leak_tests`, `floating_concurrency_tests`, `concurrent_grant_race_tests`, `job_store_shard_enqueue_tests`, `job_store_shard_restart_tests`, `job_store_shard_cancel_tests`, `concurrency_tests`, `concurrency_requester_counter_tests`, `codec_tests`, `job_store_shard_retry_tests`, `job_store_shard_import_tests`, `job_store_shard_concurrency_tests` (26 + 3 new).