### PR TITLE
Avoid thundering-herd for GetClusterInfo by blocking on single Future

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::Duration;
 
+use futures::FutureExt;
+use futures::future::{BoxFuture, Shared};
 use rand::seq::SliceRandom;
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, broadcast};
@@ -203,6 +205,12 @@ fn proto_metadata_to_domain(metadata: HashMap<String, String>) -> Option<Vec<(St
 /// server) don't take routing clients down with them.
 const CLUSTER_INFO_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Shared in-flight future returned to concurrent `GetClusterInfo` callers
+/// so a thundering herd collapses onto a single coordinator fetch. The
+/// `Ok` variant is the response to return; the `Err` variant is a status
+/// message to wrap in `Status::unavailable`.
+type ClusterInfoFuture = Shared<BoxFuture<'static, Result<GetClusterInfoResponse, String>>>;
+
 /// gRPC service implementation backed by a `ShardFactory`.
 #[derive(Clone)]
 pub struct SiloService {
@@ -213,6 +221,9 @@ pub struct SiloService {
     /// Last successful `GetClusterInfo` response, served as a fallback when
     /// the coordination layer is slow or unreachable.
     cluster_info_cache: Arc<Mutex<Option<GetClusterInfoResponse>>>,
+    /// In-flight `GetClusterInfo` future, shared across concurrent callers
+    /// so only one fetch hits the coordinator at a time.
+    cluster_info_inflight: Arc<Mutex<Option<ClusterInfoFuture>>>,
 }
 
 impl SiloService {
@@ -228,7 +239,98 @@ impl SiloService {
             cfg,
             metrics,
             cluster_info_cache: Arc::new(Mutex::new(None)),
+            cluster_info_inflight: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Build a `GetClusterInfoResponse` from the live coordination layer,
+    /// bounded by `CLUSTER_INFO_TIMEOUT` so a hung k8s/etcd backend can't
+    /// block routing clients indefinitely. On success we update the cache;
+    /// on timeout/error we serve the last good response.
+    async fn fetch_cluster_info(
+        coord: Arc<dyn Coordinator>,
+        cache: Arc<Mutex<Option<GetClusterInfoResponse>>>,
+    ) -> Result<GetClusterInfoResponse, String> {
+        let build = async {
+            let owner_map = coord
+                .get_shard_owner_map()
+                .await
+                .map_err(|e| format!("failed to get shard owner map: {}", e))?;
+
+            let shard_owners: Vec<ShardOwner> = owner_map
+                .shard_map
+                .shards()
+                .iter()
+                .map(|shard_info| {
+                    let grpc_addr = owner_map
+                        .shard_to_addr
+                        .get(&shard_info.id)
+                        .cloned()
+                        .unwrap_or_default();
+                    let node_id = owner_map
+                        .shard_to_node
+                        .get(&shard_info.id)
+                        .cloned()
+                        .unwrap_or_default();
+                    ShardOwner {
+                        shard_id: shard_info.id.to_string(),
+                        grpc_addr,
+                        node_id,
+                        range_start: shard_info.range.start.clone(),
+                        range_end: shard_info.range.end.clone(),
+                        placement_ring: shard_info.placement_ring.clone(),
+                    }
+                })
+                .collect();
+
+            let member_infos = coord
+                .get_members()
+                .await
+                .map_err(|e| format!("failed to get cluster members: {}", e))?;
+            let members: Vec<ClusterMember> = member_infos
+                .iter()
+                .map(|m| ClusterMember {
+                    node_id: m.node_id.clone(),
+                    grpc_addr: m.grpc_addr.clone(),
+                    placement_rings: m.placement_rings.clone(),
+                })
+                .collect();
+
+            Ok::<GetClusterInfoResponse, String>(GetClusterInfoResponse {
+                num_shards: owner_map.num_shards() as u32,
+                shard_owners,
+                this_node_id: coord.node_id().to_string(),
+                this_grpc_addr: coord.grpc_addr().to_string(),
+                members,
+            })
+        };
+
+        let outcome = tokio::time::timeout(CLUSTER_INFO_TIMEOUT, build).await;
+        let fallback_reason = match outcome {
+            Ok(Ok(response)) => {
+                *cache.lock().await = Some(response.clone());
+                return Ok(response);
+            }
+            Ok(Err(e)) => format!("coordinator error: {}", e),
+            Err(_) => format!(
+                "coordinator did not respond within {}s",
+                CLUSTER_INFO_TIMEOUT.as_secs()
+            ),
+        };
+
+        let cached = cache.lock().await.clone();
+        if let Some(cached) = cached {
+            warn!(
+                reason = %fallback_reason,
+                "GetClusterInfo serving cached response — coordination layer unhealthy"
+            );
+            return Ok(cached);
+        }
+
+        Err(format!(
+            "GetClusterInfo unavailable: {} (no cached response yet)",
+            fallback_reason
+        ))
     }
 
     /// Parse a shard ID string into a ShardId.
@@ -675,92 +777,36 @@ impl Silo for SiloService {
         &self,
         _req: Request<GetClusterInfoRequest>,
     ) -> Result<Response<GetClusterInfoResponse>, Status> {
-        let coord = self.coordinator.clone();
-
-        // Build the response from the live coordination layer, bounded by a
-        // timeout so a hung k8s/etcd backend can't block routing clients
-        // indefinitely. On success we update the cache; on timeout/error we
-        // serve the last good response.
-        let build = async {
-            let owner_map = coord
-                .get_shard_owner_map()
-                .await
-                .map_err(|e| format!("failed to get shard owner map: {}", e))?;
-
-            let shard_owners: Vec<ShardOwner> = owner_map
-                .shard_map
-                .shards()
-                .iter()
-                .map(|shard_info| {
-                    let grpc_addr = owner_map
-                        .shard_to_addr
-                        .get(&shard_info.id)
-                        .cloned()
-                        .unwrap_or_default();
-                    let node_id = owner_map
-                        .shard_to_node
-                        .get(&shard_info.id)
-                        .cloned()
-                        .unwrap_or_default();
-                    ShardOwner {
-                        shard_id: shard_info.id.to_string(),
-                        grpc_addr,
-                        node_id,
-                        range_start: shard_info.range.start.clone(),
-                        range_end: shard_info.range.end.clone(),
-                        placement_ring: shard_info.placement_ring.clone(),
+        // Collapse concurrent callers onto a single in-flight fetch. The
+        // shared future is installed under the lock, then awaited outside
+        // the lock so callers don't serialize on the slot.
+        let fut = {
+            let mut slot = self.cluster_info_inflight.lock().await;
+            match slot.as_ref() {
+                Some(existing) => existing.clone(),
+                None => {
+                    let coord = self.coordinator.clone();
+                    let cache = self.cluster_info_cache.clone();
+                    let inflight = self.cluster_info_inflight.clone();
+                    let fut: ClusterInfoFuture = async move {
+                        let result = Self::fetch_cluster_info(coord, cache).await;
+                        // Clear the slot so subsequent calls start a fresh
+                        // fetch rather than re-serving this resolved future.
+                        *inflight.lock().await = None;
+                        result
                     }
-                })
-                .collect();
-
-            let member_infos = coord
-                .get_members()
-                .await
-                .map_err(|e| format!("failed to get cluster members: {}", e))?;
-            let members: Vec<ClusterMember> = member_infos
-                .iter()
-                .map(|m| ClusterMember {
-                    node_id: m.node_id.clone(),
-                    grpc_addr: m.grpc_addr.clone(),
-                    placement_rings: m.placement_rings.clone(),
-                })
-                .collect();
-
-            Ok::<GetClusterInfoResponse, String>(GetClusterInfoResponse {
-                num_shards: owner_map.num_shards() as u32,
-                shard_owners,
-                this_node_id: coord.node_id().to_string(),
-                this_grpc_addr: coord.grpc_addr().to_string(),
-                members,
-            })
-        };
-
-        let outcome = tokio::time::timeout(CLUSTER_INFO_TIMEOUT, build).await;
-        let fallback_reason = match outcome {
-            Ok(Ok(response)) => {
-                *self.cluster_info_cache.lock().await = Some(response.clone());
-                return Ok(Response::new(response));
+                    .boxed()
+                    .shared();
+                    *slot = Some(fut.clone());
+                    fut
+                }
             }
-            Ok(Err(e)) => format!("coordinator error: {}", e),
-            Err(_) => format!(
-                "coordinator did not respond within {}s",
-                CLUSTER_INFO_TIMEOUT.as_secs()
-            ),
         };
 
-        let cached = self.cluster_info_cache.lock().await.clone();
-        if let Some(cached) = cached {
-            warn!(
-                reason = %fallback_reason,
-                "GetClusterInfo serving cached response — coordination layer unhealthy"
-            );
-            return Ok(Response::new(cached));
+        match fut.await {
+            Ok(response) => Ok(Response::new(response)),
+            Err(reason) => Err(Status::unavailable(reason)),
         }
-
-        Err(Status::unavailable(format!(
-            "GetClusterInfo unavailable: {} (no cached response yet)",
-            fallback_reason
-        )))
     }
 
     async fn enqueue(

--- a/tests/cluster_info_cache_tests.rs
+++ b/tests/cluster_info_cache_tests.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use silo::coordination::{
@@ -28,6 +28,12 @@ use tonic::Request;
 struct HangingCoordinator {
     base: CoordinatorBase,
     hang: Arc<AtomicBool>,
+    /// Per-call artificial latency for `get_shard_owner_map` / `get_members`
+    /// (milliseconds). Used by the dedup test to create a window where many
+    /// callers can race into the in-flight slot.
+    delay_ms: Arc<AtomicU64>,
+    owner_map_calls: Arc<AtomicUsize>,
+    member_calls: Arc<AtomicUsize>,
 }
 
 impl HangingCoordinator {
@@ -40,6 +46,9 @@ impl HangingCoordinator {
         Self {
             base,
             hang: Arc::new(AtomicBool::new(false)),
+            delay_ms: Arc::new(AtomicU64::new(0)),
+            owner_map_calls: Arc::new(AtomicUsize::new(0)),
+            member_calls: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -47,11 +56,28 @@ impl HangingCoordinator {
         self.hang.store(hang, Ordering::SeqCst);
     }
 
+    fn set_delay(&self, delay: Duration) {
+        self.delay_ms
+            .store(delay.as_millis() as u64, Ordering::SeqCst);
+    }
+
+    fn owner_map_call_count(&self) -> usize {
+        self.owner_map_calls.load(Ordering::SeqCst)
+    }
+
+    fn member_call_count(&self) -> usize {
+        self.member_calls.load(Ordering::SeqCst)
+    }
+
     async fn maybe_hang(&self) {
         if self.hang.load(Ordering::SeqCst) {
             // Sleep longer than the server's 5s GetClusterInfo timeout so the
             // server is forced into the cache-fallback path.
             tokio::time::sleep(Duration::from_secs(30)).await;
+        }
+        let delay = self.delay_ms.load(Ordering::SeqCst);
+        if delay > 0 {
+            tokio::time::sleep(Duration::from_millis(delay)).await;
         }
     }
 }
@@ -63,6 +89,7 @@ impl Coordinator for HangingCoordinator {
     }
 
     async fn get_members(&self) -> Result<Vec<MemberInfo>, CoordinationError> {
+        self.member_calls.fetch_add(1, Ordering::SeqCst);
         self.maybe_hang().await;
         Ok(vec![MemberInfo {
             node_id: self.base.node_id.clone(),
@@ -74,6 +101,7 @@ impl Coordinator for HangingCoordinator {
     }
 
     async fn get_shard_owner_map(&self) -> Result<ShardOwnerMap, CoordinationError> {
+        self.owner_map_calls.fetch_add(1, Ordering::SeqCst);
         self.maybe_hang().await;
         let shard_map = self.base.shard_map.lock().await;
         let mut shard_to_node = HashMap::new();
@@ -286,4 +314,80 @@ async fn get_cluster_info_refreshes_cache_after_recovery() {
     );
     assert_eq!(fresh.num_shards, cached.num_shards);
     assert_eq!(fresh.shard_owners.len(), cached.shard_owners.len());
+}
+
+/// Concurrent callers should collapse onto a single in-flight coordinator
+/// fetch rather than each issuing their own (thundering-herd defense). With
+/// the coordinator artificially slow, all N callers initiated within the
+/// fetch window must share the same underlying request.
+#[silo::test(flavor = "multi_thread")]
+async fn get_cluster_info_dedupes_concurrent_callers() {
+    let (svc, coord) = create_test_service().await;
+    // Slow enough that all callers will pile in before the first fetch resolves.
+    coord.set_delay(Duration::from_millis(300));
+
+    let svc = Arc::new(svc);
+    let n = 50;
+    let mut handles = Vec::with_capacity(n);
+    for _ in 0..n {
+        let svc = svc.clone();
+        handles.push(tokio::spawn(async move {
+            svc.get_cluster_info(Request::new(GetClusterInfoRequest {}))
+                .await
+                .expect("concurrent caller should succeed")
+                .into_inner()
+        }));
+    }
+
+    let mut responses = Vec::with_capacity(n);
+    for h in handles {
+        responses.push(h.await.expect("task joins cleanly"));
+    }
+
+    // Exactly one coordinator fetch should have occurred — every other
+    // caller must have awaited the shared in-flight future.
+    assert_eq!(
+        coord.owner_map_call_count(),
+        1,
+        "thundering herd should collapse to one get_shard_owner_map call, got {}",
+        coord.owner_map_call_count()
+    );
+    assert_eq!(
+        coord.member_call_count(),
+        1,
+        "thundering herd should collapse to one get_members call, got {}",
+        coord.member_call_count()
+    );
+
+    // All callers must observe the same response.
+    let first = &responses[0];
+    for (i, r) in responses.iter().enumerate() {
+        assert_eq!(
+            r.num_shards, first.num_shards,
+            "response {i} disagrees with the first on num_shards"
+        );
+        assert_eq!(
+            r.this_node_id, first.this_node_id,
+            "response {i} disagrees with the first on this_node_id"
+        );
+        assert_eq!(
+            r.shard_owners.len(),
+            first.shard_owners.len(),
+            "response {i} has a different shard_owners length"
+        );
+    }
+
+    // After the herd resolves, the in-flight slot is cleared so a fresh
+    // call hits the coordinator again.
+    coord.set_delay(Duration::ZERO);
+    let _ = svc
+        .get_cluster_info(Request::new(GetClusterInfoRequest {}))
+        .await
+        .expect("post-herd call should succeed");
+    assert_eq!(
+        coord.owner_map_call_count(),
+        2,
+        "a fresh call after the herd should produce a new fetch, got {}",
+        coord.owner_map_call_count()
+    );
 }


### PR DESCRIPTION
- Collapse concurrent GetClusterInfo callers onto a single in-flight coordinator fetch using futures::future::Shared, eliminating thundering-herd load on the coordination layer (k8s/etcd) when many routing clients refresh at once.
  - Extract the build logic into SiloService::fetch_cluster_info so it can be wrapped in an owned 'static + Send future stored in a new cluster_info_inflight slot; the slot is cleared when the future resolves so subsequent calls still get
  fresh data.
  - Preserves all existing semantics (5s timeout, cached-fallback on coordinator unavailability, Status::unavailable when no cache exists).

  - cargo test --test cluster_info_cache_tests — all 4 tests pass
  - New get_cluster_info_dedupes_concurrent_callers test: fires 50 concurrent callers against a coordinator with 300ms artificial latency and asserts:
    - get_shard_owner_map is called exactly once (not 50×)
    - get_members is called exactly once
    - All 50 callers receive identical response   - A follow-up call after the herd resolves produces a fresh fetch (slot cleared)
  - Existing timeout / cache-fallback / recovery tests still pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `GetClusterInfo` routing/topology RPC behavior and introduces shared in-flight async state; mistakes could cause stale responses, deadlocks, or more frequent `Unavailable` errors under load, though semantics and timeouts are largely preserved.
> 
> **Overview**
> **`GetClusterInfo` now collapses concurrent requests into a single coordinator fetch** by storing a shared in-flight future (`Shared<BoxFuture<...>>`) in `SiloService` and having all callers await it.
> 
> The coordinator-fetch + timeout + cached-fallback logic is extracted into `SiloService::fetch_cluster_info`, and the in-flight slot is cleared once the future resolves so subsequent calls fetch fresh data.
> 
> Tests extend the mock coordinator to track call counts/latency and add `get_cluster_info_dedupes_concurrent_callers`, asserting 50 concurrent callers produce exactly one `get_shard_owner_map` + one `get_members` call and that a post-herd call triggers a new fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8674ccd8d4bef316346810626f2c21ab421aa5cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->