### PR TITLE
Silo's OTLP trace export was silently disabled in production despite the env vars being set correctly.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3906,6 +3906,7 @@ dependencies = [
  "bytes",
  "http 1.3.1",
  "opentelemetry",
+ "reqwest",
 ]
 
 [[package]]
@@ -3922,6 +3923,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.5",
+ "reqwest",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -4828,6 +4830,7 @@ checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ turmoil = { version = "0.7", features = ["unstable-fs"], optional = true }
 tracing-opentelemetry = "0.27"
 opentelemetry = { version = "0.26" }
 opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.26", features = ["http-json", "trace"] }
+opentelemetry-otlp = { version = "0.26", features = ["http-json", "trace", "reqwest-client", "reqwest-rustls"] }
 prometheus = { version = "0.13", features = ["process"] }
 usdt = "0.6.0"
 tempfile = "3"


### PR DESCRIPTION
Silo's OTLP trace export was silently disabled in production despite the env vars being set correctly. Root cause: `opentelemetry-otlp` was built with `features = ["http-json", "trace"]`, which pulls in the OTLP HTTP wire format but *not* anactual HTTP client. With no `reqwest-client` / `reqwest-blocking-client` feature, `HttpConfig::default()` leaves `client: None`, and `install_batch(...)` fails at startup with `Error::NoHttpClient`.

  That error hits the fallback arm in `src/trace.rs`:

  ```rust
  Err(err) => {
      eprintln!("otlp init failed, falling back to fmt: {err}");
      base.init();
  }

  …so the process keeps running with fmt-only logging and zero spans exported. Because the OTLP layer is never installed, RUST_LOG=opentelemetry_otlp=debug doesn't surface anything either — the only signal was a single eprintln! line on
  stderr.

  Fix: enable reqwest-client (gives us the default async HTTP client) and reqwest-rustls (so https:// collector endpoints work if/when we use one). Endpoint resolution itself was already correct — OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is honored
  with the full /v1/traces path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables the OTLP exporter’s HTTP client via new `opentelemetry-otlp` features, which changes production tracing behavior and adds new networking/TLS dependencies at runtime.
> 
> **Overview**
> Fixes OTLP trace exporting being effectively disabled by building `opentelemetry-otlp` without an HTTP client.
> 
> Updates `opentelemetry-otlp` dependency features to include `reqwest-client` and `reqwest-rustls`, and refreshes `Cargo.lock` accordingly so the HTTP JSON exporter can actually send spans (including to HTTPS endpoints) instead of failing during `install_batch(...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a458b9eb0acd473dc2b2c9e3529c42dcf8e217ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->