### PR TITLE
Fix multi-limit deferred-grant holder leak and limit bypass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3906,7 +3906,6 @@ dependencies = [
  "bytes",
  "http 1.3.1",
  "opentelemetry",
- "reqwest",
 ]
 
 [[package]]
@@ -3923,7 +3922,6 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.5",
- "reqwest",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -4830,7 +4828,6 @@ checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ turmoil = { version = "0.7", features = ["unstable-fs"], optional = true }
 tracing-opentelemetry = "0.27"
 opentelemetry = { version = "0.26" }
 opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.26", features = ["http-json", "trace", "reqwest-client", "reqwest-rustls"] }
+opentelemetry-otlp = { version = "0.26", features = ["http-json", "trace"] }
 prometheus = { version = "0.13", features = ["process"] }
 usdt = "0.6.0"
 tempfile = "3"

--- a/schema/internal_storage.fbs
+++ b/schema/internal_storage.fbs
@@ -86,8 +86,18 @@ table RequestTicket {
   job_id: string;
   attempt_number: uint32;
   relative_attempt_number: uint32;
-  request_id: string;
+  // The original first_task_id from the enqueue chain. Used as holder identity
+  // for every queue granted across the chain so report_attempt_outcome can
+  // release them all by a single task_id.
+  task_id: string;
   task_group: string;
+  // Queues already granted under task_id earlier in the chain.
+  held_queues: [string];
+  // Canonical-order position of THIS queue in the limits chain.
+  limit_index: uint32;
+  // Full limits array, embedded so the deferred-grant path does not require a
+  // JobInfo lookup to continue the chain.
+  limits: [LimitEntry];
 }
 
 table CheckRateLimit {
@@ -115,11 +125,31 @@ table RefreshFloatingLimit {
   task_group: string;
 }
 
+// Chain-continuation task emitted by the deferred-grant paths after a
+// concurrency slot is granted. Dequeue picks this up and re-enters
+// enqueue_limit_task_at_index at next_limit_index, evaluating the remaining
+// limits in the canonical order. Carries the full limits array so no JobInfo
+// lookup is needed on the hot path.
+table ContinueLimits {
+  task_id: string;
+  tenant: string;
+  job_id: string;
+  attempt_number: uint32;
+  relative_attempt_number: uint32;
+  held_queues: [string];
+  next_limit_index: uint32;
+  limits: [LimitEntry];
+  priority: ubyte;
+  start_time_ms: int64;
+  task_group: string;
+}
+
 union TaskVariant {
   RunAttempt,
   RequestTicket,
   CheckRateLimit,
   RefreshFloatingLimit,
+  ContinueLimits,
 }
 
 table Task {
@@ -237,6 +267,16 @@ table EnqueueTask {
   attempt_number: uint32;
   relative_attempt_number: uint32;
   task_group: string;
+  // The original first_task_id from the enqueue chain. Used as holder identity
+  // for every queue granted across the chain.
+  task_id: string;
+  // Queues already granted under task_id earlier in the chain.
+  held_queues: [string];
+  // Canonical-order position of THIS queue in the limits chain.
+  limit_index: uint32;
+  // Full limits array, embedded so the grant scanner does not require a
+  // JobInfo lookup to continue the chain.
+  limits: [LimitEntry];
 }
 
 union ConcurrencyActionVariant {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -44,6 +44,149 @@ fn build_kv_pair_offsets<'a, A: flatbuffers::Allocator + 'a>(
         .collect()
 }
 
+/// Build a vector of LimitEntry offsets from a `Vec<Limit>`. Used by both
+/// JobInfo encoding and by chain-continuation tasks/actions that embed limits
+/// to avoid a JobInfo lookup on the hot path.
+fn build_limit_entry_offsets<'a, A: flatbuffers::Allocator + 'a>(
+    builder: &mut FlatBufferBuilder<'a, A>,
+    limits: &[Limit],
+) -> Vec<flatbuffers::WIPOffset<fb::LimitEntry<'a>>> {
+    limits
+        .iter()
+        .map(|lim| {
+            let (vtype, voff) = match lim {
+                Limit::Concurrency(cl) => {
+                    let key = builder.create_string(&cl.key);
+                    let entry = fb::ConcurrencyLimitEntry::create(
+                        builder,
+                        &fb::ConcurrencyLimitEntryArgs {
+                            key: Some(key),
+                            max_concurrency: cl.max_concurrency,
+                        },
+                    );
+                    (
+                        fb::LimitVariant::ConcurrencyLimitEntry,
+                        entry.as_union_value(),
+                    )
+                }
+                Limit::RateLimit(rl) => {
+                    let name = builder.create_string(&rl.name);
+                    let unique_key = builder.create_string(&rl.unique_key);
+                    let rp = fb::RateLimitRetryPolicy::create(
+                        builder,
+                        &fb::RateLimitRetryPolicyArgs {
+                            initial_backoff_ms: rl.retry_policy.initial_backoff_ms,
+                            max_backoff_ms: rl.retry_policy.max_backoff_ms,
+                            backoff_multiplier: rl.retry_policy.backoff_multiplier,
+                            max_retries: rl.retry_policy.max_retries,
+                        },
+                    );
+                    let entry = fb::RateLimitEntry::create(
+                        builder,
+                        &fb::RateLimitEntryArgs {
+                            name: Some(name),
+                            unique_key: Some(unique_key),
+                            limit: rl.limit,
+                            duration_ms: rl.duration_ms,
+                            hits: rl.hits,
+                            algorithm: rl.algorithm.as_u8(),
+                            behavior: rl.behavior,
+                            retry_policy: Some(rp),
+                        },
+                    );
+                    (fb::LimitVariant::RateLimitEntry, entry.as_union_value())
+                }
+                Limit::FloatingConcurrency(fl) => {
+                    let key = builder.create_string(&fl.key);
+                    let md = build_kv_pair_offsets(builder, &fl.metadata);
+                    let metadata = builder.create_vector(&md);
+                    let entry = fb::FloatingConcurrencyLimitEntry::create(
+                        builder,
+                        &fb::FloatingConcurrencyLimitEntryArgs {
+                            key: Some(key),
+                            default_max_concurrency: fl.default_max_concurrency,
+                            refresh_interval_ms: fl.refresh_interval_ms,
+                            metadata: Some(metadata),
+                        },
+                    );
+                    (
+                        fb::LimitVariant::FloatingConcurrencyLimitEntry,
+                        entry.as_union_value(),
+                    )
+                }
+            };
+            fb::LimitEntry::create(
+                builder,
+                &fb::LimitEntryArgs {
+                    variant_type: vtype,
+                    variant: Some(voff),
+                },
+            )
+        })
+        .collect()
+}
+
+/// Decode a flatbuffer LimitEntry vector to a `Vec<Limit>`. Symmetric with
+/// `build_limit_entry_offsets`.
+pub fn fb_limit_entries_to_owned(
+    entries: Option<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<fb::LimitEntry<'_>>>>,
+) -> Vec<Limit> {
+    use crate::job::{
+        ConcurrencyLimit, FloatingConcurrencyLimit, GubernatorAlgorithm, GubernatorRateLimit,
+        RateLimitRetryPolicy,
+    };
+    entries
+        .map(|es| {
+            es.iter()
+                .filter_map(|entry| match entry.variant_type() {
+                    fb::LimitVariant::ConcurrencyLimitEntry => {
+                        let cl = entry.variant_as_concurrency_limit_entry()?;
+                        Some(Limit::Concurrency(ConcurrencyLimit {
+                            key: cl.key().unwrap_or_default().to_string(),
+                            max_concurrency: cl.max_concurrency(),
+                        }))
+                    }
+                    fb::LimitVariant::RateLimitEntry => {
+                        let rl = entry.variant_as_rate_limit_entry()?;
+                        let rp = rl.retry_policy();
+                        Some(Limit::RateLimit(GubernatorRateLimit {
+                            name: rl.name().unwrap_or_default().to_string(),
+                            unique_key: rl.unique_key().unwrap_or_default().to_string(),
+                            limit: rl.limit(),
+                            duration_ms: rl.duration_ms(),
+                            hits: rl.hits(),
+                            algorithm: if rl.algorithm() == 1 {
+                                GubernatorAlgorithm::LeakyBucket
+                            } else {
+                                GubernatorAlgorithm::TokenBucket
+                            },
+                            behavior: rl.behavior(),
+                            retry_policy: rp
+                                .map(|p| RateLimitRetryPolicy {
+                                    initial_backoff_ms: p.initial_backoff_ms(),
+                                    max_backoff_ms: p.max_backoff_ms(),
+                                    backoff_multiplier: p.backoff_multiplier(),
+                                    max_retries: p.max_retries(),
+                                })
+                                .unwrap_or_default(),
+                        }))
+                    }
+                    fb::LimitVariant::FloatingConcurrencyLimitEntry => {
+                        let fl = entry.variant_as_floating_concurrency_limit_entry()?;
+                        Some(Limit::FloatingConcurrency(FloatingConcurrencyLimit {
+                            key: fl.key().unwrap_or_default().to_string(),
+                            default_max_concurrency: fl.default_max_concurrency(),
+                            refresh_interval_ms: fl.refresh_interval_ms(),
+                            metadata: fb_kv_pairs_to_owned(fl.metadata()),
+                        }))
+                    }
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Build a Task union (TaskVariant) into the builder. Returns (type, offset).
 fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
     builder: &mut FlatBufferBuilder<'a, A>,
@@ -93,14 +236,24 @@ fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
             job_id,
             attempt_number,
             relative_attempt_number,
-            request_id,
+            task_id,
             task_group,
+            held_queues,
+            limit_index,
+            limits,
         } => {
             let queue = builder.create_string(queue);
             let tenant = builder.create_string(tenant);
             let job_id = builder.create_string(job_id);
-            let request_id = builder.create_string(request_id);
+            let task_id = builder.create_string(task_id);
             let task_group = builder.create_string(task_group);
+            let hq: Vec<_> = held_queues
+                .iter()
+                .map(|s| builder.create_string(s))
+                .collect();
+            let held_queues = builder.create_vector(&hq);
+            let limit_offsets = build_limit_entry_offsets(builder, limits);
+            let limits = builder.create_vector(&limit_offsets);
             let rt = fb::RequestTicket::create(
                 builder,
                 &fb::RequestTicketArgs {
@@ -111,8 +264,11 @@ fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
                     job_id: Some(job_id),
                     attempt_number: *attempt_number,
                     relative_attempt_number: *relative_attempt_number,
-                    request_id: Some(request_id),
+                    task_id: Some(task_id),
                     task_group: Some(task_group),
+                    held_queues: Some(held_queues),
+                    limit_index: *limit_index,
+                    limits: Some(limits),
                 },
             );
             (fb::TaskVariant::RequestTicket, rt.as_union_value())
@@ -205,6 +361,48 @@ fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
                 },
             );
             (fb::TaskVariant::RefreshFloatingLimit, rfl.as_union_value())
+        }
+        Task::ContinueLimits {
+            task_id,
+            tenant,
+            job_id,
+            attempt_number,
+            relative_attempt_number,
+            held_queues,
+            next_limit_index,
+            limits,
+            priority,
+            start_time_ms,
+            task_group,
+        } => {
+            let task_id_s = builder.create_string(task_id);
+            let tenant_s = builder.create_string(tenant);
+            let job_id_s = builder.create_string(job_id);
+            let task_group_s = builder.create_string(task_group);
+            let hq: Vec<_> = held_queues
+                .iter()
+                .map(|s| builder.create_string(s))
+                .collect();
+            let held_queues_v = builder.create_vector(&hq);
+            let limit_offsets = build_limit_entry_offsets(builder, limits);
+            let limits_v = builder.create_vector(&limit_offsets);
+            let cl = fb::ContinueLimits::create(
+                builder,
+                &fb::ContinueLimitsArgs {
+                    task_id: Some(task_id_s),
+                    tenant: Some(tenant_s),
+                    job_id: Some(job_id_s),
+                    attempt_number: *attempt_number,
+                    relative_attempt_number: *relative_attempt_number,
+                    held_queues: Some(held_queues_v),
+                    next_limit_index: *next_limit_index,
+                    limits: Some(limits_v),
+                    priority: *priority,
+                    start_time_ms: *start_time_ms,
+                    task_group: Some(task_group_s),
+                },
+            );
+            (fb::TaskVariant::ContinueLimits, cl.as_union_value())
         }
     }
 }
@@ -474,9 +672,21 @@ pub fn encode_concurrency_action(action: &ConcurrencyAction) -> Vec<u8> {
             attempt_number,
             relative_attempt_number,
             task_group,
+            task_id,
+            held_queues,
+            limit_index,
+            limits,
         } => {
             let job_id = builder.create_string(job_id);
             let task_group = builder.create_string(task_group);
+            let task_id_s = builder.create_string(task_id);
+            let hq: Vec<_> = held_queues
+                .iter()
+                .map(|s| builder.create_string(s))
+                .collect();
+            let held_queues_v = builder.create_vector(&hq);
+            let limit_offsets = build_limit_entry_offsets(&mut builder, limits);
+            let limits_v = builder.create_vector(&limit_offsets);
             let et = fb::EnqueueTask::create(
                 &mut builder,
                 &fb::EnqueueTaskArgs {
@@ -486,6 +696,10 @@ pub fn encode_concurrency_action(action: &ConcurrencyAction) -> Vec<u8> {
                     attempt_number: *attempt_number,
                     relative_attempt_number: *relative_attempt_number,
                     task_group: Some(task_group),
+                    task_id: Some(task_id_s),
+                    held_queues: Some(held_queues_v),
+                    limit_index: *limit_index,
+                    limits: Some(limits_v),
                 },
             );
             let root = fb::ConcurrencyAction::create(
@@ -589,8 +803,14 @@ fn task_from_fb_variant(
                 job_id: rt.job_id().unwrap_or_default().to_string(),
                 attempt_number: rt.attempt_number(),
                 relative_attempt_number: rt.relative_attempt_number(),
-                request_id: rt.request_id().unwrap_or_default().to_string(),
+                task_id: rt.task_id().unwrap_or_default().to_string(),
                 task_group: rt.task_group().unwrap_or_default().to_string(),
+                held_queues: rt
+                    .held_queues()
+                    .map(|v| v.iter().map(|s| s.to_string()).collect())
+                    .unwrap_or_default(),
+                limit_index: rt.limit_index(),
+                limits: fb_limit_entries_to_owned(rt.limits()),
             })
         }
         fb::TaskVariant::CheckRateLimit => {
@@ -638,6 +858,25 @@ fn task_from_fb_variant(
                 last_refreshed_at_ms: rfl.last_refreshed_at_ms(),
                 metadata: fb_kv_pairs_to_owned(rfl.metadata()),
                 task_group: rfl.task_group().unwrap_or_default().to_string(),
+            })
+        }
+        fb::TaskVariant::ContinueLimits => {
+            let cl = unsafe { fb::ContinueLimits::init_from_table(table) };
+            Ok(Task::ContinueLimits {
+                task_id: cl.task_id().unwrap_or_default().to_string(),
+                tenant: cl.tenant().unwrap_or_default().to_string(),
+                job_id: cl.job_id().unwrap_or_default().to_string(),
+                attempt_number: cl.attempt_number(),
+                relative_attempt_number: cl.relative_attempt_number(),
+                held_queues: cl
+                    .held_queues()
+                    .map(|v| v.iter().map(|s| s.to_string()).collect())
+                    .unwrap_or_default(),
+                next_limit_index: cl.next_limit_index(),
+                limits: fb_limit_entries_to_owned(cl.limits()),
+                priority: cl.priority(),
+                start_time_ms: cl.start_time_ms(),
+                task_group: cl.task_group().unwrap_or_default().to_string(),
             })
         }
         _ => Err(CodecError::Flatbuffer(format!(

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -759,6 +759,13 @@ impl ConcurrencyManager {
         attempt_number: u32,
         relative_attempt_number: u32,
         skip_try_reserve: bool,
+        // Chain context: passed through to the request record / future ticket so
+        // the deferred-grant path can continue the limit chain without a JobInfo
+        // lookup. All four refer to the FULL canonical-order chain (`chain_limits`,
+        // `chain_limit_index`) and the holders accumulated so far under `task_id`.
+        chain_held_queues: &[String],
+        chain_limit_index: u32,
+        chain_limits: &[crate::job::Limit],
     ) -> Result<Option<RequestTicketOutcome>, ConcurrencyError> {
         // Only gate on the first limit (if any)
         let Some(limit) = limits.first() else {
@@ -813,20 +820,25 @@ impl ConcurrencyManager {
                 writer,
                 tenant,
                 queue,
+                task_id,
                 start_at_ms,
                 priority,
                 job_id,
                 attempt_number,
                 relative_attempt_number,
                 task_group,
+                chain_held_queues,
+                chain_limit_index,
+                chain_limits,
             )?;
             Ok(Some(RequestTicketOutcome::TicketRequested {
                 queue: queue.clone(),
             }))
         } else {
-            // Job scheduled for future: queue as RequestTicket task
-            let suffix = format!("{:08x}", rand::random::<u32>());
-            let request_id = format!("{job_id}:{attempt_number}:{suffix}");
+            // Job scheduled for future: queue as RequestTicket task. Use the
+            // chain's `task_id` as the ticket identity — every holder this job
+            // acquires across the chain shares one task_id so that completion
+            // releases them all via a single lease's `held_queues`.
             let ticket = Task::RequestTicket {
                 queue: queue.clone(),
                 start_time_ms: start_at_ms,
@@ -835,8 +847,11 @@ impl ConcurrencyManager {
                 job_id: job_id.to_string(),
                 attempt_number,
                 relative_attempt_number,
-                request_id: request_id.clone(),
+                task_id: task_id.to_string(),
                 task_group: task_group.to_string(),
+                held_queues: chain_held_queues.to_vec(),
+                limit_index: chain_limit_index,
+                limits: chain_limits.to_vec(),
             };
             let ticket_value = encode_task(&ticket);
             writer.put(
@@ -845,7 +860,7 @@ impl ConcurrencyManager {
             )?;
             Ok(Some(RequestTicketOutcome::FutureRequestTaskWritten {
                 queue: queue.clone(),
-                task_id: request_id,
+                task_id: task_id.to_string(),
             }))
         }
     }
@@ -1084,13 +1099,23 @@ impl ConcurrencyManager {
 
         struct ScannedRequest {
             request_key: Vec<u8>,
-            request_id: String,
+            // The chain's original first_task_id, embedded in the request
+            // value. Used as the holder identity (matches earlier-granted
+            // holders for this job) so completion can release them all via
+            // one lease's `held_queues`.
+            task_id: String,
             job_id: String,
             attempt_number: u32,
             relative_attempt_number: u32,
             start_time_ms: i64,
             priority: u8,
             task_group: String,
+            // Chain continuation context — embedded in the EnqueueTask so the
+            // scanner can build a Task::ContinueLimits without consulting
+            // JobInfo on the hot path.
+            held_queues: Vec<String>,
+            limit_index: u32,
+            limits: Vec<crate::job::Limit>,
         }
 
         let mut max_concurrency: Option<(usize, ConcurrencyLimitType)> = None;
@@ -1157,10 +1182,20 @@ impl ConcurrencyManager {
                     break;
                 }
 
-                let Some(parsed_req) = parsed_req else {
+                let Some(_parsed_req) = parsed_req else {
                     continue;
                 };
-                let request_id = parsed_req.request_id();
+                // Pull the chain identity and continuation context from the
+                // request value, not from the parsed key. Empty task_id here
+                // would indicate a malformed record (no longer expected: the
+                // DB is nuked between schema versions).
+                let task_id = et.task_id().unwrap_or_default().to_string();
+                let held_queues: Vec<String> = et
+                    .held_queues()
+                    .map(|v| v.iter().map(|s| s.to_string()).collect())
+                    .unwrap_or_default();
+                let limit_index = et.limit_index();
+                let limits = crate::codec::fb_limit_entries_to_owned(et.limits());
 
                 // Resolve max_concurrency from the first request whose job info is readable.
                 // Don't cache failures — a stale request's missing job shouldn't lock
@@ -1203,13 +1238,16 @@ impl ConcurrencyManager {
 
                 scanned.push(ScannedRequest {
                     request_key: kv.key.to_vec(),
-                    request_id,
+                    task_id,
                     job_id: job_id_str.to_string(),
                     attempt_number: et.attempt_number(),
                     relative_attempt_number: et.relative_attempt_number(),
                     start_time_ms,
                     priority: et.priority(),
                     task_group: et.task_group().unwrap_or_default().to_string(),
+                    held_queues,
+                    limit_index,
+                    limits,
                 });
             }
 
@@ -1305,10 +1343,14 @@ impl ConcurrencyManager {
                 }
 
                 // [SILO-GRANT-1] Pre: Queue has capacity — try to atomically reserve a slot
+                // Identity = the chain's task_id, NOT a parsed-key request_id.
+                // Earlier-granted holders for this job are already keyed by
+                // task_id; aligning here is what keeps the lease's held_queues
+                // releasable in one shot at completion.
                 if !self.counts.try_reserve_internal(
                     tenant,
                     queue,
-                    &req.request_id,
+                    &req.task_id,
                     limit,
                     &req.job_id,
                 ) {
@@ -1316,23 +1358,34 @@ impl ConcurrencyManager {
                     break;
                 }
 
-                // [SILO-GRANT-3] Create holder
+                // [SILO-GRANT-3] Create holder keyed by task_id
                 let holder_val = encode_holder(&HolderRecord {
                     granted_at_ms: now_ms,
                 });
                 batch.put(
-                    concurrency_holder_key(tenant, queue, &req.request_id),
+                    concurrency_holder_key(tenant, queue, &req.task_id),
                     &holder_val,
                 );
 
-                // [SILO-GRANT-4] Create RunAttempt task
-                let tval = encode_task(&Task::RunAttempt {
-                    id: req.request_id.clone(),
+                // [SILO-GRANT-4] Emit a ContinueLimits chain-continuation task.
+                // held_queues is the accumulator from earlier in the chain with
+                // this just-granted queue appended; next_limit_index points one
+                // past this limit in the canonical order. Dequeue will
+                // re-enter `enqueue_limit_task_at_index` to evaluate the
+                // remaining limits (or write the terminal RunAttempt).
+                let mut held_queues = req.held_queues.clone();
+                held_queues.push(queue.to_string());
+                let tval = encode_task(&Task::ContinueLimits {
+                    task_id: req.task_id.clone(),
                     tenant: tenant.to_string(),
                     job_id: req.job_id.clone(),
                     attempt_number: req.attempt_number,
                     relative_attempt_number: req.relative_attempt_number,
-                    held_queues: vec![queue.to_string()],
+                    held_queues,
+                    next_limit_index: req.limit_index + 1,
+                    limits: req.limits.clone(),
+                    priority: req.priority,
+                    start_time_ms: req.start_time_ms,
                     task_group: req.task_group.clone(),
                 });
                 batch.put(
@@ -1347,7 +1400,7 @@ impl ConcurrencyManager {
                 );
                 batch.delete(&req.request_key);
 
-                grants.push((req.request_id.clone(), req.task_group.clone()));
+                grants.push((req.task_id.clone(), req.task_group.clone()));
             }
 
             // --- Per-pass commit ---
@@ -1378,8 +1431,8 @@ impl ConcurrencyManager {
                 .await
             {
                 // Roll back only this pass's reservations; prior committed passes stand.
-                for (request_id, _) in &grants {
-                    self.counts.release_reservation(tenant, queue, request_id);
+                for (task_id, _) in &grants {
+                    self.counts.release_reservation(tenant, queue, task_id);
                 }
                 tracing::warn!(
                     error = %e,
@@ -1390,10 +1443,10 @@ impl ConcurrencyManager {
                 return all_granted_groups;
             }
 
-            for (request_id, task_group) in &grants {
+            for (task_id, task_group) in &grants {
                 tracing::debug!(
                     queue = %queue,
-                    request_id = %request_id,
+                    task_id = %task_id,
                     task_group = %task_group,
                     "grant scanner: granted concurrency ticket"
                 );
@@ -1460,12 +1513,16 @@ fn append_request_edits<W: WriteBatcher>(
     writer: &mut W,
     tenant: &str,
     queue: &str,
+    task_id: &str,
     start_time_ms: i64,
     priority: u8,
     job_id: &str,
     attempt_number: u32,
     relative_attempt_number: u32,
     task_group: &str,
+    chain_held_queues: &[String],
+    chain_limit_index: u32,
+    chain_limits: &[crate::job::Limit],
 ) -> Result<(), ConcurrencyError> {
     let action = ConcurrencyAction::EnqueueTask {
         start_time_ms,
@@ -1474,9 +1531,16 @@ fn append_request_edits<W: WriteBatcher>(
         attempt_number,
         relative_attempt_number,
         task_group: task_group.to_string(),
+        task_id: task_id.to_string(),
+        held_queues: chain_held_queues.to_vec(),
+        limit_index: chain_limit_index,
+        limits: chain_limits.to_vec(),
     };
     let action_val = encode_concurrency_action(&action);
-    let suffix = format!("{:08x}", rand::random::<u32>());
+    // Use task_id as the request-key suffix. This ties the durable request
+    // record directly to the chain's identity, so when the grant scanner
+    // promotes it, the new holder it writes can be keyed by the same task_id
+    // that earlier-granted holders already use.
     let req_key = concurrency_request_key(
         tenant,
         queue,
@@ -1484,7 +1548,7 @@ fn append_request_edits<W: WriteBatcher>(
         priority,
         job_id,
         attempt_number,
-        &suffix,
+        task_id,
     );
     writer.put(&req_key, &action_val)?;
 

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1367,27 +1367,41 @@ impl ConcurrencyManager {
                     &holder_val,
                 );
 
-                // [SILO-GRANT-4] Emit a ContinueLimits chain-continuation task.
-                // held_queues is the accumulator from earlier in the chain with
-                // this just-granted queue appended; next_limit_index points one
-                // past this limit in the canonical order. Dequeue will
-                // re-enter `enqueue_limit_task_at_index` to evaluate the
-                // remaining limits (or write the terminal RunAttempt).
+                // [SILO-GRANT-4] Emit either a terminal RunAttempt (if this was
+                // the last limit in the canonical chain) or a ContinueLimits
+                // chain-continuation task. Short-circuiting to RunAttempt when
+                // possible avoids a dequeue round-trip — `handle_continue_limits`
+                // would walk into the terminal "no more limits" branch and write
+                // the same RunAttempt anyway, just one cycle later.
                 let mut held_queues = req.held_queues.clone();
                 held_queues.push(queue.to_string());
-                let tval = encode_task(&Task::ContinueLimits {
-                    task_id: req.task_id.clone(),
-                    tenant: tenant.to_string(),
-                    job_id: req.job_id.clone(),
-                    attempt_number: req.attempt_number,
-                    relative_attempt_number: req.relative_attempt_number,
-                    held_queues,
-                    next_limit_index: req.limit_index + 1,
-                    limits: req.limits.clone(),
-                    priority: req.priority,
-                    start_time_ms: req.start_time_ms,
-                    task_group: req.task_group.clone(),
-                });
+                let next_limit_index = req.limit_index + 1;
+                let is_last_limit = (next_limit_index as usize) >= req.limits.len();
+                let tval = if is_last_limit {
+                    encode_task(&Task::RunAttempt {
+                        id: req.task_id.clone(),
+                        tenant: tenant.to_string(),
+                        job_id: req.job_id.clone(),
+                        attempt_number: req.attempt_number,
+                        relative_attempt_number: req.relative_attempt_number,
+                        held_queues,
+                        task_group: req.task_group.clone(),
+                    })
+                } else {
+                    encode_task(&Task::ContinueLimits {
+                        task_id: req.task_id.clone(),
+                        tenant: tenant.to_string(),
+                        job_id: req.job_id.clone(),
+                        attempt_number: req.attempt_number,
+                        relative_attempt_number: req.relative_attempt_number,
+                        held_queues,
+                        next_limit_index,
+                        limits: req.limits.clone(),
+                        priority: req.priority,
+                        start_time_ms: req.start_time_ms,
+                        task_group: req.task_group.clone(),
+                    })
+                };
                 batch.put(
                     task_key(
                         &req.task_group,

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -3,7 +3,7 @@
 use slatedb::WriteBatch;
 use slatedb::config::WriteOptions;
 
-use crate::codec::{DecodedTask, decode_task, encode_attempt, encode_lease};
+use crate::codec::{DecodedTask, decode_task, encode_attempt, encode_lease, encode_task};
 use crate::concurrency::RequestTicketTaskOutcome;
 use crate::dst_events::{self, DstEvent};
 use crate::fb::silo::fb;
@@ -171,6 +171,10 @@ impl JobStoreShard {
                             &mut state, &entry.key, decoded, worker_id, now_ms, expiry_ms,
                         )
                         .await?;
+                    }
+                    fb::TaskVariant::ContinueLimits => {
+                        self.handle_continue_limits(&mut state, &entry.key, decoded, now_ms)
+                            .await?;
                     }
                     other => {
                         return Err(JobStoreShardError::Codec(format!(
@@ -348,7 +352,11 @@ impl JobStoreShard {
         Ok(attempt_val)
     }
 
-    /// Process a RequestTicket task: check cancellation, process concurrency ticket, maybe lease.
+    /// Process a RequestTicket task: check cancellation, process concurrency
+    /// ticket, and on grant emit a `Task::ContinueLimits` so dequeue can
+    /// re-enter the limit chain at the next index. The broker picks the
+    /// continuation up on a subsequent dequeue cycle, mirroring the pattern
+    /// used by `Task::CheckRateLimit`.
     #[allow(clippy::too_many_arguments)]
     async fn handle_request_ticket(
         &self,
@@ -356,9 +364,9 @@ impl JobStoreShard {
         task_key: &[u8],
         decoded: &DecodedTask,
         shard_range: &ShardRange,
-        worker_id: &str,
+        _worker_id: &str,
         now_ms: i64,
-        expiry_ms: i64,
+        _expiry_ms: i64,
     ) -> Result<(), JobStoreShardError> {
         let rt = decoded.as_request_ticket().ok_or_else(|| {
             JobStoreShardError::Codec("expected RequestTicket variant".to_string())
@@ -368,8 +376,18 @@ impl JobStoreShard {
         let job_id = rt.job_id().unwrap_or_default();
         let attempt_number = rt.attempt_number();
         let relative_attempt_number = rt.relative_attempt_number();
-        let request_id = rt.request_id().unwrap_or_default();
+        // task_id is the original first_task_id shared by every holder in the
+        // chain. Used as the holder identity for the slot we're about to grant.
+        let task_id = rt.task_id().unwrap_or_default();
         let req_task_group = rt.task_group().unwrap_or_default();
+        let start_time_ms = rt.start_time_ms();
+        let priority = rt.priority();
+        let limit_index = rt.limit_index();
+        let prior_held_queues: Vec<String> = rt
+            .held_queues()
+            .map(|v| v.iter().map(|s| s.to_string()).collect())
+            .unwrap_or_default();
+        let limits = crate::codec::fb_limit_entries_to_owned(rt.limits());
         state.processed_internal = true;
         let tenant = tenant.to_string();
 
@@ -377,14 +395,16 @@ impl JobStoreShard {
         // by cancel_job. If a stale task appears (e.g., retry after cancel), it will
         // be processed normally and the worker discovers cancellation via heartbeat.
 
-        // Load job info
+        // Load job info (only for the JobMissing branch; the new chain context
+        // lets us continue without consulting JobInfo.limits on the hot path).
         let job_key = job_info_key(&tenant, job_id);
         let maybe_job = self.db.get(&job_key).await?;
         let job_view = maybe_job
             .as_ref()
             .and_then(|bytes| JobView::new(bytes.clone()).ok());
 
-        // Process ticket via concurrency manager
+        // Process ticket via concurrency manager — writes the holder under
+        // `task_id`, deletes the ticket task_key, reserves the in-memory slot.
         let outcome = self
             .concurrency
             .process_ticket_request_task(
@@ -394,7 +414,7 @@ impl JobStoreShard {
                 task_key,
                 &tenant,
                 queue,
-                request_id,
+                task_id,
                 job_id,
                 attempt_number,
                 now_ms,
@@ -404,52 +424,48 @@ impl JobStoreShard {
 
         match outcome {
             RequestTicketTaskOutcome::Granted { request_id, queue } => {
-                // Track grant for rollback if DB write fails
+                // request_id here equals task_id (we passed task_id in above).
+                // Track grant for rollback if DB write fails.
                 state
                     .grants_to_rollback
                     .push((tenant.clone(), queue.clone(), request_id.clone()));
 
-                // Create RunAttempt task for the lease (new Task, not a copy)
-                let run = Task::RunAttempt {
-                    id: request_id.clone(),
+                // Append the just-granted queue to held_queues, then write a
+                // ContinueLimits task at the same task_key. Dequeue's handler
+                // for ContinueLimits will call enqueue_limit_task_at_index at
+                // limit_index + 1 to evaluate any remaining limits (or, if
+                // none, write the terminal RunAttempt).
+                let mut held_queues = prior_held_queues;
+                held_queues.push(queue);
+                // Use now_ms (not the ticket's start_time_ms) so the new
+                // task_key differs from the just-tombstoned ticket key. The
+                // broker's tombstone retention would otherwise suppress this
+                // re-pickup; see the same trick in `handle_check_rate_limit`.
+                let cont = Task::ContinueLimits {
+                    task_id: request_id.clone(),
                     tenant: tenant.clone(),
                     job_id: job_id.to_string(),
                     attempt_number,
                     relative_attempt_number,
-                    held_queues: vec![queue],
+                    held_queues,
+                    next_limit_index: limit_index + 1,
+                    limits,
+                    priority,
+                    start_time_ms: now_ms,
                     task_group: req_task_group.to_string(),
                 };
+                let cont_value = encode_task(&cont);
+                let new_task_key = crate::keys::task_key(
+                    req_task_group,
+                    now_ms,
+                    priority,
+                    job_id,
+                    attempt_number,
+                );
+                state.batch.put(&new_task_key, &cont_value);
+                let _ = start_time_ms;
 
-                let attempt_val = self
-                    .write_lease_and_attempt(
-                        &mut state.batch,
-                        worker_id,
-                        &run,
-                        &request_id,
-                        &tenant,
-                        job_id,
-                        attempt_number,
-                        relative_attempt_number,
-                        now_ms,
-                        expiry_ms,
-                    )
-                    .await?;
-
-                let view = job_view.ok_or_else(|| {
-                    JobStoreShardError::Codec(format!(
-                        "job view missing for granted ticket, job_id={}",
-                        job_id
-                    ))
-                })?;
-                state
-                    .pending_attempts
-                    .push((tenant.clone(), view, attempt_val));
                 state.ack_deleted(task_key);
-
-                // Track for DST event emission after commit
-                state
-                    .leased_tasks_for_dst
-                    .push((tenant, job_id.to_string(), request_id));
 
                 // Record concurrency ticket metric and ready-to-start latency
                 if let Some(ref m) = self.metrics {
@@ -463,6 +479,10 @@ impl JobStoreShard {
                         m.record_ready_to_start_latency_ms(self.name(), req_task_group, latency_ms);
                     }
                 }
+
+                // Wake the broker so the ContinueLimits task is picked up on
+                // the next dequeue cycle.
+                self.brokers.wakeup(req_task_group);
             }
             RequestTicketTaskOutcome::Requested => {
                 // Release inflight only; task key remains in DB and must be eligible
@@ -701,6 +721,87 @@ impl JobStoreShard {
             task_group: rfl.task_group().unwrap_or_default().to_string(),
         });
         state.ack_deleted(task_key);
+
+        Ok(())
+    }
+
+    /// Process a `Task::ContinueLimits`: re-enter the limit chain at
+    /// `next_limit_index` using the embedded chain context. This is the
+    /// counterpart to the rate-limit-passed branch of `handle_check_rate_limit`
+    /// — it's how the system advances past a queue that was deferred-granted
+    /// without reading `JobInfo.limits` on the hot path.
+    ///
+    /// If `next_limit_index` is past the end of the limits chain,
+    /// `enqueue_limit_task_at_index` writes the terminal `RunAttempt` at the
+    /// same task_key — the broker leases it on the next dequeue cycle.
+    async fn handle_continue_limits(
+        &self,
+        state: &mut DequeueIterationState,
+        task_key: &[u8],
+        decoded: &DecodedTask,
+        now_ms: i64,
+    ) -> Result<(), JobStoreShardError> {
+        let Task::ContinueLimits {
+            task_id,
+            tenant,
+            job_id,
+            attempt_number,
+            relative_attempt_number,
+            held_queues,
+            next_limit_index,
+            limits,
+            priority,
+            start_time_ms,
+            task_group,
+        } = decoded.to_task()?
+        else {
+            return Err(JobStoreShardError::Codec(
+                "expected ContinueLimits variant".to_string(),
+            ));
+        };
+
+        state.processed_internal = true;
+        // Delete the ContinueLimits task itself and tombstone its key.
+        state.batch.delete(task_key);
+        state.ack_deleted(task_key);
+
+        // Use `now_ms` as start_at_ms when re-entering the chain so any
+        // chained task (CheckRateLimit, RunAttempt, RequestTicket, …) lands
+        // at a fresh task_key that doesn't collide with the just-tombstoned
+        // one. This mirrors how `handle_check_rate_limit` continues its
+        // chain (it also passes `start_at_ms: now_ms`). The original
+        // `start_time_ms` would land at the same key as the ContinueLimits
+        // we just acked, and the broker tombstone would suppress it.
+        let grants = self
+            .enqueue_limit_task_at_index(
+                &mut DbWriteBatcher::new(&self.db, &mut state.batch),
+                LimitTaskParams {
+                    tenant: &tenant,
+                    task_id: &task_id,
+                    job_id: &job_id,
+                    attempt_number,
+                    relative_attempt_number,
+                    limit_index: next_limit_index as usize,
+                    limits: &limits,
+                    priority,
+                    start_at_ms: now_ms,
+                    now_ms,
+                    held_queues,
+                    task_group: &task_group,
+                    skip_try_reserve: false,
+                },
+            )
+            .await?;
+        // Silence unused variable warning on start_time_ms; the value is
+        // load-bearing only on the originating side, not on continuation.
+        let _ = start_time_ms;
+
+        // Track any immediate grants for rollback if the outer batch fails.
+        for (queue, t_id) in grants {
+            state
+                .grants_to_rollback
+                .push((tenant.clone(), queue, t_id));
+        }
 
         Ok(())
     }

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -455,13 +455,8 @@ impl JobStoreShard {
                     task_group: req_task_group.to_string(),
                 };
                 let cont_value = encode_task(&cont);
-                let new_task_key = crate::keys::task_key(
-                    req_task_group,
-                    now_ms,
-                    priority,
-                    job_id,
-                    attempt_number,
-                );
+                let new_task_key =
+                    crate::keys::task_key(req_task_group, now_ms, priority, job_id, attempt_number);
                 state.batch.put(&new_task_key, &cont_value);
                 let _ = start_time_ms;
 
@@ -798,9 +793,7 @@ impl JobStoreShard {
 
         // Track any immediate grants for rollback if the outer batch fails.
         for (queue, t_id) in grants {
-            state
-                .grants_to_rollback
-                .push((tenant.clone(), queue, t_id));
+            state.grants_to_rollback.push((tenant.clone(), queue, t_id));
         }
 
         Ok(())

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -485,7 +485,20 @@ impl JobStoreShard {
                 state.ack_release(task_key);
             }
             RequestTicketTaskOutcome::JobMissing => {
-                // process_ticket_request_task deleted the task key.
+                // process_ticket_request_task deleted the task key. Also
+                // release any concurrency holders accumulated earlier in the
+                // chain — they're keyed by this ticket's `task_id` and would
+                // otherwise orphan, since no lease will ever be written to
+                // reach them via report_attempt_outcome. Symmetric with the
+                // JobMissing path in handle_check_rate_limit.
+                for q in &prior_held_queues {
+                    state
+                        .batch
+                        .delete(concurrency_holder_key(&tenant, q, task_id));
+                    state
+                        .holder_releases
+                        .push((tenant.clone(), q.clone(), task_id.to_string()));
+                }
                 state.ack_deleted(task_key);
             }
         }

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -524,6 +524,9 @@ impl JobStoreShard {
                             attempt_number,
                             relative_attempt_number,
                             skip_try_reserve,
+                            &current_held_queues,
+                            current_index as u32,
+                            limits,
                         )
                         .await?;
 
@@ -593,6 +596,9 @@ impl JobStoreShard {
                             attempt_number,
                             relative_attempt_number,
                             skip_try_reserve,
+                            &current_held_queues,
+                            current_index as u32,
+                            limits,
                         )
                         .await?;
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -3,7 +3,7 @@
 //! This module contains the core task types that represent units of work
 //! in the system, along with associated records for leases and concurrency.
 
-use crate::job::{GubernatorRateLimit, JobView};
+use crate::job::{GubernatorRateLimit, JobView, Limit};
 use crate::job_attempt::JobAttemptView;
 
 /// Default lease duration for dequeued tasks (milliseconds)
@@ -35,8 +35,17 @@ pub enum Task {
         attempt_number: u32,
         /// Attempt number within current run (resets to 1 on job restart)
         relative_attempt_number: u32,
-        request_id: String,
+        /// The original first_task_id from the enqueue chain — shared identity
+        /// across every holder this job acquires.
+        task_id: String,
         task_group: String,
+        /// Queues already granted under task_id earlier in the chain.
+        held_queues: Vec<String>,
+        /// Canonical-order position of THIS queue in the limits chain.
+        limit_index: u32,
+        /// Full limits array, so the deferred-grant path can continue the
+        /// chain without a JobInfo lookup.
+        limits: Vec<Limit>,
     },
     /// Internal: check a Gubernator rate limit before proceeding
     CheckRateLimit {
@@ -72,6 +81,23 @@ pub enum Task {
         metadata: Vec<(String, String)>,
         task_group: String,
     },
+    /// Internal: chain-continuation task emitted by the deferred-grant paths
+    /// after a concurrency slot is granted. Dequeue picks this up and
+    /// re-enters `enqueue_limit_task_at_index` at `next_limit_index` to evaluate
+    /// the remaining limits in the canonical order.
+    ContinueLimits {
+        task_id: String,
+        tenant: String,
+        job_id: String,
+        attempt_number: u32,
+        relative_attempt_number: u32,
+        held_queues: Vec<String>,
+        next_limit_index: u32,
+        limits: Vec<Limit>,
+        priority: u8,
+        start_time_ms: i64,
+        task_group: String,
+    },
 }
 
 impl Task {
@@ -82,6 +108,7 @@ impl Task {
             Task::RequestTicket { tenant, .. } => tenant,
             Task::CheckRateLimit { tenant, .. } => tenant,
             Task::RefreshFloatingLimit { tenant, .. } => tenant,
+            Task::ContinueLimits { tenant, .. } => tenant,
         }
     }
 }
@@ -149,6 +176,16 @@ pub enum ConcurrencyAction {
         /// Attempt number within current run (resets to 1 on job restart)
         relative_attempt_number: u32,
         task_group: String,
+        /// The original first_task_id from the enqueue chain — shared identity
+        /// across every holder this job acquires.
+        task_id: String,
+        /// Queues already granted under task_id earlier in the chain.
+        held_queues: Vec<String>,
+        /// Canonical-order position of THIS queue in the limits chain.
+        limit_index: u32,
+        /// Full limits array, so the grant scanner can continue the chain
+        /// without a JobInfo lookup.
+        limits: Vec<Limit>,
     },
 }
 

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -117,6 +117,19 @@ fn test_holder_roundtrip() {
 
 #[silo::test]
 fn test_concurrency_action_roundtrip() {
+    use silo::job::{ConcurrencyLimit, FloatingConcurrencyLimit, Limit};
+    let limits = vec![
+        Limit::Concurrency(ConcurrencyLimit {
+            key: "q-c".to_string(),
+            max_concurrency: 7,
+        }),
+        Limit::FloatingConcurrency(FloatingConcurrencyLimit {
+            key: "q-fc".to_string(),
+            default_max_concurrency: 4,
+            refresh_interval_ms: 30_000,
+            metadata: vec![("k".to_string(), "v".to_string())],
+        }),
+    ];
     let action = ConcurrencyAction::EnqueueTask {
         start_time_ms: 1000,
         priority: 5,
@@ -124,6 +137,10 @@ fn test_concurrency_action_roundtrip() {
         attempt_number: 1,
         relative_attempt_number: 1,
         task_group: "default".to_string(),
+        task_id: "task-abc".to_string(),
+        held_queues: vec!["q-c".to_string()],
+        limit_index: 1,
+        limits: limits.clone(),
     };
     let encoded = encode_concurrency_action(&action);
     let decoded = decode_concurrency_action(encoded).unwrap();
@@ -134,10 +151,26 @@ fn test_concurrency_action_roundtrip() {
     assert_eq!(et.attempt_number(), 1);
     assert_eq!(et.relative_attempt_number(), 1);
     assert_eq!(et.task_group().unwrap(), "default");
+    assert_eq!(et.task_id().unwrap(), "task-abc");
+    let held: Vec<String> = et
+        .held_queues()
+        .unwrap()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(held, vec!["q-c".to_string()]);
+    assert_eq!(et.limit_index(), 1);
+    let limits_decoded = silo::codec::fb_limit_entries_to_owned(et.limits());
+    assert_eq!(limits_decoded.len(), 2);
 }
 
 #[silo::test]
 fn test_request_ticket_roundtrip() {
+    use silo::job::{ConcurrencyLimit, Limit};
+    let limits = vec![Limit::Concurrency(ConcurrencyLimit {
+        key: "q1".to_string(),
+        max_concurrency: 3,
+    })];
     let task = Task::RequestTicket {
         queue: "q1".to_string(),
         start_time_ms: 5000,
@@ -146,8 +179,11 @@ fn test_request_ticket_roundtrip() {
         job_id: "job-42".to_string(),
         attempt_number: 2,
         relative_attempt_number: 1,
-        request_id: "req-abc".to_string(),
+        task_id: "task-99".to_string(),
         task_group: "fast".to_string(),
+        held_queues: vec!["prev-q".to_string()],
+        limit_index: 0,
+        limits: limits.clone(),
     };
     let encoded = encode_task(&task);
     let decoded = decode_task(&encoded).unwrap();
@@ -160,8 +196,11 @@ fn test_request_ticket_roundtrip() {
             job_id,
             attempt_number,
             relative_attempt_number,
-            request_id,
+            task_id,
             task_group,
+            held_queues,
+            limit_index,
+            limits: decoded_limits,
         } => {
             assert_eq!(queue, "q1");
             assert_eq!(start_time_ms, 5000);
@@ -170,8 +209,11 @@ fn test_request_ticket_roundtrip() {
             assert_eq!(job_id, "job-42");
             assert_eq!(attempt_number, 2);
             assert_eq!(relative_attempt_number, 1);
-            assert_eq!(request_id, "req-abc");
+            assert_eq!(task_id, "task-99");
             assert_eq!(task_group, "fast");
+            assert_eq!(held_queues, vec!["prev-q".to_string()]);
+            assert_eq!(limit_index, 0);
+            assert_eq!(decoded_limits.len(), 1);
         }
         _ => panic!("expected RequestTicket variant"),
     }
@@ -502,8 +544,11 @@ fn test_decoded_task_request_ticket() {
         job_id: "j-rt".to_string(),
         attempt_number: 1,
         relative_attempt_number: 1,
-        request_id: "req-rt".to_string(),
+        task_id: "req-rt".to_string(),
         task_group: "fast".to_string(),
+        held_queues: vec![],
+        limit_index: 0,
+        limits: vec![],
     };
     let encoded = encode_task(&task);
     let decoded = decode_task_validated(encoded).unwrap();

--- a/tests/concurrency_requester_counter_tests.rs
+++ b/tests/concurrency_requester_counter_tests.rs
@@ -310,6 +310,10 @@ async fn inject_fake_request(
         attempt_number: attempt,
         relative_attempt_number: attempt,
         task_group: "default".to_string(),
+        task_id: "fake0001".to_string(),
+        held_queues: vec![],
+        limit_index: 0,
+        limits: vec![],
     };
     let action_val = encode_concurrency_action(&action);
     db.put(&req_key, &action_val)

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -114,6 +114,7 @@ async fn concurrency_queues_when_full_and_grants_on_release() {
             Task::RequestTicket { .. } => {}
             Task::CheckRateLimit { .. } => {}
             Task::RefreshFloatingLimit { .. } => {}
+            Task::ContinueLimits { .. } => {}
         }
     }
 
@@ -175,6 +176,10 @@ async fn periodic_reconcile_grants_pending_request_without_signal() {
         attempt_number: 1,
         relative_attempt_number: 1,
         task_group: "default".to_string(),
+        task_id: "manual".to_string(),
+        held_queues: vec![],
+        limit_index: 0,
+        limits: vec![],
     };
     let request_key = concurrency_request_key(tenant, &queue, now, 10, &job_id, 1, "manual");
     let request_value = encode_concurrency_action(&action);
@@ -617,6 +622,7 @@ async fn concurrent_enqueues_while_holding_dont_bypass_limit() {
             Task::RequestTicket { .. } => {}
             Task::CheckRateLimit { .. } => {}
             Task::RefreshFloatingLimit { .. } => {}
+            Task::ContinueLimits { .. } => {}
         }
     }
 
@@ -721,6 +727,9 @@ async fn reap_marks_expired_lease_as_failed_and_enqueues_retry() {
         }
         Task::RefreshFloatingLimit { .. } => {
             panic!("unexpected RefreshFloatingLimit in tasks/ for this test")
+        }
+        Task::ContinueLimits { .. } => {
+            panic!("unexpected ContinueLimits in tasks/ for this test")
         }
     };
     assert_eq!(attempt2, 2);

--- a/tests/floating_concurrency_tests.rs
+++ b/tests/floating_concurrency_tests.rs
@@ -839,14 +839,16 @@ async fn floating_limit_scanner_grants_waiter_while_one_holder_remains() {
         .await
         .expect("report success");
 
+    // The grant scanner emits a `ContinueLimits` task for the granted waiter;
+    // dequeue then re-enters the limit chain and writes a terminal RunAttempt
+    // at a fresh task_key. Accept either as evidence that the scanner granted.
     let has_j3_run = poll_until(
         || async {
             let tasks = shard.peek_tasks("default", 10).await.expect("peek tasks");
-            tasks.iter().any(|t| {
-                matches!(
-                    t,
-                    Task::RunAttempt { job_id, .. } if job_id == &j3
-                )
+            tasks.iter().any(|t| match t {
+                Task::RunAttempt { job_id, .. } => job_id == &j3,
+                Task::ContinueLimits { job_id, .. } => job_id == &j3,
+                _ => false,
             })
         },
         |&found| found,
@@ -1405,16 +1407,16 @@ async fn floating_limit_uses_dynamic_max_concurrency() {
         .await
         .expect("report j1 success");
 
-    // j2 should now have a RunAttempt task.
-    // Grants happen asynchronously via the background scanner, so poll.
+    // j2 should now have either a RunAttempt or a ContinueLimits task. The
+    // grant scanner emits a ContinueLimits first; dequeue re-enters the limit
+    // chain and writes the terminal RunAttempt later.
     let has_j2_run = poll_until(
         || async {
             let tasks = shard.peek_tasks("default", 10).await.expect("peek tasks");
-            tasks.iter().any(|t| {
-                matches!(
-                    t,
-                    Task::RunAttempt { job_id, .. } if job_id == &j2
-                )
+            tasks.iter().any(|t| match t {
+                Task::RunAttempt { job_id, .. } => job_id == &j2,
+                Task::ContinueLimits { job_id, .. } => job_id == &j2,
+                _ => false,
             })
         },
         |&found| found,
@@ -1423,7 +1425,7 @@ async fn floating_limit_uses_dynamic_max_concurrency() {
     .await;
     assert!(
         has_j2_run,
-        "j2 should have RunAttempt task after j1 completes"
+        "j2 should have a granted task after j1 completes"
     );
 }
 

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2509,6 +2509,650 @@ async fn second_limit_request_must_not_leave_runnable_task() {
     );
 }
 
+// =============================================================================
+// Multi-limit grant tests (Concurrency + FloatingConcurrency combinations).
+//
+// These exercise both the immediate-grant path (all limits have capacity at
+// enqueue) and the deferred reconciliation path (one limit blocks, request is
+// written, grant scanner promotes the request to a RunAttempt once capacity
+// opens).
+//
+// In the deferred path the RunAttempt produced by `concurrency::process_grants`
+// (and the future-scheduled equivalent in `dequeue::handle_request_ticket`) is
+// constructed with `held_queues = vec![just_granted_queue]`. Any holders that
+// were granted earlier in the limit chain are missing from that list — so on
+// completion they leak — and any limits later in the chain are never acquired
+// at all, silently bypassing them. The tests below pin both shapes.
+// =============================================================================
+
+/// (1) Job with `[Concurrency, FloatingConcurrency]`, both with capacity, is
+/// granted at enqueue. Both holders must exist, the lease must list both
+/// queues, and completion must release both.
+#[silo::test]
+async fn enqueue_concurrency_and_floating_concurrency_grants_both_immediately() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+    let c_queue = "c-mlim-1".to_string();
+    let fc_queue = "fc-mlim-1".to_string();
+
+    let _job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: c_queue.clone(),
+                    max_concurrency: 5,
+                }),
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: fc_queue.clone(),
+                    default_max_concurrency: 5,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &c_queue).await,
+        1,
+        "C holder should exist"
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &fc_queue).await,
+        1,
+        "FC holder should exist"
+    );
+
+    let tasks = shard
+        .dequeue("w1", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 1, "RunAttempt should be leasable");
+    let task_id = tasks[0].attempt().task_id().to_string();
+
+    let lease_bytes = shard
+        .db()
+        .get(&silo::keys::leased_task_key(&task_id))
+        .await
+        .expect("read lease")
+        .expect("lease present");
+    let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
+    let held = decoded_lease.held_queues();
+    assert!(held.iter().any(|q| q == &c_queue), "held_queues missing C: {:?}", held);
+    assert!(held.iter().any(|q| q == &fc_queue), "held_queues missing FC: {:?}", held);
+    assert_eq!(held.len(), 2, "expected exactly C+FC in held_queues, got {:?}", held);
+
+    shard
+        .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report success");
+
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &c_queue).await,
+        0,
+        "C holder leaked"
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &fc_queue).await,
+        0,
+        "FC holder leaked"
+    );
+}
+
+/// (2) Job with `[Concurrency, FloatingConcurrency, FloatingConcurrency]`, all
+/// with capacity, is granted at enqueue. All three holders must exist, lease
+/// lists all three queues, completion releases all three.
+#[silo::test]
+async fn enqueue_concurrency_and_two_floating_concurrency_grants_all_immediately() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+    let c_queue = "c-mlim-2".to_string();
+    let fc1_queue = "fc1-mlim-2".to_string();
+    let fc2_queue = "fc2-mlim-2".to_string();
+
+    let _job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: c_queue.clone(),
+                    max_concurrency: 5,
+                }),
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: fc1_queue.clone(),
+                    default_max_concurrency: 5,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: fc2_queue.clone(),
+                    default_max_concurrency: 5,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+
+    for (label, q) in [("C", &c_queue), ("FC1", &fc1_queue), ("FC2", &fc2_queue)] {
+        assert_eq!(
+            count_holders_for_queue(shard.db(), tenant, q).await,
+            1,
+            "{label} holder should exist after immediate grant"
+        );
+    }
+
+    let tasks = shard
+        .dequeue("w1", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 1);
+    let task_id = tasks[0].attempt().task_id().to_string();
+
+    let lease_bytes = shard
+        .db()
+        .get(&silo::keys::leased_task_key(&task_id))
+        .await
+        .expect("read lease")
+        .expect("lease present");
+    let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
+    let held = decoded_lease.held_queues();
+    assert_eq!(held.len(), 3, "expected C + FC1 + FC2 in held_queues, got {:?}", held);
+    for q in [&c_queue, &fc1_queue, &fc2_queue] {
+        assert!(held.iter().any(|h| h == q), "held_queues missing {}: {:?}", q, held);
+    }
+
+    shard
+        .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report success");
+
+    for (label, q) in [("C", &c_queue), ("FC1", &fc1_queue), ("FC2", &fc2_queue)] {
+        assert_eq!(
+            count_holders_for_queue(shard.db(), tenant, q).await,
+            0,
+            "{label} holder leaked"
+        );
+    }
+}
+
+/// (3) Job with `[Concurrency, FloatingConcurrency]` where the FC slot is full
+/// at enqueue. Canonical limit order is C-first, so:
+///   - C grants immediately (holder + grant recorded).
+///   - FC `try_reserve` fails → a `concurrency_request` for FC is written
+///     and the interim RunAttempt task_key is deleted ("Queued" outcome).
+/// We then free the FC slot, the grant scanner reconciles, and the request is
+/// promoted to a RunAttempt. The new RunAttempt's `held_queues` must include
+/// BOTH the FC slot it just received AND the C slot already held — otherwise
+/// the C holder is orphaned on completion.
+#[silo::test]
+async fn concurrency_then_floating_concurrency_queued_reconciles_with_both_holders() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+    let c_queue = "c-mlim-3".to_string();
+    let fc_queue = "fc-mlim-3".to_string();
+
+    // Saturate FC (capacity = 1) by enqueueing an FC-only job and leasing it.
+    let _saturator = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "saturator"})),
+            vec![Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                key: fc_queue.clone(),
+                default_max_concurrency: 1,
+                refresh_interval_ms: 60_000,
+                metadata: vec![],
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue saturator");
+    let sat_tasks = shard.dequeue("w-sat", "default", 1).await.expect("deq sat").tasks;
+    assert_eq!(sat_tasks.len(), 1, "saturator should lease");
+    let sat_task_id = sat_tasks[0].attempt().task_id().to_string();
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &fc_queue).await,
+        1,
+        "FC saturated"
+    );
+
+    // Enqueue target job [C, FC]. C grants (capacity=5), FC is full → request.
+    let job = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "target"})),
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: c_queue.clone(),
+                    max_concurrency: 5,
+                }),
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: fc_queue.clone(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue target");
+
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &c_queue).await,
+        1,
+        "C should be granted at enqueue (target)"
+    );
+    assert!(
+        count_concurrency_requests(shard.db()).await >= 1,
+        "FC should have a pending concurrency_request for target"
+    );
+
+    // Target must not be dequeueable yet — interim RunAttempt was deleted.
+    let pre = shard.dequeue("w-pre", "default", 1).await.expect("deq pre").tasks;
+    assert!(
+        pre.iter().all(|t| t.job().id() != job),
+        "target must not be runnable while FC is full"
+    );
+
+    // Free the FC slot — completing the saturator wakes the grant scanner.
+    shard
+        .report_attempt_outcome(&sat_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("complete saturator");
+
+    // Poll for target to be leasable.
+    let mut target_task_id: Option<String> = None;
+    let start = std::time::Instant::now();
+    while start.elapsed() < std::time::Duration::from_secs(5) {
+        let r = shard.dequeue("w-target", "default", 1).await.expect("deq target");
+        if let Some(t) = r.tasks.iter().find(|t| t.job().id() == job) {
+            target_task_id = Some(t.attempt().task_id().to_string());
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    let target_task_id = target_task_id.expect(
+        "target job never became runnable after FC slot freed — grant scanner did not reconcile",
+    );
+
+    // The lease's held_queues must list both C and FC. If only FC is present,
+    // the grant scanner built the RunAttempt with `held_queues=vec![FC]` and
+    // dropped the pre-existing C holder.
+    let lease_bytes = shard
+        .db()
+        .get(&silo::keys::leased_task_key(&target_task_id))
+        .await
+        .expect("read lease")
+        .expect("lease present");
+    let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
+    let held = decoded_lease.held_queues();
+    assert!(
+        held.iter().any(|q| q == &fc_queue),
+        "held_queues missing FC after reconciliation: {:?}",
+        held
+    );
+    assert!(
+        held.iter().any(|q| q == &c_queue),
+        "held_queues missing C after reconciliation — grant scanner built the \
+         RunAttempt with only the just-granted queue, dropping the C slot \
+         already held since enqueue. Got {:?}",
+        held
+    );
+    assert_eq!(held.len(), 2, "expected exactly C+FC in held_queues, got {:?}", held);
+
+    // Complete target — every holder it acquired across the chain must release.
+    shard
+        .report_attempt_outcome(&target_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report target success");
+
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &c_queue).await,
+        0,
+        "C holder leaked after target completion — held_queues did not include C, \
+         so report_attempt_outcome never released it"
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &fc_queue).await,
+        0,
+        "FC holder leaked after target completion"
+    );
+}
+
+/// (4) Job with `[Concurrency, FloatingConcurrency, FloatingConcurrency]` where
+/// FC1 is full at enqueue. Canonical order:
+///   - C grants immediately.
+///   - FC1 `try_reserve` fails → request written; FC2 is NEVER attempted at
+///     enqueue ("Queued" — caller returns after the first failure).
+/// When FC1 frees, the grant scanner promotes the request to a RunAttempt with
+/// `held_queues=vec![FC1]`. This drops the C holder *and* skips FC2 entirely.
+/// So the job runs without ever taking an FC2 slot, and on completion the C
+/// holder leaks.
+#[silo::test]
+async fn concurrency_two_floating_concurrency_queued_on_fc1_reconciles_with_all_three() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+    let c_queue = "c-mlim-4".to_string();
+    let fc1_queue = "fc1-mlim-4".to_string();
+    let fc2_queue = "fc2-mlim-4".to_string();
+
+    // Saturate FC1 (capacity = 1).
+    let _saturator = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "saturator"})),
+            vec![Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                key: fc1_queue.clone(),
+                default_max_concurrency: 1,
+                refresh_interval_ms: 60_000,
+                metadata: vec![],
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue saturator");
+    let sat_tasks = shard.dequeue("w-sat", "default", 1).await.expect("deq sat").tasks;
+    assert_eq!(sat_tasks.len(), 1);
+    let sat_task_id = sat_tasks[0].attempt().task_id().to_string();
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &fc1_queue).await,
+        1,
+        "FC1 saturated"
+    );
+
+    // Enqueue target [C, FC1, FC2]. C grants → FC1 blocked → request written.
+    // FC2 is never even attempted at enqueue.
+    let job = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "target"})),
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: c_queue.clone(),
+                    max_concurrency: 5,
+                }),
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: fc1_queue.clone(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: fc2_queue.clone(),
+                    default_max_concurrency: 5,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue target");
+
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &c_queue).await,
+        1,
+        "C should be granted at enqueue (target)"
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &fc2_queue).await,
+        0,
+        "FC2 must NOT be granted yet — FC1 blocked before it was reached"
+    );
+
+    // Free FC1.
+    shard
+        .report_attempt_outcome(&sat_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("complete saturator");
+
+    // Poll for target to be leasable.
+    let mut target_task_id: Option<String> = None;
+    let start = std::time::Instant::now();
+    while start.elapsed() < std::time::Duration::from_secs(5) {
+        let r = shard.dequeue("w-target", "default", 1).await.expect("deq target");
+        if let Some(t) = r.tasks.iter().find(|t| t.job().id() == job) {
+            target_task_id = Some(t.attempt().task_id().to_string());
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    let target_task_id =
+        target_task_id.expect("target never became runnable — grant scanner did not reconcile");
+
+    // The grant scanner promoted the FC1 request directly to a RunAttempt
+    // without consulting the remaining limits. So:
+    //   - FC2 should have a holder (it didn't bypass)
+    //   - lease's held_queues should include C, FC1, FC2 (so completion
+    //     releases everything)
+    let fc2_holders_when_running =
+        count_holders_for_queue(shard.db(), tenant, &fc2_queue).await;
+    assert_eq!(
+        fc2_holders_when_running, 1,
+        "FC2 limit was silently bypassed — the queued path's RunAttempt skipped \
+         every limit after the one that triggered the queue. FC2 holders = {fc2_holders_when_running}"
+    );
+
+    let lease_bytes = shard
+        .db()
+        .get(&silo::keys::leased_task_key(&target_task_id))
+        .await
+        .expect("read lease")
+        .expect("lease present");
+    let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
+    let held = decoded_lease.held_queues();
+    for q in [&c_queue, &fc1_queue, &fc2_queue] {
+        assert!(
+            held.iter().any(|h| h == q),
+            "held_queues missing {} after reconciliation; got {:?}",
+            q,
+            held
+        );
+    }
+    assert_eq!(held.len(), 3, "expected C + FC1 + FC2 in held_queues, got {:?}", held);
+
+    // Complete target — every limit's holder must release.
+    shard
+        .report_attempt_outcome(&target_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report target success");
+
+    for (label, q) in [
+        ("C", &c_queue),
+        ("FC1", &fc1_queue),
+        ("FC2", &fc2_queue),
+    ] {
+        assert_eq!(
+            count_holders_for_queue(shard.db(), tenant, q).await,
+            0,
+            "{label} holder leaked after target completion"
+        );
+    }
+}
+
+/// (6) Job with `[FloatingConcurrency, FloatingConcurrency]` where FC1 is full
+/// at enqueue. Canonical order keeps FCs in their relative input order, so:
+///   - FC1 blocks first → request written; FC2 never attempted at enqueue.
+/// When FC1 frees, the grant scanner promotes the request and the RunAttempt
+/// is constructed with only FC1 — FC2 is bypassed.
+#[silo::test]
+async fn two_floating_concurrency_queued_on_fc1_reconciles_with_both() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+    let fc1_queue = "fc1-mlim-6".to_string();
+    let fc2_queue = "fc2-mlim-6".to_string();
+
+    // Saturate FC1.
+    let _saturator = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "saturator"})),
+            vec![Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                key: fc1_queue.clone(),
+                default_max_concurrency: 1,
+                refresh_interval_ms: 60_000,
+                metadata: vec![],
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue saturator");
+    let sat_tasks = shard.dequeue("w-sat", "default", 1).await.expect("deq sat").tasks;
+    assert_eq!(sat_tasks.len(), 1);
+    let sat_task_id = sat_tasks[0].attempt().task_id().to_string();
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &fc1_queue).await,
+        1,
+        "FC1 saturated"
+    );
+
+    // Enqueue target [FC1, FC2]. FC1 blocks → request written; FC2 never
+    // attempted.
+    let job = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "target"})),
+            vec![
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: fc1_queue.clone(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: fc2_queue.clone(),
+                    default_max_concurrency: 5,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue target");
+
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &fc2_queue).await,
+        0,
+        "FC2 must not be granted at enqueue — FC1 blocked first"
+    );
+
+    // Free FC1.
+    shard
+        .report_attempt_outcome(&sat_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("complete saturator");
+
+    // Poll for target.
+    let mut target_task_id: Option<String> = None;
+    let start = std::time::Instant::now();
+    while start.elapsed() < std::time::Duration::from_secs(5) {
+        let r = shard.dequeue("w-target", "default", 1).await.expect("deq target");
+        if let Some(t) = r.tasks.iter().find(|t| t.job().id() == job) {
+            target_task_id = Some(t.attempt().task_id().to_string());
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    let target_task_id =
+        target_task_id.expect("target never became runnable — grant scanner did not reconcile");
+
+    // FC2 must hold a slot now; lease must list both FC1 and FC2.
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &fc2_queue).await,
+        1,
+        "FC2 limit was silently bypassed — queued-path RunAttempt skipped \
+         every limit after FC1"
+    );
+
+    let lease_bytes = shard
+        .db()
+        .get(&silo::keys::leased_task_key(&target_task_id))
+        .await
+        .expect("read lease")
+        .expect("lease present");
+    let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
+    let held = decoded_lease.held_queues();
+    for q in [&fc1_queue, &fc2_queue] {
+        assert!(
+            held.iter().any(|h| h == q),
+            "held_queues missing {} after reconciliation; got {:?}",
+            q,
+            held
+        );
+    }
+    assert_eq!(held.len(), 2, "expected FC1 + FC2 in held_queues, got {:?}", held);
+
+    // Complete — both holders must release.
+    shard
+        .report_attempt_outcome(&target_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report target success");
+
+    for (label, q) in [("FC1", &fc1_queue), ("FC2", &fc2_queue)] {
+        assert_eq!(
+            count_holders_for_queue(shard.db(), tenant, q).await,
+            0,
+            "{label} holder leaked after target completion"
+        );
+    }
+}
+
 /// Helper: count concurrency holder keys for a specific (tenant, queue) pair.
 async fn count_holders_for_queue(
     db: &silo::instrumented_db::InstrumentedDb,

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -3231,6 +3231,113 @@ async fn two_floating_concurrency_queued_on_fc1_reconciles_with_both() {
     }
 }
 
+/// Regression: when `handle_request_ticket` discovers the job_info is gone
+/// (the `JobMissing` outcome from `process_ticket_request_task`), it must
+/// release any holders the chain accumulated earlier under the ticket's
+/// `task_id`. Otherwise those holders orphan: no lease will ever be written
+/// to reach them, and `report_attempt_outcome` won't run because the job
+/// doesn't exist. Mirrors the symmetric branch in `handle_check_rate_limit`.
+#[silo::test]
+async fn request_ticket_job_missing_releases_prior_chain_holders() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+    let c_queue = "c-rt-jm2".to_string();
+    let fc_queue = "fc-rt-jm2".to_string();
+
+    // Saturate FC so the FC limit blocks for the target.
+    let _saturator = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "saturator"})),
+            vec![Limit::FloatingConcurrency(
+                silo::job::FloatingConcurrencyLimit {
+                    key: fc_queue.clone(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                },
+            )],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue saturator");
+    let _sat = shard
+        .dequeue("w-sat", "default", 1)
+        .await
+        .expect("deq sat")
+        .tasks;
+
+    // Use a small future offset so the broker picks up the RequestTicket
+    // after a short delay.
+    let future_start = now + 100;
+    let target_job = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            future_start,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"role": "target"})),
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: c_queue.clone(),
+                    max_concurrency: 5,
+                }),
+                Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+                    key: fc_queue.clone(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue target");
+
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &c_queue).await,
+        1,
+        "target's C should be granted at enqueue"
+    );
+
+    // Delete the target's job_info directly to set up the JobMissing
+    // scenario for handle_request_ticket.
+    shard
+        .db()
+        .delete(silo::keys::job_info_key(tenant, &target_job))
+        .await
+        .expect("delete job_info");
+
+    // Poll dequeue until the RequestTicket fires. Once it does,
+    // handle_request_ticket should see job_view = None and hit the JobMissing
+    // branch, which must release the C holder we created at enqueue.
+    let start = std::time::Instant::now();
+    while start.elapsed() < std::time::Duration::from_secs(5) {
+        let _ = shard.dequeue("w-drain", "default", 5).await.expect("deq");
+        if count_holders_for_queue(shard.db(), tenant, &c_queue).await == 0 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &c_queue).await,
+        0,
+        "C holder leaked: handle_request_ticket JobMissing arm did not \
+         release prior chain holders. Without the release loop, the holder \
+         is orphaned because no lease was ever written to reach it via \
+         report_attempt_outcome."
+    );
+}
+
 /// Helper: count concurrency holder keys for a specific (tenant, queue) pair.
 async fn count_holders_for_queue(
     db: &silo::instrumented_db::InstrumentedDb,

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2603,9 +2603,22 @@ async fn enqueue_concurrency_and_floating_concurrency_grants_both_immediately() 
         .expect("lease present");
     let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
     let held = decoded_lease.held_queues();
-    assert!(held.iter().any(|q| q == &c_queue), "held_queues missing C: {:?}", held);
-    assert!(held.iter().any(|q| q == &fc_queue), "held_queues missing FC: {:?}", held);
-    assert_eq!(held.len(), 2, "expected exactly C+FC in held_queues, got {:?}", held);
+    assert!(
+        held.iter().any(|q| q == &c_queue),
+        "held_queues missing C: {:?}",
+        held
+    );
+    assert!(
+        held.iter().any(|q| q == &fc_queue),
+        "held_queues missing FC: {:?}",
+        held
+    );
+    assert_eq!(
+        held.len(),
+        2,
+        "expected exactly C+FC in held_queues, got {:?}",
+        held
+    );
 
     shard
         .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
@@ -2692,9 +2705,19 @@ async fn enqueue_concurrency_and_two_floating_concurrency_grants_all_immediately
         .expect("lease present");
     let decoded_lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
     let held = decoded_lease.held_queues();
-    assert_eq!(held.len(), 3, "expected C + FC1 + FC2 in held_queues, got {:?}", held);
+    assert_eq!(
+        held.len(),
+        3,
+        "expected C + FC1 + FC2 in held_queues, got {:?}",
+        held
+    );
     for q in [&c_queue, &fc1_queue, &fc2_queue] {
-        assert!(held.iter().any(|h| h == q), "held_queues missing {}: {:?}", q, held);
+        assert!(
+            held.iter().any(|h| h == q),
+            "held_queues missing {}: {:?}",
+            q,
+            held
+        );
     }
 
     shard
@@ -2737,18 +2760,24 @@ async fn concurrency_then_floating_concurrency_queued_reconciles_with_both_holde
             now,
             None,
             test_helpers::msgpack_payload(&serde_json::json!({"role": "saturator"})),
-            vec![Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
-                key: fc_queue.clone(),
-                default_max_concurrency: 1,
-                refresh_interval_ms: 60_000,
-                metadata: vec![],
-            })],
+            vec![Limit::FloatingConcurrency(
+                silo::job::FloatingConcurrencyLimit {
+                    key: fc_queue.clone(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                },
+            )],
             None,
             "default",
         )
         .await
         .expect("enqueue saturator");
-    let sat_tasks = shard.dequeue("w-sat", "default", 1).await.expect("deq sat").tasks;
+    let sat_tasks = shard
+        .dequeue("w-sat", "default", 1)
+        .await
+        .expect("deq sat")
+        .tasks;
     assert_eq!(sat_tasks.len(), 1, "saturator should lease");
     let sat_task_id = sat_tasks[0].attempt().task_id().to_string();
     assert_eq!(
@@ -2795,7 +2824,11 @@ async fn concurrency_then_floating_concurrency_queued_reconciles_with_both_holde
     );
 
     // Target must not be dequeueable yet — interim RunAttempt was deleted.
-    let pre = shard.dequeue("w-pre", "default", 1).await.expect("deq pre").tasks;
+    let pre = shard
+        .dequeue("w-pre", "default", 1)
+        .await
+        .expect("deq pre")
+        .tasks;
     assert!(
         pre.iter().all(|t| t.job().id() != job),
         "target must not be runnable while FC is full"
@@ -2811,7 +2844,10 @@ async fn concurrency_then_floating_concurrency_queued_reconciles_with_both_holde
     let mut target_task_id: Option<String> = None;
     let start = std::time::Instant::now();
     while start.elapsed() < std::time::Duration::from_secs(5) {
-        let r = shard.dequeue("w-target", "default", 1).await.expect("deq target");
+        let r = shard
+            .dequeue("w-target", "default", 1)
+            .await
+            .expect("deq target");
         if let Some(t) = r.tasks.iter().find(|t| t.job().id() == job) {
             target_task_id = Some(t.attempt().task_id().to_string());
             break;
@@ -2845,7 +2881,12 @@ async fn concurrency_then_floating_concurrency_queued_reconciles_with_both_holde
          already held since enqueue. Got {:?}",
         held
     );
-    assert_eq!(held.len(), 2, "expected exactly C+FC in held_queues, got {:?}", held);
+    assert_eq!(
+        held.len(),
+        2,
+        "expected exactly C+FC in held_queues, got {:?}",
+        held
+    );
 
     // Complete target — every holder it acquired across the chain must release.
     shard
@@ -2893,18 +2934,24 @@ async fn concurrency_two_floating_concurrency_queued_on_fc1_reconciles_with_all_
             now,
             None,
             test_helpers::msgpack_payload(&serde_json::json!({"role": "saturator"})),
-            vec![Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
-                key: fc1_queue.clone(),
-                default_max_concurrency: 1,
-                refresh_interval_ms: 60_000,
-                metadata: vec![],
-            })],
+            vec![Limit::FloatingConcurrency(
+                silo::job::FloatingConcurrencyLimit {
+                    key: fc1_queue.clone(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                },
+            )],
             None,
             "default",
         )
         .await
         .expect("enqueue saturator");
-    let sat_tasks = shard.dequeue("w-sat", "default", 1).await.expect("deq sat").tasks;
+    let sat_tasks = shard
+        .dequeue("w-sat", "default", 1)
+        .await
+        .expect("deq sat")
+        .tasks;
     assert_eq!(sat_tasks.len(), 1);
     let sat_task_id = sat_tasks[0].attempt().task_id().to_string();
     assert_eq!(
@@ -2968,7 +3015,10 @@ async fn concurrency_two_floating_concurrency_queued_on_fc1_reconciles_with_all_
     let mut target_task_id: Option<String> = None;
     let start = std::time::Instant::now();
     while start.elapsed() < std::time::Duration::from_secs(5) {
-        let r = shard.dequeue("w-target", "default", 1).await.expect("deq target");
+        let r = shard
+            .dequeue("w-target", "default", 1)
+            .await
+            .expect("deq target");
         if let Some(t) = r.tasks.iter().find(|t| t.job().id() == job) {
             target_task_id = Some(t.attempt().task_id().to_string());
             break;
@@ -2983,8 +3033,7 @@ async fn concurrency_two_floating_concurrency_queued_on_fc1_reconciles_with_all_
     //   - FC2 should have a holder (it didn't bypass)
     //   - lease's held_queues should include C, FC1, FC2 (so completion
     //     releases everything)
-    let fc2_holders_when_running =
-        count_holders_for_queue(shard.db(), tenant, &fc2_queue).await;
+    let fc2_holders_when_running = count_holders_for_queue(shard.db(), tenant, &fc2_queue).await;
     assert_eq!(
         fc2_holders_when_running, 1,
         "FC2 limit was silently bypassed — the queued path's RunAttempt skipped \
@@ -3007,7 +3056,12 @@ async fn concurrency_two_floating_concurrency_queued_on_fc1_reconciles_with_all_
             held
         );
     }
-    assert_eq!(held.len(), 3, "expected C + FC1 + FC2 in held_queues, got {:?}", held);
+    assert_eq!(
+        held.len(),
+        3,
+        "expected C + FC1 + FC2 in held_queues, got {:?}",
+        held
+    );
 
     // Complete target — every limit's holder must release.
     shard
@@ -3015,11 +3069,7 @@ async fn concurrency_two_floating_concurrency_queued_on_fc1_reconciles_with_all_
         .await
         .expect("report target success");
 
-    for (label, q) in [
-        ("C", &c_queue),
-        ("FC1", &fc1_queue),
-        ("FC2", &fc2_queue),
-    ] {
+    for (label, q) in [("C", &c_queue), ("FC1", &fc1_queue), ("FC2", &fc2_queue)] {
         assert_eq!(
             count_holders_for_queue(shard.db(), tenant, q).await,
             0,
@@ -3050,18 +3100,24 @@ async fn two_floating_concurrency_queued_on_fc1_reconciles_with_both() {
             now,
             None,
             test_helpers::msgpack_payload(&serde_json::json!({"role": "saturator"})),
-            vec![Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
-                key: fc1_queue.clone(),
-                default_max_concurrency: 1,
-                refresh_interval_ms: 60_000,
-                metadata: vec![],
-            })],
+            vec![Limit::FloatingConcurrency(
+                silo::job::FloatingConcurrencyLimit {
+                    key: fc1_queue.clone(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                },
+            )],
             None,
             "default",
         )
         .await
         .expect("enqueue saturator");
-    let sat_tasks = shard.dequeue("w-sat", "default", 1).await.expect("deq sat").tasks;
+    let sat_tasks = shard
+        .dequeue("w-sat", "default", 1)
+        .await
+        .expect("deq sat")
+        .tasks;
     assert_eq!(sat_tasks.len(), 1);
     let sat_task_id = sat_tasks[0].attempt().task_id().to_string();
     assert_eq!(
@@ -3116,7 +3172,10 @@ async fn two_floating_concurrency_queued_on_fc1_reconciles_with_both() {
     let mut target_task_id: Option<String> = None;
     let start = std::time::Instant::now();
     while start.elapsed() < std::time::Duration::from_secs(5) {
-        let r = shard.dequeue("w-target", "default", 1).await.expect("deq target");
+        let r = shard
+            .dequeue("w-target", "default", 1)
+            .await
+            .expect("deq target");
         if let Some(t) = r.tasks.iter().find(|t| t.job().id() == job) {
             target_task_id = Some(t.attempt().task_id().to_string());
             break;
@@ -3150,7 +3209,12 @@ async fn two_floating_concurrency_queued_on_fc1_reconciles_with_both() {
             held
         );
     }
-    assert_eq!(held.len(), 2, "expected FC1 + FC2 in held_queues, got {:?}", held);
+    assert_eq!(
+        held.len(),
+        2,
+        "expected FC1 + FC2 in held_queues, got {:?}",
+        held
+    );
 
     // Complete — both holders must release.
     shard

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -622,6 +622,7 @@ async fn concurrency_queues_when_full_and_grants_on_release() {
             Task::RequestTicket { .. } => {}
             Task::CheckRateLimit { .. } => {}
             Task::RefreshFloatingLimit { .. } => {}
+            Task::ContinueLimits { .. } => {}
         }
     }
 
@@ -970,6 +971,7 @@ async fn concurrent_enqueues_while_holding_dont_bypass_limit() {
             Task::RequestTicket { .. } => {}
             Task::CheckRateLimit { .. } => {}
             Task::RefreshFloatingLimit { .. } => {}
+            Task::ContinueLimits { .. } => {}
         }
     }
 
@@ -1638,6 +1640,10 @@ async fn grant_scanner_skips_stale_requests_and_grants_valid_ones() {
             attempt_number: 1,
             relative_attempt_number: 1,
             task_group: "tg".to_string(),
+            task_id: format!("stale-tid-{}", i),
+            held_queues: vec![],
+            limit_index: 0,
+            limits: vec![],
         };
         let key = silo::keys::concurrency_request_key(
             tenant,
@@ -1699,6 +1705,10 @@ async fn grant_scanner_handles_all_stale_requests() {
             attempt_number: 1,
             relative_attempt_number: 1,
             task_group: "tg".to_string(),
+            task_id: format!("ghost-tid-{}", i),
+            held_queues: vec![],
+            limit_index: 0,
+            limits: vec![],
         };
         let key = silo::keys::concurrency_request_key(
             tenant,
@@ -1994,6 +2004,10 @@ async fn grant_scanner_interleaved_stale_and_valid_requests() {
             attempt_number: 1,
             relative_attempt_number: 1,
             task_group: "tg".to_string(),
+            task_id: format!("phantom-tid-{}", i),
+            held_queues: vec![],
+            limit_index: 0,
+            limits: vec![],
         };
         let key = silo::keys::concurrency_request_key(
             tenant,

--- a/tests/job_store_shard_import_tests.rs
+++ b/tests/job_store_shard_import_tests.rs
@@ -3109,6 +3109,10 @@ async fn reimport_failed_to_scheduled_ignores_stale_concurrency_requests() {
         attempt_number: 1,
         relative_attempt_number: 1,
         task_group: "default".to_string(),
+        task_id: "stale".to_string(),
+        held_queues: vec![],
+        limit_index: 0,
+        limits: vec![],
     };
     let stale_request_key = silo::keys::concurrency_request_key(
         "-",

--- a/tests/job_store_shard_retry_tests.rs
+++ b/tests/job_store_shard_retry_tests.rs
@@ -189,6 +189,9 @@ async fn error_with_retries_enqueues_next_attempt_until_limit() {
             Task::RefreshFloatingLimit { .. } => {
                 panic!("unexpected RefreshFloatingLimit in tasks/ for this test")
             }
+            Task::ContinueLimits { .. } => {
+                panic!("unexpected ContinueLimits in tasks/ for this test")
+            }
         };
         assert_eq!(attempt, 2);
 
@@ -223,6 +226,9 @@ async fn error_with_retries_enqueues_next_attempt_until_limit() {
             }
             Task::RefreshFloatingLimit { .. } => {
                 panic!("unexpected RefreshFloatingLimit in tasks/ for this test")
+            }
+            Task::ContinueLimits { .. } => {
+                panic!("unexpected ContinueLimits in tasks/ for this test")
             }
         };
         assert_eq!(attempt3, 3);
@@ -463,6 +469,9 @@ async fn retry_count_one_boundary_enqueues_attempt2_then_stops_on_second_error()
         Task::CheckRateLimit { .. } => panic!("unexpected CheckRateLimit in tasks/ for this test"),
         Task::RefreshFloatingLimit { .. } => {
             panic!("unexpected RefreshFloatingLimit in tasks/ for this test")
+        }
+        Task::ContinueLimits { .. } => {
+            panic!("unexpected ContinueLimits in tasks/ for this test")
         }
     };
     assert_eq!(attempt2, 2);
@@ -1055,6 +1064,9 @@ async fn reap_marks_expired_lease_as_failed_and_enqueues_retry() {
         Task::CheckRateLimit { .. } => panic!("unexpected CheckRateLimit in tasks/ for this test"),
         Task::RefreshFloatingLimit { .. } => {
             panic!("unexpected RefreshFloatingLimit in tasks/ for this test")
+        }
+        Task::ContinueLimits { .. } => {
+            panic!("unexpected ContinueLimits in tasks/ for this test")
         }
     };
     assert_eq!(attempt2, 2);


### PR DESCRIPTION
## Summary

Two bugs in the multi-limit deferred-grant path, reproduced by the regression tests in the prior commit:

1. **Holder leak.** Job `[C, FC]` where C grants at enqueue but FC must queue: when FC was later reconciled, the grant scanner built a `RunAttempt` with `held_queues = vec!["FC"]` and an identifier derived from the parsed request key. The earlier C holder (keyed by `first_task_id`) was orphaned forever, wedging the queue's capacity.

2. **Limit bypass.** Job `[…, L_blocking, L_after]` where `L_blocking` queues: the enqueue loop returned without evaluating `L_after`. On reconciliation the scanner wrote a terminal `RunAttempt` directly, silently skipping `L_after`.

Root cause: the durable `ConcurrencyAction::EnqueueTask` record carried no chain context — no holders accumulated so far, no original `task_id`, no canonical-order position, no limits list. So the deferred-grant path had nothing to continue the chain with.

## Fix

Extend `ConcurrencyAction::EnqueueTask` and `Task::RequestTicket` to carry the chain context (`task_id`, `held_queues`, `limit_index`, `limits`). Routes both deferred-grant paths (`process_grants` and `handle_request_ticket`) through a new `Task::ContinueLimits` task, which `handle_continue_limits` then feeds back into `enqueue_limit_task_at_index` at `next_limit_index` — the same chain-continuation pattern `Task::CheckRateLimit` already uses. No JobInfo lookup on the hot path; limits are embedded in the continuation.

Identity is now consistent: every holder a multi-limit job acquires is keyed by the same `first_task_id`, so `report_attempt_outcome` releases them all via one lease's `held_queues`.

**Schema is breaking.** DB is being nuked pre-launch, so no migration shim.

**Broker-tombstone trap.** When the continuation task lands at the same task_key the dequeue just ack-deleted, the broker tombstone suppresses re-pickup. Fixed by using `now_ms` for the new task_key (mirroring the existing `handle_check_rate_limit` precedent).

## Test plan

- [x] All 5 regression tests from `f09ec24` pass:
  - `enqueue_concurrency_and_floating_concurrency_grants_both_immediately`
  - `enqueue_concurrency_and_two_floating_concurrency_grants_all_immediately`
  - `concurrency_then_floating_concurrency_queued_reconciles_with_both_holders`
  - `concurrency_two_floating_concurrency_queued_on_fc1_reconciles_with_all_three`
  - `two_floating_concurrency_queued_on_fc1_reconciles_with_both`
- [x] Existing `fc_before_concurrency_wedges_floating_only_jobs_via_orphaned_holder` regression still passes
- [x] Adjacent suites clean: `concurrency_tests` (22/22), `floating_concurrency_tests` (22/22), `concurrent_grant_race_tests` (6/6), `concurrency_counts_tests`, `concurrency_requester_counter_tests`, `holder_leak_tests`, `codec_tests`, `job_store_shard_retry_tests`, `job_store_shard_concurrency_tests` (31/31), and ~25 other binaries — all clean
- [ ] One pre-existing intermittent flake under parallel load: `concurrency_no_overgrant_with_lazy_hydration` (passes in isolation; broker-buffer timing, not introduced by this change)
- [ ] Skipped: `cluster_query_integration_tests` (needs etcd) and `rate_limit_tests` (needs Gubernator) — pre-existing environmental deps