### PR TITLE
Adding gdb to silo so that we can better debug where it's hanging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,8 +126,8 @@ tonic-build = "0.12"
 protoc-bin-vendored = "3.0"
 
 [profile.release]
-debug = 1     # debug info with line tables only for profiling
-strip = false # do not strip symbols for profiling
+debug = "full" # full DWARF — gdb can inspect locals/types, profilers get symbols
+strip = false  # do not strip symbols for profiling
 # NOTE: pprof uses frame-pointer based stack unwinding. The nix build in
 # nix/modules/rust.nix sets RUSTFLAGS="-C force-frame-pointers=yes" to ensure
 # frame pointers are preserved. Without this, production profiles will have

--- a/nix/modules/docker.nix
+++ b/nix/modules/docker.nix
@@ -1,6 +1,23 @@
 { inputs, ... }:
 {
-  perSystem = { config, self', pkgs, lib, system, ... }: {
+  perSystem = { config, self', pkgs, lib, system, ... }:
+    let
+      # Extract just the Rust gdb pretty-printer Python files from the toolchain
+      # so the prod image can ship `rust-gdb` without dragging in the entire
+      # Rust toolchain (~hundreds of MB of rustc + stdlib sources).
+      rust-gdb-printers = pkgs.runCommand "rust-gdb-printers" { } ''
+        mkdir -p $out/share/rust-gdb
+        cp ${self'.packages.rust-toolchain}/lib/rustlib/etc/*.py $out/share/rust-gdb/
+      '';
+      rust-gdb = pkgs.writeShellScriptBin "rust-gdb" ''
+        PYTHONPATH="''${PYTHONPATH:+$PYTHONPATH:}${rust-gdb-printers}/share/rust-gdb" \
+        exec ${pkgs.gdb}/bin/gdb \
+          -d "${rust-gdb-printers}/share/rust-gdb" \
+          -iex "add-auto-load-safe-path ${rust-gdb-printers}/share/rust-gdb" \
+          "$@"
+      '';
+    in
+    {
     packages.silo-docker = pkgs.dockerTools.buildLayeredImage {
       name = "silo";
       tag = "latest";
@@ -9,6 +26,10 @@
         self'.packages.silo
         # Include CA certificates for TLS
         pkgs.cacert
+        # Debugger + Rust pretty-printer wrapper for attaching to silo in prod.
+        # Adds ~50MB for gdb; the rust-gdb wrapper itself is tiny.
+        pkgs.gdb
+        rust-gdb
       ];
 
       # pprof CPU profiler needs /tmp for temporary files during profile collection

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -129,6 +129,9 @@
       packages.default = silo;
       packages.silo = silo;
       packages.silo-debug = silo-debug;
+      # Exposed so docker.nix can lift the Rust gdb pretty-printers out of the
+      # toolchain without re-importing rust-overlay.
+      packages.rust-toolchain = rustToolchain;
       packages.silo-autoscaler = silo-autoscaler;
       packages.silo-compactor = silo-compactor;
       packages.siloctl = siloctl;


### PR DESCRIPTION
This is temporary to get better info for debugging where the grant scanner is getting stuck. Should be compiling in all of the debug symbols

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to production build/profile changes and a larger runtime image (includes `gdb` and full DWARF symbols), which can affect artifact size and deployment characteristics but not application logic.
> 
> **Overview**
> Builds are adjusted to make production debugging easier by **enabling full release DWARF symbols** (`[profile.release] debug = "full"`, `strip = false`).
> 
> The `silo` Docker image now includes `gdb` plus a lightweight `rust-gdb` wrapper that bundles only Rust pretty-printer Python files (exporting `rust-toolchain` from `rust.nix` so `docker.nix` can copy them), avoiding shipping the full Rust toolchain in the image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb32fafd0963aa06616aff83927115eb9b26b7c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->