### PR TITLE
Fix resumed concurrency-chain task discovery and legacy request grants

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1167,11 +1167,7 @@ impl ConcurrencyManager {
     ///
     /// On a transient DB error, the failing tuple is re-queued so the next
     /// tick (or sub-tick wake) retries it.
-    pub async fn reconcile_pending_holders(
-        &self,
-        db: &Arc<InstrumentedDb>,
-        range: &ShardRange,
-    ) {
+    pub async fn reconcile_pending_holders(&self, db: &Arc<InstrumentedDb>, range: &ShardRange) {
         let pending = self.counts.drain_pending_reconciliations();
         if pending.is_empty() {
             return;
@@ -1181,10 +1177,7 @@ impl ConcurrencyManager {
         // per pass.
         let mut by_queue: BTreeMap<(String, String), Vec<String>> = BTreeMap::new();
         for (tenant, queue, task_id) in pending {
-            by_queue
-                .entry((tenant, queue))
-                .or_default()
-                .push(task_id);
+            by_queue.entry((tenant, queue)).or_default().push(task_id);
         }
 
         for ((tenant, queue), task_ids) in by_queue {
@@ -1225,11 +1218,8 @@ impl ConcurrencyManager {
                             task_id = %task_id,
                             "reconciler: durable lookup failed; re-queueing"
                         );
-                        self.counts.enqueue_reconciliation(
-                            tenant.clone(),
-                            queue.clone(),
-                            task_id,
-                        );
+                        self.counts
+                            .enqueue_reconciliation(tenant.clone(), queue.clone(), task_id);
                         continue;
                     }
                 };

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -58,13 +58,14 @@ use crate::codec::{
     encode_holder, encode_task,
 };
 use crate::dst_events::{self, DstEvent};
-use crate::job::{ConcurrencyLimit, JobStatusKind, Limit};
+use crate::job::{ConcurrencyLimit, JobStatusKind, JobView, Limit};
 use crate::job_store_shard::helpers::decode_job_status_owned;
+use crate::job_store_shard::limit_processing_order;
 use crate::keys::{
     concurrency_counts_key, concurrency_holder_key, concurrency_holders_prefix,
     concurrency_holders_queue_prefix, concurrency_request_key, concurrency_request_prefix,
     concurrency_requester_counter_key, concurrency_requests_prefix, end_bound,
-    floating_limit_state_key, job_status_key, parse_concurrency_holder_key,
+    floating_limit_state_key, job_info_key, job_status_key, parse_concurrency_holder_key,
     parse_concurrency_request_key, task_key,
 };
 use crate::metrics::Metrics;
@@ -182,6 +183,30 @@ const STATUS_LOOKUP_CONCURRENCY: usize = 64;
 /// memory; the outer loop iterates as many passes as needed to drain
 /// the requested count.
 const MAX_GRANTS_PER_PASS: usize = 256;
+
+fn concurrency_queue_for_limit(limit: &Limit) -> Option<&str> {
+    match limit {
+        Limit::Concurrency(cl) => Some(&cl.key),
+        Limit::FloatingConcurrency(fl) => Some(&fl.key),
+        Limit::RateLimit(_) => None,
+    }
+}
+
+fn limit_index_matches_queue(limits: &[Limit], limit_index: u32, queue: &str) -> bool {
+    let order = limit_processing_order(limits);
+    order
+        .get(limit_index as usize)
+        .and_then(|&idx| concurrency_queue_for_limit(&limits[idx]))
+        == Some(queue)
+}
+
+fn canonical_limit_index_for_queue(limits: &[Limit], queue: &str) -> Option<u32> {
+    let order = limit_processing_order(limits);
+    order
+        .iter()
+        .position(|&idx| concurrency_queue_for_limit(&limits[idx]) == Some(queue))
+        .map(|idx| idx as u32)
+}
 
 /// Result of attempting to enqueue a job with concurrency limits
 #[derive(Debug)]
@@ -1251,7 +1276,12 @@ impl ConcurrencyManager {
                     }
                 };
 
-                let parsed_req = parse_concurrency_request_key(&kv.key);
+                let Some(parsed_req) = parse_concurrency_request_key(&kv.key) else {
+                    tracing::warn!(queue = %queue, "grant scanner: malformed request key, deleting");
+                    batch.delete(&kv.key);
+                    stale_and_corrupt_count += 1;
+                    continue;
+                };
 
                 let decoded = match decode_concurrency_action(kv.value.clone()) {
                     Ok(d) => d,
@@ -1270,8 +1300,13 @@ impl ConcurrencyManager {
                     continue;
                 };
 
-                let start_time_ms = et.start_time_ms();
-                let job_id_str = et.job_id().unwrap_or_default();
+                // The request key is authoritative for scheduler ordering and
+                // storage identity. Legacy values written before task_id/limits
+                // were added still have these fields in the key.
+                let start_time_ms = parsed_req.start_time_ms as i64;
+                let job_id_str = parsed_req.job_id.as_str();
+                let attempt_number = parsed_req.attempt_number;
+                let priority = parsed_req.priority;
 
                 if start_time_ms > now_ms {
                     // Concurrency request keys encode `start_time_ms` ahead of
@@ -1284,37 +1319,63 @@ impl ConcurrencyManager {
                     break;
                 }
 
-                // The request key's suffix is only used for storage
-                // uniqueness; we no longer use it as the task_id. (`parsed_req`
-                // could be Some or None; both are fine because we delete by
-                // the raw key bytes below.)
-                let _ = parsed_req;
-
-                let task_id_str = et.task_id().unwrap_or_default().to_string();
-                if task_id_str.is_empty() {
-                    tracing::warn!(
-                        queue = %queue,
-                        job_id = %job_id_str,
-                        "grant scanner: request missing task_id; deleting"
-                    );
-                    batch.delete(&kv.key);
-                    stale_and_corrupt_count += 1;
-                    continue;
-                }
+                let task_id_str = match et.task_id() {
+                    Some(task_id) if !task_id.is_empty() => task_id.to_string(),
+                    _ => parsed_req.request_id(),
+                };
                 let held_queues: Vec<String> = et
                     .held_queues()
                     .map(|v| v.iter().map(|s| s.to_string()).collect())
                     .unwrap_or_default();
-                let limits = crate::codec::limit_entries_to_owned(et.limits());
+                let mut limits = crate::codec::limit_entries_to_owned(et.limits());
+                let mut task_group = et.task_group().unwrap_or_default().to_string();
+
+                if limits.is_empty() || task_group.is_empty() {
+                    match db.get(&job_info_key(tenant, job_id_str)).await {
+                        Ok(Some(job_raw)) => match JobView::new(job_raw) {
+                            Ok(job_view) => {
+                                if limits.is_empty() {
+                                    limits = job_view.limits();
+                                }
+                                if task_group.is_empty() {
+                                    task_group = job_view.task_group().to_string();
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    queue = %queue,
+                                    job_id = %job_id_str,
+                                    error = %e,
+                                    "grant scanner: request needs JobInfo fallback but JobInfo is unreadable; deleting"
+                                );
+                                batch.delete(&kv.key);
+                                stale_and_corrupt_count += 1;
+                                continue;
+                            }
+                        },
+                        Ok(None) => {
+                            tracing::warn!(
+                                queue = %queue,
+                                job_id = %job_id_str,
+                                "grant scanner: request needs JobInfo fallback but JobInfo is missing; deleting"
+                            );
+                            batch.delete(&kv.key);
+                            stale_and_corrupt_count += 1;
+                            continue;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                queue = %queue,
+                                job_id = %job_id_str,
+                                error = %e,
+                                "grant scanner: failed to load JobInfo fallback; skipping request this pass"
+                            );
+                            continue;
+                        }
+                    }
+                }
 
                 if limits.is_empty() {
-                    // Post-schema-update every request has its limits
-                    // populated. An empty list is either a decode-shape
-                    // failure or a stale pre-deploy record. The chain
-                    // resumer with `limits=[]` would silently fall through
-                    // to a terminal RunAttempt that bypasses every gate —
-                    // safer to treat this exactly like a decode failure:
-                    // log, delete, skip.
                     tracing::warn!(
                         queue = %queue,
                         job_id = %job_id_str,
@@ -1324,6 +1385,32 @@ impl ConcurrencyManager {
                     stale_and_corrupt_count += 1;
                     continue;
                 }
+                if task_group.is_empty() {
+                    tracing::warn!(
+                        queue = %queue,
+                        job_id = %job_id_str,
+                        "grant scanner: request has no task group after fallback; deleting"
+                    );
+                    batch.delete(&kv.key);
+                    stale_and_corrupt_count += 1;
+                    continue;
+                }
+
+                let raw_limit_index = et.limit_index();
+                let limit_index = if limit_index_matches_queue(&limits, raw_limit_index, queue) {
+                    raw_limit_index
+                } else if let Some(idx) = canonical_limit_index_for_queue(&limits, queue) {
+                    idx
+                } else {
+                    tracing::warn!(
+                        queue = %queue,
+                        job_id = %job_id_str,
+                        "grant scanner: request queue is not in job limits; deleting"
+                    );
+                    batch.delete(&kv.key);
+                    stale_and_corrupt_count += 1;
+                    continue;
+                };
 
                 // Resolve max_concurrency from the first request's limits
                 // (always populated, per the check above).
@@ -1338,12 +1425,15 @@ impl ConcurrencyManager {
                     request_key: kv.key.to_vec(),
                     task_id: task_id_str,
                     job_id: job_id_str.to_string(),
-                    attempt_number: et.attempt_number(),
-                    relative_attempt_number: et.relative_attempt_number(),
+                    attempt_number,
+                    relative_attempt_number: {
+                        let rel = et.relative_attempt_number();
+                        if rel == 0 { attempt_number } else { rel }
+                    },
                     start_time_ms,
-                    priority: et.priority(),
-                    task_group: et.task_group().unwrap_or_default().to_string(),
-                    limit_index: et.limit_index(),
+                    priority,
+                    task_group,
+                    limit_index,
                     held_queues,
                     limits,
                 });

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1323,7 +1323,7 @@ impl ConcurrencyManager {
                     Some(task_id) if !task_id.is_empty() => task_id.to_string(),
                     _ => parsed_req.request_id(),
                 };
-                let held_queues: Vec<String> = et
+                let mut held_queues: Vec<String> = et
                     .held_queues()
                     .map(|v| v.iter().map(|s| s.to_string()).collect())
                     .unwrap_or_default();
@@ -1411,6 +1411,42 @@ impl ConcurrencyManager {
                     stale_and_corrupt_count += 1;
                     continue;
                 };
+
+                // If the value omitted `held_queues` (pre-unify-chain
+                // schema) but the chain is gated at a later limit, upstream
+                // concurrency slots may have been acquired under this
+                // task_id. Probe each earlier concurrency queue and add any
+                // matching holder to `held_queues` so completion / cancel
+                // releases them. Pre-unify chains used a UUID task_id
+                // distinct from `parsed_req.request_id()`, so the probe
+                // won't reach those — they stay orphaned regardless. This
+                // matters for any storage state where task_id consistency
+                // was preserved but held_queues was dropped.
+                if held_queues.is_empty() && limit_index > 0 {
+                    let order = limit_processing_order(&limits);
+                    let upstream_end = (limit_index as usize).min(order.len());
+                    for &lim_idx in &order[..upstream_end] {
+                        let Some(upstream_queue) = concurrency_queue_for_limit(&limits[lim_idx])
+                        else {
+                            continue;
+                        };
+                        let holder_key =
+                            concurrency_holder_key(tenant, upstream_queue, &task_id_str);
+                        match db.get(&holder_key).await {
+                            Ok(Some(_)) => held_queues.push(upstream_queue.to_string()),
+                            Ok(None) => {}
+                            Err(e) => {
+                                tracing::warn!(
+                                    queue = %queue,
+                                    upstream_queue = %upstream_queue,
+                                    job_id = %job_id_str,
+                                    error = %e,
+                                    "grant scanner: upstream holder probe failed; held_queues may be incomplete"
+                                );
+                            }
+                        }
+                    }
+                }
 
                 // Resolve max_concurrency from the first request's limits
                 // (always populated, per the check above).

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -36,7 +36,7 @@
 //!   request from a restart or retry is still in the DB. Since Cancelled is terminal,
 //!   this also catches any stale cancelled requests.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -284,6 +284,15 @@ pub struct ConcurrencyCounts {
     /// have already scanned every non-empty queue. When `false`, the
     /// singleflighted per-queue scan runs on miss.
     hydrate_all_at_startup: bool,
+    /// (tenant, queue, task_id) tuples submitted by RAII guards on drop of a
+    /// dequeue future, awaiting per-task_id reconciliation against the durable
+    /// holder row. BTreeSet for deterministic iteration order (DST) and
+    /// natural deduplication of repeated tuples.
+    ///
+    /// Mutex is held only for synchronous `insert` and `mem::take` — never
+    /// across `.await`, matching the locking discipline at the top of this
+    /// module.
+    pending_reconciliations: Mutex<BTreeSet<(String, String, String)>>,
 }
 
 impl Default for ConcurrencyCounts {
@@ -304,6 +313,7 @@ impl ConcurrencyCounts {
         Self {
             queues: Arc::new(DashMap::new()),
             hydrate_all_at_startup,
+            pending_reconciliations: Mutex::new(BTreeSet::new()),
         }
     }
 
@@ -584,6 +594,77 @@ impl ConcurrencyCounts {
             .unwrap_or(0)
     }
 
+    /// Whether this task_id is currently recorded as an in-memory holder for
+    /// `(tenant, queue)`. Used by the reconciler to compare against the
+    /// durable holder row.
+    pub fn contains_holder(&self, tenant: &str, queue: &str, task_id: &str) -> bool {
+        let key = queue_key(tenant, queue);
+        self.queues
+            .get(&key)
+            .map(|entry| entry.holders.contains(task_id))
+            .unwrap_or(false)
+    }
+
+    /// Insert an in-memory holder without going through `try_reserve` (no
+    /// capacity check). Used by the reconciler when it observes a durable
+    /// holder row with no matching in-memory entry — a possible outcome of
+    /// the ambiguous "commit landed during cancellation" case on the
+    /// grant-side guard, which the reconciler self-heals.
+    pub fn insert_holder(&self, tenant: &str, queue: &str, task_id: &str) {
+        let key = queue_key(tenant, queue);
+        let mut entry = self.queues.entry(key).or_insert_with(QueueEntry::new);
+        entry.holders.insert(task_id.to_string());
+    }
+
+    /// Push a `(tenant, queue, task_id)` tuple onto the per-task_id
+    /// reconciliation queue. Idempotent: BTreeSet dedupes repeats.
+    ///
+    /// Called by `PendingGrantGuard::drop` and `PendingHolderReleaseGuard::drop`
+    /// in `dequeue.rs` when a dequeue future is cancelled around its commit.
+    /// The actual reconciliation runs on the periodic
+    /// `spawn_concurrency_reconcile_task`, woken sub-tick via
+    /// `ConcurrencyManager::request_reconciliation`.
+    pub fn enqueue_reconciliation(&self, tenant: String, queue: String, task_id: String) {
+        let mut p = self.pending_reconciliations.lock().unwrap();
+        p.insert((tenant, queue, task_id));
+    }
+
+    /// Drain the pending reconciliation set. Synchronous — does not touch the
+    /// `await_durable` path.
+    fn drain_pending_reconciliations(&self) -> BTreeSet<(String, String, String)> {
+        let mut p = self.pending_reconciliations.lock().unwrap();
+        std::mem::take(&mut *p)
+    }
+
+    /// Count of pending reconciliation tuples. Used by metrics and a stuck-
+    /// reconciler warn.
+    pub fn pending_reconciliations_len(&self) -> usize {
+        self.pending_reconciliations.lock().unwrap().len()
+    }
+
+    /// Snapshot every hydrated (tenant, queue) and its current in-memory
+    /// holder count. Used by the reconciler tick to compute drift against
+    /// the durable holder rows for each queue.
+    ///
+    /// `NotHydrated` and `Hydrating` queues are intentionally skipped: we
+    /// haven't loaded their durable rows yet, so comparing in-memory (empty)
+    /// against durable (unknown) is meaningless.
+    pub fn hydrated_queue_holders_snapshot(&self) -> Vec<(String, String, usize)> {
+        let mut out = Vec::new();
+        for entry in self.queues.iter() {
+            if !matches!(entry.state, HydrationState::Hydrated) {
+                continue;
+            }
+            let (tenant_arc, queue_arc) = entry.key();
+            out.push((
+                tenant_arc.to_string(),
+                queue_arc.to_string(),
+                entry.holders.len(),
+            ));
+        }
+        out
+    }
+
     /// Snapshot the sizes of the in-memory holders cache for metrics reporting.
     pub fn cache_stats(&self) -> ConcurrencyCacheStats {
         let mut total_holders = 0usize;
@@ -731,6 +812,13 @@ pub struct ConcurrencyManager {
     pending_grants: Mutex<BTreeMap<Vec<u8>, (String, String, u32)>>,
     grant_notify: tokio::sync::Notify,
     grant_running: AtomicBool,
+    /// Sub-tick wake for the periodic holder reconciler. Fired by
+    /// `request_reconciliation` after a dequeue future is cancelled around
+    /// its commit (via `PendingGrantGuard::drop` / `PendingHolderReleaseGuard::drop`).
+    /// Sibling to `grant_notify` — separate notify because the grant scanner
+    /// and the holder reconciler are distinct concerns (granting vs
+    /// reconciling); the periodic-reconcile task selects on this directly.
+    reconcile_notify: Arc<tokio::sync::Notify>,
     /// In-memory cache of resolved concurrency limits per queue.
     /// Key: concurrency_counts_key(tenant, queue). Populated during enqueue and grant_next.
     limit_cache: Mutex<HashMap<Vec<u8>, CachedQueueLimit>>,
@@ -760,6 +848,7 @@ impl ConcurrencyManager {
             pending_grants: Mutex::new(BTreeMap::new()),
             grant_notify: tokio::sync::Notify::new(),
             grant_running: AtomicBool::new(false),
+            reconcile_notify: Arc::new(tokio::sync::Notify::new()),
             limit_cache: Mutex::new(HashMap::new()),
             metrics,
             chain_resumer: Mutex::new(None),
@@ -1044,6 +1133,220 @@ impl ConcurrencyManager {
     /// Wakes the grant scanner to process pending requests.
     pub fn request_grant(&self, tenant: &str, queue: &str) {
         self.request_grant_count(tenant, queue, 1);
+    }
+
+    /// Clone-able handle to the reconcile-notify so the periodic reconcile
+    /// task can `select!` on it without holding the manager.
+    pub fn reconcile_notify(&self) -> Arc<tokio::sync::Notify> {
+        Arc::clone(&self.reconcile_notify)
+    }
+
+    /// Queue a `(tenant, queue, task_id)` for the periodic reconciler to
+    /// verify against the durable holder row. Wakes the reconciler sub-tick.
+    ///
+    /// Called by `PendingGrantGuard::drop` and `PendingHolderReleaseGuard::drop`
+    /// in `dequeue.rs` after a dequeue future is cancelled around its commit
+    /// — the only place where in-memory and durable holder state can drift.
+    pub fn request_reconciliation(&self, tenant: String, queue: String, task_id: String) {
+        self.counts.enqueue_reconciliation(tenant, queue, task_id);
+        self.reconcile_notify.notify_one();
+    }
+
+    /// Drain the pending reconciliation set and reconcile each
+    /// `(tenant, queue, task_id)` against the durable holder row.
+    ///
+    /// Per-task_id, idempotent. Resolves the ambiguity of "cancellation mid
+    /// commit-await may or may not have applied to the WAL" deterministically:
+    ///
+    /// | durable | in-memory | action                                   |
+    /// |---------|-----------|------------------------------------------|
+    /// | Y       | Y         | no-op (consistent)                       |
+    /// | N       | N         | no-op (consistent)                       |
+    /// | Y       | N         | `insert_holder` (mirror case self-heal)  |
+    /// | N       | Y         | `atomic_release` + `request_grant` (ghost) |
+    ///
+    /// On a transient DB error, the failing tuple is re-queued so the next
+    /// tick (or sub-tick wake) retries it.
+    pub async fn reconcile_pending_holders(
+        &self,
+        db: &Arc<InstrumentedDb>,
+        range: &ShardRange,
+    ) {
+        let pending = self.counts.drain_pending_reconciliations();
+        if pending.is_empty() {
+            return;
+        }
+
+        // Group by (tenant, queue) so each queue is hydrated at most once
+        // per pass.
+        let mut by_queue: BTreeMap<(String, String), Vec<String>> = BTreeMap::new();
+        for (tenant, queue, task_id) in pending {
+            by_queue
+                .entry((tenant, queue))
+                .or_default()
+                .push(task_id);
+        }
+
+        for ((tenant, queue), task_ids) in by_queue {
+            // Skip tenants outside this shard's range — they may have been
+            // queued before a shard split.
+            if !range.contains_tenant(&tenant) {
+                continue;
+            }
+
+            if let Err(e) = self
+                .counts
+                .ensure_hydrated(db, range, &tenant, &queue)
+                .await
+            {
+                tracing::warn!(
+                    error = %e,
+                    tenant = %tenant,
+                    queue = %queue,
+                    "reconciler: hydrate failed; re-queueing for next tick"
+                );
+                for tid in task_ids {
+                    self.counts
+                        .enqueue_reconciliation(tenant.clone(), queue.clone(), tid);
+                }
+                continue;
+            }
+
+            let mut any_released = false;
+            for task_id in task_ids {
+                let key = concurrency_holder_key(&tenant, &queue, &task_id);
+                let durable_present = match db.get(&key).await {
+                    Ok(opt) => opt.is_some(),
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            tenant = %tenant,
+                            queue = %queue,
+                            task_id = %task_id,
+                            "reconciler: durable lookup failed; re-queueing"
+                        );
+                        self.counts.enqueue_reconciliation(
+                            tenant.clone(),
+                            queue.clone(),
+                            task_id,
+                        );
+                        continue;
+                    }
+                };
+                let in_mem_present = self.counts.contains_holder(&tenant, &queue, &task_id);
+
+                match (durable_present, in_mem_present) {
+                    (true, true) | (false, false) => {
+                        // Consistent — nothing to do.
+                    }
+                    (true, false) => {
+                        // Durable holder exists with no in-memory entry.
+                        // Reachable if a grant-side guard's Drop fired after
+                        // the commit landed but the rollback never ran (the
+                        // mirror case of the ghost). Re-insert to match.
+                        self.counts.insert_holder(&tenant, &queue, &task_id);
+                        tracing::info!(
+                            tenant = %tenant,
+                            queue = %queue,
+                            task_id = %task_id,
+                            "reconciler: re-inserted in-memory holder to match durable"
+                        );
+                    }
+                    (false, true) => {
+                        // Ghost: durable holder is gone but the in-memory
+                        // reservation survives. This is the wedge bug.
+                        // Release and wake the grant scanner.
+                        self.counts.atomic_release(&tenant, &queue, &task_id);
+                        any_released = true;
+                        tracing::info!(
+                            tenant = %tenant,
+                            queue = %queue,
+                            task_id = %task_id,
+                            "reconciler: released ghost in-memory holder (no durable row)"
+                        );
+                    }
+                }
+            }
+            if any_released {
+                // One grant kick per queue that saw a release.
+                self.request_grant(&tenant, &queue);
+            }
+        }
+
+        // Stuck-reconciler signal: if the pending set keeps growing across
+        // ticks, something is wrong (slatedb unavailable, etc.).
+        let remaining = self.counts.pending_reconciliations_len();
+        if remaining > 10_000 {
+            tracing::warn!(
+                pending = remaining,
+                "reconciler: pending_reconciliations growing — backlog suggests stuck reconciler"
+            );
+        }
+    }
+
+    /// Walk every hydrated (tenant, queue) in this shard, compare the
+    /// in-memory holder count to the durable holder count (one ranged scan
+    /// per queue), and publish:
+    ///
+    /// * `silo_concurrency_holder_drift` — Σ |in_mem - durable| across hydrated queues
+    /// * `silo_concurrency_reconciliation_pending` — current size of the
+    ///   per-task_id reconciliation queue (stuck-reconciler signal)
+    ///
+    /// Called from the periodic reconciler's tick (NOT from the reactive
+    /// sub-tick wake) — keeps the cost amortized at the deployment-configured
+    /// `concurrency_reconcile_interval` rather than firing on every dropped
+    /// dequeue future. Noop if metrics are disabled.
+    pub async fn report_holder_drift(&self, db: &Arc<InstrumentedDb>, range: &ShardRange) {
+        let Some(metrics) = self.metrics.as_ref() else {
+            // Always publish the pending gauge if metrics are present; if not, skip everything.
+            return;
+        };
+
+        let mut drift_total: u64 = 0;
+        for (tenant, queue, in_mem_count) in self.counts.hydrated_queue_holders_snapshot() {
+            if !range.contains_tenant(&tenant) {
+                continue;
+            }
+            // Per-queue ranged scan. Cost dominated by holder count; capped
+            // by the deployment's reconcile interval.
+            let start = crate::keys::concurrency_holders_queue_prefix(&tenant, &queue);
+            let end = crate::keys::end_bound(&start);
+            let mut iter = match db
+                .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+                .await
+            {
+                Ok(i) => i,
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        tenant = %tenant,
+                        queue = %queue,
+                        "report_holder_drift: scan failed; skipping queue"
+                    );
+                    continue;
+                }
+            };
+            let mut durable_count: usize = 0;
+            loop {
+                match iter.next().await {
+                    Ok(Some(_)) => durable_count += 1,
+                    Ok(None) => break,
+                    Err(e) => {
+                        tracing::debug!(
+                            error = %e,
+                            tenant = %tenant,
+                            queue = %queue,
+                            "report_holder_drift: iter error; partial count"
+                        );
+                        break;
+                    }
+                }
+            }
+            drift_total += (in_mem_count as i64 - durable_count as i64).unsigned_abs();
+        }
+
+        let pending = self.counts.pending_reconciliations_len() as u64;
+        metrics.set_concurrency_reconciler_signals(&self.shard, drift_total, pending);
     }
 
     fn request_grant_count(&self, tenant: &str, queue: &str, count: u32) {

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -14,6 +14,7 @@ use crate::keys::{
     attempt_key, concurrency_holder_key, job_info_key, job_status_key, leased_task_key,
     parse_task_key,
 };
+use crate::concurrency::ConcurrencyManager;
 use crate::shard_range::ShardRange;
 use crate::task::{
     DEFAULT_LEASE_MS, HolderRecord, LeaseRecord, LeasedRefreshTask, LeasedTask, Task,
@@ -120,6 +121,161 @@ impl Drop for ClaimedInflightGuard<'_> {
     }
 }
 
+/// RAII guard over the in-memory concurrency reservations made by
+/// `try_reserve` during a dequeue iteration but not yet confirmed durable.
+///
+/// **Why this exists.** `try_reserve` bumps `ConcurrencyCounts.holders` *before*
+/// the batch commits, so admission decisions see the reservation immediately
+/// (see `concurrency.rs` TOCTOU note). Three exit paths handle this today:
+/// handler-error-before-commit and commit-failure both call `rollback_grant`;
+/// commit-success leaves the reservation in place (now backed by the durable
+/// holder row written by the same batch). A fourth exit — the dequeue future
+/// being cancelled around the `write_with_options(...await_durable).await`
+/// — was unhandled, so on cancellation the in-memory reservation stayed but
+/// nothing in the rollback paths ran, leaking a phantom holder.
+///
+/// **What it does.** Holds the `(tenant, queue, task_id)` tuples awaiting
+/// commit confirmation. On every normal exit (handler-error / commit-failure
+/// / commit-success), the dequeue body calls `take()` or `clear()` to handle
+/// the contents itself. If the future is instead dropped or panics, the Drop
+/// fires with whatever is still in `pending` and enqueues each tuple onto
+/// `ConcurrencyManager`'s reconciliation queue. The periodic reconciler then
+/// resolves the ambiguous "did the WAL apply?" by point-lookup against the
+/// durable holder row — see `ConcurrencyManager::reconcile_pending_holders`.
+///
+/// Sibling to [`ClaimedInflightGuard`]; same `Option<Vec<…>>` armed/disarmed
+/// pattern.
+struct PendingGrantGuard<'a> {
+    concurrency: &'a ConcurrencyManager,
+    pending: Option<Vec<(String, String, String)>>,
+}
+
+impl<'a> PendingGrantGuard<'a> {
+    fn new(concurrency: &'a ConcurrencyManager) -> Self {
+        Self {
+            concurrency,
+            pending: Some(Vec::new()),
+        }
+    }
+
+    fn extend<I: IntoIterator<Item = (String, String, String)>>(&mut self, iter: I) {
+        if let Some(v) = self.pending.as_mut() {
+            v.extend(iter);
+        }
+    }
+
+    /// Empty the buffer without disarming. Used after commit-success — the
+    /// reservations are now backed by durable rows, no further action needed,
+    /// and the guard stays armed for the next iteration.
+    fn clear(&mut self) {
+        if let Some(v) = self.pending.as_mut() {
+            v.clear();
+        }
+    }
+
+    /// Take ownership of the pending tuples back, neutralizing the guard so
+    /// its Drop is a no-op. Used at terminal exit paths (commit-failure +
+    /// dequeue Ok return); callers that disarm on commit-failure run
+    /// `rollback_grant` over the returned vec themselves.
+    fn disarm(&mut self) -> Vec<(String, String, String)> {
+        self.pending.take().unwrap_or_default()
+    }
+}
+
+impl Drop for PendingGrantGuard<'_> {
+    fn drop(&mut self) {
+        let Some(pending) = self.pending.take() else {
+            return;
+        };
+        if pending.is_empty() {
+            return;
+        }
+        tracing::warn!(
+            count = pending.len(),
+            "dequeue future dropped/panicked with pending concurrency grants; queueing reconciliation"
+        );
+        for (tenant, queue, task_id) in pending {
+            self.concurrency
+                .request_reconciliation(tenant, queue, task_id);
+        }
+    }
+}
+
+/// RAII guard over durable concurrency holders that the iteration's batch
+/// has staged for deletion, paired with an in-memory `atomic_release` +
+/// `request_grant` that the dequeue body runs post-commit.
+///
+/// **Why this exists.** When `handle_run_attempt` finds a task whose
+/// `job_info` is missing (migration/cleanup race), it adds the durable
+/// holder-row delete to the batch and queues a matching in-memory release.
+/// `write_with_options(... await_durable: true)` applies the batch to the
+/// WAL on first poll, so by the time the await yields, the durable row may
+/// already be gone — but the post-commit `atomic_release` loop only runs if
+/// the await resolves cleanly. Cancellation mid-await leaves durable=0,
+/// in_memory=1: a ghost holder that wedges the queue (the prod 300/300 bug).
+///
+/// **What it does.** Same shape as [`PendingGrantGuard`]. On normal exit the
+/// dequeue body calls `take_all()` to run the in-memory release loop itself.
+/// If the future is dropped or panics, Drop enqueues each tuple for the
+/// reconciler, which point-looks-up the durable holder row to decide
+/// whether to release the in-memory entry (the WAL apply landed) or leave
+/// it alone (the WAL apply did not). Per-task_id, idempotent, correct in
+/// both branches of the ambiguity.
+struct PendingHolderReleaseGuard<'a> {
+    concurrency: &'a ConcurrencyManager,
+    pending: Option<Vec<(String, String, String)>>,
+}
+
+impl<'a> PendingHolderReleaseGuard<'a> {
+    fn new(concurrency: &'a ConcurrencyManager) -> Self {
+        Self {
+            concurrency,
+            pending: Some(Vec::new()),
+        }
+    }
+
+    fn extend<I: IntoIterator<Item = (String, String, String)>>(&mut self, iter: I) {
+        if let Some(v) = self.pending.as_mut() {
+            v.extend(iter);
+        }
+    }
+
+    /// Drain and return the current pending releases while leaving the guard
+    /// armed (with an empty buffer) for the next iteration. Used on the
+    /// commit-success path so the dequeue body runs the existing
+    /// `atomic_release` + `request_grant` loop itself.
+    fn take_all(&mut self) -> Vec<(String, String, String)> {
+        self.pending.as_mut().map(std::mem::take).unwrap_or_default()
+    }
+
+    /// Neutralize the guard. Used at terminal exit paths (commit-failure /
+    /// dequeue Ok return). On commit-failure the caller discards the
+    /// returned vec: the batch didn't land so the durable holder is still
+    /// there and the in-memory state is already correct.
+    fn disarm(&mut self) -> Vec<(String, String, String)> {
+        self.pending.take().unwrap_or_default()
+    }
+}
+
+impl Drop for PendingHolderReleaseGuard<'_> {
+    fn drop(&mut self) {
+        let Some(pending) = self.pending.take() else {
+            return;
+        };
+        if pending.is_empty() {
+            return;
+        }
+        tracing::warn!(
+            count = pending.len(),
+            "dequeue future dropped/panicked with pending holder releases; queueing reconciliation"
+        );
+        for (tenant, queue, task_id) in pending {
+            self.concurrency
+                .request_reconciliation(tenant, queue, task_id);
+        }
+    }
+}
+
 impl JobStoreShard {
     /// Dequeue up to `max_tasks` tasks available now, ordered by time then priority.
     ///
@@ -147,14 +303,18 @@ impl JobStoreShard {
         let mut pending_attempts: Vec<(String, JobView, Vec<u8>)> = Vec::with_capacity(max_tasks);
 
         // Track grants made during this dequeue for rollback on failure
-        // Format: (tenant, queue, task_id)
-        let mut grants_to_rollback: Vec<(String, String, String)> = Vec::new();
+        // *and* for reconciliation on dequeue-future cancellation. Format:
+        // (tenant, queue, task_id). See `PendingGrantGuard` for the
+        // cancellation-safety rationale.
+        let mut grant_guard = PendingGrantGuard::new(&self.concurrency);
         // Track leased tasks for DST event emission after commit
         // Format: (tenant, job_id, task_id)
         let mut leased_tasks_for_dst: Vec<(String, String, String)> = Vec::new();
         // Track holders deleted in the batch that need post-commit in-memory
-        // release + grant-scanner wakeup. Format: (tenant, queue, task_id).
-        let mut holder_releases: Vec<(String, String, String)> = Vec::new();
+        // release + grant-scanner wakeup *and* reconciliation on
+        // cancellation. Format: (tenant, queue, task_id). See
+        // `PendingHolderReleaseGuard` for the cancellation-safety rationale.
+        let mut holder_guard = PendingHolderReleaseGuard::new(&self.concurrency);
 
         // Loop to process internal tasks until we have tasks that are destined for the worker, or no more ready tasks at all.
         const MAX_INTERNAL_ITERATIONS: usize = 10;
@@ -269,9 +429,14 @@ impl JobStoreShard {
                 return Err(e);
             }
 
-            // Merge iteration state into outer accumulators
-            grants_to_rollback.append(&mut state.grants_to_rollback);
-            holder_releases.append(&mut state.holder_releases);
+            // Merge iteration state into the cancellation-safe guards. Pushes
+            // moved here from the iteration-local `state.*` only after every
+            // handler in this iteration succeeded — the handler-error path
+            // above already drained `state.grants_to_rollback` synchronously
+            // and discarded `state.holder_releases` (paired with a batch that
+            // will not commit), matching today's semantics.
+            grant_guard.extend(state.grants_to_rollback.drain(..));
+            holder_guard.extend(state.holder_releases.drain(..));
 
             // Two-phase DST events: emit before write for correct causal ordering,
             // confirm after write succeeds, cancel if write fails.
@@ -314,24 +479,33 @@ impl JobStoreShard {
                     .await
             {
                 dst_events::cancel_write(write_op);
-                // Rollback all grants made during this iteration
-                for (tenant, queue, task_id) in &grants_to_rollback {
-                    self.concurrency.rollback_grant(tenant, queue, task_id);
+                // Commit failed: known not-durable. Roll back all grants and
+                // discard pending holder releases (paired durable deletes
+                // didn't land, so the durable rows still exist and the
+                // in-memory state is already correct). Disarming both guards
+                // here means their Drop is a no-op on the `return Err` below.
+                for (tenant, queue, task_id) in grant_guard.disarm() {
+                    self.concurrency.rollback_grant(&tenant, &queue, &task_id);
                 }
+                let _ = holder_guard.disarm();
                 // Put back all claimed entries since we didn't lease them durably
                 self.brokers.requeue(inflight_guard.disarm());
                 return Err(JobStoreShardError::from(e));
             }
             dst_events::confirm_write(write_op);
 
-            // DB write succeeded - clear rollback lists for next iteration
-            grants_to_rollback.clear();
+            // DB write succeeded — grants are now backed by durable holder
+            // rows, no rollback needed. Clear the guard's buffer (keeps it
+            // armed for the next iteration); the next iteration's pushes
+            // start from empty.
+            grant_guard.clear();
 
             // Post-commit: drop in-memory slots for any holders we removed in
             // this batch (e.g. a RunAttempt task we dropped because its job_info
             // was missing) and wake the grant scanner so a queued requester
-            // can take the freed slot.
-            for (tenant, queue, task_id) in holder_releases.drain(..) {
+            // can take the freed slot. `take_all` empties the guard but keeps
+            // it armed for the next iteration.
+            for (tenant, queue, task_id) in holder_guard.take_all() {
                 self.concurrency
                     .counts()
                     .atomic_release(&tenant, &queue, &task_id);

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -604,7 +604,7 @@ impl JobStoreShard {
         let new_task_key_start_ms = now_ms.max(parent_start_time_ms + 1);
 
         let mut writer = DbWriteBatcher::new(&self.db, &mut state.batch);
-        let chain_grants = self
+        let chain_result = self
             .enqueue_limit_task_at_index(
                 &mut writer,
                 LimitTaskParams {
@@ -633,8 +633,18 @@ impl JobStoreShard {
 
         // Each (queue, task_id) the chain reserved also needs rollback if the
         // batch write fails.
-        for (q, tid) in chain_grants {
+        for (q, tid) in chain_result.grants {
             state.grants_to_rollback.push((tenant.clone(), q, tid));
+        }
+        if let Some(task_key_start_ms) = chain_result.pending_task_key_start_ms {
+            self.retarget_scheduled_task_key(
+                &mut writer,
+                &tenant,
+                &job_id,
+                attempt_number,
+                task_key_start_ms,
+            )
+            .await?;
         }
 
         // Metrics: account the grant as a Scanned-path ticket.
@@ -765,7 +775,7 @@ impl JobStoreShard {
                 // the follow-up key cannot collide with the just-deleted
                 // CheckRateLimit's task_key.
                 let new_task_key_start_ms = now_ms.max(parent_start_time_ms + 1);
-                let grants = self
+                let chain_result = self
                     .enqueue_limit_task_at_index(
                         &mut DbWriteBatcher::new(&self.db, &mut state.batch),
                         LimitTaskParams {
@@ -787,10 +797,20 @@ impl JobStoreShard {
                     )
                     .await?;
                 // Track any immediate grants for rollback if DB write fails
-                for (queue, task_id) in grants {
+                for (queue, task_id) in chain_result.grants {
                     state
                         .grants_to_rollback
                         .push((tenant.clone(), queue, task_id));
+                }
+                if let Some(task_key_start_ms) = chain_result.pending_task_key_start_ms {
+                    self.retarget_scheduled_task_key(
+                        &mut DbWriteBatcher::new(&self.db, &mut state.batch),
+                        tenant,
+                        job_id,
+                        attempt_number,
+                        task_key_start_ms,
+                    )
+                    .await?;
                 }
             }
             Ok(result) => {

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -4,6 +4,7 @@ use slatedb::WriteBatch;
 use slatedb::config::WriteOptions;
 
 use crate::codec::{DecodedTask, decode_task, encode_attempt, encode_holder, encode_lease};
+use crate::concurrency::ConcurrencyManager;
 use crate::dst_events::{self, DstEvent};
 use crate::fb::silo::fb;
 use crate::job::{JobStatus, JobStatusKind, JobView, Limit};
@@ -14,7 +15,6 @@ use crate::keys::{
     attempt_key, concurrency_holder_key, job_info_key, job_status_key, leased_task_key,
     parse_task_key,
 };
-use crate::concurrency::ConcurrencyManager;
 use crate::shard_range::ShardRange;
 use crate::task::{
     DEFAULT_LEASE_MS, HolderRecord, LeaseRecord, LeasedRefreshTask, LeasedTask, Task,
@@ -245,7 +245,10 @@ impl<'a> PendingHolderReleaseGuard<'a> {
     /// commit-success path so the dequeue body runs the existing
     /// `atomic_release` + `request_grant` loop itself.
     fn take_all(&mut self) -> Vec<(String, String, String)> {
-        self.pending.as_mut().map(std::mem::take).unwrap_or_default()
+        self.pending
+            .as_mut()
+            .map(std::mem::take)
+            .unwrap_or_default()
     }
 
     /// Neutralize the guard. Used at terminal exit paths (commit-failure /

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use crate::codec::{encode_job_info, encode_job_status};
 use crate::concurrency::RequestTicketOutcome;
 use crate::dst_events::{self, DstEvent};
-use crate::job::{JobInfo, JobStatus, Limit};
+use crate::job::{JobInfo, JobStatus, JobStatusKind, Limit};
 use crate::job_store_shard::JobStoreShard;
 use crate::job_store_shard::JobStoreShardError;
 use crate::job_store_shard::counters::encode_counter;
@@ -60,6 +60,17 @@ pub(crate) struct LimitTaskParams<'a> {
     pub skip_try_reserve: bool,
 }
 
+/// Result of walking a job's remaining limits.
+pub(crate) struct LimitTaskWriteResult {
+    /// In-memory grants made while walking the chain. Callers must roll these
+    /// back if their surrounding durable write fails.
+    pub grants: Vec<(String, String)>,
+    /// The task-key timestamp when this walk wrote a concrete DB task
+    /// (`RunAttempt`, `CheckRateLimit`, or future `RequestTicket`). `None`
+    /// means the walk parked on a durable concurrency request instead.
+    pub pending_task_key_start_ms: Option<i64>,
+}
+
 /// Canonical processing order for a job's limits: Concurrency first, then
 /// FloatingConcurrency, then RateLimit, stable within each kind. Returns
 /// indices into the caller-provided `limits` slice. A `Limit::Concurrency`
@@ -85,7 +96,9 @@ enum GrantResult {
     /// Slot granted immediately; caller should advance to the next limit.
     Granted,
     /// Not granted; a RequestTicket/request was written. Caller should return.
-    Queued,
+    Queued {
+        pending_task_key_start_ms: Option<i64>,
+    },
 }
 
 /// Process the outcome of a `handle_enqueue` call, updating shared loop state.
@@ -94,6 +107,7 @@ enum GrantResult {
 fn record_grant_outcome(
     outcome: Option<RequestTicketOutcome>,
     queue_key: &str,
+    task_key_start_ms: i64,
     grants: &mut Vec<(String, String)>,
     current_task_id: &str,
     current_held_queues: &mut Vec<String>,
@@ -123,13 +137,17 @@ fn record_grant_outcome(
             *current_index += 1;
             GrantResult::Granted
         }
-        Some(RequestTicketOutcome::TicketRequested { .. })
-        | Some(RequestTicketOutcome::FutureRequestTaskWritten { .. }) => {
+        Some(RequestTicketOutcome::TicketRequested { .. }) => {
             // Not granted - a request/RequestTicket was already written by
             // handle_enqueue. Stop processing further limits; remaining ones
             // will be applied when the queued request is granted later.
-            GrantResult::Queued
+            GrantResult::Queued {
+                pending_task_key_start_ms: None,
+            }
         }
+        Some(RequestTicketOutcome::FutureRequestTaskWritten { .. }) => GrantResult::Queued {
+            pending_task_key_start_ms: Some(task_key_start_ms),
+        },
     }
 }
 
@@ -429,6 +447,7 @@ impl JobStoreShard {
             },
         )
         .await
+        .map(|result| result.grants)
     }
 
     /// Complete an enqueue after successful write/commit and DST event emission.
@@ -470,7 +489,8 @@ impl JobStoreShard {
     /// For concurrency limits (regular and floating), this tries immediate grant as an
     /// optimization. If granted, it proceeds to the next limit (iteratively).
     ///
-    /// Returns a Vec of all grants made (queue, task_id) for potential rollback if DB write fails.
+    /// Returns all grants made for potential rollback if DB write fails, plus
+    /// the concrete task-key timestamp when this walk wrote a DB task.
     ///
     /// **Error semantics:** if the walk errors mid-chain (e.g. a db.get for
     /// floating-limit state fails between an immediate grant and the next
@@ -484,13 +504,16 @@ impl JobStoreShard {
         &self,
         writer: &mut W,
         params: LimitTaskParams<'_>,
-    ) -> Result<Vec<(String, String)>, JobStoreShardError> {
+    ) -> Result<LimitTaskWriteResult, JobStoreShardError> {
         // Save the tenant ref so we can roll back grants if walk_limit_chain errors.
         // (references are Copy, so this doesn't conflict with moving `params`.)
         let tenant_for_rollback: &str = params.tenant;
         let mut grants: Vec<(String, String)> = Vec::new();
         match self.walk_limit_chain(writer, params, &mut grants).await {
-            Ok(()) => Ok(grants),
+            Ok(pending_task_key_start_ms) => Ok(LimitTaskWriteResult {
+                grants,
+                pending_task_key_start_ms,
+            }),
             Err(e) => {
                 for (queue, task_id) in &grants {
                     self.concurrency
@@ -503,15 +526,17 @@ impl JobStoreShard {
 
     /// Inner loop body for `enqueue_limit_task_at_index`. Pushes successful
     /// in-memory grants to `grants` as it goes. Returns `Ok(())` on normal
-    /// completion (the caller hands `grants` back to its caller) or `Err(_)`
-    /// with `grants` containing whatever was accumulated up to the failure
-    /// point — the outer wrapper rolls those back before returning the error.
+    /// completion (the caller hands `grants` back to its caller), returning
+    /// the concrete task-key timestamp when the walk wrote a DB task, or
+    /// `Err(_)` with `grants` containing whatever was accumulated up to the
+    /// failure point — the outer wrapper rolls those back before returning the
+    /// error.
     async fn walk_limit_chain<W: WriteBatcher>(
         &self,
         writer: &mut W,
         params: LimitTaskParams<'_>,
         grants: &mut Vec<(String, String)>,
-    ) -> Result<(), JobStoreShardError> {
+    ) -> Result<Option<i64>, JobStoreShardError> {
         let LimitTaskParams {
             tenant,
             task_id,
@@ -573,7 +598,7 @@ impl JobStoreShard {
                     attempt_number,
                     &run_task,
                 )?;
-                return Ok(());
+                return Ok(Some(task_key_start_ms));
             }
 
             match &limits[order[current_index]] {
@@ -611,23 +636,24 @@ impl JobStoreShard {
                         crate::concurrency::ConcurrencyLimitType::Fixed,
                     );
 
-                    if matches!(
-                        record_grant_outcome(
-                            outcome,
-                            &cl.key,
-                            grants,
-                            &current_task_id,
-                            &mut current_held_queues,
-                            &mut current_index,
-                        ),
-                        GrantResult::Queued
+                    match record_grant_outcome(
+                        outcome,
+                        &cl.key,
+                        task_key_start_ms,
+                        grants,
+                        &current_task_id,
+                        &mut current_held_queues,
+                        &mut current_index,
                     ) {
-                        // No interim `task_key` write to clean up here:
-                        // `append_grant_edits` only writes the holder; the
-                        // `RunAttempt` task_key is written exclusively by the
-                        // terminal branch below, which we won't reach on this
-                        // return.
-                        return Ok(());
+                        GrantResult::Granted => {}
+                        GrantResult::Queued {
+                            pending_task_key_start_ms,
+                        } => {
+                            // No partial RunAttempt task is written before a
+                            // queued concurrency gate; if this was a future
+                            // RequestTicket, report its concrete task key.
+                            return Ok(pending_task_key_start_ms);
+                        }
                     }
                 }
 
@@ -696,21 +722,23 @@ impl JobStoreShard {
                         )?;
                     }
 
-                    if matches!(
-                        record_grant_outcome(
-                            outcome,
-                            &fl.key,
-                            grants,
-                            &current_task_id,
-                            &mut current_held_queues,
-                            &mut current_index,
-                        ),
-                        GrantResult::Queued
+                    match record_grant_outcome(
+                        outcome,
+                        &fl.key,
+                        task_key_start_ms,
+                        grants,
+                        &current_task_id,
+                        &mut current_held_queues,
+                        &mut current_index,
                     ) {
-                        // See the Conc-branch comment: `append_grant_edits`
-                        // doesn't write a `task_key` anymore, so there's
-                        // nothing here to clean up before returning.
-                        return Ok(());
+                        GrantResult::Granted => {}
+                        GrantResult::Queued {
+                            pending_task_key_start_ms,
+                        } => {
+                            // See the Concurrency branch comment: holder-only
+                            // grants continue, queued gates stop the walk.
+                            return Ok(pending_task_key_start_ms);
+                        }
                     }
                 }
 
@@ -739,7 +767,7 @@ impl JobStoreShard {
                         attempt_number,
                         &task,
                     )?;
-                    return Ok(());
+                    return Ok(Some(task_key_start_ms));
                 }
             }
         }
@@ -831,5 +859,42 @@ impl JobStoreShard {
         )?;
 
         Ok(())
+    }
+
+    /// Retarget a Scheduled job's pending-task timestamp to the concrete DB
+    /// task key written by a resumed limit chain.
+    ///
+    /// Status-based operations such as cancel, reimport, and direct lease
+    /// reconstruct the pending task key from `next_attempt_starts_after_ms`.
+    /// When a resumed chain deliberately writes at a fresh task-key timestamp
+    /// to dodge broker tombstones, this keeps those operations able to find
+    /// the task without falling back to a broad task scan.
+    pub(crate) async fn retarget_scheduled_task_key<W: WriteBatcher>(
+        &self,
+        writer: &mut W,
+        tenant: &str,
+        job_id: &str,
+        attempt_number: u32,
+        task_key_start_ms: i64,
+    ) -> Result<(), JobStoreShardError> {
+        let Some(old_raw) = writer.get(&job_status_key(tenant, job_id)).await? else {
+            return Ok(());
+        };
+        let old = decode_job_status_owned(&old_raw)?;
+        if old.kind != JobStatusKind::Scheduled
+            || old.current_attempt != Some(attempt_number)
+            || old.next_attempt_starts_after_ms == Some(task_key_start_ms)
+        {
+            return Ok(());
+        }
+
+        let new_status = JobStatus::new(
+            JobStatusKind::Scheduled,
+            old.changed_at_ms,
+            Some(task_key_start_ms),
+            old.current_attempt,
+        );
+        self.set_job_status_with_index(writer, tenant, job_id, new_status)
+            .await
     }
 }

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -298,7 +298,8 @@ impl JobStoreShard {
                         skip_try_reserve: false,
                     },
                 )
-                .await?;
+                .await?
+                .grants;
         }
 
         // Include counters in the transaction (unmark_write excludes them from conflict detection)
@@ -724,7 +725,8 @@ impl JobStoreShard {
                         skip_try_reserve: false,
                     },
                 )
-                .await?;
+                .await?
+                .grants;
         }
         // [SILO-REIMP-7] If terminal: status is terminal, no new tasks
 

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -270,7 +270,8 @@ impl JobStoreShard {
                                     skip_try_reserve: true,
                                 },
                             )
-                            .await?;
+                            .await?
+                            .grants;
 
                         // [SILO-RETRY-3] Set job status to Scheduled with next attempt time
                         let job_status =

--- a/src/job_store_shard/limit_chain.rs
+++ b/src/job_store_shard/limit_chain.rs
@@ -18,7 +18,9 @@ use slatedb::WriteBatch;
 
 use crate::concurrency::{ConcurrencyError, LimitChainResumer, ResumeChainParams};
 use crate::job_store_shard::helpers::DbWriteBatcher;
-use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
+use crate::job_store_shard::{
+    JobStoreShard, JobStoreShardError, LimitTaskParams, LimitTaskWriteResult,
+};
 
 pub(crate) struct ShardChainResumer {
     shard: Weak<JobStoreShard>,
@@ -73,7 +75,7 @@ impl LimitChainResumer for ShardChainResumer {
         // priority, job_id, attempt_number) are constant within a chain.
         let task_key_start_ms = now_ms.max(params.start_at_ms + 1);
         let mut writer = DbWriteBatcher::new(&shard.db, batch);
-        shard
+        let result = shard
             .enqueue_limit_task_at_index(
                 &mut writer,
                 LimitTaskParams {
@@ -94,8 +96,42 @@ impl LimitChainResumer for ShardChainResumer {
                 },
             )
             .await
-            .map_err(into_concurrency_error)
+            .map_err(into_concurrency_error)?;
+
+        if let Err(e) = retarget_if_concrete_task(&shard, &mut writer, &params, &result).await {
+            for (queue, task_id) in &result.grants {
+                shard
+                    .concurrency
+                    .rollback_grant(&params.tenant, queue, task_id);
+            }
+            return Err(into_concurrency_error(e));
+        }
+
+        Ok(result.grants)
     }
+}
+
+async fn retarget_if_concrete_task(
+    shard: &JobStoreShard,
+    writer: &mut DbWriteBatcher<'_>,
+    params: &ResumeChainParams,
+    result: &LimitTaskWriteResult,
+) -> Result<(), JobStoreShardError> {
+    let Some(task_key_start_ms) = result.pending_task_key_start_ms else {
+        return Ok(());
+    };
+    if task_key_start_ms == params.start_at_ms {
+        return Ok(());
+    }
+    shard
+        .retarget_scheduled_task_key(
+            writer,
+            &params.tenant,
+            &params.job_id,
+            params.attempt_number,
+            task_key_start_ms,
+        )
+        .await
 }
 
 fn into_concurrency_error(e: JobStoreShardError) -> ConcurrencyError {

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -542,6 +542,15 @@ impl JobStoreShard {
         // missed in-memory notifications or transient scanner failures.
         shard.spawn_concurrency_reconcile_task(range.clone());
 
+        // Reactive holder reconciler — wakes on `reconcile_notify` from a
+        // `PendingGrantGuard` / `PendingHolderReleaseGuard` Drop in dequeue
+        // and immediately reconciles. Sibling to the periodic task above; no
+        // jitter and no interval, so a dropped dequeue future un-wedges its
+        // queue within milliseconds rather than waiting up to one reconcile
+        // interval. The periodic task still runs `reconcile_pending_holders`
+        // on its tick as a safety net against missed notifications.
+        shard.spawn_holder_reconcile_task(range.clone());
+
         // Watch slatedb's status channel and emit prometheus metrics on each
         // change (durable_seq advances, manifest revisions). No-op when
         // metrics are disabled.
@@ -712,6 +721,41 @@ impl JobStoreShard {
         });
     }
 
+    /// Reactive holder reconciler — drains the per-task_id reconciliation
+    /// queue immediately on a `reconcile_notify` wake from a dropped
+    /// `PendingGrantGuard` / `PendingHolderReleaseGuard`. No jitter, no
+    /// periodic tick: a wedged queue (durable=0, in_mem=1 after the dequeue
+    /// future was cancelled around its commit) un-wedges as soon as Drop
+    /// runs. The periodic task (`spawn_concurrency_reconcile_task`) still
+    /// calls `reconcile_pending_holders` on its tick as a safety net.
+    fn spawn_holder_reconcile_task(self: &Arc<Self>, range: ShardRange) {
+        let shard = Arc::clone(self);
+        let cancellation = self.cancellation.clone();
+        let shard_name = self.name.clone();
+        let reconcile_notify = self.concurrency.reconcile_notify();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = reconcile_notify.notified() => {
+                        shard
+                            .concurrency
+                            .reconcile_pending_holders(&shard.db, &range)
+                            .await;
+                    }
+                    _ = cancellation.cancelled() => {
+                        tracing::debug!(
+                            shard = %shard_name,
+                            "stopping reactive holder reconciler (shard closing)"
+                        );
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
     fn spawn_concurrency_reconcile_task(self: &Arc<Self>, range: ShardRange) {
         let shard = Arc::clone(self);
         let cancellation = self.cancellation.clone();
@@ -753,9 +797,27 @@ impl JobStoreShard {
                 tokio::select! {
                     biased;
                     _ = interval.tick() => {
+                        // Holders first: the request scan can grant new slots,
+                        // and we want the in-memory holder set consistent
+                        // before that grant decision runs. This is the safety
+                        // net for any missed `reconcile_notify` wake; the
+                        // reactive `spawn_holder_reconcile_task` is the
+                        // primary low-latency path.
+                        shard
+                            .concurrency
+                            .reconcile_pending_holders(&shard.db, &range)
+                            .await;
                         shard
                             .concurrency
                             .reconcile_pending_requests(shard.db.as_ref(), &range)
+                            .await;
+                        // After draining, snapshot drift + pending-queue size
+                        // for prometheus. Cheap per tick (one ranged scan per
+                        // hydrated queue); the per-tick cadence keeps the
+                        // total cost bounded.
+                        shard
+                            .concurrency
+                            .report_holder_drift(&shard.db, &range)
                             .await;
                     }
                     _ = cancellation.cancelled() => {
@@ -884,6 +946,49 @@ impl JobStoreShard {
     /// (tenant, queue). Useful for tests and ad-hoc debugging.
     pub fn concurrency_holder_count(&self, tenant: &str, queue: &str) -> usize {
         self.concurrency.counts().holder_count(tenant, queue)
+    }
+
+    /// Whether a specific `task_id` is currently recorded as an in-memory
+    /// holder for `(tenant, queue)`. Test-only accessor used by the
+    /// four-quadrant reconciler test.
+    pub fn concurrency_contains_holder(
+        &self,
+        tenant: &str,
+        queue: &str,
+        task_id: &str,
+    ) -> bool {
+        self.concurrency.counts().contains_holder(tenant, queue, task_id)
+    }
+
+    /// Test-only: enqueue a `(tenant, queue, task_id)` for reconciliation.
+    /// Mirrors what `PendingHolderReleaseGuard::drop` does on cancellation,
+    /// so the four-quadrant test can drive the reconciler deterministically
+    /// without orchestrating a real dequeue future cancellation.
+    pub fn request_concurrency_reconciliation(
+        &self,
+        tenant: String,
+        queue: String,
+        task_id: String,
+    ) {
+        self.concurrency
+            .request_reconciliation(tenant, queue, task_id);
+    }
+
+    /// Test-only: insert an in-memory holder directly, used to set up the
+    /// "in_mem present, durable absent" ghost quadrant.
+    pub fn concurrency_insert_holder(&self, tenant: &str, queue: &str, task_id: &str) {
+        self.concurrency.counts().insert_holder(tenant, queue, task_id);
+    }
+
+    /// Test-only: drain pending reconciliations and apply them now. The
+    /// production path goes through `spawn_holder_reconcile_task` woken via
+    /// `reconcile_notify`; this synchronous entry point lets tests assert
+    /// post-state without a sleep race.
+    pub async fn reconcile_pending_holders_for_test(&self) {
+        let range = self.get_range();
+        self.concurrency
+            .reconcile_pending_holders(&self.db, &range)
+            .await;
     }
     /// Get the SlateDB metrics registry for this shard.
     /// Use this to collect storage-level statistics for observability.

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -26,7 +26,7 @@ pub use import::JobNotReimportableError;
 pub use lease_task::JobNotLeaseableError;
 pub use restart::JobNotRestartableError;
 
-pub(crate) use enqueue::LimitTaskParams;
+pub(crate) use enqueue::{LimitTaskParams, LimitTaskWriteResult, limit_processing_order};
 use helpers::DbWriteBatcher;
 use helpers::WriteBatcher;
 pub use helpers::now_epoch_ms;

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -951,13 +951,10 @@ impl JobStoreShard {
     /// Whether a specific `task_id` is currently recorded as an in-memory
     /// holder for `(tenant, queue)`. Test-only accessor used by the
     /// four-quadrant reconciler test.
-    pub fn concurrency_contains_holder(
-        &self,
-        tenant: &str,
-        queue: &str,
-        task_id: &str,
-    ) -> bool {
-        self.concurrency.counts().contains_holder(tenant, queue, task_id)
+    pub fn concurrency_contains_holder(&self, tenant: &str, queue: &str, task_id: &str) -> bool {
+        self.concurrency
+            .counts()
+            .contains_holder(tenant, queue, task_id)
     }
 
     /// Test-only: enqueue a `(tenant, queue, task_id)` for reconciliation.
@@ -977,7 +974,9 @@ impl JobStoreShard {
     /// Test-only: insert an in-memory holder directly, used to set up the
     /// "in_mem present, durable absent" ghost quadrant.
     pub fn concurrency_insert_holder(&self, tenant: &str, queue: &str, task_id: &str) {
-        self.concurrency.counts().insert_holder(tenant, queue, task_id);
+        self.concurrency
+            .counts()
+            .insert_holder(tenant, queue, task_id);
     }
 
     /// Test-only: drain pending reconciliations and apply them now. The

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -132,6 +132,17 @@ pub struct Metrics {
     concurrency_holders_cache_holders: GaugeVec,
     concurrency_holders_cache_queues: GaugeVec,
     concurrency_holders_cache_hydrated_queues: GaugeVec,
+    /// Sum of `|in_memory_holders - durable_holders|` across hydrated queues.
+    /// A non-zero value means a reconciler tick observed a drift between the
+    /// authoritative durable holder rows and the in-memory `holders` set —
+    /// the same signal that, if left to persist, would manifest as a wedge
+    /// (the 300/300 production case).
+    concurrency_holder_drift: GaugeVec,
+    /// Count of `(tenant, queue, task_id)` tuples currently queued for the
+    /// per-task_id reconciler (drained on each tick + on `reconcile_notify`).
+    /// Steady-state expected to be 0; sustained growth means the reconciler
+    /// is stuck (slatedb unavailable, etc.).
+    concurrency_reconciliation_pending: GaugeVec,
 
     // SlateDB watcher metrics (driven by Db::subscribe)
     slatedb_durable_seq: GaugeVec,
@@ -451,6 +462,25 @@ impl Metrics {
         self.concurrency_holders_cache_hydrated_queues
             .with_label_values(&[shard])
             .set(stats.hydrated_queue_count as f64);
+    }
+
+    /// Update per-shard reconciler signal gauges:
+    /// * `drift` = sum of |in_memory - durable| holder counts across hydrated
+    ///   queues, computed at the end of each periodic reconciler tick.
+    /// * `pending` = current size of the per-task_id reconciliation queue.
+    ///
+    /// Non-zero `drift` or sustained-non-zero `pending` indicates the
+    /// reconciler is observing inconsistency between in-memory and durable
+    /// holder state — the same signal that, if it grows, manifests as the
+    /// production queue wedge. Pair with an alert that fires if either
+    /// remains non-zero across multiple scrape intervals.
+    pub fn set_concurrency_reconciler_signals(&self, shard: &str, drift: u64, pending: u64) {
+        self.concurrency_holder_drift
+            .with_label_values(&[shard])
+            .set(drift as f64);
+        self.concurrency_reconciliation_pending
+            .with_label_values(&[shard])
+            .set(pending as f64);
     }
 
     /// Update SlateDB storage metrics from a shard's StatRegistry.
@@ -1253,6 +1283,28 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let concurrency_holder_drift = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_concurrency_holder_drift",
+                "Per-shard sum of |in_memory - durable| holder counts across hydrated queues, observed at the last reconciler tick. Non-zero = drift the reconciler will release; sustained non-zero means the reconciler is stuck.",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_reconciliation_pending = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_concurrency_reconciliation_pending",
+                "Number of (tenant, queue, task_id) tuples awaiting per-task_id reconciliation against durable holder rows. Steady-state expected 0; sustained > 0 means the reconciler is wedged.",
+            ),
+            &["shard"],
+        )?,
+    );
+
     // SlateDB watcher metrics (driven by Db::subscribe)
     let slatedb_durable_seq = register(
         &registry,
@@ -1354,6 +1406,8 @@ pub fn init() -> anyhow::Result<Metrics> {
         concurrency_holders_cache_holders,
         concurrency_holders_cache_queues,
         concurrency_holders_cache_hydrated_queues,
+        concurrency_holder_drift,
+        concurrency_reconciliation_pending,
         slatedb_durable_seq,
         slatedb_manifest_revisions,
         slatedb_manifest_last_l0_seq,

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -1357,3 +1357,424 @@ async fn steady_state_zero_holders_under_mixed_workload() {
     // referenced after construction; explicitly drop it here for clarity.
     let _ = MockGubernatorClient::new_arc();
 }
+
+/// Regression for the "stranded inflight task → orphaned holder" defect that
+/// `e6660cd` ("Clear up stranded inflight tasks with drop guard") targets.
+///
+/// Failure shape this reproduces:
+///   1. A concurrency-limited job is enqueued. `handle_enqueue` grants the slot
+///      immediately: `append_grant_edits` writes the durable holder in the SAME
+///      batch as the terminal `RunAttempt` task. Holder committed, task durable.
+///   2. A worker dequeues the `RunAttempt`. `claim_ready` moves the task into the
+///      broker's in-memory `inflight` set. Then, under worker overload, the
+///      `LeaseTasks` RPC future is *cancelled* (deadline / disconnect / drop)
+///      before the lease is durably written.
+///   3. Without the drop guard the task is stranded in `inflight` forever (no
+///      TTL): the scanner skips inflight keys, so the `RunAttempt` is never
+///      re-leased — yet the holder from step 1 keeps consuming the slot. That's
+///      the leak: holder committed, task consumed, no lease ever appears.
+///
+/// The guard closes this by releasing the claimed key from `inflight` on drop
+/// (without re-buffering), so the DB scanner — which still sees the un-deleted
+/// task key — re-adds it and a later dequeue leases it exactly once. This test
+/// drives the *real* `dequeue` future, cancels it mid-flight right after the
+/// claim, and asserts the task recovers and the holder never leaks.
+///
+/// If the guard regresses, the recovery loop below never re-leases the task and
+/// the `expect` fires with "never re-leased — holder orphaned".
+#[silo::test]
+async fn dropped_dequeue_future_does_not_orphan_holder() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "drop-guard-q";
+
+    // (1) Enqueue a Concurrency(max=1) job. The slot is free, so the grant is
+    // immediate: holder + RunAttempt land together in the enqueue batch.
+    let _job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![conc_limit(queue, 1)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "concurrency grant should write a holder at enqueue time"
+    );
+    assert_eq!(
+        shard.concurrency_holder_count(tenant, queue),
+        1,
+        "in-memory holder reservation should exist after the immediate grant"
+    );
+
+    // Wait for the background scanner to buffer the RunAttempt so the dequeue's
+    // first `claim_ready` is synchronous — guaranteeing the single poll below
+    // claims the task (moves it into `inflight`) before parking on an await.
+    let buffered = poll_until(|| async { shard.broker_buffer_len() }, |n| *n >= 1, 2_000).await;
+    assert!(buffered >= 1, "scanner should buffer the RunAttempt task");
+
+    // (2) Drive the real dequeue future, poll it exactly once, then drop it.
+    // The first poll claims the task synchronously — `claim_ready` moves the key
+    // into the broker's `inflight` set — then parks awaiting durability. The
+    // future is then dropped (cancelled RPC), which must run
+    // `ClaimedInflightGuard::drop`.
+    {
+        let mut fut = Box::pin(shard.dequeue("w-overloaded", "default", 1));
+        let polled = futures::poll!(fut.as_mut());
+        assert!(
+            polled.is_pending(),
+            "single poll must leave the dequeue mid-flight (claimed, not yet acked); \
+             got a ready result instead, so the cancellation window was not exercised"
+        );
+        // While the future is alive and parked, the claimed key is in-flight.
+        assert_eq!(
+            shard.broker_inflight_len("default"),
+            1,
+            "the claimed RunAttempt must be in-flight while the dequeue is mid-flight"
+        );
+        drop(fut); // ClaimedInflightGuard::drop → release_inflight(key)
+    }
+
+    // PRIMARY REGRESSION ASSERTION (deterministic): dropping the dequeue future
+    // must have released the claimed key from the in-flight set. Without the
+    // drop guard (e6660cd) the key is stranded here forever — the scanner skips
+    // in-flight keys, so the RunAttempt is never re-leased and its holder leaks.
+    assert_eq!(
+        shard.broker_inflight_len("default"),
+        0,
+        "cancelled dequeue left the claimed task stranded in-flight — drop guard regression; \
+         the holder it backs can never be re-leased and is orphaned"
+    );
+
+    // Holder is still committed from enqueue and must NOT have been doubled or
+    // dropped by the cancellation.
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "holder count must stay at exactly 1 across the cancellation"
+    );
+
+    // (3) Recovery: a subsequent dequeue must re-lease the stranded task. With a
+    // broken/absent guard the task is stuck in `inflight`, the scanner never
+    // re-adds it, and this loop never finds a lease.
+    let mut recovered_task_id: Option<String> = None;
+    for _ in 0..50 {
+        let res = shard
+            .dequeue("w-healthy", "default", 1)
+            .await
+            .expect("recovery dequeue");
+        if let Some(t) = res.tasks.first() {
+            recovered_task_id = Some(t.attempt().task_id().to_string());
+            break;
+        }
+        // Tolerate the ambiguous case where the cancelled write actually landed:
+        // a lease may already exist even though the future was dropped.
+        if let Some((_, lease_val)) = first_lease_kv(shard.db()).await {
+            if let Ok(Task::RunAttempt { id, .. }) =
+                decode_lease(lease_val).expect("decode lease").to_task()
+            {
+                recovered_task_id = Some(id);
+                break;
+            }
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+    }
+
+    let task_id = recovered_task_id.expect(
+        "dropped RunAttempt was never re-leased — the holder is orphaned (no task, no lease, \
+         yet the concurrency slot stays consumed). This is the stranded-inflight holder leak \
+         the e6660cd drop guard must prevent.",
+    );
+
+    // Exactly one holder backs the (now re-leased) task — no phantom duplicate.
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "re-lease must reuse the original holder, not mint a second one"
+    );
+
+    // (4) Completing the job releases the holder — proving it was never orphaned
+    // and the slot is reclaimable.
+    shard
+        .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report success");
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "durable holder must be released once the recovered job completes"
+    );
+    assert_eq!(
+        shard.concurrency_holder_count(tenant, queue),
+        0,
+        "in-memory holder reservation must also drain to zero — no slot leak"
+    );
+}
+
+/// PRODUCTION WEDGE REPRODUCTION — an in-memory concurrency holder that the
+/// dequeue drop guard does NOT release, permanently consuming a queue's cap.
+///
+/// A concurrency holder has two halves: a durable KV row (prefix 0x09) AND an
+/// in-memory reservation (`ConcurrencyCounts`, a per-(tenant,queue) set of
+/// task_ids). `try_reserve`/`process_grants` gate admission on the IN-MEMORY
+/// count, so an in-memory reservation with no durable backing silently steals a
+/// slot forever (nothing durable for cancel/reap/expiry to key a release off,
+/// and hydration only ever *inserts*). Accumulate enough — prod hit 300/300 for
+/// env-10000215255 — and the queue wedges while ~1M requesters starve.
+///
+/// The drop guard `ClaimedInflightGuard` (e6660cd) only rolls back the broker's
+/// `inflight` set; it has no reference to `self.concurrency`. So any in-memory
+/// holder bookkeeping that lives in `dequeue`'s post-commit tail is lost when
+/// the future is cancelled. This test pins the cleanest, deterministic instance:
+///
+///   `handle_run_attempt` for a RunAttempt whose `job_info` is gone deletes the
+///   held concurrency holder *in the committed batch* but performs the matching
+///   in-memory `atomic_release` only afterwards, in `dequeue`'s post-commit loop
+///   (dequeue.rs ~334-339). `write_with_options` applies the batch to the WAL on
+///   its first poll, so the durable delete lands even if the future is then
+///   dropped — but the post-commit `atomic_release` never runs. Net: durable
+///   holder gone, in-memory reservation retained = a ghost that wedges the queue.
+///
+/// The sibling on the *grant* side (handle_request_ticket's `try_reserve` not
+/// rolled back on drop) produces the same ghost when the commit doesn't land;
+/// it needs a genuinely-pending pre-commit await (a cold hydration scan over a
+/// large queue in prod) to hit, so it isn't deterministic in the warm test DB.
+/// Both share one root cause and one fix: roll back in-memory concurrency state
+/// on the dequeue future-drop path, exactly as the error/commit-failure paths do.
+///
+/// This test cancels the real `dequeue` future at the commit and asserts the
+/// queue is NOT wedged. It FAILS on current code (durable=0 but in-memory=1),
+/// reproducing the leak; it passes once the drop path releases in-memory holders.
+///
+/// Fixed: a pair of layered RAII guards (`PendingHolderReleaseGuard` and
+/// `PendingGrantGuard` in `src/job_store_shard/dequeue.rs`, sibling to the
+/// pre-existing `ClaimedInflightGuard`) now own the iteration's in-memory
+/// holder-release and grant-bump tuples. On dequeue-future drop their `Drop`
+/// enqueues each `(tenant, queue, task_id)` onto
+/// `ConcurrencyManager::request_reconciliation`; the periodic reconciler
+/// (`spawn_concurrency_reconcile_task`, woken sub-tick by `reconcile_notify`)
+/// point-looks-up the durable holder row, observes durable=0/in_mem=1, and
+/// calls `atomic_release` + `request_grant`. The queue un-wedges before the
+/// test's recovery dequeue loop expires.
+#[tokio::test]
+async fn dropped_dequeue_future_skips_inmemory_holder_release_and_wedges_queue() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "wedge-q";
+    let task_group = "default";
+
+    // Enqueue a Concurrency(max=1) job: holder granted at enqueue (in-memory +
+    // durable), and a RunAttempt carrying held_queues=[queue] is written.
+    let job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![conc_limit(queue, 1)],
+            None,
+            task_group,
+        )
+        .await
+        .expect("enqueue");
+
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1, "durable holder at enqueue");
+    assert_eq!(shard.concurrency_holder_count(tenant, queue), 1, "in-memory holder at enqueue");
+
+    // The job_info row disappears before the worker dequeues (migration / cleanup
+    // race / partial restore). `handle_run_attempt` will take the missing-job
+    // branch: delete the task AND the held concurrency holder in the batch, then
+    // (post-commit) `atomic_release` the in-memory slot.
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.delete(&job_info_key(tenant, &job_id));
+        shard.db().write(batch).await.expect("delete job_info");
+        shard.db().flush().await.expect("flush");
+    }
+
+    // Wait for the scanner to buffer the RunAttempt.
+    let buffered = poll_until(|| async { shard.broker_buffer_len() }, |n| *n >= 1, 5_000).await;
+    assert!(buffered >= 1, "scanner should buffer the RunAttempt");
+
+    // Drive the real dequeue future to the commit, then cancel it there.
+    //
+    // We poll with `yield_now` (which does NOT advance the paused clock), so the
+    // 10ms flush timer never fires and the `write_with_options` await stays
+    // pending — the future parks exactly at the commit with the batch already
+    // applied to the WAL. Dropping there is the overloaded-worker RPC cancel.
+    {
+        let mut fut = Box::pin(shard.dequeue("w-overloaded", task_group, 1));
+        for _ in 0..500 {
+            let polled = futures::poll!(fut.as_mut());
+            assert!(
+                polled.is_pending(),
+                "dequeue completed before we could cancel it at the commit"
+            );
+            tokio::task::yield_now().await;
+        }
+        drop(fut); // cancel at the commit await; the post-commit atomic_release never runs
+    }
+
+    // Let the flush land the buffered batch (durable holder delete).
+    let durable = poll_until(
+        || async { count_concurrency_holders(shard.db()).await },
+        |n| *n == 0,
+        5_000,
+    )
+    .await;
+
+    // The committed batch's durable delete landed during the parked
+    // `write_with_options.await`. Pre-fix, the in-memory `atomic_release`
+    // only ran in dequeue's post-commit loop — which the cancelled future
+    // skipped — so in_mem stayed at 1 (a "ghost") and wedged the queue.
+    //
+    // Post-fix, the `PendingHolderReleaseGuard`'s Drop queues a
+    // reconciliation request; the reactive `spawn_holder_reconcile_task`
+    // wakes on `reconcile_notify`, point-looks-up the durable row (gone),
+    // and `atomic_release`s the ghost. The reactive task is a sibling
+    // tokio::spawn, so its run is concurrent with this test thread —
+    // depending on the runtime's scheduling decision the in-memory count
+    // read here may be 0 (reconciler already ran) or 1 (still queued).
+    // Either is correct as long as the queue un-wedges before the
+    // recovery dequeue loop below times out.
+    assert_eq!(durable, 0, "durable holder should be deleted by the committed batch");
+
+    // The slot must not stay wedged: a fresh Concurrency(max=1) job on the
+    // same queue must be grantable once the reconciler has released the
+    // ghost (or immediately if it already had).
+    let _job2 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![conc_limit(queue, 1)],
+            None,
+            task_group,
+        )
+        .await
+        .expect("enqueue job2");
+
+    let mut job2_leased = false;
+    for _ in 0..50 {
+        let res = shard.dequeue("w2", task_group, 1).await.expect("dequeue job2");
+        if !res.tasks.is_empty() {
+            job2_leased = true;
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+    }
+
+    assert!(
+        job2_leased,
+        "QUEUE WEDGED: the ghost in-memory holder is still occupying the only slot \
+         (durable={durable}, in_mem={final_inmem}) — pre-fix this was permanent, lasting \
+         until process restart; with the fix the reactive holder reconciler should have \
+         released it within the recovery loop's 1s budget.",
+        final_inmem = shard.concurrency_holder_count(tenant, queue),
+    );
+
+    // After job2 leases, in-memory count is 1 again (job2's own grant) but
+    // the ghost is provably gone (because admission was granted). The
+    // wedge is cleared.
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "exactly one durable holder (job2's) — the ghost left no trace"
+    );
+}
+
+/// Direct exercise of `ConcurrencyManager::reconcile_pending_holders` over
+/// all four (durable, in_memory) quadrants. Drives the reconciler via the
+/// test accessor on `JobStoreShard` so the assertions hold without racing a
+/// background task.
+#[tokio::test]
+async fn reconcile_pending_holders_four_quadrants() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "quadrants-q";
+
+    // Force per-queue hydration before the reconciler runs, so
+    // `contains_holder` reads against a Hydrated entry rather than a
+    // NotHydrated one (whose presence/absence semantics differ).
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(
+            &concurrency_holder_key(tenant, queue, "hydrate-seed"),
+            &encode_holder(&silo::task::HolderRecord { granted_at_ms: 0 }),
+        );
+        shard.db().write(batch).await.expect("seed write");
+        shard.db().flush().await.expect("flush seed");
+    }
+
+    // Quadrant 1: durable=Y, in_mem=Y — both present.
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(
+            &concurrency_holder_key(tenant, queue, "task-both"),
+            &encode_holder(&silo::task::HolderRecord { granted_at_ms: 0 }),
+        );
+        shard.db().write(batch).await.expect("durable write");
+        shard.db().flush().await.expect("flush");
+    }
+    shard.concurrency_insert_holder(tenant, queue, "task-both");
+
+    // Quadrant 2: durable=N, in_mem=N — both absent. No setup needed.
+
+    // Quadrant 3: durable=Y, in_mem=N — mirror case (commit landed but the
+    // in-memory entry was somehow lost).
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(
+            &concurrency_holder_key(tenant, queue, "task-durable-only"),
+            &encode_holder(&silo::task::HolderRecord { granted_at_ms: 0 }),
+        );
+        shard.db().write(batch).await.expect("durable-only write");
+        shard.db().flush().await.expect("flush");
+    }
+
+    // Quadrant 4: durable=N, in_mem=Y — the ghost, the wedge bug.
+    shard.concurrency_insert_holder(tenant, queue, "task-ghost");
+
+    // Enqueue all four for reconciliation.
+    for tid in ["task-both", "task-neither", "task-durable-only", "task-ghost"] {
+        shard.request_concurrency_reconciliation(
+            tenant.to_string(),
+            queue.to_string(),
+            tid.to_string(),
+        );
+    }
+
+    shard.reconcile_pending_holders_for_test().await;
+
+    assert!(
+        shard.concurrency_contains_holder(tenant, queue, "task-both"),
+        "Q1 (durable=Y, in_mem=Y): reconciler must leave consistent state alone"
+    );
+    assert!(
+        !shard.concurrency_contains_holder(tenant, queue, "task-neither"),
+        "Q2 (durable=N, in_mem=N): reconciler must leave consistent state alone"
+    );
+    assert!(
+        shard.concurrency_contains_holder(tenant, queue, "task-durable-only"),
+        "Q3 (durable=Y, in_mem=N): reconciler must re-insert to match durable"
+    );
+    assert!(
+        !shard.concurrency_contains_holder(tenant, queue, "task-ghost"),
+        "Q4 (durable=N, in_mem=Y): reconciler must release the ghost — the wedge fix"
+    );
+}

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -5,7 +5,7 @@
 
 mod test_helpers;
 
-use silo::codec::{decode_lease, encode_holder, encode_lease, encode_task};
+use silo::codec::{decode_lease, decode_task, encode_holder, encode_lease, encode_task};
 use silo::job::{ConcurrencyLimit, FloatingConcurrencyLimit, JobStatusKind, Limit};
 use silo::job_attempt::AttemptOutcome;
 use silo::job_store_shard::JobStoreShardError;
@@ -23,6 +23,32 @@ fn fc_limit(queue: &str, default_max: u32) -> Limit {
         refresh_interval_ms: 60_000,
         metadata: vec![],
     })
+}
+
+async fn find_task_for_job(
+    db: &silo::instrumented_db::InstrumentedDb,
+    job_id: &str,
+) -> Option<Task> {
+    let start = silo::keys::tasks_prefix();
+    let end = silo::keys::end_bound(&start);
+    let mut iter = db.scan::<Vec<u8>, _>(start..end).await.ok()?;
+    while let Ok(Some(kv)) = iter.next().await {
+        if let Ok(task) = decode_task(&kv.value)
+            && task_job_id(&task) == Some(job_id)
+        {
+            return Some(task);
+        }
+    }
+    None
+}
+
+fn task_job_id(task: &Task) -> Option<&str> {
+    match task {
+        Task::RunAttempt { job_id, .. }
+        | Task::RequestTicket { job_id, .. }
+        | Task::CheckRateLimit { job_id, .. } => Some(job_id),
+        Task::RefreshFloatingLimit { .. } => None,
+    }
 }
 
 /// Force the worker's lease for `task_id` to be already expired by rewriting the
@@ -716,7 +742,7 @@ async fn resume_chain_writes_run_attempt_at_now_not_original_start_at_ms() {
     // Job B has no slot to take — it queues as a concurrency request and the
     // chain walker drops its interim RunAttempt at `task_key(original_enqueue_ms, …)`
     // in the same batch as the request write.
-    let _job_b = shard
+    let job_b = shard
         .enqueue(
             tenant,
             None,
@@ -805,6 +831,32 @@ async fn resume_chain_writes_run_attempt_at_now_not_original_start_at_ms() {
          ({}), so any tombstone planted at that key would silently suppress this \
          task — exactly the leak the fix is meant to prevent.",
         original_enqueue_ms,
+    );
+
+    let b_status = shard
+        .get_job_status(tenant, &job_b)
+        .await
+        .expect("load job B status")
+        .expect("job B status exists");
+    assert_eq!(b_status.kind, JobStatusKind::Scheduled);
+    assert_eq!(
+        b_status.next_attempt_starts_after_ms,
+        Some(b_start as i64),
+        "Scheduled status must point at the retargeted resumed RunAttempt key"
+    );
+
+    shard
+        .cancel_job(tenant, &job_b)
+        .await
+        .expect("cancel retargeted job B");
+    assert!(
+        find_task_for_job(shard.db(), &job_b).await.is_none(),
+        "cancel must find and delete the resumed RunAttempt via status-derived task key"
+    );
+    assert_eq!(
+        count_concurrency_holders_for_tenant(shard.db(), tenant).await,
+        0,
+        "cancel must release the holder created by the grant scanner"
     );
 }
 

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -1590,8 +1590,16 @@ async fn dropped_dequeue_future_skips_inmemory_holder_release_and_wedges_queue()
         .await
         .expect("enqueue");
 
-    assert_eq!(count_concurrency_holders(shard.db()).await, 1, "durable holder at enqueue");
-    assert_eq!(shard.concurrency_holder_count(tenant, queue), 1, "in-memory holder at enqueue");
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "durable holder at enqueue"
+    );
+    assert_eq!(
+        shard.concurrency_holder_count(tenant, queue),
+        1,
+        "in-memory holder at enqueue"
+    );
 
     // The job_info row disappears before the worker dequeues (migration / cleanup
     // race / partial restore). `handle_run_attempt` will take the missing-job
@@ -1649,7 +1657,10 @@ async fn dropped_dequeue_future_skips_inmemory_holder_release_and_wedges_queue()
     // read here may be 0 (reconciler already ran) or 1 (still queued).
     // Either is correct as long as the queue un-wedges before the
     // recovery dequeue loop below times out.
-    assert_eq!(durable, 0, "durable holder should be deleted by the committed batch");
+    assert_eq!(
+        durable, 0,
+        "durable holder should be deleted by the committed batch"
+    );
 
     // The slot must not stay wedged: a fresh Concurrency(max=1) job on the
     // same queue must be grantable once the reconciler has released the
@@ -1671,7 +1682,10 @@ async fn dropped_dequeue_future_skips_inmemory_holder_release_and_wedges_queue()
 
     let mut job2_leased = false;
     for _ in 0..50 {
-        let res = shard.dequeue("w2", task_group, 1).await.expect("dequeue job2");
+        let res = shard
+            .dequeue("w2", task_group, 1)
+            .await
+            .expect("dequeue job2");
         if !res.tasks.is_empty() {
             job2_leased = true;
             break;
@@ -1751,7 +1765,12 @@ async fn reconcile_pending_holders_four_quadrants() {
     shard.concurrency_insert_holder(tenant, queue, "task-ghost");
 
     // Enqueue all four for reconciliation.
-    for tid in ["task-both", "task-neither", "task-durable-only", "task-ghost"] {
+    for tid in [
+        "task-both",
+        "task-neither",
+        "task-durable-only",
+        "task-ghost",
+    ] {
         shard.request_concurrency_reconciliation(
             tenant.to_string(),
             queue.to_string(),

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -3861,6 +3861,193 @@ async fn grant_scanner_hydrates_legacy_request_without_task_id_or_limits() {
     );
 }
 
+/// `grant_scanner_recovers_held_queues_for_legacy_request_with_upstream_holders`:
+/// when a pre-unify-chain request value (no `held_queues`, no `task_id`, no
+/// `limits`) is resumed by the grant scanner, the upstream-holder probe added
+/// by the legacy fallback must rediscover any concurrency slots already held
+/// under the recovered task_id. Without the probe the resumed `RunAttempt`
+/// carries only the just-granted queue in its `held_queues`, and completion
+/// / cancel leaks the earlier slots.
+#[silo::test]
+async fn grant_scanner_recovers_held_queues_for_legacy_request_with_upstream_holders() {
+    use silo::codec::{decode_concurrency_action, encode_holder};
+    use silo::task::HolderRecord;
+
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+    let queue_a = "legacy-upstream-a".to_string();
+    let queue_b = "legacy-upstream-b".to_string();
+
+    let limits = vec![
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: queue_a.clone(),
+            max_concurrency: 100,
+        }),
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: queue_b.clone(),
+            max_concurrency: 1,
+        }),
+    ];
+
+    // Job1 grabs Q_B's single slot. Q_A has slack so job2 can also grab Q_A.
+    let job1 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            limits.clone(),
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue job1");
+
+    let leased1 = shard
+        .dequeue("w1", "default", 1)
+        .await
+        .expect("dequeue job1")
+        .tasks;
+    assert_eq!(leased1.len(), 1);
+    assert_eq!(leased1[0].job().id(), job1);
+    let job1_task_id = leased1[0].attempt().task_id().to_string();
+
+    // Job2 acquires Q_A (slot 2/100), then queues at Q_B.
+    let job2 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            limits.clone(),
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue job2");
+
+    let (request_key, request_val) = first_concurrency_request_kv(shard.db())
+        .await
+        .expect("job2 should have a queued Q_B request");
+    let parsed_req =
+        silo::keys::parse_concurrency_request_key(&request_key).expect("request key should parse");
+    assert_eq!(parsed_req.job_id, job2);
+    assert_eq!(parsed_req.queue, queue_b);
+    let legacy_task_id = parsed_req.request_id();
+
+    // Pull job2's modern chain task_id out of the request value (the holder
+    // for Q_A is keyed under this id today). Then move that holder to a key
+    // matching `parsed_req.request_id()`, the id our legacy fallback derives.
+    let modern_task_id = {
+        let decoded = decode_concurrency_action(request_val).expect("decode action");
+        let a = decoded.fb();
+        let et = a
+            .variant_as_enqueue_task()
+            .expect("request variant is EnqueueTask");
+        et.task_id().expect("modern value has task_id").to_string()
+    };
+    assert_ne!(
+        modern_task_id, legacy_task_id,
+        "test relies on the modern chain task_id differing from the request-key request_id"
+    );
+    assert_ne!(modern_task_id, job1_task_id);
+
+    let modern_q_a_holder = concurrency_holder_key(tenant, &queue_a, &modern_task_id);
+    assert!(
+        shard
+            .db()
+            .get(&modern_q_a_holder)
+            .await
+            .expect("get modern Q_A holder")
+            .is_some(),
+        "Q_A holder should exist under job2's modern chain task_id"
+    );
+
+    // Rekey job2's Q_A holder to the legacy task_id, in both DB and the
+    // in-memory concurrency cache.
+    shard
+        .db()
+        .delete(&modern_q_a_holder)
+        .await
+        .expect("delete modern Q_A holder");
+    shard
+        .db()
+        .put(
+            &concurrency_holder_key(tenant, &queue_a, &legacy_task_id),
+            &encode_holder(&HolderRecord { granted_at_ms: now }),
+        )
+        .await
+        .expect("seed legacy Q_A holder");
+    let reserved = shard
+        .force_reserve_concurrency_for_test(tenant, &queue_a, &legacy_task_id, 100)
+        .await;
+    assert!(
+        reserved,
+        "in-memory reservation for legacy Q_A holder should succeed"
+    );
+
+    // Overwrite job2's Q_B request value with the pre-unify schema shape:
+    // task_id / held_queues / limits are absent.
+    let legacy_value = encode_legacy_enqueue_task_value(&parsed_req, "default");
+    shard
+        .db()
+        .put(&request_key, &legacy_value)
+        .await
+        .expect("overwrite request with legacy value");
+
+    // Complete job1, freeing Q_B and waking the grant scanner.
+    shard
+        .report_attempt_outcome(&job1_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("complete job1");
+
+    // Wait for job2's resumed RunAttempt.
+    let mut leased2 = Vec::new();
+    for _ in 0..50 {
+        leased2 = shard
+            .dequeue("w2", "default", 1)
+            .await
+            .expect("dequeue job2")
+            .tasks;
+        if !leased2.is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert_eq!(leased2.len(), 1, "legacy request should be granted");
+    assert_eq!(leased2[0].job().id(), job2);
+
+    let job2_task_id = leased2[0].attempt().task_id().to_string();
+    assert_eq!(
+        job2_task_id, legacy_task_id,
+        "resumed chain must reuse the recovered task_id so probed holders match"
+    );
+
+    // Completing job2 must release both Q_A and Q_B. Without the probe, only
+    // Q_B would be released and Q_A would stay populated under
+    // `legacy_task_id`.
+    shard
+        .report_attempt_outcome(&job2_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("complete job2");
+
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_a).await,
+        0,
+        "Q_A holder must be released via the probed held_queues",
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_b).await,
+        0,
+        "Q_B holder must be released by the completed chain",
+    );
+}
+
 async fn find_task_key_and_task_for_tenant(
     db: &silo::instrumented_db::InstrumentedDb,
     tenant: &str,

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -1,7 +1,9 @@
 mod test_helpers;
 
 use silo::codec::{decode_task, encode_concurrency_action};
-use silo::job::{GubernatorAlgorithm, GubernatorRateLimit, Limit, RateLimitRetryPolicy};
+use silo::job::{
+    GubernatorAlgorithm, GubernatorRateLimit, JobStatusKind, Limit, RateLimitRetryPolicy,
+};
 use silo::job_attempt::AttemptOutcome;
 use silo::keys::concurrency_holder_key;
 use silo::retry::RetryPolicy;
@@ -3625,7 +3627,7 @@ async fn deferred_concurrency_resumes_into_rate_limit() {
     // Job 2: [A(cap=2), B(cap=1), RateLimit]. Conc-A still has a slot, so the
     // chain grants A immediately; B is full so it defers via a
     // concurrency_request_key. The chain does NOT reach RateLimit yet.
-    let _job2 = shard
+    let job2 = shard
         .enqueue(
             tenant,
             None,
@@ -3679,19 +3681,30 @@ async fn deferred_concurrency_resumes_into_rate_limit() {
     // Poll for the CheckRateLimit task. Pre-fix the scanner would have
     // written a RunAttempt and bypassed the rate limit — that assertion
     // below would fail with `RunAttempt` instead.
-    let mut check_rl: Option<Task> = None;
+    let mut check_rl: Option<(silo::keys::ParsedTaskKey, Task)> = None;
     for _ in 0..50 {
-        if let Some(t) = find_task_for_tenant(shard.db(), tenant).await
+        if let Some((key, t)) = find_task_key_and_task_for_tenant(shard.db(), tenant).await
             && matches!(t, Task::CheckRateLimit { .. })
         {
-            check_rl = Some(t);
+            check_rl = Some((key, t));
             break;
         }
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
     }
-    let check_rl = check_rl.expect(
+    let (check_rl_key, check_rl) = check_rl.expect(
         "expected a CheckRateLimit task for job 2 after Conc-B was promoted by the grant scanner; \
          if a RunAttempt was written instead, the chain shortcut bypassed RateLimit",
+    );
+    let job2_status = shard
+        .get_job_status(tenant, &job2)
+        .await
+        .expect("load job2 status")
+        .expect("job2 status exists");
+    assert_eq!(job2_status.kind, JobStatusKind::Scheduled);
+    assert_eq!(
+        job2_status.next_attempt_starts_after_ms,
+        Some(check_rl_key.start_time_ms as i64),
+        "Scheduled status must point at the retargeted CheckRateLimit key"
     );
 
     // Verify held_queues = [A, B] — Conc-A's prior grant survived into the
@@ -3726,15 +3739,132 @@ async fn deferred_concurrency_resumes_into_rate_limit() {
         count_holders_for_queue(shard.db(), tenant, &queue_b).await,
         1
     );
+
+    shard
+        .cancel_job(tenant, &job2)
+        .await
+        .expect("cancel job2 after grant scanner wrote CheckRateLimit");
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_a).await,
+        0,
+        "cancel must find retargeted CheckRateLimit and release Conc-A"
+    );
+    assert_eq!(
+        count_holders_for_queue(shard.db(), tenant, &queue_b).await,
+        0,
+        "cancel must find retargeted CheckRateLimit and release Conc-B"
+    );
+    assert_eq!(
+        count_check_rate_limit_tasks_for_tenant(shard.db(), tenant).await,
+        0,
+        "cancel must delete the retargeted CheckRateLimit task"
+    );
     let _ = end_bound(&tasks_prefix());
 }
 
-/// Helper: scan the tasks prefix and return the first task for the given
-/// tenant (used by `deferred_concurrency_resumes_into_rate_limit`).
-async fn find_task_for_tenant(
+#[silo::test]
+async fn grant_scanner_hydrates_legacy_request_without_task_id_or_limits() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+    let queue = "legacy-request-q".to_string();
+
+    let job1 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue holder job");
+    let job2 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue queued job");
+
+    let (request_key, _) = first_concurrency_request_kv(shard.db())
+        .await
+        .expect("queued job should have a request");
+    let parsed =
+        silo::keys::parse_concurrency_request_key(&request_key).expect("request key should parse");
+    assert_eq!(parsed.job_id, job2);
+
+    // Simulate a request value written by the pre-upgrade schema: the durable
+    // key still carries the request id, but the value has no task_id, limits,
+    // held_queues, or limit_index fields.
+    let legacy_value = encode_legacy_enqueue_task_value(&parsed, "default");
+    shard
+        .db()
+        .put(&request_key, &legacy_value)
+        .await
+        .expect("overwrite request with legacy value");
+
+    let leased_a = shard
+        .dequeue("w1", "default", 1)
+        .await
+        .expect("dequeue job1")
+        .tasks;
+    assert_eq!(leased_a.len(), 1);
+    assert_eq!(leased_a[0].job().id(), job1);
+    let task1 = leased_a[0].attempt().task_id().to_string();
+
+    shard
+        .report_attempt_outcome(&task1, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("complete job1");
+
+    let mut leased_b = Vec::new();
+    for _ in 0..50 {
+        leased_b = shard
+            .dequeue("w2", "default", 1)
+            .await
+            .expect("dequeue job2")
+            .tasks;
+        if !leased_b.is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    assert_eq!(
+        leased_b.len(),
+        1,
+        "legacy request should be granted, not deleted as corrupt"
+    );
+    assert_eq!(leased_b[0].job().id(), job2);
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "granted legacy request should be consumed"
+    );
+}
+
+async fn find_task_key_and_task_for_tenant(
     db: &silo::instrumented_db::InstrumentedDb,
     tenant: &str,
-) -> Option<Task> {
+) -> Option<(silo::keys::ParsedTaskKey, Task)> {
     let start = silo::keys::tasks_prefix();
     let end = silo::keys::end_bound(&start);
     let mut iter = db
@@ -3742,13 +3872,49 @@ async fn find_task_for_tenant(
         .await
         .ok()?;
     while let Ok(Some(kv)) = iter.next().await {
+        let Some(parsed) = silo::keys::parse_task_key(&kv.key) else {
+            continue;
+        };
         if let Ok(task) = decode_task(&kv.value)
             && task.tenant() == tenant
         {
-            return Some(task);
+            return Some((parsed, task));
         }
     }
     None
+}
+
+fn encode_legacy_enqueue_task_value(
+    parsed: &silo::keys::ParsedConcurrencyRequestKey,
+    task_group: &str,
+) -> Vec<u8> {
+    let mut builder = flatbuffers::FlatBufferBuilder::with_capacity(128);
+    let job_id = builder.create_string(&parsed.job_id);
+    let task_group = builder.create_string(task_group);
+    let et = silo::fb::silo::fb::EnqueueTask::create(
+        &mut builder,
+        &silo::fb::silo::fb::EnqueueTaskArgs {
+            start_time_ms: parsed.start_time_ms as i64,
+            priority: parsed.priority,
+            job_id: Some(job_id),
+            attempt_number: parsed.attempt_number,
+            relative_attempt_number: parsed.attempt_number,
+            task_group: Some(task_group),
+            limit_index: 0,
+            held_queues: None,
+            task_id: None,
+            limits: None,
+        },
+    );
+    let root = silo::fb::silo::fb::ConcurrencyAction::create(
+        &mut builder,
+        &silo::fb::silo::fb::ConcurrencyActionArgs {
+            variant_type: silo::fb::silo::fb::ConcurrencyActionVariant::EnqueueTask,
+            variant: Some(et.as_union_value()),
+        },
+    );
+    builder.finish(root, None);
+    builder.finished_data().to_vec()
 }
 
 /// Helper: count `CheckRateLimit` tasks for a tenant.


### PR DESCRIPTION
Fix two grant-chain edge cases:

 - Retarget `Scheduled.next_attempt_starts_after_ms` when a resumed limit chain writes its follow-up task at a fresh task-key timestamp.
 - Preserve pre-upgrade queued concurrency requests whose value is missing newer fields like `task_id` or `limits`.

 Without the status retarget, status-derived operations like cancel, reimport, and direct lease can miss resumed `RunAttempt` / `CheckRateLimit` tasks and leave holders behind. Without the legacy
 fallback, rolling upgrades can delete already-queued requests and strand scheduled jobs.

 ## Changes

 - Return `LimitTaskWriteResult` from the shared limit-chain writer so callers know whether a concrete DB task was written.
 - Retarget scheduled status after grant-scanner, RequestTicket, and CheckRateLimit continuations write a new task key.
 - Hydrate legacy concurrency request values from the parsed request key plus `JobInfo` instead of treating missing fields as corrupt.
 - Add regression coverage for:
   - Cancel finding and cleaning up a retargeted resumed task.
   - Cancel cleaning up a retargeted resumed `CheckRateLimit`.
   - Grant scanner preserving and granting a legacy queued request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes concurrency admission, dequeue commit/cancellation paths, grant scanner behavior, and scheduled job status—areas tied to production queue wedges and holder leaks.
> 
> **Overview**
> This PR fixes **concurrency limit-chain continuity** and **in-memory vs durable holder drift** that could wedge queues or strand scheduled jobs.
> 
> When a resumed chain writes a follow-up task at a **new task-key timestamp** (tombstone dodge), it now **retargets** `Scheduled.next_attempt_starts_after_ms` via `LimitTaskWriteResult` / `retarget_scheduled_task_key`, so cancel, reimport, and direct lease still find the `RunAttempt` or `CheckRateLimit` task instead of leaving holders behind.
> 
> The **grant scanner** treats the concurrency **request key** as authoritative for ordering and identity, **hydrates** sparse pre-upgrade request values from `JobInfo`, and can **probe upstream durable holders** to rebuild `held_queues` for legacy queued requests.
> 
> **Dequeue** gains RAII `PendingGrantGuard` / `PendingHolderReleaseGuard`: if a dequeue future is cancelled around `await_durable`, dropped pending in-memory grants or holder releases are **queued for reconciliation**. A reactive task plus the periodic reconciler compare durable holder rows to the in-memory cache (release ghosts, re-insert mirrors) and expose **drift / pending** metrics.
> 
> Regression tests cover retargeted cancel paths, legacy request grants, upstream `held_queues` recovery, dropped-dequeue recovery, queue wedge reproduction, and four-quadrant reconciler behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee89716a0c469db814b6ff1f49d7c3d2602f7ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->