### PR TITLE
Rename enable_counter_reconciliation to counter_reconciliation_seconds

### DIFF
--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -612,7 +612,7 @@ pub async fn clone_golden_shard(
             concurrency_reconcile_interval: Duration::from_millis(
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS,
             ),
-            enable_counter_reconciliation: false,
+            counter_reconciliation_seconds: None,
             hydrate_all_at_startup: false,
         },
         ShardRange::full(),

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -191,7 +191,7 @@ impl ShardFactory {
                         concurrency_reconcile_interval: Duration::from_millis(
                             template.concurrency_reconcile_interval_ms.max(1),
                         ),
-                        enable_counter_reconciliation: template.enable_counter_reconciliation,
+                        counter_reconciliation_seconds: template.counter_reconciliation_seconds,
                         hydrate_all_at_startup: template.hydrate_all_at_startup,
                     },
                     range.clone(),

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -84,11 +84,12 @@ pub struct OpenShardOptions {
     pub metrics: Option<Metrics>,
     /// Interval for periodic concurrency request reconciliation.
     pub concurrency_reconcile_interval: Duration,
-    /// When true, spawns the per-shard counter reconciliation background
-    /// task. The reconciler exists to correct counter drift caused by the
-    /// standalone compactor dropping terminal job rows; deployments that run
-    /// the standalone compactor enable it. Defaults to off.
-    pub enable_counter_reconciliation: bool,
+    /// Interval in seconds for the per-shard counter reconciliation
+    /// background task. The reconciler exists to correct counter drift caused
+    /// by the standalone compactor dropping terminal job rows; deployments
+    /// that run the standalone compactor set this to enable it. `None`
+    /// (the default) disables the task entirely.
+    pub counter_reconciliation_seconds: Option<u64>,
     /// When true, scan every concurrency holder into the in-memory cache
     /// before opening the shard for ticket granting, and treat
     /// `ensure_hydrated` misses thereafter as empty queues. When false, no
@@ -335,7 +336,7 @@ impl JobStoreShard {
                 concurrency_reconcile_interval: Duration::from_millis(
                     crate::settings::DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS.max(1),
                 ),
-                enable_counter_reconciliation: cfg.enable_counter_reconciliation,
+                counter_reconciliation_seconds: cfg.counter_reconciliation_seconds,
                 hydrate_all_at_startup: cfg.hydrate_all_at_startup,
             },
             range,
@@ -373,7 +374,7 @@ impl JobStoreShard {
             rate_limiter,
             metrics,
             concurrency_reconcile_interval,
-            enable_counter_reconciliation,
+            counter_reconciliation_seconds,
             hydrate_all_at_startup,
         } = options;
 
@@ -487,8 +488,8 @@ impl JobStoreShard {
         // Only enabled when the deployment runs the standalone compactor, which
         // drops terminal job rows without a writable Db handle and therefore
         // cannot decrement counters at drop time.
-        if enable_counter_reconciliation {
-            shard.spawn_counter_reconcile_task(range);
+        if let Some(interval_seconds) = counter_reconciliation_seconds {
+            shard.spawn_counter_reconcile_task(range, interval_seconds);
         }
 
         // Set the shard creation timestamp if this is the first time opening
@@ -710,21 +711,17 @@ impl JobStoreShard {
     ///
     /// Unlike the concurrency reconciler (small scan, fast cadence), this task
     /// scans all `JOB_INFO` + `JOB_STATUS` rows in the shard and so runs at
-    /// hourly cadence by default. To avoid all shards spiking object-store
-    /// reads at the same wall-clock minute on process boot, we sleep a
-    /// shard-deterministic jitter `[0, interval)` before the first tick. The
-    /// jitter is derived from the shard name's hash so that deterministic
-    /// simulation tests remain reproducible.
-    fn spawn_counter_reconcile_task(self: &Arc<Self>, range: ShardRange) {
+    /// the deployment-configured cadence (typically hourly). To avoid all
+    /// shards spiking object-store reads at the same wall-clock minute on
+    /// process boot, we sleep a shard-deterministic jitter `[0, interval)`
+    /// before the first tick. The jitter is derived from the shard name's
+    /// hash so that deterministic simulation tests remain reproducible.
+    fn spawn_counter_reconcile_task(self: &Arc<Self>, range: ShardRange, interval_seconds: u64) {
         let shard = Arc::clone(self);
         let cancellation = self.cancellation.clone();
         let shard_name = self.name.clone();
-        // Hardcoded: this counter is eventually-consistent observability with
-        // no operational SLA, so there's no reason to tune it per-shard or
-        // per-deployment. Plumbing a knob here would force every test/bench
-        // that constructs OpenShardOptions/DatabaseTemplate to set a value.
         let reconcile_interval =
-            Duration::from_millis(crate::settings::DEFAULT_COUNTER_RECONCILE_INTERVAL_MS.max(1));
+            Duration::from_millis(interval_seconds.saturating_mul(1000).max(1));
 
         tokio::spawn(async move {
             // Deterministic jitter based on shard name so we don't stampede

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -182,17 +182,6 @@ fn default_concurrency_reconcile_interval_ms() -> u64 {
     DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS
 }
 
-/// Hardcoded interval for the per-shard counter reconciliation background
-/// task. The reconciler corrects counter drift caused by the standalone
-/// compactor dropping terminal job rows without a writable `Db` handle. There
-/// is no operational reason to tune it per-shard or per-deployment, so it is
-/// not exposed as a config field.
-pub const DEFAULT_COUNTER_RECONCILE_INTERVAL_MS: u64 = 60 * 60 * 1000;
-
-fn default_enable_counter_reconciliation() -> bool {
-    false
-}
-
 fn default_hydrate_all_at_startup() -> bool {
     false
 }
@@ -221,13 +210,14 @@ pub struct DatabaseTemplate {
     /// to self-heal from missed in-memory notifications.
     #[serde(default = "default_concurrency_reconcile_interval_ms")]
     pub concurrency_reconcile_interval_ms: u64,
-    /// When true, enables the periodic counter reconciliation background task
-    /// that re-derives counter truth from JOB_INFO/JOB_STATUS to correct drift
-    /// caused by the standalone compactor dropping terminal job rows. Other
-    /// counter writes (in transactions, in `reconcile_pending_requests`, etc.)
-    /// are unaffected. Defaults to false (reconciliation disabled).
-    #[serde(default = "default_enable_counter_reconciliation")]
-    pub enable_counter_reconciliation: bool,
+    /// Interval in seconds for the periodic counter reconciliation background
+    /// task that re-derives counter truth from JOB_INFO/JOB_STATUS to correct
+    /// drift caused by the standalone compactor dropping terminal job rows.
+    /// `None` (the default) disables the task entirely. `Some(n)` runs it
+    /// every `n` seconds. Other counter writes (in transactions, in
+    /// `reconcile_pending_requests`, etc.) are unaffected.
+    #[serde(default)]
+    pub counter_reconciliation_seconds: Option<u64>,
     /// When true, scan every concurrency holder into the in-memory cache before
     /// the shard accepts traffic, and treat later `ensure_hydrated` misses as
     /// empty queues. When false, no startup scan runs and the singleflighted
@@ -257,7 +247,7 @@ impl Default for DatabaseTemplate {
             wal: None,
             apply_wal_on_close: default_apply_wal_on_close(),
             concurrency_reconcile_interval_ms: default_concurrency_reconcile_interval_ms(),
-            enable_counter_reconciliation: default_enable_counter_reconciliation(),
+            counter_reconciliation_seconds: None,
             hydrate_all_at_startup: default_hydrate_all_at_startup(),
             slatedb: None,
             memory_cache: None,
@@ -508,10 +498,11 @@ pub struct DatabaseConfig {
     /// Defaults to true when WAL is configured.
     #[serde(default = "default_apply_wal_on_close")]
     pub apply_wal_on_close: bool,
-    /// When true, enables the periodic counter reconciliation background task.
-    /// See `DatabaseTemplate::enable_counter_reconciliation` for details.
-    #[serde(default = "default_enable_counter_reconciliation")]
-    pub enable_counter_reconciliation: bool,
+    /// Interval in seconds for the counter reconciliation background task.
+    /// `None` disables the task; `Some(n)` runs it every `n` seconds. See
+    /// `DatabaseTemplate::counter_reconciliation_seconds` for details.
+    #[serde(default)]
+    pub counter_reconciliation_seconds: Option<u64>,
     /// When true, eagerly scan every concurrency holder into the in-memory
     /// cache at startup. See `DatabaseTemplate::hydrate_all_at_startup` for
     /// details. Defaults to false.
@@ -539,7 +530,7 @@ impl Default for DatabaseConfig {
             path: "/tmp/silo-shard".to_string(),
             wal: None,
             apply_wal_on_close: default_apply_wal_on_close(),
-            enable_counter_reconciliation: default_enable_counter_reconciliation(),
+            counter_reconciliation_seconds: None,
             hydrate_all_at_startup: default_hydrate_all_at_startup(),
             slatedb: None,
             memory_cache: None,

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -571,7 +571,7 @@ concurrency_reconcile_interval_ms = 25
 }
 
 #[silo::test]
-fn parse_toml_enable_counter_reconciliation_defaults_off() {
+fn parse_toml_counter_reconciliation_seconds_defaults_off() {
     let toml_str = r#"
 [database]
 backend = "fs"
@@ -579,21 +579,21 @@ path = "/tmp/silo-%shard%"
 "#;
     let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
     assert!(
-        !cfg.database.enable_counter_reconciliation,
+        cfg.database.counter_reconciliation_seconds.is_none(),
         "counter reconciliation should be off by default"
     );
 }
 
 #[silo::test]
-fn parse_toml_enable_counter_reconciliation_opt_in() {
+fn parse_toml_counter_reconciliation_seconds_opt_in() {
     let toml_str = r#"
 [database]
 backend = "fs"
 path = "/tmp/silo-%shard%"
-enable_counter_reconciliation = true
+counter_reconciliation_seconds = 3600
 "#;
     let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
-    assert!(cfg.database.enable_counter_reconciliation);
+    assert_eq!(cfg.database.counter_reconciliation_seconds, Some(3600));
 }
 
 /// Guards against the manual `Default` impl on `DatabaseTemplate` drifting away
@@ -619,8 +619,8 @@ path = "/tmp/silo-%shard%"
         from_toml.database.concurrency_reconcile_interval_ms
     );
     assert_eq!(
-        from_default.enable_counter_reconciliation,
-        from_toml.database.enable_counter_reconciliation
+        from_default.counter_reconciliation_seconds,
+        from_toml.database.counter_reconciliation_seconds
     );
     assert!(from_default.wal.is_none() && from_toml.database.wal.is_none());
     assert!(from_default.slatedb.is_none() && from_toml.database.slatedb.is_none());
@@ -647,8 +647,8 @@ path = "/tmp/silo-shard"
         from_toml.apply_wal_on_close
     );
     assert_eq!(
-        from_default.enable_counter_reconciliation,
-        from_toml.enable_counter_reconciliation
+        from_default.counter_reconciliation_seconds,
+        from_toml.counter_reconciliation_seconds
     );
     assert!(from_default.wal.is_none() && from_toml.wal.is_none());
     assert!(from_default.slatedb.is_none() && from_toml.slatedb.is_none());

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -102,7 +102,7 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             rate_limiter,
             metrics: None,
             concurrency_reconcile_interval: Duration::from_millis(interval_ms.max(1)),
-            enable_counter_reconciliation: false,
+            counter_reconciliation_seconds: None,
             hydrate_all_at_startup: false,
         },
         ShardRange::full(),


### PR DESCRIPTION
## Summary

Need this so we can tune how frequently these counters get updated. The counters are shard wide counters like number of jobs, useful for the webui. They need to be reconciled because our expiration won't manually update these counts when values get tombstoned.

Replace the `enable_counter_reconciliation: bool` toggle (paired with a hardcoded 1h interval) with an `Option<u64>` seconds-based interval named `counter_reconciliation_seconds`.

- `None` (the default) disables the per-shard counter reconciliation background task entirely.
- `Some(n)` runs it every `n` seconds.

This lets operators tune the cadence per-deployment instead of inheriting the hidden 1h default. Read once at startup; not dynamic.

This is PR 1/4 in the job-retention stack split (see follow-ups for: expiration helpers, RPC-side TTL on cancel + import, terminal-status TTL on completion/failure).

**Migration note:** operators currently setting `enable_counter_reconciliation = true` must switch to `counter_reconciliation_seconds = <N>` (e.g. `3600`). Absence is equivalent to disabled, matching the old `false` default.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --lib --bins --all-features -- -D warnings`
- [x] `cargo check --all-targets`
- [x] `cargo test --test config_and_db_tests` — 35 passed