### PR TITLE
Introduce terminal-job expiration helpers and settings

### DIFF
--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -614,6 +614,8 @@ pub async fn clone_golden_shard(
             ),
             counter_reconciliation_seconds: None,
             hydrate_all_at_startup: false,
+            completed_job_expire_s: None,
+            terminal_job_expire_s: None,
         },
         ShardRange::full(),
     )

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -193,6 +193,8 @@ impl ShardFactory {
                         ),
                         counter_reconciliation_seconds: template.counter_reconciliation_seconds,
                         hydrate_all_at_startup: template.hydrate_all_at_startup,
+                        completed_job_expire_s: template.completed_job_expire_s,
+                        terminal_job_expire_s: template.terminal_job_expire_s,
                     },
                     range.clone(),
                 )

--- a/src/instrumented_db.rs
+++ b/src/instrumented_db.rs
@@ -20,7 +20,7 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use slatedb::bytes::Bytes;
-use slatedb::config::{FlushOptions, ScanOptions, WriteOptions};
+use slatedb::config::{FlushOptions, PutOptions, ScanOptions, WriteOptions};
 use slatedb::{Db, DbIterator, DbTransaction, IsolationLevel, KeyValue, WriteBatch, WriteHandle};
 use tracing::{Instrument, Span};
 
@@ -199,6 +199,20 @@ impl InstrumentedDbTransaction {
     {
         let _g = self.span.enter();
         self.inner.put(key, value)
+    }
+
+    pub fn put_with_options<K, V>(
+        &self,
+        key: K,
+        value: V,
+        options: &PutOptions,
+    ) -> Result<(), slatedb::Error>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        let _g = self.span.enter();
+        self.inner.put_with_options(key, value, options)
     }
 
     pub fn delete<K: AsRef<[u8]>>(&self, key: K) -> Result<(), slatedb::Error> {

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -689,6 +689,23 @@ impl JobStoreShard {
         job_id: &str,
         new_status: JobStatus,
     ) -> Result<(), JobStoreShardError> {
+        self.set_job_status_with_index_opts(writer, tenant, job_id, new_status, None)
+            .await
+    }
+
+    /// Update job status with optional row TTL on the new status/index records.
+    ///
+    /// When `expire_ts` is `Some`, the new `JOB_STATUS` and `IDX_STATUS_TIME`
+    /// rows are written with a SlateDB TTL expiring at `expire_ts` (epoch ms).
+    /// Used by the terminal-job expiration path; pass `None` everywhere else.
+    pub(crate) async fn set_job_status_with_index_opts<W: WriteBatcher>(
+        &self,
+        writer: &mut W,
+        tenant: &str,
+        job_id: &str,
+        new_status: JobStatus,
+        expire_ts: Option<i64>,
+    ) -> Result<(), JobStoreShardError> {
         // Delete old index entries if present
         if let Some(old_raw) = writer.get(&job_status_key(tenant, job_id)).await? {
             let old = decode_job_status_owned(&old_raw)?;
@@ -702,7 +719,7 @@ impl JobStoreShard {
             )?;
         }
 
-        Self::write_job_status_with_index(writer, tenant, job_id, new_status)
+        Self::write_job_status_with_index_opts(writer, tenant, job_id, new_status, expire_ts)
     }
 
     /// Shared helper: write status value and index entry.
@@ -712,9 +729,25 @@ impl JobStoreShard {
         job_id: &str,
         new_status: JobStatus,
     ) -> Result<(), JobStoreShardError> {
+        Self::write_job_status_with_index_opts(writer, tenant, job_id, new_status, None)
+    }
+
+    /// Shared helper variant that accepts an optional `expire_ts` for the new
+    /// status and index rows.
+    pub(crate) fn write_job_status_with_index_opts<W: WriteBatcher>(
+        writer: &mut W,
+        tenant: &str,
+        job_id: &str,
+        new_status: JobStatus,
+        expire_ts: Option<i64>,
+    ) -> Result<(), JobStoreShardError> {
         // Write new status value
         let job_status_value = encode_job_status(&new_status);
-        writer.put(job_status_key(tenant, job_id), &job_status_value)?;
+        let status_key = job_status_key(tenant, job_id);
+        match expire_ts {
+            Some(ts) => writer.put_with_expire(&status_key, &job_status_value, ts)?,
+            None => writer.put(&status_key, &job_status_value)?,
+        }
 
         // Insert new index entries
         // For Scheduled statuses, use next_attempt_starts_after_ms as the timestamp
@@ -722,7 +755,10 @@ impl JobStoreShard {
         let new_kind = new_status.kind;
         let ts = status_index_timestamp(&new_status);
         let timek = idx_status_time_key(tenant, new_kind.as_str(), ts, job_id);
-        writer.put(&timek, [])?;
+        match expire_ts {
+            Some(ets) => writer.put_with_expire(&timek, [], ets)?,
+            None => writer.put(&timek, [])?,
+        }
 
         // Increment tenant status counter for the new status
         writer.merge(

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -5,10 +5,10 @@ use slatedb::config::{PutOptions, Ttl};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::codec::encode_task;
-use crate::instrumented_db::{InstrumentedDb, InstrumentedDbTransaction};
+use crate::instrumented_db::{InstrumentedDb, InstrumentedDbIterator, InstrumentedDbTransaction};
 use crate::job::JobStatus;
 use crate::job_store_shard::JobStoreShardError;
-use crate::keys::task_key;
+use crate::keys::{end_bound, task_key};
 use crate::task::Task;
 
 /// A trait that abstracts over SlateDB's two ways of writing in groups: `WriteBatch` and `DbTransaction`.
@@ -60,12 +60,25 @@ pub(crate) trait WriteBatcher {
 
     /// Get a value by key.
     ///
-    /// For transactions, this reads from the transaction snapshot.
+    /// For transactions, this reads from the transaction snapshot and tracks
+    /// the read key in the SSI read set (so a concurrent writer to the same
+    /// key trips a read-write conflict at commit).
     /// For batches, this reads from the underlying database.
     fn get(
         &self,
         key: &[u8],
     ) -> impl std::future::Future<Output = Result<Option<Bytes>, slatedb::Error>> + Send;
+
+    /// Scan all keys with the given prefix.
+    ///
+    /// For transactions, this reads from the transaction snapshot and tracks
+    /// the scanned range in the SSI read set (so a concurrent writer that
+    /// inserts a key into the range trips a phantom-read conflict at commit).
+    /// For batches, this reads from the underlying database.
+    fn scan_prefix(
+        &self,
+        prefix: &[u8],
+    ) -> impl std::future::Future<Output = Result<InstrumentedDbIterator, slatedb::Error>> + Send;
 }
 
 /// Wrapper around `&mut WriteBatch` that implements `WriteBatcher`
@@ -125,6 +138,11 @@ impl WriteBatcher for DbWriteBatcher<'_> {
     async fn get(&self, key: &[u8]) -> Result<Option<Bytes>, slatedb::Error> {
         self.db.get(key).await
     }
+
+    async fn scan_prefix(&self, prefix: &[u8]) -> Result<InstrumentedDbIterator, slatedb::Error> {
+        let end = end_bound(prefix);
+        self.db.scan::<Vec<u8>, _>(prefix.to_vec()..end).await
+    }
 }
 
 /// Wrapper around `&InstrumentedDbTransaction` that implements `WriteBatcher`.
@@ -175,6 +193,11 @@ impl WriteBatcher for TxnWriter<'_> {
 
     async fn get(&self, key: &[u8]) -> Result<Option<Bytes>, slatedb::Error> {
         self.0.get(key).await
+    }
+
+    async fn scan_prefix(&self, prefix: &[u8]) -> Result<InstrumentedDbIterator, slatedb::Error> {
+        let end = end_bound(prefix);
+        self.0.scan::<Vec<u8>, _>(prefix.to_vec()..end).await
     }
 }
 

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -1,6 +1,7 @@
 //! Helper functions shared across job_store_shard submodules.
 use slatedb::WriteBatch;
 use slatedb::bytes::Bytes;
+use slatedb::config::{PutOptions, Ttl};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::codec::encode_task;
@@ -25,6 +26,21 @@ pub(crate) trait WriteBatcher {
         &mut self,
         key: K,
         value: V,
+    ) -> Result<(), slatedb::Error>;
+
+    /// Put a key-value pair with a SlateDB row TTL set to `expire_ts`
+    /// (epoch milliseconds). Used by the terminal-job expiration path so the
+    /// row is dropped during compaction once it ages past `expire_ts`.
+    ///
+    /// No default impl — every implementor must thread the TTL through to
+    /// the underlying writer. A silent fallback that drops the TTL would
+    /// produce data that never expires without any compile-time signal, so
+    /// the trait forces every writer to decide explicitly.
+    fn put_with_expire<K: AsRef<[u8]>, V: AsRef<[u8]>>(
+        &mut self,
+        key: K,
+        value: V,
+        expire_ts: i64,
     ) -> Result<(), slatedb::Error>;
 
     /// Delete a key.
@@ -76,6 +92,22 @@ impl WriteBatcher for DbWriteBatcher<'_> {
         Ok(())
     }
 
+    fn put_with_expire<K: AsRef<[u8]>, V: AsRef<[u8]>>(
+        &mut self,
+        key: K,
+        value: V,
+        expire_ts: i64,
+    ) -> Result<(), slatedb::Error> {
+        self.batch.put_with_options(
+            key,
+            value,
+            &PutOptions {
+                ttl: Ttl::ExpireAt(expire_ts),
+            },
+        );
+        Ok(())
+    }
+
     fn delete<K: AsRef<[u8]>>(&mut self, key: K) -> Result<(), slatedb::Error> {
         self.batch.delete(key);
         Ok(())
@@ -109,6 +141,21 @@ impl WriteBatcher for TxnWriter<'_> {
         value: V,
     ) -> Result<(), slatedb::Error> {
         self.0.put(key, value)
+    }
+
+    fn put_with_expire<K: AsRef<[u8]>, V: AsRef<[u8]>>(
+        &mut self,
+        key: K,
+        value: V,
+        expire_ts: i64,
+    ) -> Result<(), slatedb::Error> {
+        self.0.put_with_options(
+            key,
+            value,
+            &PutOptions {
+                ttl: Ttl::ExpireAt(expire_ts),
+            },
+        )
     }
 
     fn delete<K: AsRef<[u8]>>(&mut self, key: K) -> Result<(), slatedb::Error> {

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -613,26 +613,19 @@ impl JobStoreShard {
     /// `JOB_STATUS` and `IDX_STATUS_TIME` are written with TTL by the caller via
     /// `set_job_status_with_index_opts`, so they are intentionally not handled here.
     ///
-    /// The attempt scan reads from `self.db` directly (committed state,
-    /// pre-batch). For the current attempt this returns its old Running
-    /// value, so the caller MUST put the new terminal ATTEMPT row **after**
-    /// invoking this helper. `WriteBatch` is last-write-wins per key, and
-    /// putting the new row earlier would be silently clobbered when the
-    /// helper re-puts the old Running value with TTL.
+    /// All reads go through `writer` so that when the caller uses a
+    /// `TxnWriter`, the JOB_INFO / ATTEMPT range / JOB_CANCELLED reads are
+    /// tracked in the transaction's SSI read set. A concurrent writer that
+    /// mutates any of those keys between this helper and the caller's commit
+    /// will trip a read-write (or phantom-read) conflict, so the re-put
+    /// cannot silently clobber a concurrent write with stale bytes.
     ///
-    /// Transaction-race caveat: the helper's reads bypass the open
-    /// transaction's optimistic concurrency tracker. A concurrent writer
-    /// that mutates one of these keys between the helper's read and the
-    /// caller's commit would NOT be detected as a conflict by
-    /// `SerializableSnapshot`, and the helper's re-put would silently
-    /// clobber the concurrent write with stale bytes (plus a TTL). Today
-    /// this is safe because every JOB_INFO mutator also writes
-    /// `JOB_STATUS` in the same txn, and the cancel txn reads
-    /// `JOB_STATUS` early — so any JOB_INFO race is closed transitively
-    /// via the status-key read conflict. Callers that introduce new
-    /// JOB_INFO / ATTEMPT / JOB_CANCELLED mutators MUST gate them on a
-    /// `JOB_STATUS` read in the same txn, or this helper needs to be
-    /// reworked to read through the transaction.
+    /// The attempt scan returns the *committed* (pre-batch) attempt rows. For
+    /// the current attempt this means the old Running value, so the caller
+    /// MUST put the new terminal ATTEMPT row **after** invoking this helper.
+    /// `WriteBatch` is last-write-wins per key, and putting the new row
+    /// earlier would be silently clobbered when the helper re-puts the old
+    /// Running value with TTL.
     #[allow(dead_code)] // wired up in follow-up retention PRs (cancel, import, terminal)
     pub(crate) async fn expire_terminal_job_records<W: WriteBatcher>(
         &self,
@@ -642,7 +635,7 @@ impl JobStoreShard {
         expire_ts: i64,
     ) -> Result<(), JobStoreShardError> {
         let info_key = job_info_key(tenant, job_id);
-        let metadata_pairs = if let Some(info_raw) = self.db.get(&info_key).await? {
+        let metadata_pairs = if let Some(info_raw) = writer.get(&info_key).await? {
             let view = JobView::new(info_raw.clone())?;
             let pairs = view.metadata();
             writer.put_with_expire(&info_key, info_raw, expire_ts)?;
@@ -657,17 +650,13 @@ impl JobStoreShard {
         }
 
         let attempt_start = attempt_prefix(tenant, job_id);
-        let attempt_end = end_bound(&attempt_start);
-        let mut iter = self
-            .db
-            .scan::<Vec<u8>, _>(attempt_start..attempt_end)
-            .await?;
+        let mut iter = writer.scan_prefix(&attempt_start).await?;
         while let Some(kv) = iter.next().await? {
             writer.put_with_expire(&kv.key, &kv.value, expire_ts)?;
         }
 
         let cancelled_key = job_cancelled_key(tenant, job_id);
-        if let Some(cancelled_raw) = self.db.get(&cancelled_key).await? {
+        if let Some(cancelled_raw) = writer.get(&cancelled_key).await? {
             writer.put_with_expire(&cancelled_key, cancelled_raw, expire_ts)?;
         }
 

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -11,11 +11,12 @@ use crate::codec::{
 use crate::dst_events::{self, DstEvent};
 use crate::job::{FloatingLimitState, JobStatus, JobView};
 use crate::job_attempt::{AttemptOutcome, AttemptStatus, JobAttempt};
-use crate::job_store_shard::helpers::{DbWriteBatcher, now_epoch_ms};
+use crate::job_store_shard::helpers::{DbWriteBatcher, WriteBatcher, now_epoch_ms};
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
-    attempt_key, concurrency_holder_key, concurrency_holders_tenant_prefix, end_bound,
-    floating_limit_state_key, job_info_key, leased_task_key, parse_concurrency_holder_key,
+    attempt_key, attempt_prefix, concurrency_holder_key, concurrency_holders_tenant_prefix,
+    end_bound, floating_limit_state_key, idx_metadata_key, job_cancelled_key, job_info_key,
+    leased_task_key, parse_concurrency_holder_key,
 };
 use crate::task::{DEFAULT_LEASE_MS, HeartbeatResult};
 use tracing::{debug, info_span};
@@ -597,5 +598,79 @@ impl JobStoreShard {
         }
 
         Ok(to_delete.len())
+    }
+
+    /// Re-put all KV records associated with a job that has reached a terminal
+    /// status, applying a SlateDB row TTL of `expire_ts` (epoch ms) so the
+    /// rows are dropped during compaction once they age past `expire_ts`.
+    ///
+    /// Records covered:
+    ///   - `JOB_INFO`            (read existing bytes, re-put with TTL)
+    ///   - `IDX_METADATA`        (one entry per metadata pair on the job)
+    ///   - `ATTEMPT`             (scan all attempt rows for the job, re-put each)
+    ///   - `JOB_CANCELLED`       (re-put with TTL if present)
+    ///
+    /// `JOB_STATUS` and `IDX_STATUS_TIME` are written with TTL by the caller via
+    /// `set_job_status_with_index_opts`, so they are intentionally not handled here.
+    ///
+    /// The attempt scan reads from `self.db` directly (committed state,
+    /// pre-batch). For the current attempt this returns its old Running
+    /// value, so the caller MUST put the new terminal ATTEMPT row **after**
+    /// invoking this helper. `WriteBatch` is last-write-wins per key, and
+    /// putting the new row earlier would be silently clobbered when the
+    /// helper re-puts the old Running value with TTL.
+    ///
+    /// Transaction-race caveat: the helper's reads bypass the open
+    /// transaction's optimistic concurrency tracker. A concurrent writer
+    /// that mutates one of these keys between the helper's read and the
+    /// caller's commit would NOT be detected as a conflict by
+    /// `SerializableSnapshot`, and the helper's re-put would silently
+    /// clobber the concurrent write with stale bytes (plus a TTL). Today
+    /// this is safe because every JOB_INFO mutator also writes
+    /// `JOB_STATUS` in the same txn, and the cancel txn reads
+    /// `JOB_STATUS` early — so any JOB_INFO race is closed transitively
+    /// via the status-key read conflict. Callers that introduce new
+    /// JOB_INFO / ATTEMPT / JOB_CANCELLED mutators MUST gate them on a
+    /// `JOB_STATUS` read in the same txn, or this helper needs to be
+    /// reworked to read through the transaction.
+    #[allow(dead_code)] // wired up in follow-up retention PRs (cancel, import, terminal)
+    pub(crate) async fn expire_terminal_job_records<W: WriteBatcher>(
+        &self,
+        writer: &mut W,
+        tenant: &str,
+        job_id: &str,
+        expire_ts: i64,
+    ) -> Result<(), JobStoreShardError> {
+        let info_key = job_info_key(tenant, job_id);
+        let metadata_pairs = if let Some(info_raw) = self.db.get(&info_key).await? {
+            let view = JobView::new(info_raw.clone())?;
+            let pairs = view.metadata();
+            writer.put_with_expire(&info_key, info_raw, expire_ts)?;
+            pairs
+        } else {
+            Vec::new()
+        };
+
+        for (mk, mv) in &metadata_pairs {
+            let mkey = idx_metadata_key(tenant, mk, mv, job_id);
+            writer.put_with_expire(&mkey, [], expire_ts)?;
+        }
+
+        let attempt_start = attempt_prefix(tenant, job_id);
+        let attempt_end = end_bound(&attempt_start);
+        let mut iter = self
+            .db
+            .scan::<Vec<u8>, _>(attempt_start..attempt_end)
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            writer.put_with_expire(&kv.key, &kv.value, expire_ts)?;
+        }
+
+        let cancelled_key = job_cancelled_key(tenant, job_id);
+        if let Some(cancelled_raw) = self.db.get(&cancelled_key).await? {
+            writer.put_with_expire(&cancelled_key, cancelled_raw, expire_ts)?;
+        }
+
+        Ok(())
     }
 }

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -99,6 +99,39 @@ pub struct OpenShardOptions {
     /// Populated from `DatabaseConfig::hydrate_all_at_startup` /
     /// `DatabaseTemplate::hydrate_all_at_startup`; tests set it explicitly.
     pub hydrate_all_at_startup: bool,
+    /// When set, jobs that reach Succeeded have their associated KV records
+    /// re-put with a SlateDB row TTL of this many seconds. `None` disables
+    /// the feature for successful jobs.
+    pub completed_job_expire_s: Option<u64>,
+    /// When set, jobs that reach any non-success terminal status (Failed,
+    /// Cancelled, …) have their associated KV records re-put with a SlateDB
+    /// row TTL of this many seconds. `None` disables the feature for those
+    /// jobs.
+    pub terminal_job_expire_s: Option<u64>,
+}
+
+/// Compute the row TTL (`expire_ts`, epoch ms) for a job that reached the
+/// given terminal status, given the two configured expiration windows.
+/// Returns `None` for non-terminal kinds (`Scheduled`, `Running`) — those
+/// jobs are still alive and must never be tagged for expiry.
+///
+/// `seconds: u64` is operator-supplied; saturating arithmetic keeps the
+/// `u64 → i64` cast meaningful even if someone passes an absurd value
+/// (would otherwise wrap to a negative `expire_ts`, which SlateDB
+/// interprets as already-expired).
+pub(crate) fn compute_terminal_expire_ts(
+    kind: JobStatusKind,
+    now_ms: i64,
+    completed_job_expire_s: Option<u64>,
+    terminal_job_expire_s: Option<u64>,
+) -> Option<i64> {
+    let seconds = match kind {
+        JobStatusKind::Succeeded => completed_job_expire_s?,
+        JobStatusKind::Failed | JobStatusKind::Cancelled => terminal_job_expire_s?,
+        JobStatusKind::Scheduled | JobStatusKind::Running => return None,
+    };
+    let ms_i64 = i64::try_from(seconds.saturating_mul(1000)).unwrap_or(i64::MAX);
+    Some(now_ms.saturating_add(ms_i64))
 }
 
 fn expand_slatedb_settings_for_shard(
@@ -163,6 +196,12 @@ pub struct JobStoreShard {
     range: ShardRange,
     /// Metrics recorder for SlateDB, passed to DbBuilder and used for stats collection.
     slatedb_metrics_recorder: Arc<DefaultMetricsRecorder>,
+    /// TTL (seconds) applied to Succeeded jobs' associated records. `None`
+    /// disables the feature for successful jobs.
+    pub(crate) completed_job_expire_s: Option<u64>,
+    /// TTL (seconds) applied to non-success terminal jobs' associated records
+    /// (Failed, Cancelled, …). `None` disables the feature for those jobs.
+    pub(crate) terminal_job_expire_s: Option<u64>,
 }
 
 #[derive(Debug, Error)]
@@ -338,6 +377,8 @@ impl JobStoreShard {
                 ),
                 counter_reconciliation_seconds: cfg.counter_reconciliation_seconds,
                 hydrate_all_at_startup: cfg.hydrate_all_at_startup,
+                completed_job_expire_s: cfg.completed_job_expire_s,
+                terminal_job_expire_s: cfg.terminal_job_expire_s,
             },
             range,
         )
@@ -376,6 +417,8 @@ impl JobStoreShard {
             concurrency_reconcile_interval,
             counter_reconciliation_seconds,
             hydrate_all_at_startup,
+            completed_job_expire_s,
+            terminal_job_expire_s,
         } = options;
 
         let slatedb_metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
@@ -473,6 +516,8 @@ impl JobStoreShard {
             db_path: db_path.to_string(),
             range: range.clone(),
             slatedb_metrics_recorder,
+            completed_job_expire_s,
+            terminal_job_expire_s,
         });
 
         // Periodically reconcile pending concurrency requests to self-heal from
@@ -789,6 +834,18 @@ impl JobStoreShard {
 
     pub fn db(&self) -> &InstrumentedDb {
         &self.db
+    }
+
+    /// Resolve the row TTL (`expire_ts`, epoch ms) for a job that reached the
+    /// given terminal status, or `None` if no TTL is configured.
+    #[allow(dead_code)] // wired up in follow-up retention PRs (cancel, import, terminal)
+    pub(crate) fn terminal_expire_ts(&self, kind: JobStatusKind, now_ms: i64) -> Option<i64> {
+        compute_terminal_expire_ts(
+            kind,
+            now_ms,
+            self.completed_job_expire_s,
+            self.terminal_job_expire_s,
+        )
     }
 
     /// Snapshot the in-memory concurrency limit cache for use by the query system.
@@ -1131,7 +1188,68 @@ impl JobStoreShard {
 
 #[cfg(test)]
 mod tests {
-    use super::expand_slatedb_settings_for_shard;
+    use super::{JobStatusKind, compute_terminal_expire_ts, expand_slatedb_settings_for_shard};
+
+    #[test]
+    fn terminal_expire_ts_succeeded_uses_completed_expire_setting() {
+        let ts = compute_terminal_expire_ts(JobStatusKind::Succeeded, 1_000, Some(60), Some(30));
+        assert_eq!(ts, Some(1_000 + 60_000));
+    }
+
+    #[test]
+    fn terminal_expire_ts_failed_uses_terminal_expire_setting() {
+        let ts = compute_terminal_expire_ts(JobStatusKind::Failed, 1_000, Some(60), Some(30));
+        assert_eq!(ts, Some(1_000 + 30_000));
+    }
+
+    #[test]
+    fn terminal_expire_ts_cancelled_uses_terminal_expire_setting() {
+        let ts = compute_terminal_expire_ts(JobStatusKind::Cancelled, 1_000, Some(60), Some(30));
+        assert_eq!(ts, Some(1_000 + 30_000));
+    }
+
+    #[test]
+    fn terminal_expire_ts_returns_none_for_scheduled_even_when_both_settings_set() {
+        // Live jobs (Scheduled/Running) must never carry a TTL: they're still
+        // reachable and tagging them would let SlateDB drop the row out from
+        // under an active worker.
+        let ts = compute_terminal_expire_ts(JobStatusKind::Scheduled, 1_000, Some(60), Some(30));
+        assert_eq!(ts, None);
+    }
+
+    #[test]
+    fn terminal_expire_ts_returns_none_for_running_even_when_both_settings_set() {
+        let ts = compute_terminal_expire_ts(JobStatusKind::Running, 1_000, Some(60), Some(30));
+        assert_eq!(ts, None);
+    }
+
+    #[test]
+    fn terminal_expire_ts_returns_none_when_succeeded_setting_unset() {
+        let ts = compute_terminal_expire_ts(JobStatusKind::Succeeded, 1_000, None, Some(30));
+        assert_eq!(ts, None);
+    }
+
+    #[test]
+    fn terminal_expire_ts_returns_none_when_terminal_setting_unset() {
+        let ts = compute_terminal_expire_ts(JobStatusKind::Failed, 1_000, Some(60), None);
+        assert_eq!(ts, None);
+    }
+
+    #[test]
+    fn terminal_expire_ts_saturates_on_overflowing_seconds() {
+        let huge = u64::MAX;
+        let ts = compute_terminal_expire_ts(JobStatusKind::Failed, 1_000, None, Some(huge));
+        // `u64::MAX * 1000` overflows; the cast saturates to `i64::MAX`.
+        // Then `1_000 + i64::MAX` saturates again at `i64::MAX`.
+        assert_eq!(ts, Some(i64::MAX));
+    }
+
+    #[test]
+    fn terminal_expire_ts_saturates_when_now_ms_is_near_max() {
+        // Sane seconds; `now_ms` near i64::MAX. Add must saturate, not wrap negative.
+        let ts = compute_terminal_expire_ts(JobStatusKind::Failed, i64::MAX - 5, None, Some(60));
+        assert_eq!(ts, Some(i64::MAX));
+    }
 
     #[test]
     fn expands_shard_placeholder_in_slatedb_cache_root_folder() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -225,6 +225,35 @@ pub struct DatabaseTemplate {
     /// access. Defaults to false.
     #[serde(default = "default_hydrate_all_at_startup")]
     pub hydrate_all_at_startup: bool,
+    /// When set, jobs that finished successfully (Succeeded) have all of their
+    /// associated KV records re-put with a SlateDB row TTL expiring this many
+    /// seconds in the future. `None` (the default) disables the behaviour for
+    /// successful jobs. A typical value is 604800 (7 days).
+    ///
+    /// Adds work to the job-termination hot path.
+    ///
+    /// **Counter consistency:** when this is enabled, compaction will silently
+    /// drop terminal `JOB_INFO`/`JOB_STATUS` rows, which the `COUNTER_*` rows
+    /// do not see — counters can drift high over time. Pair with
+    /// `counter_reconciliation_seconds = <interval>` to periodically rederive
+    /// counter values from the surviving job rows.
+    #[serde(default)]
+    pub completed_job_expire_s: Option<u64>,
+    /// When set, jobs that reach any non-success terminal status (Failed,
+    /// Cancelled, etc.) have all of their associated KV records re-put with a
+    /// SlateDB row TTL expiring this many seconds in the future. `None` (the
+    /// default) disables the behaviour for failed/cancelled jobs. A typical
+    /// value is 604800 (7 days).
+    ///
+    /// Adds work to the job-termination hot path.
+    ///
+    /// **Counter consistency:** when this is enabled, compaction will silently
+    /// drop terminal `JOB_INFO`/`JOB_STATUS` rows, which the `COUNTER_*` rows
+    /// do not see — counters can drift high over time. Pair with
+    /// `counter_reconciliation_seconds = <interval>` to periodically rederive
+    /// counter values from the surviving job rows.
+    #[serde(default)]
+    pub terminal_job_expire_s: Option<u64>,
     /// Optional SlateDB-specific settings for tuning database performance.
     /// If not specified, SlateDB defaults are used. When partially specified,
     /// unspecified fields use SlateDB defaults.
@@ -249,6 +278,8 @@ impl Default for DatabaseTemplate {
             concurrency_reconcile_interval_ms: default_concurrency_reconcile_interval_ms(),
             counter_reconciliation_seconds: None,
             hydrate_all_at_startup: default_hydrate_all_at_startup(),
+            completed_job_expire_s: None,
+            terminal_job_expire_s: None,
             slatedb: None,
             memory_cache: None,
         }
@@ -508,6 +539,14 @@ pub struct DatabaseConfig {
     /// details. Defaults to false.
     #[serde(default = "default_hydrate_all_at_startup")]
     pub hydrate_all_at_startup: bool,
+    /// TTL (seconds) applied to Succeeded jobs' associated records. See
+    /// `DatabaseTemplate::completed_job_expire_s` for details.
+    #[serde(default)]
+    pub completed_job_expire_s: Option<u64>,
+    /// TTL (seconds) applied to non-success terminal jobs' associated records.
+    /// See `DatabaseTemplate::terminal_job_expire_s` for details.
+    #[serde(default)]
+    pub terminal_job_expire_s: Option<u64>,
     /// Optional SlateDB-specific settings for tuning database performance.
     /// If not specified, SlateDB defaults are used. When partially specified,
     /// unspecified fields use SlateDB defaults.
@@ -532,6 +571,8 @@ impl Default for DatabaseConfig {
             apply_wal_on_close: default_apply_wal_on_close(),
             counter_reconciliation_seconds: None,
             hydrate_all_at_startup: default_hydrate_all_at_startup(),
+            completed_job_expire_s: None,
+            terminal_job_expire_s: None,
             slatedb: None,
             memory_cache: None,
         }

--- a/tests/expire_helper_tests.rs
+++ b/tests/expire_helper_tests.rs
@@ -1,0 +1,61 @@
+//! Tests for the terminal-job expiration settings plumb.
+//!
+//! The `expire_terminal_job_records` helper itself and the
+//! `set_job_status_with_index_opts` writer are `pub(crate)` and exercised
+//! end-to-end by the cancel / import / completion integration tests added
+//! in the follow-up retention PRs. This file pins the wiring that those
+//! PRs depend on: that the two new `DatabaseConfig` / `DatabaseTemplate`
+//! settings deserialize correctly, default to disabled, and flow into a
+//! freshly opened shard without panicking.
+
+mod test_helpers;
+
+use silo::settings::{AppConfig, DatabaseConfig, DatabaseTemplate};
+use test_helpers::open_temp_shard;
+
+#[silo::test]
+fn database_template_expire_settings_default_to_none() {
+    let t = DatabaseTemplate::default();
+    assert_eq!(t.completed_job_expire_s, None);
+    assert_eq!(t.terminal_job_expire_s, None);
+}
+
+#[silo::test]
+fn database_config_expire_settings_default_to_none() {
+    let c = DatabaseConfig::default();
+    assert_eq!(c.completed_job_expire_s, None);
+    assert_eq!(c.terminal_job_expire_s, None);
+}
+
+#[silo::test]
+fn parse_toml_expire_settings_omitted_yields_none() {
+    let toml_str = r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+"#;
+    let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
+    assert_eq!(cfg.database.completed_job_expire_s, None);
+    assert_eq!(cfg.database.terminal_job_expire_s, None);
+}
+
+#[silo::test]
+fn parse_toml_expire_settings_round_trip() {
+    let toml_str = r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+completed_job_expire_s = 86400
+terminal_job_expire_s = 604800
+"#;
+    let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
+    assert_eq!(cfg.database.completed_job_expire_s, Some(86400));
+    assert_eq!(cfg.database.terminal_job_expire_s, Some(604800));
+}
+
+#[silo::test]
+async fn shard_opens_with_expire_settings_unset() {
+    // Smoke test: with no TTL configured (matches main today), opening a
+    // shard must continue to succeed.
+    let (_tmp, _shard) = open_temp_shard().await;
+}

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -104,6 +104,8 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             concurrency_reconcile_interval: Duration::from_millis(interval_ms.max(1)),
             counter_reconciliation_seconds: None,
             hydrate_all_at_startup: false,
+            completed_job_expire_s: None,
+            terminal_job_expire_s: None,
         },
         ShardRange::full(),
     )


### PR DESCRIPTION
## Summary

These helpers expire jobs transactionally, by re-writing them and their metadata with new expire_ts.

PR 2/4 in the job-retention stack split. Stacks on #329 (`kirin/job_retention/counter_reconciliation_settings`).

Adds the plumbing the cancel / import / completion paths need to apply a SlateDB row TTL on terminal job records. **No production caller is wired up yet** — that lands in the next two PRs in this stack.

What this PR adds:

- `DatabaseTemplate` / `DatabaseConfig` gain `completed_job_expire_s` and `terminal_job_expire_s`, both `Option<u64>` and defaulted to `None`.
- `JobStoreShard` carries both values through `OpenShardOptions`.
- New `compute_terminal_expire_ts` resolver (and its `JobStoreShard` wrapper) computes `now_ms + seconds * 1000` with saturating arithmetic so an absurd operator value cannot wrap to a negative `expire_ts`.
- `WriteBatcher::put_with_expire` is added to the trait with **no default impl** — every implementor must thread the TTL through explicitly. A silent fallback that dropped the TTL would produce data that never expires with no compile-time signal, so the trait forces each writer to decide. Real overrides on `DbWriteBatcher` and `TxnWriter` route through `slatedb::config::PutOptions { ttl: Ttl::ExpireAt(ts) }`. `InstrumentedDbTransaction` gains a `put_with_options` shim.
- `set_job_status_with_index_opts` / `write_job_status_with_index_opts` accept an optional `expire_ts` and tag JOB_STATUS + IDX_STATUS_TIME via `put_with_expire`.
- `expire_terminal_job_records` re-puts JOB_INFO, IDX_METADATA pairs, every prior ATTEMPT row, and JOB_CANCELLED (if present) with the row TTL.

Unused-yet items carry a narrow `#[allow(dead_code)]` pointing at the follow-up PRs; those allows go away when the callers land.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --lib --bins --all-features -- -D warnings`
- [x] `cargo check --all-targets`
- [x] Inline unit tests for `compute_terminal_expire_ts` (Succeeded vs other terminal, missing config, u64→i64 overflow saturation, `now_ms` near `i64::MAX`).
- [x] `cargo test --test expire_helper_tests` — 5 passed (TOML round-trip + shard-open smoke).
- [x] `cargo test --test config_and_db_tests` — 35 passed, no regressions.
- [ ] End-to-end coverage of `expire_terminal_job_records` itself comes via the integration tests in the follow-up cancel/import (PR 3/4) and completion/failure (PR 4/4) PRs that wire the helper to its real callers.