### PR TITLE
Apply terminal-job row TTL on cancel and import paths

### DIFF
--- a/src/instrumented_db.rs
+++ b/src/instrumented_db.rs
@@ -104,6 +104,16 @@ impl InstrumentedDb {
         self.inner.get(key).instrument(self.span.clone()).await
     }
 
+    pub async fn get_key_value<K: AsRef<[u8]> + Send>(
+        &self,
+        key: K,
+    ) -> Result<Option<KeyValue>, slatedb::Error> {
+        self.inner
+            .get_key_value(key)
+            .instrument(self.span.clone())
+            .await
+    }
+
     pub async fn scan<K, T>(&self, range: T) -> Result<InstrumentedDbIterator, slatedb::Error>
     where
         K: AsRef<[u8]> + Send,

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -96,9 +96,11 @@ impl JobStoreShard {
         // [SILO-CXL-2] Post: Mark job as cancelled (write cancellation record).
         // If this cancellation transitions the job to terminal, tag the new
         // JOB_CANCELLED row with the row TTL directly. `expire_terminal_job_records`
-        // re-puts an existing JOB_CANCELLED row by reading from committed state
-        // via `self.db.get`, but the row we just wrote lives in the open
-        // transaction, so the helper wouldn't see it.
+        // reads through the `TxnWriter` (so reads see this txn's own writes and
+        // join the SSI read set), so it would also re-put this row with the same
+        // TTL — tagging it here keeps the TTL co-located with the only put site
+        // and makes the JOB_CANCELLED row's TTL correct independent of helper
+        // ordering.
         let cancellation = JobCancellation {
             cancelled_at_ms: now_ms,
         };
@@ -221,10 +223,13 @@ impl JobStoreShard {
         // tagged at its put site, so the helper only needs to handle the
         // remaining records.
         //
-        // The helper reads existing values via `self.db.get` (committed
-        // state). For JOB_INFO and any prior ATTEMPT rows that is correct
-        // (those were written by earlier transactions). It re-puts via the
-        // TxnWriter, which goes through the open transaction.
+        // The helper reads and re-puts through the `TxnWriter`: reads go via
+        // `txn.get` / `txn.scan`, which see this transaction's own buffered
+        // writes and join the SSI read set so a concurrent mutation of any of
+        // these keys trips a conflict rather than being silently clobbered with
+        // stale bytes (see `expire_terminal_job_records`). JOB_INFO and any
+        // prior ATTEMPT rows were written by earlier transactions; re-putting
+        // them here tags them with the row TTL.
         if let Some(ts) = terminal_expire_ts {
             self.expire_terminal_job_records(&mut TxnWriter(&txn), tenant, id, ts)
                 .await?;

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -77,15 +77,44 @@ impl JobStoreShard {
             ));
         }
 
-        // [SILO-CXL-2] Post: Mark job as cancelled (write cancellation record)
+        // Track whether we're transitioning a scheduled job to terminal state.
+        // For Running cancellations the worker discovers the cancellation on
+        // heartbeat and transitions to Cancelled via `report_attempt_outcome`,
+        // which applies its own TTL — so we only tag the records here when the
+        // cancel itself produces the terminal transition.
+        let was_scheduled = status.kind == JobStatusKind::Scheduled;
+
+        // Compute the row-TTL deadline once, up front. Scheduled → Cancelled
+        // uses `terminal_job_expire_s` (Cancelled is a non-success terminal).
+        let terminal_expire_ts: Option<i64> = if was_scheduled {
+            self.terminal_expire_ts(JobStatusKind::Cancelled, now_ms)
+        } else {
+            None
+        };
+
+        // [SILO-CXL-2] Post: Mark job as cancelled (write cancellation record).
+        // If this cancellation transitions the job to terminal, tag the new
+        // JOB_CANCELLED row with the row TTL directly. `expire_terminal_job_records`
+        // re-puts an existing JOB_CANCELLED row by reading from committed state
+        // via `self.db.get`, but the row we just wrote lives in the open
+        // transaction, so the helper wouldn't see it.
         let cancellation = JobCancellation {
             cancelled_at_ms: now_ms,
         };
         let cancellation_value = encode_job_cancellation(&cancellation);
-        txn.put(&cancelled_key, &cancellation_value)?;
-
-        // Track whether we're transitioning a scheduled job to terminal state
-        let was_scheduled = status.kind == JobStatusKind::Scheduled;
+        match terminal_expire_ts {
+            Some(ts) => {
+                use slatedb::config::{PutOptions, Ttl};
+                txn.put_with_options(
+                    &cancelled_key,
+                    &cancellation_value,
+                    &PutOptions {
+                        ttl: Ttl::ExpireAt(ts),
+                    },
+                )?;
+            }
+            None => txn.put(&cancelled_key, &cancellation_value)?,
+        }
 
         // Track concurrency state for post-commit cleanup
         let mut held_queues_to_release: Vec<String> = Vec::new();
@@ -102,8 +131,14 @@ impl JobStoreShard {
                 status.next_attempt_starts_after_ms,
                 status.current_attempt,
             );
-            self.set_job_status_with_index(&mut TxnWriter(&txn), tenant, id, cancelled_status)
-                .await?;
+            self.set_job_status_with_index_opts(
+                &mut TxnWriter(&txn),
+                tenant,
+                id,
+                cancelled_status,
+                terminal_expire_ts,
+            )
+            .await?;
 
             // Read job info to get task_group, priority, and limits for task key reconstruction
             let job_key = job_info_key(tenant, id);
@@ -183,6 +218,22 @@ impl JobStoreShard {
         // Include counter in the transaction (unmark_write excludes it from conflict detection)
         if was_scheduled {
             self.increment_completed_jobs_counter(&mut TxnWriter(&txn))?;
+        }
+
+        // Re-put the job's prior associated records (JOB_INFO, IDX_METADATA,
+        // any pre-existing ATTEMPT rows) with the row TTL so they age out of
+        // slatedb alongside JOB_STATUS / JOB_CANCELLED. JOB_STATUS was tagged
+        // above via set_job_status_with_index_opts, and JOB_CANCELLED was
+        // tagged at its put site, so the helper only needs to handle the
+        // remaining records.
+        //
+        // The helper reads existing values via `self.db.get` (committed
+        // state). For JOB_INFO and any prior ATTEMPT rows that is correct
+        // (those were written by earlier transactions). It re-puts via the
+        // TxnWriter, which goes through the open transaction.
+        if let Some(ts) = terminal_expire_ts {
+            self.expire_terminal_job_records(&mut TxnWriter(&txn), tenant, id, ts)
+                .await?;
         }
 
         // Commit the transaction - this will detect conflicts with concurrent modifications

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -6,7 +6,8 @@ use crate::codec::{decode_cancellation_at_ms, decode_task, encode_job_cancellati
 use crate::job::{JobCancellation, JobStatus, JobStatusKind, JobView, Limit};
 use crate::job_store_shard::counters::encode_counter;
 use crate::job_store_shard::helpers::{
-    TxnWriter, decode_job_status_owned, now_epoch_ms, retry_on_txn_conflict,
+    TxnWriter, decode_job_status_owned, now_epoch_ms, put_with_optional_expire,
+    retry_on_txn_conflict,
 };
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
@@ -102,19 +103,12 @@ impl JobStoreShard {
             cancelled_at_ms: now_ms,
         };
         let cancellation_value = encode_job_cancellation(&cancellation);
-        match terminal_expire_ts {
-            Some(ts) => {
-                use slatedb::config::{PutOptions, Ttl};
-                txn.put_with_options(
-                    &cancelled_key,
-                    &cancellation_value,
-                    &PutOptions {
-                        ttl: Ttl::ExpireAt(ts),
-                    },
-                )?;
-            }
-            None => txn.put(&cancelled_key, &cancellation_value)?,
-        }
+        put_with_optional_expire(
+            &txn,
+            &cancelled_key,
+            &cancellation_value,
+            terminal_expire_ts,
+        )?;
 
         // Track concurrency state for post-commit cleanup
         let mut held_queues_to_release: Vec<String> = Vec::new();

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -201,6 +201,31 @@ impl WriteBatcher for TxnWriter<'_> {
     }
 }
 
+/// Put `value` at `key` through the transaction, applying a SlateDB row TTL
+/// expiring at `expire_ts` (epoch ms) when `expire_ts` is `Some`, and a plain
+/// put otherwise.
+///
+/// Centralizes the terminal-vs-non-terminal put branch used across the import
+/// and cancel paths, where every record written in the txn must pick up the
+/// row TTL iff the job lands in a terminal status.
+pub(crate) fn put_with_optional_expire(
+    txn: &InstrumentedDbTransaction,
+    key: impl AsRef<[u8]>,
+    value: impl AsRef<[u8]>,
+    expire_ts: Option<i64>,
+) -> Result<(), slatedb::Error> {
+    match expire_ts {
+        Some(ts) => txn.put_with_options(
+            key,
+            value,
+            &PutOptions {
+                ttl: Ttl::ExpireAt(ts),
+            },
+        ),
+        None => txn.put(key, value),
+    }
+}
+
 /// Get current epoch time in milliseconds.
 ///
 /// Uses `std::time::SystemTime::now()` which returns real wall-clock time in production.

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -185,10 +185,10 @@ impl JobStoreShard {
 
         // Determine the resulting status up-front so we can tag every record
         // written in this txn with a row TTL when the job lands in a terminal
-        // status. `expire_terminal_job_records` reads from committed state
-        // (pre-txn), so it can't see anything written here — for a brand-new
-        // import we apply the TTL inline at each put site instead of calling
-        // the helper post-write.
+        // status. A brand-new import has no pre-existing committed records for
+        // `expire_terminal_job_records` to re-put — every record is created
+        // here — so we apply the TTL inline at each put site instead of calling
+        // the helper.
         let num_attempts = params.attempts.len() as u32;
         let (job_status, status_kind, is_terminal) =
             determine_import_status(params, num_attempts, now_ms, effective_start_at_ms);
@@ -510,10 +510,12 @@ impl JobStoreShard {
         // If this reimport lands the job in a terminal status, retroactively
         // tag the records that already exist in committed state (old JOB_INFO,
         // IDX_METADATA rows for unchanged metadata pairs, prior ATTEMPT rows,
-        // any JOB_CANCELLED marker) with the row TTL. The helper reads from
-        // `self.db` (pre-txn), so it must run *before* the in-txn writes that
-        // override the same keys (updated JOB_INFO below, JOB_CANCELLED delete
-        // further down) — the txn's WriteBatch is last-write-wins per key.
+        // any JOB_CANCELLED marker) with the row TTL. The helper reads and
+        // re-puts through the `TxnWriter`, and the txn's WriteBatch is
+        // last-write-wins per key, so it must run *before* the in-txn writes
+        // that override the same keys (updated JOB_INFO below, JOB_CANCELLED
+        // delete further down) — otherwise the helper's re-put of the old value
+        // would clobber the new one.
         if let Some(ts) = terminal_expire_ts {
             self.expire_terminal_job_records(&mut TxnWriter(&txn), tenant, job_id, ts)
                 .await?;

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -4,7 +4,7 @@
 //! Unlike enqueue, import accepts completed attempts and lets Silo take ownership going forward.
 
 use slatedb::IsolationLevel;
-use slatedb::config::WriteOptions;
+use slatedb::config::{PutOptions, Ttl, WriteOptions};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -182,6 +182,21 @@ impl JobStoreShard {
             return Err(JobStoreShardError::InvalidArgument(msg));
         }
 
+        // Determine the resulting status up-front so we can tag every record
+        // written in this txn with a row TTL when the job lands in a terminal
+        // status. `expire_terminal_job_records` reads from committed state
+        // (pre-txn), so it can't see anything written here — for a brand-new
+        // import we apply the TTL inline at each put site instead of calling
+        // the helper post-write.
+        let num_attempts = params.attempts.len() as u32;
+        let (job_status, status_kind, is_terminal) =
+            determine_import_status(params, num_attempts, now_ms, effective_start_at_ms);
+        let terminal_expire_ts: Option<i64> = if is_terminal {
+            self.terminal_expire_ts(status_kind, now_ms)
+        } else {
+            None
+        };
+
         // Write JobInfo
         let job = JobInfo {
             id: job_id.to_string(),
@@ -194,17 +209,34 @@ impl JobStoreShard {
             task_group: params.task_group.clone(),
         };
         let job_value = encode_job_info(&job);
-        txn.put(&info_key, &job_value)?;
+        match terminal_expire_ts {
+            Some(ts) => txn.put_with_options(
+                &info_key,
+                &job_value,
+                &PutOptions {
+                    ttl: Ttl::ExpireAt(ts),
+                },
+            )?,
+            None => txn.put(&info_key, &job_value)?,
+        }
 
         // Write metadata secondary index
         for (mk, mv) in &job.metadata {
             let mkey = idx_metadata_key(tenant, mk, mv, job_id);
-            txn.put(&mkey, [])?;
+            match terminal_expire_ts {
+                Some(ts) => txn.put_with_options(
+                    &mkey,
+                    [],
+                    &PutOptions {
+                        ttl: Ttl::ExpireAt(ts),
+                    },
+                )?,
+                None => txn.put(&mkey, [])?,
+            }
         }
 
         // [SILO-IMP-2] Write imported attempt records (existing statuses unchanged - vacuously true for new import)
         // [SILO-IMP-3] All new attempts are terminal (validated by validate_import_attempts)
-        let num_attempts = params.attempts.len() as u32;
         for (i, imported) in params.attempts.iter().enumerate() {
             let attempt_number = (i as u32) + 1;
             let task_id = Uuid::new_v4().to_string();
@@ -234,15 +266,27 @@ impl JobStoreShard {
             };
             let attempt_value = encode_attempt(&attempt_record);
             let akey = attempt_key(tenant, job_id, attempt_number);
-            txn.put(&akey, &attempt_value)?;
+            match terminal_expire_ts {
+                Some(ts) => txn.put_with_options(
+                    &akey,
+                    &attempt_value,
+                    &PutOptions {
+                        ttl: Ttl::ExpireAt(ts),
+                    },
+                )?,
+                None => txn.put(&akey, &attempt_value)?,
+            }
         }
 
-        let (job_status, status_kind, is_terminal) =
-            determine_import_status(params, num_attempts, now_ms, effective_start_at_ms);
-
-        // Write status + index
+        // Write status + index (TTL applied when the import lands terminal)
         let mut writer = TxnWriter(&txn);
-        Self::write_job_status_with_index(&mut writer, tenant, job_id, job_status)?;
+        Self::write_job_status_with_index_opts(
+            &mut writer,
+            tenant,
+            job_id,
+            job_status,
+            terminal_expire_ts,
+        )?;
 
         // [SILO-IMP-5] Terminal status set by determine_import_status (Succeeded/Failed/Cancelled)
         // [SILO-IMP-6] Scheduled status set by determine_import_status when retries remain
@@ -478,10 +522,32 @@ impl JobStoreShard {
             return Err(JobStoreShardError::InvalidArgument(msg));
         }
 
+        // === Determine new status (resolved before any writes so we can apply
+        // the terminal-row TTL inline to everything we write in this txn) ===
+        let total_attempts = params.attempts.len() as u32;
+        let (new_job_status, status_kind, is_terminal) =
+            determine_import_status(params, total_attempts, now_ms, effective_start_at_ms);
+        let terminal_expire_ts: Option<i64> = if is_terminal {
+            self.terminal_expire_ts(status_kind, now_ms)
+        } else {
+            None
+        };
+
+        // If this reimport lands the job in a terminal status, retroactively
+        // tag the records that already exist in committed state (old JOB_INFO,
+        // IDX_METADATA rows for unchanged metadata pairs, prior ATTEMPT rows,
+        // any JOB_CANCELLED marker) with the row TTL. The helper reads from
+        // `self.db` (pre-txn), so it must run *before* the in-txn writes that
+        // override the same keys (updated JOB_INFO below, JOB_CANCELLED delete
+        // further down) — the txn's WriteBatch is last-write-wins per key.
+        if let Some(ts) = terminal_expire_ts {
+            self.expire_terminal_job_records(&mut TxnWriter(&txn), tenant, job_id, ts)
+                .await?;
+        }
+
         // === Write only new attempt records ===
         // [SILO-IMP-2] existing attempt statuses unchanged (we don't touch them)
         // [SILO-IMP-3] new attempts are terminal (validated above)
-        let total_attempts = params.attempts.len() as u32;
         for i in existing_count..params.attempts.len() {
             let imported = &params.attempts[i];
             let attempt_number = (i as u32) + 1;
@@ -512,12 +578,17 @@ impl JobStoreShard {
             };
             let attempt_value = encode_attempt(&attempt_record);
             let akey = attempt_key(tenant, job_id, attempt_number);
-            txn.put(&akey, &attempt_value)?;
+            match terminal_expire_ts {
+                Some(ts) => txn.put_with_options(
+                    &akey,
+                    &attempt_value,
+                    &PutOptions {
+                        ttl: Ttl::ExpireAt(ts),
+                    },
+                )?,
+                None => txn.put(&akey, &attempt_value)?,
+            }
         }
-
-        // === Determine new status ===
-        let (new_job_status, status_kind, is_terminal) =
-            determine_import_status(params, total_attempts, now_ms, effective_start_at_ms);
 
         // Persist the updated retry policy so future retry decisions (e.g. in
         // report_attempt_outcome) stay consistent with this reimport.
@@ -532,7 +603,17 @@ impl JobStoreShard {
             task_group: existing_job.task_group().to_string(),
         };
         let updated_job_value = encode_job_info(&updated_job);
-        txn.put(job_info_key(tenant, job_id), &updated_job_value)?;
+        let info_key = job_info_key(tenant, job_id);
+        match terminal_expire_ts {
+            Some(ts) => txn.put_with_options(
+                &info_key,
+                &updated_job_value,
+                &PutOptions {
+                    ttl: Ttl::ExpireAt(ts),
+                },
+            )?,
+            None => txn.put(&info_key, &updated_job_value)?,
+        }
 
         // === Clean up old scheduling state ===
 
@@ -619,8 +700,14 @@ impl JobStoreShard {
         // === Update status, scheduling state, and counters ===
         let mut writer = TxnWriter(&txn);
 
-        self.set_job_status_with_index(&mut writer, tenant, job_id, new_job_status)
-            .await?;
+        self.set_job_status_with_index_opts(
+            &mut writer,
+            tenant,
+            job_id,
+            new_job_status,
+            terminal_expire_ts,
+        )
+        .await?;
 
         // Clean up cancelled key: cancel_job writes a separate cancelled key that blocks
         // lease creation. The marker can outlive Cancelled status (for example when a

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -4,7 +4,7 @@
 //! Unlike enqueue, import accepts completed attempts and lets Silo take ownership going forward.
 
 use slatedb::IsolationLevel;
-use slatedb::config::{PutOptions, Ttl, WriteOptions};
+use slatedb::config::WriteOptions;
 use tracing::debug;
 use uuid::Uuid;
 
@@ -14,7 +14,8 @@ use crate::fb::silo::fb;
 use crate::job::{JobInfo, JobStatus, JobStatusKind, JobView, Limit};
 use crate::job_attempt::{AttemptStatus, JobAttempt};
 use crate::job_store_shard::helpers::{
-    TxnWriter, decode_job_status_owned, now_epoch_ms, retry_on_txn_conflict,
+    TxnWriter, decode_job_status_owned, now_epoch_ms, put_with_optional_expire,
+    retry_on_txn_conflict,
 };
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
@@ -209,30 +210,12 @@ impl JobStoreShard {
             task_group: params.task_group.clone(),
         };
         let job_value = encode_job_info(&job);
-        match terminal_expire_ts {
-            Some(ts) => txn.put_with_options(
-                &info_key,
-                &job_value,
-                &PutOptions {
-                    ttl: Ttl::ExpireAt(ts),
-                },
-            )?,
-            None => txn.put(&info_key, &job_value)?,
-        }
+        put_with_optional_expire(&txn, &info_key, &job_value, terminal_expire_ts)?;
 
         // Write metadata secondary index
         for (mk, mv) in &job.metadata {
             let mkey = idx_metadata_key(tenant, mk, mv, job_id);
-            match terminal_expire_ts {
-                Some(ts) => txn.put_with_options(
-                    &mkey,
-                    [],
-                    &PutOptions {
-                        ttl: Ttl::ExpireAt(ts),
-                    },
-                )?,
-                None => txn.put(&mkey, [])?,
-            }
+            put_with_optional_expire(&txn, &mkey, [], terminal_expire_ts)?;
         }
 
         // [SILO-IMP-2] Write imported attempt records (existing statuses unchanged - vacuously true for new import)
@@ -266,16 +249,7 @@ impl JobStoreShard {
             };
             let attempt_value = encode_attempt(&attempt_record);
             let akey = attempt_key(tenant, job_id, attempt_number);
-            match terminal_expire_ts {
-                Some(ts) => txn.put_with_options(
-                    &akey,
-                    &attempt_value,
-                    &PutOptions {
-                        ttl: Ttl::ExpireAt(ts),
-                    },
-                )?,
-                None => txn.put(&akey, &attempt_value)?,
-            }
+            put_with_optional_expire(&txn, &akey, &attempt_value, terminal_expire_ts)?;
         }
 
         // Write status + index (TTL applied when the import lands terminal)
@@ -578,16 +552,7 @@ impl JobStoreShard {
             };
             let attempt_value = encode_attempt(&attempt_record);
             let akey = attempt_key(tenant, job_id, attempt_number);
-            match terminal_expire_ts {
-                Some(ts) => txn.put_with_options(
-                    &akey,
-                    &attempt_value,
-                    &PutOptions {
-                        ttl: Ttl::ExpireAt(ts),
-                    },
-                )?,
-                None => txn.put(&akey, &attempt_value)?,
-            }
+            put_with_optional_expire(&txn, &akey, &attempt_value, terminal_expire_ts)?;
         }
 
         // Persist the updated retry policy so future retry decisions (e.g. in
@@ -604,16 +569,7 @@ impl JobStoreShard {
         };
         let updated_job_value = encode_job_info(&updated_job);
         let info_key = job_info_key(tenant, job_id);
-        match terminal_expire_ts {
-            Some(ts) => txn.put_with_options(
-                &info_key,
-                &updated_job_value,
-                &PutOptions {
-                    ttl: Ttl::ExpireAt(ts),
-                },
-            )?,
-            None => txn.put(&info_key, &updated_job_value)?,
-        }
+        put_with_optional_expire(&txn, &info_key, &updated_job_value, terminal_expire_ts)?;
 
         // === Clean up old scheduling state ===
 

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -626,7 +626,6 @@ impl JobStoreShard {
     /// `WriteBatch` is last-write-wins per key, and putting the new row
     /// earlier would be silently clobbered when the helper re-puts the old
     /// Running value with TTL.
-    #[allow(dead_code)] // wired up in follow-up retention PRs (cancel, import, terminal)
     pub(crate) async fn expire_terminal_job_records<W: WriteBatcher>(
         &self,
         writer: &mut W,

--- a/tests/job_store_shard_restart_tests.rs
+++ b/tests/job_store_shard_restart_tests.rs
@@ -1396,3 +1396,116 @@ async fn terminal_reimport_tags_existing_and_new_records_with_expire_ts() {
         }
     });
 }
+
+/// A terminal import must source its row TTL from the status-specific setting:
+/// Succeeded → `completed_job_expire_s`, Failed → `terminal_job_expire_s`.
+/// Configures the two settings to widely disjoint values so a swap of the two
+/// sources (which `open_temp_shard_with_terminal_expire_s` can't catch, since it
+/// sets both equal) lands the `expire_ts` in the wrong window and fails.
+#[silo::test]
+async fn terminal_import_uses_status_specific_ttl_source() {
+    with_timeout!(20000, {
+        use silo::keys::job_status_key;
+
+        let completed_s: u64 = 100 * 24 * 60 * 60; // 100 days
+        let terminal_s: u64 = 24 * 60 * 60; // 1 day
+        let completed_ms: i64 = completed_s as i64 * 1000;
+        let terminal_ms: i64 = terminal_s as i64 * 1000;
+        let (_tmp, shard) = open_temp_shard_with_split_expire_s(completed_s, terminal_s).await;
+
+        let before_ms = now_ms();
+
+        // Succeeded import → completed_job_expire_s.
+        let mut ok = import_base("import-succeeded");
+        ok.attempts = vec![import_succeeded_attempt(before_ms - 1_000)];
+
+        // Failed import (no retry policy → retries exhausted → terminal Failed)
+        // → terminal_job_expire_s.
+        let mut failed = import_base("import-failed");
+        failed.attempts = vec![import_failed_attempt(before_ms - 1_000)];
+
+        let results = shard
+            .import_jobs("-", vec![ok, failed])
+            .await
+            .expect("import_jobs");
+        assert_eq!(results[0].status, JobStatusKind::Succeeded);
+        assert_eq!(results[1].status, JobStatusKind::Failed);
+        let after_ms = now_ms();
+
+        let raw_db = shard.db();
+        for (id, ttl_ms) in [
+            ("import-succeeded", completed_ms),
+            ("import-failed", terminal_ms),
+        ] {
+            let kv = raw_db
+                .get_key_value(&job_status_key("-", id))
+                .await
+                .expect("get_key_value")
+                .expect("row present");
+            let expire_ts = kv.expire_ts.expect("terminal import must carry expire_ts");
+            let lower = before_ms + ttl_ms - 5_000;
+            let upper = after_ms + ttl_ms + 5_000;
+            assert!(
+                expire_ts >= lower && expire_ts <= upper,
+                "expire_ts {expire_ts} for {id} outside expected window [{lower}, {upper}] \
+                 — wrong TTL source?"
+            );
+        }
+    });
+}
+
+/// Reimporting a Scheduled job to another non-terminal (Scheduled) status must
+/// NOT tag any record with `expire_ts`. Complements
+/// `non_terminal_import_does_not_tag_records` (new import) and the terminal
+/// reimport coverage by exercising the reimport branch when it stays
+/// non-terminal.
+#[silo::test]
+async fn non_terminal_reimport_does_not_tag_records() {
+    with_timeout!(20000, {
+        use silo::keys::{attempt_key, job_info_key, job_status_key};
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        // First import: Scheduled (no attempts).
+        let initial = import_base("reimport-scheduled");
+        shard
+            .import_jobs("-", vec![initial])
+            .await
+            .expect("initial import");
+
+        // Reimport with one Failed attempt but a retry policy that still allows
+        // retries → job stays Scheduled (non-terminal).
+        let mut step = import_base("reimport-scheduled");
+        step.retry_policy = Some(RetryPolicy {
+            retry_count: 5,
+            initial_interval_ms: 100,
+            max_interval_ms: 10_000,
+            randomize_interval: false,
+            backoff_factor: 2.0,
+        });
+        step.attempts = vec![import_failed_attempt(now_ms() - 1_000)];
+        let results = shard
+            .import_jobs("-", vec![step])
+            .await
+            .expect("reimport step");
+        assert!(results[0].success);
+        assert_eq!(results[0].status, JobStatusKind::Scheduled);
+
+        let raw_db = shard.db();
+        for key in [
+            job_status_key("-", "reimport-scheduled"),
+            job_info_key("-", "reimport-scheduled"),
+            attempt_key("-", "reimport-scheduled", 1),
+        ] {
+            let kv = raw_db
+                .get_key_value(&key)
+                .await
+                .expect("get_key_value")
+                .expect("row present");
+            assert!(
+                kv.expire_ts.is_none(),
+                "non-terminal reimport must not tag record: key={key:?}"
+            );
+        }
+    });
+}

--- a/tests/job_store_shard_restart_tests.rs
+++ b/tests/job_store_shard_restart_tests.rs
@@ -3,6 +3,7 @@ mod test_helpers;
 use silo::job::JobStatusKind;
 use silo::job_attempt::AttemptOutcome;
 use silo::job_store_shard::JobStoreShardError;
+use silo::job_store_shard::import::{ImportJobParams, ImportedAttempt, ImportedAttemptStatus};
 use silo::retry::RetryPolicy;
 use silo::task::Task;
 
@@ -745,5 +746,653 @@ async fn multiple_restarts_of_same_job() {
             .expect("status")
             .expect("exists");
         assert_eq!(final_status.kind, JobStatusKind::Succeeded);
+    });
+}
+#[silo::test]
+async fn cancel_scheduled_job_tags_records_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::{job_cancelled_key, job_info_key, job_status_key};
+
+        let ttl_s: u64 = 7 * 24 * 60 * 60; // 7 days
+        let ttl_ms: i64 = ttl_s as i64 * 1000;
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(ttl_s).await;
+
+        let before_ms = now_ms();
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        shard.cancel_job("-", &job_id).await.expect("cancel_job");
+        let after_ms = now_ms();
+
+        // JOB_STATUS, JOB_INFO, and JOB_CANCELLED must all carry an `expire_ts`
+        // set to roughly `now + ttl_s*1000`. Allow a generous window around the
+        // wall-clock bounds (the implementation samples `now_ms` once per
+        // cancellation call).
+        let raw_db = shard.db();
+        for key in [
+            job_status_key("-", &job_id),
+            job_info_key("-", &job_id),
+            job_cancelled_key("-", &job_id),
+        ] {
+            let kv = raw_db
+                .get_key_value(&key)
+                .await
+                .expect("get_key_value")
+                .expect("row present");
+            let expire_ts = kv
+                .expire_ts
+                .expect("cancellation-terminal record should carry expire_ts");
+            let lower = before_ms + ttl_ms - 5_000;
+            let upper = after_ms + ttl_ms + 5_000;
+            assert!(
+                expire_ts >= lower && expire_ts <= upper,
+                "expire_ts {expire_ts} outside expected window [{lower}, {upper}] for key {key:?}"
+            );
+        }
+    });
+}
+
+/// The new IDX_STATUS_TIME row written for the Cancelled status by
+/// `set_job_status_with_index_opts` must carry the row TTL when the cancel
+/// path transitions a Scheduled job to terminal.
+#[silo::test]
+async fn cancel_scheduled_job_tags_idx_status_time_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::job::JobStatusKind;
+        use silo::keys::{idx_status_time_key, status_index_timestamp};
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        shard.cancel_job("-", &job_id).await.expect("cancel_job");
+
+        let status = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("get status")
+            .expect("exists");
+        assert_eq!(status.kind, JobStatusKind::Cancelled);
+        let ts = status_index_timestamp(&status);
+        let kv = shard
+            .db()
+            .get_key_value(&idx_status_time_key(
+                "-",
+                JobStatusKind::Cancelled.as_str(),
+                ts,
+                &job_id,
+            ))
+            .await
+            .expect("get_key_value")
+            .expect("IDX_STATUS_TIME row present");
+        assert!(
+            kv.expire_ts.is_some(),
+            "IDX_STATUS_TIME row for terminal Cancelled status must carry expire_ts"
+        );
+    });
+}
+
+/// IDX_METADATA rows must also be re-put with the row TTL on the cancel
+/// path. Mirrors `terminal_idx_metadata_rows_are_tagged_with_expire_ts` for
+/// the cancel-driven terminal transition.
+#[silo::test]
+async fn cancel_scheduled_job_tags_idx_metadata_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::idx_metadata_key;
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        let metadata = vec![
+            ("env".to_string(), "prod".to_string()),
+            ("region".to_string(), "us-east-1".to_string()),
+        ];
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                Some(metadata.clone()),
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        shard.cancel_job("-", &job_id).await.expect("cancel_job");
+
+        for (k, v) in &metadata {
+            let kv = shard
+                .db()
+                .get_key_value(&idx_metadata_key("-", k, v, &job_id))
+                .await
+                .expect("get_key_value")
+                .unwrap_or_else(|| panic!("IDX_METADATA row missing for {k}={v}"));
+            assert!(
+                kv.expire_ts.is_some(),
+                "IDX_METADATA row for {k}={v} must carry expire_ts after cancel"
+            );
+        }
+    });
+}
+
+/// A prior ATTEMPT row written by a retry-scheduling outcome was left
+/// without a TTL on purpose (job wasn't yet terminal). When the job is
+/// later cancelled via the cancel RPC, the cancel path must re-put that
+/// attempt row with the row TTL — that's what
+/// `expire_terminal_job_records` does, and we want to pin it down for the
+/// cancel call site.
+#[silo::test]
+async fn cancel_scheduled_job_tags_prior_attempt_rows_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::attempt_key;
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        let retry_policy = RetryPolicy {
+            retry_count: 3,
+            initial_interval_ms: 1_000,
+            max_interval_ms: 60_000,
+            randomize_interval: false,
+            backoff_factor: 2.0,
+        };
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                Some(retry_policy),
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Run-and-fail attempt 1 → retry-scheduling branch (job back to
+        // Scheduled, attempt 1 row has NO TTL).
+        let tasks = shard
+            .dequeue("worker-1", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(
+                &task_id,
+                AttemptOutcome::Error {
+                    error_code: "TEST".to_string(),
+                    error: b"boom".to_vec(),
+                },
+            )
+            .await
+            .expect("report failure");
+
+        // Sanity: attempt 1 row currently has no TTL.
+        let attempt_kv = shard
+            .db()
+            .get_key_value(&attempt_key("-", &job_id, 1))
+            .await
+            .expect("get_key_value")
+            .expect("attempt row present");
+        assert!(
+            attempt_kv.expire_ts.is_none(),
+            "pre-cancel attempt row should not yet carry expire_ts"
+        );
+
+        // Cancel — the job is back to Scheduled, so cancel transitions it
+        // straight to terminal Cancelled and the prior attempt row must
+        // pick up the TTL.
+        shard.cancel_job("-", &job_id).await.expect("cancel_job");
+
+        let attempt_kv_after = shard
+            .db()
+            .get_key_value(&attempt_key("-", &job_id, 1))
+            .await
+            .expect("get_key_value")
+            .expect("attempt row still present");
+        assert!(
+            attempt_kv_after.expire_ts.is_some(),
+            "prior attempt row must carry expire_ts after terminal cancel"
+        );
+    });
+}
+
+/// Running-job cancellation does NOT immediately tag records with the row
+/// TTL. The job is still Running until the worker acknowledges via
+/// `report_attempt_outcome(Cancelled)` — only then is it terminal. Tagging
+/// records on the cancel call would mean records expire before the worker
+/// even hears about the cancellation. The worker-ack path
+/// (`cancelled_terminal_job_cancellation_row_is_tagged_with_expire_ts`)
+/// covers TTL for that case.
+#[silo::test]
+async fn cancel_running_job_does_not_tag_records_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::{job_cancelled_key, job_info_key, job_status_key};
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Dequeue first so the job is Running.
+        let _ = shard
+            .dequeue("worker-1", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+
+        shard.cancel_job("-", &job_id).await.expect("cancel_job");
+
+        let status = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("status")
+            .expect("exists");
+        assert_eq!(
+            status.kind,
+            JobStatusKind::Running,
+            "status should still be Running until worker acknowledges"
+        );
+
+        let raw_db = shard.db();
+        for key in [
+            job_status_key("-", &job_id),
+            job_info_key("-", &job_id),
+            job_cancelled_key("-", &job_id),
+        ] {
+            let kv = raw_db
+                .get_key_value(&key)
+                .await
+                .expect("get_key_value")
+                .expect("row present");
+            assert!(
+                kv.expire_ts.is_none(),
+                "running-cancel must not pre-tag record with expire_ts: key={key:?}"
+            );
+        }
+    });
+}
+
+/// Sanity: when the terminal-expire feature is *not* configured, cancellation
+/// of a Scheduled job must NOT tag any record with `expire_ts`. Guards
+/// against an accidental hard-coded default that would enable the TTL
+/// feature for operators that haven't opted in.
+#[silo::test]
+async fn cancel_without_terminal_expire_config_writes_no_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::{job_cancelled_key, job_info_key, job_status_key};
+
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        shard.cancel_job("-", &job_id).await.expect("cancel_job");
+
+        let raw_db = shard.db();
+        for key in [
+            job_status_key("-", &job_id),
+            job_info_key("-", &job_id),
+            job_cancelled_key("-", &job_id),
+        ] {
+            let kv = raw_db
+                .get_key_value(&key)
+                .await
+                .expect("get_key_value")
+                .expect("row present");
+            assert!(
+                kv.expire_ts.is_none(),
+                "cancel without TTL config must not tag record: key={key:?}"
+            );
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Import / reimport TTL coverage
+//
+// When an import or reimport lands the job directly in a terminal status, the
+// records it writes (JOB_INFO, JOB_STATUS, IDX_STATUS_TIME, IDX_METADATA,
+// ATTEMPT) must carry a SlateDB row TTL so they age out alongside the
+// `report_attempt_outcome` and `cancel_job` paths — otherwise import-driven
+// terminal records would stick around indefinitely.
+// ---------------------------------------------------------------------------
+
+fn import_base(id: &str) -> ImportJobParams {
+    ImportJobParams {
+        id: id.to_string(),
+        priority: 50,
+        enqueue_time_ms: 1_700_000_000_000,
+        start_at_ms: 0,
+        retry_policy: None,
+        payload: test_helpers::msgpack_payload(&serde_json::json!({"imported": true})),
+        limits: vec![],
+        metadata: None,
+        task_group: "default".to_string(),
+        attempts: vec![],
+    }
+}
+
+fn import_succeeded_attempt(finished_at_ms: i64) -> ImportedAttempt {
+    ImportedAttempt {
+        status: ImportedAttemptStatus::Succeeded {
+            result: vec![1, 2, 3],
+        },
+        started_at_ms: finished_at_ms - 1000,
+        finished_at_ms,
+    }
+}
+
+fn import_failed_attempt(finished_at_ms: i64) -> ImportedAttempt {
+    ImportedAttempt {
+        status: ImportedAttemptStatus::Failed {
+            error_code: "ERR".to_string(),
+            error: vec![4, 5, 6],
+        },
+        started_at_ms: finished_at_ms - 1000,
+        finished_at_ms,
+    }
+}
+
+/// Importing a job with a terminal final attempt must tag JOB_STATUS,
+/// JOB_INFO, and every ATTEMPT row with a row TTL. Mirrors
+/// `terminal_records_are_tagged_with_expire_ts` for the import path.
+#[silo::test]
+async fn terminal_import_tags_records_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::{attempt_key, job_info_key, job_status_key};
+
+        let ttl_s: u64 = 7 * 24 * 60 * 60;
+        let ttl_ms: i64 = ttl_s as i64 * 1000;
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(ttl_s).await;
+
+        let before_ms = now_ms();
+        let mut params = import_base("import-terminal");
+        params.attempts = vec![
+            import_failed_attempt(before_ms - 5_000),
+            import_succeeded_attempt(before_ms - 1_000),
+        ];
+
+        let results = shard
+            .import_jobs("-", vec![params])
+            .await
+            .expect("import_jobs");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        assert_eq!(results[0].status, JobStatusKind::Succeeded);
+        let after_ms = now_ms();
+
+        let raw_db = shard.db();
+        for key in [
+            job_status_key("-", "import-terminal"),
+            job_info_key("-", "import-terminal"),
+            attempt_key("-", "import-terminal", 1),
+            attempt_key("-", "import-terminal", 2),
+        ] {
+            let kv = raw_db
+                .get_key_value(&key)
+                .await
+                .expect("get_key_value")
+                .expect("row present");
+            let expire_ts = kv
+                .expire_ts
+                .expect("import-terminal record should carry expire_ts");
+            let lower = before_ms + ttl_ms - 5_000;
+            let upper = after_ms + ttl_ms + 5_000;
+            assert!(
+                expire_ts >= lower && expire_ts <= upper,
+                "expire_ts {expire_ts} outside [{lower}, {upper}] for key {key:?}"
+            );
+        }
+    });
+}
+
+/// IDX_STATUS_TIME and IDX_METADATA secondary-index rows written by a
+/// terminal import must also carry the row TTL.
+#[silo::test]
+async fn terminal_import_tags_secondary_indexes_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::{idx_metadata_key, idx_status_time_key, status_index_timestamp};
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        let metadata = vec![
+            ("env".to_string(), "prod".to_string()),
+            ("region".to_string(), "us-east-1".to_string()),
+        ];
+        let mut params = import_base("import-idx");
+        params.metadata = Some(metadata.clone());
+        params.attempts = vec![import_succeeded_attempt(now_ms() - 1_000)];
+
+        shard
+            .import_jobs("-", vec![params])
+            .await
+            .expect("import_jobs");
+
+        let status = shard
+            .get_job_status("-", "import-idx")
+            .await
+            .expect("get status")
+            .expect("exists");
+        assert_eq!(status.kind, JobStatusKind::Succeeded);
+        let ts = status_index_timestamp(&status);
+        let idx_key = idx_status_time_key("-", status.kind.as_str(), ts, "import-idx");
+        let kv = shard
+            .db()
+            .get_key_value(&idx_key)
+            .await
+            .expect("get_key_value")
+            .expect("IDX_STATUS_TIME row present");
+        assert!(
+            kv.expire_ts.is_some(),
+            "IDX_STATUS_TIME row for terminal import must carry expire_ts"
+        );
+
+        for (k, v) in &metadata {
+            let kv = shard
+                .db()
+                .get_key_value(&idx_metadata_key("-", k, v, "import-idx"))
+                .await
+                .expect("get_key_value")
+                .unwrap_or_else(|| panic!("IDX_METADATA row missing for {k}={v}"));
+            assert!(
+                kv.expire_ts.is_some(),
+                "IDX_METADATA row for {k}={v} must carry expire_ts on terminal import"
+            );
+        }
+    });
+}
+
+/// Importing a job that lands non-terminal (Scheduled) must NOT carry a row
+/// TTL — the TTL is only applied when the resulting status is terminal.
+#[silo::test]
+async fn non_terminal_import_does_not_tag_records() {
+    with_timeout!(20000, {
+        use silo::keys::{job_info_key, job_status_key};
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        let params = import_base("import-scheduled");
+        // No attempts → Scheduled (per determine_import_status).
+        shard
+            .import_jobs("-", vec![params])
+            .await
+            .expect("import_jobs");
+
+        let raw_db = shard.db();
+        for key in [
+            job_status_key("-", "import-scheduled"),
+            job_info_key("-", "import-scheduled"),
+        ] {
+            let kv = raw_db
+                .get_key_value(&key)
+                .await
+                .expect("get_key_value")
+                .expect("row present");
+            assert!(
+                kv.expire_ts.is_none(),
+                "non-terminal import must not tag record: key={key:?}"
+            );
+        }
+    });
+}
+
+/// Reimporting a Scheduled job to a terminal status must tag both the
+/// pre-existing attempt rows (rewritten via `expire_terminal_job_records`)
+/// and the new in-txn attempt rows, plus the updated JOB_INFO. Exercises the
+/// reimport branch end-to-end.
+#[silo::test]
+async fn terminal_reimport_tags_existing_and_new_records_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::{attempt_key, job_info_key, job_status_key};
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        // First import: Scheduled (no attempts, no retry policy needed because
+        // zero attempts always lands Scheduled).
+        let initial = import_base("reimport-terminal");
+        shard
+            .import_jobs("-", vec![initial])
+            .await
+            .expect("initial import");
+
+        // Manually write one prior ATTEMPT row by reimporting with a single
+        // Failed attempt + retry policy that still allows more retries.
+        // The fail timestamp must be stable across the two reimport calls so
+        // the reimport's attempt-equality check passes on attempt #1.
+        let failed_at_ms = now_ms() - 3_000;
+        let mut step = import_base("reimport-terminal");
+        step.retry_policy = Some(RetryPolicy {
+            retry_count: 5,
+            initial_interval_ms: 100,
+            max_interval_ms: 10_000,
+            randomize_interval: false,
+            backoff_factor: 2.0,
+        });
+        step.attempts = vec![import_failed_attempt(failed_at_ms)];
+        let step_results = shard
+            .import_jobs("-", vec![step])
+            .await
+            .expect("reimport step");
+        assert!(step_results[0].success);
+        assert_eq!(step_results[0].status, JobStatusKind::Scheduled);
+
+        // First ATTEMPT row was just written without a TTL because the job is
+        // still Scheduled — sanity-check that pre-condition.
+        let raw_db = shard.db();
+        let pre_attempt = raw_db
+            .get_key_value(&attempt_key("-", "reimport-terminal", 1))
+            .await
+            .expect("get_key_value")
+            .expect("attempt 1 present");
+        assert!(
+            pre_attempt.expire_ts.is_none(),
+            "non-terminal reimport must leave attempt row untagged"
+        );
+
+        // Now reimport with attempt 2 = Succeeded. This lands the job
+        // terminal, and the helper should retroactively tag the existing
+        // attempt 1 alongside the new in-txn attempt 2.
+        let mut terminal = import_base("reimport-terminal");
+        terminal.retry_policy = Some(RetryPolicy {
+            retry_count: 5,
+            initial_interval_ms: 100,
+            max_interval_ms: 10_000,
+            randomize_interval: false,
+            backoff_factor: 2.0,
+        });
+        terminal.attempts = vec![
+            import_failed_attempt(failed_at_ms),
+            import_succeeded_attempt(now_ms() - 500),
+        ];
+        let terminal_results = shard
+            .import_jobs("-", vec![terminal])
+            .await
+            .expect("terminal reimport");
+        assert!(
+            terminal_results[0].success,
+            "terminal reimport failed: {:?}",
+            terminal_results[0].error
+        );
+        assert_eq!(terminal_results[0].status, JobStatusKind::Succeeded);
+
+        for key in [
+            job_status_key("-", "reimport-terminal"),
+            job_info_key("-", "reimport-terminal"),
+            attempt_key("-", "reimport-terminal", 1),
+            attempt_key("-", "reimport-terminal", 2),
+        ] {
+            let kv = shard
+                .db()
+                .get_key_value(&key)
+                .await
+                .expect("get_key_value")
+                .expect("row present");
+            assert!(
+                kv.expire_ts.is_some(),
+                "reimport-terminal record must carry expire_ts: key={key:?}"
+            );
+        }
     });
 }

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -82,6 +82,30 @@ pub async fn open_temp_shard_with_metrics() -> (
     (tmp, shard, metrics)
 }
 
+/// Open a temp shard with both `completed_job_expire_s` and
+/// `terminal_job_expire_s` set to the same value (in seconds). Lets cancel /
+/// import / completion tests assert that terminal-job records carry the
+/// expected row TTL without caring which terminal status each test produces.
+pub async fn open_temp_shard_with_terminal_expire_s(
+    expire_s: u64,
+) -> (tempfile::TempDir, std::sync::Arc<JobStoreShard>) {
+    let rate_limiter = MockGubernatorClient::new_arc();
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = DatabaseConfig {
+        name: "test".to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        completed_job_expire_s: Some(expire_s),
+        terminal_job_expire_s: Some(expire_s),
+        ..Default::default()
+    };
+    let shard = JobStoreShard::open(&cfg, rate_limiter, None, ShardRange::full())
+        .await
+        .expect("open shard");
+    (tmp, shard)
+}
+
 /// Open a temp shard with a custom periodic concurrency reconciliation interval.
 pub async fn open_temp_shard_with_reconcile_interval_ms(
     interval_ms: u64,

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -106,6 +106,31 @@ pub async fn open_temp_shard_with_terminal_expire_s(
     (tmp, shard)
 }
 
+/// Open a temp shard with *distinct* `completed_job_expire_s` and
+/// `terminal_job_expire_s` values (in seconds). Lets tests assert that a
+/// terminal status picks the correct TTL source — Succeeded → completed,
+/// Failed/Cancelled → terminal — rather than conflating the two.
+pub async fn open_temp_shard_with_split_expire_s(
+    completed_expire_s: u64,
+    terminal_expire_s: u64,
+) -> (tempfile::TempDir, std::sync::Arc<JobStoreShard>) {
+    let rate_limiter = MockGubernatorClient::new_arc();
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = DatabaseConfig {
+        name: "test".to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        completed_job_expire_s: Some(completed_expire_s),
+        terminal_job_expire_s: Some(terminal_expire_s),
+        ..Default::default()
+    };
+    let shard = JobStoreShard::open(&cfg, rate_limiter, None, ShardRange::full())
+        .await
+        .expect("open shard");
+    (tmp, shard)
+}
+
 /// Open a temp shard with a custom periodic concurrency reconciliation interval.
 pub async fn open_temp_shard_with_reconcile_interval_ms(
     interval_ms: u64,


### PR DESCRIPTION
## Summary

PR 3/4 in the job-retention stack split. Stacks on #330 (`kirin/job_retention/expiration_helpers`).

Wires the `expire_terminal_job_records` helper into the two RPC paths that can land a job directly in a terminal status without going through `report_attempt_outcome`. The completion / failure / worker-ack-cancel paths come next in PR 4/4.

### Cancel (`cancel_job_inner`)
- Compute `terminal_expire_ts` once, gated on `was_scheduled` — only Scheduled→Cancelled transitions tag records. Running cancellations stay Running until the worker acks; that path gets covered in PR 4/4.
- JOB_CANCELLED is written inside the open txn and tagged inline at its put site via `Ttl::ExpireAt(ts)`. The helper (called with `TxnWriter`) reads through the open txn, so it *would* re-put the same row with the same TTL — tagging it inline keeps the TTL co-located with the only put site and independent of helper ordering.
- `set_job_status_with_index` → `set_job_status_with_index_opts` so JOB_STATUS + IDX_STATUS_TIME carry the TTL.
- `expire_terminal_job_records` runs after all in-txn writes are queued to retroactively tag JOB_INFO, IDX_METADATA, and prior ATTEMPT rows.

### Import (`import_job_inner` and `reimport_job_inner`)
- Resolve the final status up-front via `determine_import_status`. Pick the TTL via `terminal_expire_ts(status_kind, now_ms)`: Succeeded → `completed_job_expire_s`, Failed / Cancelled → `terminal_job_expire_s`.
- **New import**: every put site (JOB_INFO, IDX_METADATA, ATTEMPT, JOB_STATUS, IDX_STATUS_TIME) is tagged inline. A brand-new job has no pre-existing committed records for the helper to re-put, so inline tagging is simpler and correct.
- **Reimport**: when the reimport lands the job terminal, call `expire_terminal_job_records` *before* the in-txn writes that override the same keys (WriteBatch is last-write-wins per key), then tag the new ATTEMPT and updated JOB_INFO rows inline.

### Read semantics note
- On both call sites the helper is invoked with `TxnWriter`, whose `get`/`scan` read through the open transaction — they see this txn's own buffered writes (read-your-own-writes) and join the SSI read set so a concurrent mutation of any re-put key trips a conflict instead of being silently clobbered with stale bytes. (This differs from the `DbWriteBatcher` path, whose `get` reads committed `self.db` state; the comments were reworded to match the actual `TxnWriter` behavior documented on `expire_terminal_job_records` in `lease.rs`.)

### Plumbing
- `InstrumentedDb::get_key_value` so tests can read a row together with its SlateDB `expire_ts` metadata.
- `open_temp_shard_with_terminal_expire_s(seconds)` test helper.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --lib --bins --all-features -- -D warnings`
- [x] `cargo check --all-targets`
- [x] `cargo test --test job_store_shard_restart_tests` — 19 passed (0 regressions)
- [x] `cargo test --test job_store_shard_restart_tests -- cancel_ import_ reimport_ non_terminal` — 10 new tests pass:
  - `cancel_scheduled_job_tags_records_with_expire_ts`
  - `cancel_scheduled_job_tags_idx_status_time_with_expire_ts`
  - `cancel_scheduled_job_tags_idx_metadata_with_expire_ts`
  - `cancel_scheduled_job_tags_prior_attempt_rows_with_expire_ts`
  - `cancel_running_job_does_not_tag_records_with_expire_ts`
  - `cancel_without_terminal_expire_config_writes_no_expire_ts`
  - `terminal_import_tags_records_with_expire_ts`
  - `terminal_import_tags_secondary_indexes_with_expire_ts`
  - `non_terminal_import_does_not_tag_records`
  - `terminal_reimport_tags_existing_and_new_records_with_expire_ts`
- [x] `cargo test --test expire_helper_tests` — 5 passed
