### PR TITLE
Apply terminal-job row TTL on completion / failure paths

### DIFF
--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -118,6 +118,11 @@ impl JobStoreShard {
         }
 
         let now_ms = now_epoch_ms();
+        // The row-TTL deadline for terminal records depends on which terminal
+        // status the job reaches — `completed_job_expire_s` for Succeeded,
+        // `terminal_job_expire_s` for Failed/Cancelled. We resolve it inside
+        // each terminal branch below via `self.terminal_expire_ts(kind, now_ms)`.
+        let mut terminal_expire_ts: Option<i64> = None;
         let attempt_status = match &outcome {
             AttemptOutcome::Success { result } => AttemptStatus::Succeeded {
                 finished_at_ms: now_ms,
@@ -147,10 +152,11 @@ impl JobStoreShard {
         };
         let attempt_val = encode_attempt(&attempt);
 
-        // Atomically update attempt and remove lease
+        // Atomically update attempt and remove lease.
+        // Note: the attempt put is deferred until after we determine whether the
+        // job reached a terminal status, so that we can apply the row TTL only
+        // to attempts of terminal jobs.
         let mut batch = WriteBatch::new();
-        // [SILO-SUCC-4][SILO-FAIL-4][SILO-RETRY-4] Update attempt status
-        batch.put(&attempt_key, &attempt_val);
         // [SILO-SUCC-2][SILO-FAIL-2][SILO-RETRY-2] Release lease
         batch.delete(&leased_task_key);
 
@@ -160,16 +166,23 @@ impl JobStoreShard {
         let mut retry_grants: Vec<(String, String)> = Vec::new();
         // Track the new job status for DST event emission
         let mut new_job_status_for_dst: Option<String> = None;
+        // Whether the job reached a terminal status during this call. Drives
+        // both the `expire_terminal_job_records` invocation and the TTL on the
+        // new attempt row written below.
+        let mut reached_terminal = false;
 
         match &outcome {
             // [SILO-SUCC-3] If success: mark job succeeded now (pure write)
             AttemptOutcome::Success { .. } => {
                 let job_status = JobStatus::succeeded(now_ms);
-                self.set_job_status_with_index(
+                terminal_expire_ts =
+                    self.terminal_expire_ts(crate::job::JobStatusKind::Succeeded, now_ms);
+                self.set_job_status_with_index_opts(
                     &mut DbWriteBatcher::new(&self.db, &mut batch),
                     &tenant,
                     &job_id,
                     job_status,
+                    terminal_expire_ts,
                 )
                 .await?;
                 // Job reached terminal state - include counter in batch
@@ -177,15 +190,19 @@ impl JobStoreShard {
                     &self.db, &mut batch,
                 ))?;
                 new_job_status_for_dst = Some("Succeeded".to_string());
+                reached_terminal = true;
             }
             // Worker acknowledges cancellation - set job status to Cancelled
             AttemptOutcome::Cancelled => {
                 let job_status = JobStatus::cancelled(now_ms);
-                self.set_job_status_with_index(
+                terminal_expire_ts =
+                    self.terminal_expire_ts(crate::job::JobStatusKind::Cancelled, now_ms);
+                self.set_job_status_with_index_opts(
                     &mut DbWriteBatcher::new(&self.db, &mut batch),
                     &tenant,
                     &job_id,
                     job_status,
+                    terminal_expire_ts,
                 )
                 .await?;
                 // Job reached terminal state - include counter in batch
@@ -193,6 +210,7 @@ impl JobStoreShard {
                     &self.db, &mut batch,
                 ))?;
                 new_job_status_for_dst = Some("Cancelled".to_string());
+                reached_terminal = true;
             }
             // Error: maybe enqueue next attempt; otherwise mark job failed
             AttemptOutcome::Error { .. } => {
@@ -263,11 +281,14 @@ impl JobStoreShard {
                     // [SILO-FAIL-3] If no follow-up scheduled, mark job as failed (pure write)
                     if !scheduled_followup {
                         let job_status = JobStatus::failed(now_ms);
-                        self.set_job_status_with_index(
+                        terminal_expire_ts =
+                            self.terminal_expire_ts(crate::job::JobStatusKind::Failed, now_ms);
+                        self.set_job_status_with_index_opts(
                             &mut DbWriteBatcher::new(&self.db, &mut batch),
                             &tenant,
                             &job_id,
                             job_status,
+                            terminal_expire_ts,
                         )
                         .await?;
                         // Job reached terminal state (failed permanently) - include counter in batch
@@ -275,11 +296,57 @@ impl JobStoreShard {
                             &self.db, &mut batch,
                         ))?;
                         new_job_status_for_dst = Some("Failed".to_string());
+                        reached_terminal = true;
                     }
                 } else {
                     job_missing_error = Some(JobStoreShardError::JobNotFound(job_id.clone()));
                 }
             }
+        }
+
+        // Re-put all of the job's *prior* associated records (JOB_INFO,
+        // IDX_METADATA, earlier ATTEMPT rows, JOB_CANCELLED) with the TTL.
+        //
+        // Ordering note: this MUST happen before we write the new ATTEMPT row
+        // for the current attempt. The helper scans `attempt_prefix` from
+        // `self.db` (which reflects committed state, pre-batch) — so the row
+        // for the current attempt comes back with its old Running status, and
+        // would clobber a freshly-batched terminal put on the same key
+        // because WriteBatch is last-write-wins per key. Writing the new
+        // attempt afterwards lets it win.
+        //
+        // Concurrency note: another writer cannot mutate this job's
+        // attempt rows in parallel — the lease for the running attempt was
+        // just deleted earlier in this batch, no other attempt for this
+        // job_id can be Running, and the job's terminal status will block
+        // dequeue / restart / reimport, so the scan sees a stable view.
+        if reached_terminal && let Some(ts) = terminal_expire_ts {
+            self.expire_terminal_job_records(
+                &mut DbWriteBatcher::new(&self.db, &mut batch),
+                &tenant,
+                &job_id,
+                ts,
+            )
+            .await?;
+        }
+
+        // [SILO-SUCC-4][SILO-FAIL-4][SILO-RETRY-4] Update attempt status.
+        // Apply TTL to terminal-job attempts so they expire alongside the rest of
+        // the job's records. The retry-scheduling branch leaves the attempt
+        // without a TTL — it'll be picked up by the helper's scan when the job
+        // ultimately hits a terminal status.
+        match (reached_terminal, terminal_expire_ts) {
+            (true, Some(ts)) => {
+                use slatedb::config::{PutOptions, Ttl};
+                batch.put_with_options(
+                    &attempt_key,
+                    &attempt_val,
+                    &PutOptions {
+                        ttl: Ttl::ExpireAt(ts),
+                    },
+                );
+            }
+            _ => batch.put(&attempt_key, &attempt_val),
         }
 
         // [SILO-REL-1][SILO-RETRY-REL] Delete concurrency holders in the batch.

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -838,7 +838,6 @@ impl JobStoreShard {
 
     /// Resolve the row TTL (`expire_ts`, epoch ms) for a job that reached the
     /// given terminal status, or `None` if no TTL is configured.
-    #[allow(dead_code)] // wired up in follow-up retention PRs (cancel, import, terminal)
     pub(crate) fn terminal_expire_ts(&self, kind: JobStatusKind, now_ms: i64) -> Option<i64> {
         compute_terminal_expire_ts(
             kind,

--- a/tests/job_store_shard_restart_tests.rs
+++ b/tests/job_store_shard_restart_tests.rs
@@ -1509,3 +1509,389 @@ async fn non_terminal_reimport_does_not_tag_records() {
         }
     });
 }
+
+#[silo::test]
+async fn terminal_records_are_tagged_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::{job_info_key, job_status_key};
+        let ttl_s: u64 = 7 * 24 * 60 * 60; // 7 days
+        let ttl_ms: i64 = ttl_s as i64 * 1000;
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(ttl_s).await;
+
+        let before_ms = now_ms();
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Drive the job to Failed (no retry policy → first error is permanent).
+        let tasks = shard
+            .dequeue("worker-1", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(
+                &task_id,
+                AttemptOutcome::Error {
+                    error_code: "TEST".to_string(),
+                    error: b"boom".to_vec(),
+                },
+            )
+            .await
+            .expect("report failure");
+        let after_ms = now_ms();
+
+        // JOB_STATUS and JOB_INFO must both carry an `expire_ts` set to roughly
+        // `now + ttl_ms`. Allow a generous window around the wall-clock bounds
+        // (clocks can skew under load and the implementation samples `now_ms`
+        // once per termination call).
+        let raw_db = shard.db();
+        for key in [job_status_key("-", &job_id), job_info_key("-", &job_id)] {
+            let kv = raw_db
+                .get_key_value(&key)
+                .await
+                .expect("get_key_value")
+                .expect("row present");
+            let expire_ts = kv
+                .expire_ts
+                .expect("terminal record should carry expire_ts");
+            let lower = before_ms + ttl_ms - 5_000;
+            let upper = after_ms + ttl_ms + 5_000;
+            assert!(
+                expire_ts >= lower && expire_ts <= upper,
+                "expire_ts {expire_ts} outside expected window [{lower}, {upper}] for key {key:?}"
+            );
+        }
+    });
+}
+
+/// Regression: when terminal_job_expire_s is set, the ATTEMPT row for the
+/// job's current attempt must reflect the **terminal** outcome status (e.g.
+/// Succeeded), not the prior Running status that was on disk before
+/// `report_attempt_outcome` ran. An earlier implementation re-scanned
+/// ATTEMPT rows after writing the new terminal attempt and clobbered the
+/// new value with the old Running value because WriteBatch is last-write-wins
+/// per key. This test reads the ATTEMPT row directly and asserts both the
+/// terminal status and the TTL are present.
+#[silo::test]
+async fn terminal_attempt_row_keeps_terminal_status_under_ttl() {
+    with_timeout!(20000, {
+        use silo::job_attempt::{AttemptStatus, JobAttemptView};
+        use silo::keys::attempt_key;
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        let tasks = shard
+            .dequeue("worker-1", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: Vec::new() })
+            .await
+            .expect("report success");
+
+        // The committed attempt row for attempt 1 must be Succeeded with a TTL.
+        let kv = shard
+            .db()
+            .get_key_value(&attempt_key("-", &job_id, 1))
+            .await
+            .expect("get_key_value")
+            .expect("attempt row present");
+        assert!(
+            kv.expire_ts.is_some(),
+            "terminal attempt row should carry expire_ts"
+        );
+        let view = JobAttemptView::new(kv.value).expect("decode attempt");
+        match view.state() {
+            AttemptStatus::Succeeded { .. } => {}
+            other => panic!("expected AttemptStatus::Succeeded, got {:?}", other),
+        }
+    });
+}
+
+/// IDX_METADATA rows are the reason `expire_terminal_job_records` reads
+/// JOB_INFO back: we extract the metadata pairs from JOB_INFO so we know
+/// which IDX_METADATA keys to TTL. This test pins down that every
+/// IDX_METADATA row for a terminal job carries the row TTL.
+#[silo::test]
+async fn terminal_idx_metadata_rows_are_tagged_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::idx_metadata_key;
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        let metadata = vec![
+            ("env".to_string(), "prod".to_string()),
+            ("region".to_string(), "us-east-1".to_string()),
+            ("kind".to_string(), "ingest".to_string()),
+        ];
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                Some(metadata.clone()),
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        let tasks = shard
+            .dequeue("worker-1", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: Vec::new() })
+            .await
+            .expect("report success");
+
+        for (k, v) in &metadata {
+            let kv = shard
+                .db()
+                .get_key_value(&idx_metadata_key("-", k, v, &job_id))
+                .await
+                .expect("get_key_value")
+                .unwrap_or_else(|| panic!("IDX_METADATA row missing for {k}={v}"));
+            assert!(
+                kv.expire_ts.is_some(),
+                "IDX_METADATA row for {k}={v} must carry expire_ts"
+            );
+        }
+    });
+}
+
+/// IDX_STATUS_TIME row written for the new terminal status must carry the
+/// row TTL. This is written inside `write_job_status_with_index_opts` rather
+/// than the helper, so it's a separate code path from the JOB_INFO/ATTEMPT
+/// re-puts and worth its own assertion.
+#[silo::test]
+async fn terminal_idx_status_time_row_is_tagged_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::job::JobStatusKind;
+        use silo::keys::{idx_status_time_key, status_index_timestamp};
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        let tasks = shard
+            .dequeue("worker-1", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: Vec::new() })
+            .await
+            .expect("report success");
+
+        // Re-derive the IDX_STATUS_TIME key for the new (Succeeded) status from
+        // the recorded JobStatus so this test stays in lockstep with however
+        // `set_job_status_with_index_opts` constructs the key.
+        let status = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("get_job_status")
+            .expect("status present");
+        assert_eq!(status.kind, JobStatusKind::Succeeded);
+        let ts = status_index_timestamp(&status);
+        let idx_key = idx_status_time_key("-", status.kind.as_str(), ts, &job_id);
+        let kv = shard
+            .db()
+            .get_key_value(&idx_key)
+            .await
+            .expect("get_key_value")
+            .expect("IDX_STATUS_TIME row present");
+        assert!(
+            kv.expire_ts.is_some(),
+            "IDX_STATUS_TIME row for terminal status must carry expire_ts"
+        );
+    });
+}
+
+/// JOB_CANCELLED rows are written on the cancellation path and must also
+/// be TTL'd when the cancellation results in a terminal outcome. Exercises
+/// the Cancelled-acknowledgement branch which neither of the other new
+/// tests touches.
+#[silo::test]
+async fn cancelled_terminal_job_cancellation_row_is_tagged_with_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::job_cancelled_key;
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Dequeue so the job is Running; only then does worker-acknowledged
+        // cancellation flow through report_attempt_outcome(Cancelled).
+        let tasks = shard
+            .dequeue("worker-1", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        let task_id = tasks[0].attempt().task_id().to_string();
+
+        // Cancel from the API side first (writes JOB_CANCELLED), then have the
+        // worker acknowledge with AttemptOutcome::Cancelled.
+        shard.cancel_job("-", &job_id).await.expect("cancel_job");
+        shard
+            .report_attempt_outcome(&task_id, AttemptOutcome::Cancelled)
+            .await
+            .expect("report cancelled");
+
+        let kv = shard
+            .db()
+            .get_key_value(&job_cancelled_key("-", &job_id))
+            .await
+            .expect("get_key_value")
+            .expect("JOB_CANCELLED row present");
+        assert!(
+            kv.expire_ts.is_some(),
+            "JOB_CANCELLED row for terminal Cancelled job must carry expire_ts"
+        );
+    });
+}
+
+/// When `report_attempt_outcome(Error)` schedules a retry (job goes back to
+/// Scheduled, not terminal), the just-finalized attempt row must NOT carry
+/// a TTL. Otherwise retried jobs that never reach terminal status would
+/// silently lose their attempt history once the next compaction runs.
+/// This is the inverse of `terminal_attempt_row_keeps_terminal_status_under_ttl`
+/// and pins down the doc-comment claim in lease.rs.
+#[silo::test]
+async fn retry_branch_attempt_row_has_no_expire_ts() {
+    with_timeout!(20000, {
+        use silo::keys::attempt_key;
+
+        let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+
+        // Retry policy so the first error leads to retry-scheduling, not Failed.
+        let retry_policy = RetryPolicy {
+            retry_count: 3,
+            initial_interval_ms: 1_000,
+            max_interval_ms: 60_000,
+            randomize_interval: false,
+            backoff_factor: 2.0,
+        };
+
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let job_id = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                Some(retry_policy),
+                payload,
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        let tasks = shard
+            .dequeue("worker-1", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(
+                &task_id,
+                AttemptOutcome::Error {
+                    error_code: "TEST".to_string(),
+                    error: b"boom".to_vec(),
+                },
+            )
+            .await
+            .expect("report error");
+
+        // Job should be back to Scheduled (retry scheduled), not terminal.
+        let status = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("status")
+            .expect("present");
+        assert_eq!(status.kind, JobStatusKind::Scheduled);
+
+        let kv = shard
+            .db()
+            .get_key_value(&attempt_key("-", &job_id, 1))
+            .await
+            .expect("get_key_value")
+            .expect("attempt row present");
+        assert!(
+            kv.expire_ts.is_none(),
+            "attempt row written under the retry-scheduling branch must NOT carry expire_ts \
+             (job is still alive and could be retried for hours); got {:?}",
+            kv.expire_ts
+        );
+    });
+}


### PR DESCRIPTION
## Summary

PR 4/4 — the final PR in the job-retention stack split. Stacks on #331 (`kirin/job_retention/rpc_expiration`).

Wires the `expire_terminal_job_records` helper into `report_attempt_outcome`. With this PR every path that lands a job in a terminal status now tags the job's KV records with a SlateDB row TTL.

### Behavior
- **Success** → `terminal_expire_ts(Succeeded)` → `completed_job_expire_s`.
- **Worker-ack Cancelled** → `terminal_expire_ts(Cancelled)` → `terminal_job_expire_s`. Complements the Scheduled→Cancelled RPC path from PR 3/4; this one covers Running→worker-ack→Cancelled.
- **Error, retries remaining** → next attempt scheduled, status stays Scheduled, **no TTL**. The job is still alive.
- **Error, retries exhausted** → terminal `Failed` → `terminal_expire_ts(Failed)` → `terminal_job_expire_s`.

### Implementation notes
- All three terminal `set_job_status_with_index` calls become `_opts` so JOB_STATUS + IDX_STATUS_TIME carry the TTL.
- `expire_terminal_job_records` is invoked once after the match block, gated on `reached_terminal && terminal_expire_ts.is_some()`. It retro-tags JOB_INFO, IDX_METADATA, any prior ATTEMPT rows (earlier retries), and JOB_CANCELLED.
- **Ordering matters**: the new ATTEMPT row for the current attempt is written *after* the helper. Reversing this order would clobber the in-batch terminal attempt with the helper's re-put of the committed Running row, since `WriteBatch` is last-write-wins per key and the helper scans `attempt_prefix` from committed state. A dedicated test (`terminal_attempt_row_keeps_terminal_status_under_ttl`) guards this.
- Concurrency: another writer cannot mutate this job's attempt rows in parallel — the lease was just deleted, no other attempt for this job_id can be Running, and the terminal status blocks dequeue / restart / reimport.
- The retry-scheduling branch leaves the new attempt without a TTL — it gets picked up by the helper's scan when the job eventually hits a terminal status.

### Cleanup
- Drop the `#[allow(dead_code)]` on `expire_terminal_job_records` and `terminal_expire_ts` now that production callers exist.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --lib --bins --all-features -- -D warnings`
- [x] `cargo check --all-targets`
- [x] `cargo test --test job_store_shard_restart_tests` — 25 passed (0 regressions)
- [x] New tests, all pass:
  - `terminal_records_are_tagged_with_expire_ts` — JOB_STATUS, JOB_INFO, ATTEMPT all carry expire_ts after Succeeded
  - `terminal_attempt_row_keeps_terminal_status_under_ttl` — guards the attempt-row clobber fix
  - `terminal_idx_metadata_rows_are_tagged_with_expire_ts`
  - `terminal_idx_status_time_row_is_tagged_with_expire_ts`
  - `cancelled_terminal_job_cancellation_row_is_tagged_with_expire_ts` — worker-ack path
  - `retry_branch_attempt_row_has_no_expire_ts` — inverse: retryable Failed does NOT tag
- [x] `cargo test --test expire_helper_tests` — 5 passed
- [x] `cargo test --test job_store_shard_lease_task_tests` — 7 passed