### PR TITLE
Unify concurrency request chain identity

### DIFF
--- a/docs/RFCs/Unify silo's enqueue + concurrency-gra.md
+++ b/docs/RFCs/Unify silo's enqueue + concurrency-gra.md
@@ -1,0 +1,367 @@
+# Unify silo's enqueue + concurrency-grant via the intent model
+
+## Context
+
+Silo has two parallel paths that admit a job through its multi-limit chain, and they share no state about the chain:
+
+- **Immediate path** — `JobStoreShard::enqueue_limit_task_at_index` (`src/job_store_shard/enqueue.rs:452`) walks limits in canonical order. For each `Concurrency`/`FloatingConcurrency`, it calls `ConcurrencyManager::handle_enqueue` (`src/concurrency.rs:746`), which on success writes a holder via `append_grant_edits` plus an interim `Task::RunAttempt` at the chain's `task_key`. The walker continues, and each successful limit overwrites the same `task_key` with a fresh interim `Task::RunAttempt` until the terminal branch emits the final one with the full accumulated `held_queues`.
+- **Deferred path** — when `try_reserve` fails, `handle_enqueue` writes a `ConcurrencyAction::EnqueueTask` intent record via `append_request_edits` keyed at `concurrency_request_key(tenant, queue, …, suffix)`. The background scanner `ConcurrencyManager::process_grants` (`src/concurrency.rs:1051`) later promotes that request — but the intent carries no chain context, so the scanner fabricates `request_id = "{job_id}:{attempt_number}:{suffix}"` (`src/keys.rs:419-422`), keys the new holder under that synthetic id (`src/concurrency.rs:1324`), and writes a *terminal* `RunAttempt` with `held_queues: vec![queue]` only (`src/concurrency.rs:1335`).
+
+When a chain mixes the two paths (e.g. limits `[Concurrency_A, FloatingConcurrency_B]` where A grants immediately and B has to queue), three bugs fall out as special cases of the same structural problem — the durable intent doesn't carry chain context, and resurrection from the request key forces the scanner to invent identity and forget remaining limits.
+
+*A chain holding queues mid-pause is fine — FIFO at each queue plus eventual resolution (grant or cancel) ensures progress.* The bugs below are not about the mid-pause state; they're about what happens at the **terminal** moment (chain completion or cancel), where identity mismatches make holders un-releasable or limits silently un-enforced.
+
+1. **Permanent holder leak at completion** — A's holder is keyed by `first_task_id` (Uuid generated at `enqueue.rs:371`, also written as the immediate-path `RunAttempt.id`). When B queues, the scanner later promotes it: the new holder is keyed by `request_id = "{job_id}:{attempt}:{suffix}"` from `ParsedConcurrencyRequestKey::request_id()` (`keys.rs:419-422`), and the terminal `Task::RunAttempt` the scanner writes has `id = request_id` and `held_queues = [B]` only (`concurrency.rs:1330, 1335`). When the job runs and `report_attempt_outcome` (`lease.rs:286-288`) releases by `(held_queues × task_id)`, it deletes `(B, request_id)` — A's holder under `first_task_id` is in neither the `held_queues` list nor the matching `task_id` slot and is never reached. Even after the chain completes, A's slot is permanently consumed. Verified by code inspection: no cross-holder release path keys on chain-wide context (job_id, attempt_number).
+2. **Limit bypass (silent under-enforcement)** — if the chain were `[A, B, C]` and B queues, the scanner has no view of C; it writes the terminal `RunAttempt` after granting B, silently skipping C. Not a leak — a correctness violation, since C's quota is never enforced for this chain.
+3. **`Task::RequestTicket` (future-scheduled)** — same shape as bugs 1 + 2. For `start_at_ms > now_ms`, `handle_enqueue`'s third branch (`concurrency.rs:826-849`) writes only a `RequestTicket` for the first concurrency queue; `process_ticket_request_task` (`concurrency.rs:863`) on grant creates a holder under the synthetic id + a single-queue terminal `RunAttempt`, dropping the rest of the chain (limit bypass) and orphaning any earlier holders that might exist (leak — though structurally `RequestTicket` is the *first* concurrency limit, so usually there are no earlier holders to orphan).
+
+The `specs/job_shard.als` `TicketHolder.th_task: one TaskId` invariant (line 158-162) encodes the right structural property — every holder belongs to one task identity. But the `holdersRequireActiveTask` assertion (line 2115) currently only counts `RunAttempt`, `CheckRateLimit`, and `RequestTicket` as "active tasks" — not `EnqueueTask` durable intents, which today carry no `task_id` to bind anything to. After this refactor, the durable `EnqueueTask` *is* the active marker for a partially-walked chain, so the spec must be updated to count it. The Alloy model changes are listed in the Critical files section; the implementation goal is then to comply with the (updated) assertion.
+
+The recently-merged PR #317 (`b868f2c`: "Delete stale interim RunAttempt when later limit returns TicketRequested") patches the dequeue-races-the-pause symptom (see `record_grant_outcome`'s `queued_with_request && !grants.is_empty()` task-key delete at `enqueue.rs:552-560` and again at `:640-648`); the regression test is `second_limit_request_must_not_leave_runnable_task` (`tests/job_store_shard_concurrency_tests.rs:2420`). This plan goes further and eliminates the interim-RunAttempt write entirely so the dance becomes unnecessary.
+
+## Design: `LimitWalkState` + `WalkOutcome` as the single walker API
+
+Every entry point — initial enqueue, retry, import, rate-limit continuation, scanner resumption, future-ticket grant — constructs the same in-memory `LimitWalkState` value and calls the walker. The walker advances it through limits in canonical order and returns a `WalkOutcome` describing where it stopped. Callers stage durable edits into the same `WriteBatch` and act on the outcome (notify task group, set up immediate lease, roll back reservations).
+
+```rust
+struct LimitWalkState {
+    tenant: Tenant,
+    task_id: Uuid,              // chain identity
+    job_id, attempt_number, relative_attempt_number, task_group, priority,
+    start_time_ms: i64,         // unchanged across pauses; drives FIFO at every queue
+    held_queues: Vec<String>,   // queues already acquired, in canonical order
+    next_limit_index: u32,      // resume position into limits[]
+    limits: Vec<LimitEntry>,    // *already canonicalized* at construction
+}
+
+enum WalkOutcome {
+    Resolved,                   // walker wrote terminal Task::RunAttempt
+    PausedOnRateLimit,          // walker wrote Task::CheckRateLimit
+    PausedOnConcurrency {       // walker wrote a durable EnqueueTask intent
+        queue: String,          //   (need queue for task-group wake; counter handling)
+    },
+    Future {                    // walker wrote Task::RequestTicket; scheduler will wake
+        queue: String,
+        start_time_ms: i64,
+    },
+}
+```
+
+The walker returns a `WalkResult` carrying everything callers need without introspecting WriteBatch internals:
+
+```rust
+struct WalkResult {
+    outcome: WalkOutcome,
+    reservations: Vec<(String /*queue*/, Uuid /*task_id*/)>,  // in-memory rollback set
+    request_record_ops: Vec<RequestRecordOp>,                  // counter-delta source of truth
+}
+enum RequestRecordOp { Put { queue: String }, Delete { queue: String } }
+```
+
+Reservations are *in addition to* the WriteBatch holder edits — they are the side-effect on `ConcurrencyManager`'s in-memory ticket map that must be undone if the batch fails. `request_record_ops` is the walker's authoritative record of every `concurrency_request_key` Put/Delete it appended this call; the scanner driver derives `concurrency_requester_counter_key` deltas from this list (one increment per `Put.queue`, one decrement per `Delete.queue`) rather than parsing WriteBatch mutations.
+
+Walker invariants (encoded as `debug_assert!` at emit sites):
+- `WalkOutcome::Resolved` ⇒ exactly one terminal `Task::RunAttempt` is in the WriteBatch at this chain's `task_key`, with `held_queues` equal to the union acquired across all walker calls for this chain.
+- `held_queues` ordering is the canonical-acquisition order (queue pushed at success of `process_concurrency_limit`); deterministic across runs, useful for test assertions and log readability.
+- `Task::RequestTicket` is emitted only when `next_limit_index` points at the first concurrency limit; its `held_queues` is structurally empty.
+
+```
+                    ┌──────────────────────────────────────────────────────────┐
+                    │ walk(LimitWalkState, now_ms, skip_first_try_reserve)     │
+                    │ → (WalkOutcome, Vec<reservation>)                        │
+                    │                                                          │
+                    │ loop over limits[state.next_limit_index..]:              │
+                    │   Concurrency / FloatingConcurrency:                     │
+                    │     - if first concurrency seen AND start_time > now:    │
+                    │         emit Task::RequestTicket(full state),            │
+                    │         return Future.                                   │
+                    │     - if skip_first_try_reserve AND this is first        │
+                    │       concurrency limit seen this call: skip reserve →   │
+                    │       emit EnqueueTask(full state), return Paused.       │
+                    │     - process_concurrency_limit(state, limit_idx, batch) │
+                    │       does: floating state setup, refresh scheduling,    │
+                    │       queue-limit cache update, try_reserve, holder edit │
+                    │       on success.                                        │
+                    │     - on success: state.held_queues.push(queue);         │
+                    │                   state.next_limit_index += 1;           │
+                    │     - on capacity-exhausted: emit EnqueueTask(state) at  │
+                    │       concurrency_request_key, return Paused.            │
+                    │   RateLimit:                                             │
+                    │     - emit Task::CheckRateLimit(state), return.          │
+                    │   end of limits:                                         │
+                    │     - emit Task::RunAttempt(state.task_id,               │
+                    │       held_queues=state.held_queues), return Resolved.   │
+                    └──────────────────────────────────────────────────────────┘
+                       ▲             ▲             ▲             ▲
+   initial enqueue     retry         scanner       RequestTicket CheckRateLimit
+   build state         build state   resume:       grant:        re-entry: build
+   from job,           skip_first_   decode        decode        state from
+   index=0,            try_reserve   EnqueueTask   RequestTicket CheckRateLimit
+   held_queues=[]      = true        payload →     payload →     payload (already
+                                     walk          walk          carries everything)
+                                                                 → walk
+```
+
+### `process_concurrency_limit` shared helper
+
+The bulk of today's `handle_enqueue` body (`concurrency.rs:746-849`) factors into `process_concurrency_limit(state, limit_idx, batch) -> ProcessLimit { Granted | CapacityExhausted | RetryDeferred }`. This helper owns: floating-concurrency state resolution + `current_max` derivation (today's `concurrency.rs:769-799`); refresh scheduling for floating windows; queue-limit cache updates; `try_reserve_internal` call; holder edit append on success. The walker calls it; the scanner does not — scanner just calls the walker, which calls the helper. This addresses **review issue #3**: scanner does not pre-grant outside the walker; floating-concurrency setup runs identically for scanner-resumed and initial-path executions.
+
+### Canonical ordering
+
+`LimitWalkState.limits` is stored *already in canonical order*. The walker indexes directly: `state.limits[state.next_limit_index]`. Canonicalization runs once at construction time (initial enqueue, retry, import, rate-limit continuation re-entry). The scanner and ticket-processor decode payloads that were already canonical when written, so no re-canonicalization on resume. This addresses **review issue #6** (no `order[next_limit_index]` indirection).
+
+When the scanner picks up an `EnqueueTask` from `concurrency_request_key(tenant, queue_k, …)`, it validates `state.limits[state.next_limit_index].queue == queue_k` before calling the walker. Mismatch → log + skip + delete the orphaned record (defensive; should be unreachable).
+
+### Future scheduling
+
+Future scheduling stays on `Task::RequestTicket`, driven by the existing scheduler's `start_time_ms` wake-up. The walker, when called with `start_time_ms > now_ms` and arriving at the *first concurrency limit*, emits `Task::RequestTicket` (carrying the full `LimitWalkState` payload) and returns `Future`. The scheduler wakes the task at `start_time_ms`; `process_ticket_request_task` decodes the payload → calls the walker → walker treats `start_time_ms <= now_ms` and proceeds normally. This addresses **review issue #2**: one mechanism for time waits (scheduler-driven `RequestTicket`), one mechanism for capacity waits (scanner-driven `EnqueueTask`), walker chooses based on `start_time_ms` vs `now_ms`.
+
+`RequestTicket.held_queues` is structurally empty (`start_time_ms` is per-job and gates the *first* concurrency limit; no holders are taken before that). Cancel still must handle it for safety — see Cancel path below.
+
+### WalkOutcome consumers
+
+- **`write_enqueue_data`** (initial enqueue): doesn't branch on outcome — caller proceeds with whatever the WriteBatch contains.
+- **Scanner**: on `Resolved` or `PausedOnRateLimit`, the task group whose work was admitted must be woken (notify worker pool). On `PausedOnConcurrency` at a *different* queue than the one that was resolved, that queue's request counter is incremented by the walker's request-edit append; on the resolved queue, the request counter is decremented (mirroring today's `concurrency.rs:1316-1322`). The driver collects these counter deltas from the walker's `WriteBatch` mutations.
+- **`process_ticket_request_task`**: on `Resolved`, immediately create a lease for the just-promoted task (today's `dequeue.rs:412-446` path). On other outcomes, commit and return; scanner or scheduler will wake the next stage.
+- **`handle_check_rate_limit`**: outcome is informational; caller doesn't act on it directly (rate-limit continuation either resolves or pauses again, both committed via the WriteBatch).
+
+### Counter management on scanner resumption
+
+Today's grant pass decrements the request counter for each promoted request (`concurrency.rs:1316-1322`) under the assumption: one request resolved → one counter decrement on its queue. After this refactor, scanner-resumed walks can:
+
+1. Resolve the request (most common) → decrement counter on the resolved queue.
+2. Pause again on the *same* queue (e.g. floating-concurrency window shrinks mid-walk) → no net counter change; existing request key stays.
+3. Pause on a *different, later* queue → decrement counter on resolved queue, increment counter on new pause queue. Both the request-record delete and the new request-record write happen in the walker's WriteBatch; the scanner driver derives per-queue counter deltas from `WalkResult.request_record_ops` (each `Put.queue` → counter +1, each `Delete.queue` → counter −1) and appends counter mutations to the same batch before commit. This addresses the **counter management gap** without batch introspection.
+
+There is no `Task::ContinueLimits` and no broker round-trip for scanner-driven resumption — the walker runs to its next pause inside the scanner's same `WriteBatch`.
+
+### Identity unification
+
+The chain's UUIDv4 `task_id` (minted at `enqueue.rs:371` initial, `lease.rs:222` retry, `import.rs:258/634` import) is the single identity throughout:
+
+- Every holder for every queue the chain acquires is `concurrency_holder_key(tenant, queue, task_id)`.
+- `EnqueueTask.task_id` (new field) carries it through the durable intent.
+- `Task::RunAttempt.id`, `Task::CheckRateLimit.task_id`, `Task::RequestTicket.task_id` (renamed from `request_id`) all equal it.
+
+The `suffix` in `concurrency_request_key` stays purely as a key-uniqueness tiebreaker and never escapes the key. `ParsedConcurrencyRequestKey::request_id()` (`src/keys.rs:419-422`) loses its current role as identity source — consumers needing a task identity read `task_id` from the decoded `EnqueueTask` payload instead. (Audit map below.)
+
+### Payload extensions
+
+All three durable types that carry walker state — `ConcurrencyAction::EnqueueTask`, `Task::CheckRateLimit`, `Task::RequestTicket` — encode the same `LimitWalkState` shape so the walker can resume from any of them. Today `CheckRateLimit` already carries most of it; this refactor brings `EnqueueTask` and `RequestTicket` into alignment.
+
+**`ConcurrencyAction::EnqueueTask`** (`src/task.rs:141-153`, schema `schema/internal_storage.fbs:233-240`, codec `src/codec.rs:467`) gains:
+
+```
+table EnqueueTask {
+  start_time_ms, priority, job_id, attempt_number, relative_attempt_number, task_group;  // existing
+  task_id: string;                  // chain identity
+  held_queues: [string];            // queues already acquired
+  next_limit_index: uint32;         // walker resume position
+  limits: [LimitEntry];             // *canonical order at construction*; walker indexes directly
+}
+```
+
+`LimitEntry` already exists for `JobInfo.limits`; reuse it. Canonicalization runs once at the construction site (initial enqueue, retry, import); decoded values are already canonical and the walker does not reorder.
+
+**`Task::RequestTicket`** (`task.rs:28-40`, schema `internal_storage.fbs:81-91`) gains `task_id` (renamed from `request_id`), `next_limit_index`, and `limits`. It does *not* gain `held_queues` — `start_time_ms` gates the first concurrency limit, before any holders are taken, so a `RequestTicket` mid-flight always has `held_queues = []`. (If a future change ever lets `RequestTicket` exist mid-chain, add the field then.)
+
+The rename `request_id` → `task_id` is a semantic change, not an append-only field addition. The new field's slot may be wire-compatible with the old, but consumers of the accessor change. Pre-launch DB nuke covers the data side; the code change is mechanical (audit map in Critical files).
+
+### Shrinkages from the walker becoming the single entry
+
+- `handle_enqueue` (`concurrency.rs:746`) is dissolved: its concurrency-limit body becomes `process_concurrency_limit` (called by the walker); its `Task::RunAttempt`-writing branch is removed entirely; its `Task::RequestTicket` branch moves into the walker's `Future` outcome.
+- `append_grant_edits` (`concurrency.rs:1421`) shrinks to a holder-only put; drop lines 1440-1453 (the `Task::RunAttempt` construction and `put_task`).
+- `append_request_edits` (`concurrency.rs:1459`) is extended to encode the new payload fields.
+- `record_grant_outcome` + `GrantResult` (`enqueue.rs:69-117`) are removed entirely; the walker mutates `LimitWalkState` directly instead of routing through the outcome enum.
+- `LimitTaskParams` (`enqueue.rs:28-46`) is replaced by `LimitWalkState` + the two runtime args (`now_ms`, `skip_first_try_reserve`). Tenant lives inside `LimitWalkState` (in the in-memory shape only; the durable wire format derives tenant from the request/task key).
+- PR #317's stale-task-key delete dance at `enqueue.rs:552-560` and `:640-648` is removed — no interim `task_key` is ever written, so nothing to clean up on pause.
+
+### Initial enqueue (`write_enqueue_data`)
+
+`write_enqueue_data` (`enqueue.rs:344`) builds an in-memory `LimitWalkState`:
+
+```rust
+let state = LimitWalkState {
+    tenant, task_id: first_task_id, job_id, attempt_number: 1,
+    relative_attempt_number: 1, priority, start_time_ms: start_at_ms, task_group,
+    held_queues: vec![], next_limit_index: 0,
+    limits: canonicalize(job.limits.clone()),
+};
+self.walk(writer, state, now_ms, /* skip_first_try_reserve */ false).await
+```
+
+Walker advances. Full grant → batch contains holders + `Task::RunAttempt`. Partial grant → batch contains holders for granted limits + `EnqueueTask` durable record at the paused queue's `concurrency_request_key`. Future-scheduled → batch contains a single `Task::RequestTicket` at the first concurrency queue, no holders. No interim task ever exists.
+
+### Scanner resumption (`process_grants`)
+
+Today's `process_grants` (`concurrency.rs:1051`) lives on `ConcurrencyManager`, which doesn't own the walker. Restructuring:
+
+- Keep `ConcurrencyManager` owning `pending_grants`, `grant_notify`, `try_reserve_internal`, hydration. The in-memory primitives stay there. Expose `drain_pending() -> Vec<(tenant, queue, count)>` if needed.
+- Move the grant-scanner driver out of `ConcurrencyManager::start_grant_scanner` into `JobStoreShard`. `JobStoreShard::open_internal` (`src/job_store_shard/mod.rs:457`) spawns it, holding a `Weak<JobStoreShard>` so it can call the walker. Pattern mirrors `spawn_concurrency_reconcile_task` (`mod.rs:479`). Shutdown wiring goes through `JobStoreShard::close` (`mod.rs:520`), replacing `stop_grant_scanner` (`concurrency.rs:979`).
+
+New per-pass shape (one `WriteBatch` per pass):
+
+1. Scan up to `MAX_GRANTS_PER_PASS` candidates from the request prefix (unchanged).
+2. Validate via the existing `[SILO-GRANT-5]` status gate (unchanged).
+3. For each valid candidate: decode the (extended) `EnqueueTask` payload into a `LimitWalkState`. Validate consistency: payload `tenant`, `job_id`, `attempt_number`, `priority`, `start_time_ms` match the request key's parsed fields, and `state.limits[state.next_limit_index].queue` matches the request key's queue. Mismatch → log + delete the orphan record + skip.
+4. Call the walker against the same `WriteBatch`. The walker — not the scanner — handles the paused limit via `process_concurrency_limit`, which runs the full floating-concurrency logic (state setup, refresh scheduling, queue-limit cache, `try_reserve_internal`). On success it pushes the queue to `held_queues`, increments the index, and continues; on capacity-exhausted it emits the request-record edit and returns. (This addresses **review issue #3**.)
+5. Apply per-queue counter deltas from each candidate's `WalkResult.request_record_ops` (Put → +1, Delete → −1) as `concurrency_requester_counter_key` mutations in the same batch.
+6. Commit. On batch-write failure, roll back *every* in-memory reservation accumulated this pass — concatenate each candidate's `WalkResult.reservations` into a per-pass set and release all of them. Extend the existing rollback at `concurrency.rs:1381-1383` accordingly.
+7. **Post-commit only** — for each candidate whose outcome was `Resolved` or `PausedOnRateLimit`, wake the corresponding task group. Wake-ups never fire before commit (avoids workers picking up a row that the failing batch would have rolled back). Today's pending-grant decrement at `concurrency.rs:1316-1322` is subsumed into step 5.
+
+### Future-scheduled path (`process_ticket_request_task`)
+
+`process_ticket_request_task` (`concurrency.rs:863`) on scheduler wake-up: decode the (extended) `RequestTicket` payload into `LimitWalkState` (with `held_queues: vec![]`, `next_limit_index: 0`), call the walker with `now_ms >= start_time_ms`. Walker runs `process_concurrency_limit` for the first concurrency limit (the one the ticket was waiting on) and continues. `handle_request_ticket` in `dequeue.rs:388-476` inspects `WalkOutcome`: on `Resolved`, immediately create a lease (today's `:412-446` path); on any other outcome, just commit and let the scanner/scheduler handle further wake-ups.
+
+### Rate-limit continuation (`handle_check_rate_limit`)
+
+`handle_check_rate_limit` (`src/job_store_shard/dequeue.rs:482-661`) already builds the walker-input shape today (`LimitTaskParams` at `:565-579`). Replace with `LimitWalkState` constructed directly from the `CheckRateLimit` fields (which already carry `task_id`, `held_queues`, `limit_index`), pulling `limits` from `job_info` and canonicalizing once. Walker re-entry is otherwise unchanged.
+
+### Retry path
+
+`lease.rs:228`'s call sets `skip_first_try_reserve: true`. When the walker hits the first concurrency limit in a retry chain, `skip_first_try_reserve` short-circuits straight to the pause branch (write `EnqueueTask` intent, no `try_reserve`). This protects `[SILO-RETRY-5-CONC]`: the old holder is still in-memory (released post-commit). The flag only suppresses the *first* `try_reserve` the walker reaches; subsequent limits in the same chain reserve normally — but those don't happen synchronously here because the chain has already paused at limit 0. (If the future schedules retries to reserve later limits eagerly, that's a separate design decision; preserve today's "pause-and-defer" semantics.)
+
+### Cancel and reimport cleanup
+
+Today `cancel_job` (`src/job_store_shard/cancel.rs:130-176`) finds the chain's task in the queue and:
+- `Task::RunAttempt`: deletes its holders.
+- `Task::RequestTicket`: deletes only the task. (Currently safe because today's `RequestTicket` carries no holders; will stay safe after the refactor for the same reason.)
+- `Task::CheckRateLimit`: ⚠️ **pre-existing bug** — today's cancel does *not* release the `held_queues` a `CheckRateLimit` carries. Worth fixing in this refactor since the cleanup path is being touched anyway.
+- No-task-found (`TicketRequested`): calls `delete_concurrency_requests_for_job` which scans by `(tenant, queue, job_id, attempt_number)` prefix and deletes request records — *but* today's records carry no holders, so there's nothing to release beyond the records themselves.
+
+After the refactor, the durable records that carry `held_queues` (and therefore require holder release on cancel) are:
+- `Task::RunAttempt` — full chain (already handled).
+- `Task::CheckRateLimit` — partial chain (fix the pre-existing bug here).
+- `ConcurrencyAction::EnqueueTask` — partial chain (new with this refactor).
+
+`delete_concurrency_requests_for_job` (today in `cancel.rs:219`, also called from reimport at `import.rs:600`) is upgraded to *read* each `EnqueueTask` record before deleting, decode `task_id` + `held_queues`, and *return* the decoded chain references to the caller (so cancel and reimport both apply holder deletes + post-commit in-memory release for those queues, deduplicated against any already released for the same `task_id`). Reimport uses the same helper, so this lines up automatically. (This addresses **review issue #5**.)
+
+Cancel of `Task::CheckRateLimit` follows the same pattern: read the task, decode `held_queues` + `task_id`, append holder deletes, then delete the task. Cancel of `Task::RequestTicket` continues to delete only the task (held_queues is structurally empty).
+
+### FIFO at pause points
+
+A chain that pauses at limit_index `k` writes its intent at `concurrency_request_key(tenant, queue_k, original_start_time_ms, priority, job_id, attempt_number, suffix)`. The walker threads `start_time_ms` unchanged through the `EnqueueTask` payload, so a chain that took real wallclock time to walk earlier limits still races FIFO by job age — paused chains aren't penalized for chain progress.
+
+### Stale limits in durable payloads
+
+`EnqueueTask` / `RequestTicket` / `CheckRateLimit` all duplicate the chain's `limits` so the walker doesn't have to re-read `job_info`. Risk: if the job's limits change between when the record was written and when the walker resumes, the walker uses stale data. Mitigation:
+- Job status is the validity gate (`[SILO-GRANT-5]`). A cancelled or completed job's records are skipped + deleted regardless of payload.
+- Reimport / job mutation paths aggressively delete all durable chain records for a given `(job_id, attempt_number)` via the upgraded `delete_concurrency_requests_for_job`. Limits-changed-mid-flight is reduced to "record exists with old limits AND status still gates it" — a small window relative to today, where the same data is read indirectly via the same `job_info` field.
+
+If this proves too risky, the alternative is "look up `limits` from `job_info` on resume" — but that re-introduces the inconsistency `CheckRateLimit` already accepts today, so duplication is the simpler choice.
+
+### Schema baseline (no migration)
+
+Silo is pre-production and this change ships on net-new shards — there are no existing durable records to migrate or nuke. The schema additions (`EnqueueTask` gaining `task_id` / `held_queues` / `next_limit_index` / `limits` / `limits_fingerprint`; `RequestTicket` renaming `request_id` → `task_id` and gaining chain fields) become the baseline for every shard from first boot.
+
+For *future* (post-launch) schema evolution, the additions are still done append-only by Flatbuffer convention so later upgrades remain backwards-compatible. The `RequestTicket` rename is irreversible in code (consumers switch accessors), so any later wire-level concern would be a separate forward-only decision; not relevant now.
+
+`concurrency_holder_key`'s on-disk *value* (`HolderRecord { granted_at_ms }`) is unchanged; only the key's `task_id` slot is now uniformly the chain's UUID. `concurrency_requester_counter_key` semantics are unchanged.
+
+## Hardening invariants & observability
+
+These guards must ship with the implementation rather than be retrofitted. Listed once here so they aren't lost between design and code review.
+
+### Payload validation at every decode boundary
+
+`EnqueueTask`, `RequestTicket`, and `CheckRateLimit` are all walker-resumption inputs; each decode site validates and on failure: structured warn log + delete the orphan record + increment `silo_walker_payload_malformed_total{kind, reason}` + skip.
+
+- `next_limit_index <= limits.len()` (equality means terminal-pending; strictly less means a queue must match below).
+- If `next_limit_index < limits.len()`: for `EnqueueTask`, `limits[next_limit_index].queue == parsed_request_key.queue`; for `RequestTicket`, `limits[next_limit_index]` is the first concurrency limit.
+- `task_id` non-empty and parses as a Uuid.
+- Payload key-fields (`tenant`, `job_id`, `attempt_number`, `priority`, `start_time_ms`) match the parsed request/task key.
+- `RequestTicket.held_queues` is empty (debug-assert; structural invariant per the design section).
+
+### Limits fingerprint
+
+Add `limits_fingerprint: u64` (xxhash of the canonical `limits` payload bytes) to `EnqueueTask`, `RequestTicket`, and `CheckRateLimit`. At decode sites that already read `job_info` (cancel, reimport, scanner's status-gate), compare against `hash(canonicalize(job_info.limits))`. Mismatch → warn + `silo_walker_limits_fingerprint_mismatch_total{kind}`; policy: prefer the durable payload's `limits` (already canonical, already what the chain was walking) and rely on status-gate cleanup to retire the record. The fingerprint is informational; hot paths (scanner per-candidate) do not pay an extra `job_info` read for it.
+
+### Idempotency contract for scanner reprocessing
+
+Scanner reprocessing is idempotent by construction:
+- Walker actions are keyed on durable identity (`concurrency_holder_key(tenant, queue, task_id)`, `concurrency_request_key(...)`, `task_key`). A re-run after a partial pass either finds the request record already deleted (status-gate skips trivially) or re-runs the walk producing a bitwise-equivalent WriteBatch.
+- `try_reserve_internal`'s existing pending-grant dedupe prevents double in-memory reservation on the same `(queue, task_id)` within the same `ConcurrencyManager` instance.
+- After restart, in-memory reservations are gone; `reconcile_pending_requests` (`concurrency.rs:988`) rebuilds counters from durable records.
+
+Stated invariant (encoded in `test_scanner_idempotent_replay`, not a debug-assert because it spans passes): the per-queue durable request-record set after committing a pass equals the pre-pass set minus all `Delete` op queues plus all `Put` op queues across all candidates that pass committed. Replaying the same pass on the post-commit state is a no-op.
+
+### Cancel-path dedupe
+
+Cancel collects holders to release as a `HashMap<(queue, task_id), ()>` across `Task::RunAttempt.held_queues`, `Task::CheckRateLimit.held_queues`, and every chain `EnqueueTask.held_queues`. Multiple records referencing the same `(queue, task_id)` coalesce into one holder delete + one in-memory release. Without this, cancel of a chain holding both a paused `EnqueueTask` and a stale `CheckRateLimit` with overlapping `held_queues` would double-release. The `(queue, task_id)` tuple is the explicit dedupe key.
+
+### Scanner driver lifecycle
+
+The relocated driver (now on `JobStoreShard`) has explicit lifecycle:
+- **Startup ordering** — spawned by `open_internal` *after* `reconcile_pending_requests` finishes hydration and *after* the existing reconcile task is spawned, so the first walker pass sees consistent counters.
+- **Stop signal** — `close` flips an `AtomicBool` and notifies via a `Notify` (mirrors today's `stop_grant_scanner` at `concurrency.rs:979`). The driver checks the signal *between candidates within a pass*, not just between passes, to bound shutdown latency under high candidate counts.
+- **Join timeout** — `close` awaits the driver's `JoinHandle` with a 5s deadline. On timeout: structured warn + force-abort. The in-flight pass's WriteBatch is dropped (commit is atomic, so no half-applied state).
+- **No-double-scanner invariant** — `JobStoreShard` holds a single `Option<JoinHandle>` taken on close; any second spawn attempt panics in debug, logs + skips in release.
+
+### Observability counters
+
+All `silo_*`-namespaced:
+- `silo_walker_payload_malformed_total{kind, reason}` — guardrail trip at decode.
+- `silo_walker_limits_fingerprint_mismatch_total{kind}` — limits changed mid-flight.
+- `silo_scanner_reservation_rollback_total{reason}` — batch write failure → in-memory release.
+- `silo_counter_drift_corrected_total{queue}` — `reconcile_pending_requests` adjustments at restart.
+- `silo_holder_release_miss_total{reason}` — `report_attempt_outcome`'s debug-assert site (logs + counts even when the assert is compiled out, so production sees mismatches).
+- `silo_scanner_pass_walker_calls_total{outcome}` — `WalkOutcome` variant distribution.
+
+### `request_id` → `task_id` log audit
+
+The rename is a semantic change, not a wire-only field swap. Before merging, audit `src/` and `tests/` for every log site emitting `request_id` (grep both `request_id =` style and `tracing::field("request_id"…)`/`%request_id`/`?request_id` interpolations) and rename to `task_id`. Do not alias — mixed naming during rollout causes confusion in production triage.
+
+## Critical files
+
+- `src/concurrency.rs` — shrink `handle_enqueue` (drop task writes), shrink `append_grant_edits` (holder only), extend `append_request_edits` (4 new fields), restructure `process_grants` to construct `EnqueueTask` from durable payload and call walker, restructure `process_ticket_request_task` similarly, extract scanner driver out to `JobStoreShard`, expose `drain_pending`.
+- `src/job_store_shard/enqueue.rs` — `enqueue_limit_task_at_index` takes an `EnqueueTask` value; `write_enqueue_data` constructs the initial value; remove `LimitTaskParams` / `record_grant_outcome` / `GrantResult` (`:28-117`), remove PR #317's task-key-delete dance (`:552-560`, `:640-648`).
+- `src/job_store_shard/mod.rs` — spawn grant-scanner driver here (replace `:457`); `Weak<JobStoreShard>` drives walker calls; wire shutdown into `close` (`:520`).
+- `src/job_store_shard/dequeue.rs` — `handle_request_ticket` (`:351`) consumes extended `RequestTicket` and calls walker; `handle_check_rate_limit`'s walker re-entry (`:563`) constructs `EnqueueTask` from the `CheckRateLimit` fields.
+- `src/job_store_shard/lease.rs` — retry call site (`:228`) updated to construct `EnqueueTask`; add debug-assert in release loop (`:286-288`) that each holder key existed.
+- `src/job_store_shard/cancel.rs` — `delete_concurrency_requests_for_job` (`:219`) decodes `EnqueueTask` payloads, returns decoded `(task_id, held_queues)` to callers, and queues holder deletes for `held_queues`. `cancel_job` (`:130`) also fixes the pre-existing `Task::CheckRateLimit` holder-leak by decoding `held_queues` from the task before deletion and releasing them.
+- `src/job_store_shard/import.rs` — both walker call sites (`:261`, `:641`) construct `EnqueueTask` values; no logic change.
+- `src/task.rs` — extend `ConcurrencyAction::EnqueueTask` (4 fields + tenant), extend `Task::RequestTicket` (rename `request_id` → `task_id`, add chain fields).
+- `src/codec.rs` — encode/decode for both extended types; existing pattern around `:467` and `RequestTicket` codec.
+- `src/keys.rs` — leave `parse_concurrency_request_key` intact; consumers that read identity must instead decode the `EnqueueTask` value:
+  - `query.rs:1630` — column comes from the request record; decode `EnqueueTask` and use its `task_id`. (Requires reading the value, not just the key.)
+  - `concurrency.rs:1163` — replace with payload's `task_id`.
+  - `dequeue.rs:371` — uses `RequestTicket.request_id()`; switch to renamed `task_id` accessor.
+  - `codec.rs:592` — accessor on the `RequestTicket` codec follows the schema rename.
+  - `cleanup.rs:154` — uses only `parsed.tenant`; no change.
+- `schema/internal_storage.fbs` — extend `EnqueueTask` and `RequestTicket` tables.
+- `specs/job_shard.als` — model update: amend the predicate(s) underlying `holdersRequireActiveTask` (line 2115) so a durable `EnqueueTask` request record with a non-empty `task_id` counts as an "active task" capable of holding the chain's holders. Concretely, extend whatever today enumerates active tasks (the union over `RunAttempt`, `CheckRateLimit`, `RequestTicket`) to also include `EnqueueTask` request records bound to a `task_id`. Then re-check the assertion. Without this, the assertion fails on legitimate post-refactor states (chain paused mid-walk with holders + EnqueueTask).
+
+## Risks
+
+- **Per-pass scanner rollback spans multiple queues' reservations.** Today rollback (`concurrency.rs:1381-1383`) iterates `grants` for the single queue the pass was promoting. With walker-driven resumption a pass may reserve across multiple queues (scanner promotes FC1 candidate; walker advances into FC2; FC2 reserves in-memory; batch write fails). The pass must track every reservation accumulated across all candidates and release all of them.
+- **`Task::RequestTicket` semantic change.** Future-scheduled multi-limit chains will now correctly walk all limits at grant time. Today they silently bypass; tests that assert the bypass will need updates.
+- **Scanner driver relocation.** Moving the spawn from `ConcurrencyManager::start_grant_scanner` to `JobStoreShard` changes shutdown ordering. `stop_grant_scanner` (`concurrency.rs:979`) flips an `AtomicBool` + notifies; the relocated driver needs equivalent shutdown wiring through `JobStoreShard::close` (`mod.rs:520`).
+- **Counter accuracy across multi-queue pauses.** Counter deltas now derive from the walker's explicit `request_record_ops` artifact, not WriteBatch introspection (see Walker output contract). A miscount would mean the walker emitted inconsistent ops vs WriteBatch writes — caught by a debug-assert that pairs each `Put`/`Delete` op with the matching batch mutation, plus the `silo_counter_drift_corrected_total` metric exposing reconciler corrections at restart.
+- **Stale-limits window** on durable payloads carrying `limits` (discussed in design). Status-gate is the validity guard.
+
+## Verification
+
+1. **New regression cases** in `tests/holder_leak_tests.rs` and `tests/job_store_shard_concurrency_tests.rs`:
+   - `[C immediate, FC queued]` → both holders share `task_id`; both released on terminal outcome.
+   - `[C immediate, FC1 queued → granted, FC2 queued → granted, terminal]` → three holders all keyed by chain's `task_id`.
+   - `[C immediate, FC queued, R rate-limit]` → granted concurrency holders survive the rate-limit pause; `CheckRateLimit` carries them; cancel during rate-limit pause releases all of them (also exercises the pre-existing CheckRateLimit cleanup fix).
+   - Mid-pause crash + restart: `reconcile_pending_requests` (`concurrency.rs:988`) re-emits grant signals; the next scanner pass resumes from the durable `EnqueueTask` payload.
+   - Future-scheduled `[C, FC]` multi-limit job: `RequestTicket` fires at `start_time_ms`; walker walks both limits at grant time.
+   - Scanner-resumed walk that pauses on a *different* queue (FC1 resolves → walker tries FC2 → FC2 capacity-exhausted): old request record at FC1 deleted, new at FC2, counter deltas correct on both queues.
+   - Cancel during mid-pause: all chain holders torn down by `task_id`, all durable chain records deleted, counters decremented on every queue with a request.
+   - Reimport during mid-pause: same as cancel cleanup, then new chain enqueued.
+2. **Strengthen `second_limit_request_must_not_leave_runnable_task`** (`tests/job_store_shard_concurrency_tests.rs:2420`): assert "no `task_key` record ever exists between chain-pause and terminal-walker write" — true by construction after this refactor.
+3. **Run full concurrency suites**: `concurrency_tests`, `floating_concurrency_tests`, `concurrent_grant_race_tests`, `concurrency_counts_tests`, `concurrency_requester_counter_tests`, `holder_leak_tests`, `job_store_shard_concurrency_tests`, `job_store_shard_retry_tests`, `cancel_tests` (or equivalent), `import_tests`. All should pass.
+4. **Re-run `specs/job_shard.als`** with the updated `holdersRequireActiveTask` predicate (EnqueueTask counted as active). Assertion should pass; verify by deliberately breaking the implementation (skip holder release on cancel) and confirming the model catches it.
+5. **Codec roundtrip tests** in `tests/codec_tests.rs` for both extended payloads, including: empty `held_queues`, populated `held_queues`, `next_limit_index` at boundaries (0, len, len-1), canonical-order `limits`, fingerprint stability across encode/decode.
+6. **Malformed-payload guardrails** (`tests/walker_guardrails_tests.rs`, new): exercise each decode-site validation:
+   - `next_limit_index > limits.len()` → record deleted, malformed counter incremented, no panic.
+   - `EnqueueTask` with `limits[next_limit_index].queue` ≠ parsed key's queue → same.
+   - Empty `task_id` → same.
+   - `RequestTicket` with non-empty `held_queues` → debug-assert fires (test runs in debug build).
+   - `limits_fingerprint` mismatch at cancel-time → warn metric, payload's `limits` used.
+7. **Idempotent scanner replay** (`test_scanner_idempotent_replay`): drive a pass to completion, snapshot durable state, replay the same pass from the post-commit state, assert WriteBatch is empty + no in-memory side effects + counters unchanged.
+8. **Batch-fail rollback across multiple queues**: inject a write-failure after the walker reserved on two queues in the same candidate; assert both in-memory reservations released, no holders persisted, request record at the resumed queue unchanged, `silo_scanner_reservation_rollback_total` incremented.
+9. **Shutdown race**: `JobStoreShard::close` while a scanner pass has reserved on multiple queues. Assert (a) no leaked in-memory reservations after close returns, (b) durable state consistent (either fully-committed pass or fully-rolled-back), (c) join completes within the 5s timeout.
+10. **Manual smoke** at high contention with `enqueue_with_two_concurrency_limits_grants_both` to verify capacity reclaim across the immediate/scanner path mix (no leaks in `snapshot_holders` metrics).
+11. **Counter audit**: after each scanner pass test, snapshot `concurrency_requester_counter_key` values per queue and verify they equal the count of durable `EnqueueTask` records at that queue.

--- a/schema/internal_storage.fbs
+++ b/schema/internal_storage.fbs
@@ -237,6 +237,10 @@ table EnqueueTask {
   attempt_number: uint32;
   relative_attempt_number: uint32;
   task_group: string;
+  task_id: string;
+  held_queues: [string];
+  next_limit_index: uint32;
+  limits: [LimitEntry];
 }
 
 union ConcurrencyActionVariant {

--- a/specs/job_shard.als
+++ b/specs/job_shard.als
@@ -565,6 +565,42 @@ pred enqueueWithConcurrencyQueued[tid: TaskId, j: Job, q: Queue, t: Time, tnext:
     holdersUnchanged[t, tnext]
 }
 
+-- Transition: ENQUEUE_WITH_CONCURRENCY_MIXED - Walker grants holder on one
+-- queue, pauses on another. Models the post-refactor multi-limit chain where
+-- the walker carries a single task_id through every artifact (holders +
+-- durable EnqueueTask intent). Both the new holder at `qGranted` and the
+-- TicketRequest at `qPaused` bind the same `tid`; the chain has no DbQueuedTask
+-- and no CheckRateLimit row at this point. The chain becomes resolvable when
+-- `qPaused` opens (see grantNextRequest, which then creates the RunAttempt).
+-- See implementation plan: enqueue/concurrency unification.
+pred enqueueWithConcurrencyMixed[tid: TaskId, j: Job, qGranted: Queue, qPaused: Queue, t: Time, tnext: Time] {
+    enqueuePreConditions[tid, j, t]
+    enqueueJobCreated[j, t, tnext]
+    enqueueFrameConditions[tid, t, tnext]
+
+    -- Pre: distinct queues, both required by the job
+    qGranted != qPaused
+    qGranted in jobQueues[j]
+    qPaused in jobQueues[j]
+
+    -- Pre: walker grants on the first, pauses on the second
+    queueHasCapacity[qGranted, t]
+    not queueHasCapacity[qPaused, t]
+
+    -- Post: holder created at qGranted, others unchanged
+    holdersAt[qGranted, tnext] = tid
+    all q2: Queue | q2 != qGranted implies holdersAt[q2, tnext] = holdersAt[q2, t]
+
+    -- Post: NO RunAttempt task in DB (chain unresolved)
+    no qt: DbQueuedTask | qt.db_qtask = tid and qt.db_qtime = tnext
+    all tid2: TaskId | dbQueuedAt[tid2, tnext] = dbQueuedAt[tid2, t]
+
+    -- Post: durable request at qPaused, same chain task_id
+    one r: TicketRequest | r.tr_job = j and r.tr_queue = qPaused and r.tr_task = tid and r.tr_time = tnext
+    requestTasksAt[qPaused, tnext] = requestTasksAt[qPaused, t] + tid
+    all q2: Queue | q2 != qPaused implies requestTasksAt[q2, tnext] = requestTasksAt[q2, t]
+}
+
 -- Transition: BROKER_SCAN - Read from DB to Buffer
 -- See: task_broker.rs::scan_tasks
 pred brokerScan[t: Time, tnext: Time] {
@@ -1062,9 +1098,16 @@ pred cancelJob[j: Job, t: Time, tnext: Time] {
     attemptExistsAt[tnext] = attemptExistsAt[t]
     all a: attemptExistsAt[t] | attemptStatusAt[a, tnext] = attemptStatusAt[a, t]
 
-    -- Concurrency cleanup: release holders for cancelled job's tasks (removed from DB queue)
-    -- and delete requests for cancelled job
-    all q: Queue | holdersAt[q, tnext] = { tid: holdersAt[q, t] | dbQueuedAt[tid, t] != j }
+    -- Concurrency cleanup: release holders for cancelled job's tasks regardless
+    -- of which durable artifact carries the chain (DbQueuedTask, DbCheckRateLimitTask,
+    -- or a TicketRequest binding the chain's task_id). The latter two cases close
+    -- pre-existing gaps the enqueue/concurrency unification surfaces: a paused
+    -- chain may carry holders with no DbQueuedTask, marked only by CheckRateLimit
+    -- or by a TicketRequest (the EnqueueTask durable intent).
+    all q: Queue | holdersAt[q, tnext] = { tid: holdersAt[q, t] |
+        dbQueuedAt[tid, t] != j and
+        dbCheckRateLimitAt[tid, t] != j and
+        (no r: TicketRequest | r.tr_task = tid and r.tr_job = j and r.tr_time = t) }
     all q: Queue | requestTasksAt[q, tnext] = { tid: requestTasksAt[q, t] |
         no r: TicketRequest | r.tr_job = j and r.tr_queue = q and r.tr_task = tid and r.tr_time = t }
 }
@@ -1920,6 +1963,7 @@ pred step[t: Time, tnext: Time] {
     -- Concurrency ticket management
     or (some tid: TaskId, j: Job, q: Queue | enqueueWithConcurrencyGranted[tid, j, q, t, tnext])
     or (some tid: TaskId, j: Job, q: Queue | enqueueWithConcurrencyQueued[tid, j, q, t, tnext])
+    or (some tid: TaskId, j: Job, qGranted: Queue, qPaused: Queue | enqueueWithConcurrencyMixed[tid, j, qGranted, qPaused, t, tnext])
     or (some q: Queue, tid: TaskId | grantNextRequest[q, tid, t, tnext])
     or (some q: Queue, tid: TaskId | dropStaleRequest[q, tid, t, tnext])
     or (some tid: TaskId, w: Worker, q: Queue | completeSuccessReleaseTicket[tid, w, q, t, tnext])
@@ -2093,17 +2137,27 @@ assert queueLimitEnforced {
 
 /**
  * Holders only exist for tasks that are active in some form (in DB queue, in
- * buffer, leased, or carried by a CheckRateLimit task).
+ * buffer, leased, carried by a CheckRateLimit task, or referenced by a
+ * durable concurrency request that binds the chain's task_id).
  *
- * A ticket holder is created at enqueue (granted), at grant_next, or by an
+ * A ticket holder is created at enqueue (granted), at grant_next, by an
  * enqueue-with-concurrency-and-rate-limit (where the task is a CheckRateLimit
- * carrying the holder), and released when:
+ * carrying the holder), or by enqueueWithConcurrencyMixed (where the walker
+ * grants on one queue and pauses on another, leaving the chain referenced
+ * only by a TicketRequest in the durable EnqueueTask intent). It is released
+ * when:
  * - Task completes successfully or fails: [SILO-REL-1]
  * - Lease expires: [SILO-REAP-*] releases via completion path
  * - Job cancelled with task in queue: [SILO-CXL-3] eagerly removes holders
  * - Dequeue handler drops the task on an early-return path (max retries,
  *   missing job_info, malformed job_info): dequeueDropRunAttempt /
  *   dequeueDropCheckRateLimit
+ *
+ * The TicketRequest clause covers the post-refactor mid-walk pause shape
+ * introduced by the enqueue/concurrency unification: a chain that holds
+ * earlier queues' holders while its remaining limit is still pending in a
+ * durable EnqueueTask intent. Without that clause this assertion would flag
+ * the legitimate paused-mid-walk state as a leak.
  *
  * If a future drop-path forgets to release the held queues, this assertion
  * produces a counterexample — that's exactly the bug shape fixed in PR #255
@@ -2118,7 +2172,9 @@ assert holdersRequireActiveTask {
         some bufferedAt[h.th_task, h.th_time] or
         some leaseAt[h.th_task, h.th_time] or
         some dbCheckRateLimitAt[h.th_task, h.th_time] or
-        some bufferedCheckRateLimitAt[h.th_task, h.th_time]
+        some bufferedCheckRateLimitAt[h.th_task, h.th_time] or
+        (some r: TicketRequest |
+            r.tr_task = h.th_task and r.tr_time = h.th_time)
 }
 
 /**
@@ -2381,6 +2437,50 @@ pred exampleCancelledRequestCleanup {
         -- t2: j2 is cancelled, request eagerly removed
         isCancelledAt[j2, t2]
         no r: TicketRequest | r.tr_job = j2 and r.tr_queue = q and r.tr_time = t2  -- Request eagerly removed
+    }
+}
+
+/**
+ * Scenario: Multi-limit chain is partially granted: walker holds qGranted and
+ * pauses on qPaused with a durable EnqueueTask intent binding the same task_id.
+ * Witness for the post-refactor state shape that the enqueue/concurrency
+ * unification makes legal — `holdersRequireActiveTask` must accept this via
+ * its TicketRequest clause.
+ */
+pred exampleEnqueueMixedHolderAndRequest {
+    some tid: TaskId, j: Job, qGranted: Queue, qPaused: Queue, t: Time | {
+        qGranted != qPaused
+        -- holder for the chain on qGranted
+        some h: TicketHolder | h.th_task = tid and h.th_queue = qGranted and h.th_time = t
+        -- durable request at qPaused with the chain's task_id
+        some r: TicketRequest | r.tr_task = tid and r.tr_job = j and r.tr_queue = qPaused and r.tr_time = t
+        -- chain unresolved: no RunAttempt/buffer/lease/CRL task
+        no dbQueuedAt[tid, t]
+        no bufferedAt[tid, t]
+        no leaseAt[tid, t]
+        no dbCheckRateLimitAt[tid, t]
+        no bufferedCheckRateLimitAt[tid, t]
+    }
+}
+
+/**
+ * Scenario: Cancel during a partially-granted mixed state must release the
+ * holder, not just the request. Witnesses that cancelJob's holder filter
+ * recognizes a chain marked only by TicketRequest.
+ */
+pred exampleCancelReleasesMixedHolders {
+    some tid: TaskId, j: Job, qGranted: Queue, qPaused: Queue, t1, t2: Time | {
+        lt[t1, t2]
+        qGranted != qPaused
+        -- t1: mixed state (holder + request, no DB task)
+        some h: TicketHolder | h.th_task = tid and h.th_queue = qGranted and h.th_time = t1
+        some r: TicketRequest | r.tr_task = tid and r.tr_job = j and r.tr_queue = qPaused and r.tr_time = t1
+        no dbQueuedAt[tid, t1]
+        not isCancelledAt[j, t1]
+        -- t2: job cancelled; both holder and request gone for this chain
+        isCancelledAt[j, t2]
+        no h: TicketHolder | h.th_task = tid and h.th_time = t2
+        no r: TicketRequest | r.tr_task = tid and r.tr_time = t2
     }
 }
 
@@ -3214,6 +3314,21 @@ run exampleConcurrencyWaitsInQueue for 4 but exactly 2 Job, 1 Worker, 3 TaskId, 
 
 run exampleCancelledRequestCleanup for 4 but exactly 2 Job, 1 Worker, 3 TaskId, 3 Attempt, 8 Time, 1 Queue,
     16 JobState, 8 AttemptState, 6 DbQueuedTask, 6 BufferedTask, 4 Lease, 8 AttemptExists, 8 JobExists, 3 JobAttemptRelation, 16 JobCancelled,
+    2 JobQueueRequirement, 8 TicketRequest, 8 TicketHolder
+
+-- Witness that the new mixed-grant pause state is reachable. Scope keeps
+-- 2 queues + at least 2 task ids so the holder for the predecessor (occupying
+-- qPaused) and the chain's own task_id can coexist.
+run exampleEnqueueMixedHolderAndRequest for 4 but exactly 1 Job, 1 Worker, 2 TaskId, 2 Attempt, 6 Time, 2 Queue,
+    6 JobState, 6 AttemptState, 4 DbQueuedTask, 4 BufferedTask, 2 Lease,
+    6 AttemptExists, 6 JobExists, 2 JobAttemptRelation, 6 JobCancelled,
+    2 JobQueueRequirement, 6 TicketRequest, 6 TicketHolder
+
+-- Witness that cancellation releases holders for a chain marked only by a
+-- TicketRequest (the post-refactor mixed pause shape).
+run exampleCancelReleasesMixedHolders for 5 but exactly 1 Job, 1 Worker, 2 TaskId, 2 Attempt, 8 Time, 2 Queue,
+    8 JobState, 8 AttemptState, 4 DbQueuedTask, 4 BufferedTask, 2 Lease,
+    8 AttemptExists, 8 JobExists, 2 JobAttemptRelation, 8 JobCancelled,
     2 JobQueueRequirement, 8 TicketRequest, 8 TicketHolder
 
 run exampleCancelledJobReleasesTicketOnComplete for 3 but exactly 1 Job, 1 Worker, 2 TaskId, 2 Attempt, 8 Time, 1 Queue,

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -311,6 +311,146 @@ pub fn encode_attempt(attempt: &JobAttempt) -> Vec<u8> {
     builder.finished_data().to_vec()
 }
 
+fn build_limit_entry_offsets<'a, A: flatbuffers::Allocator + 'a>(
+    builder: &mut FlatBufferBuilder<'a, A>,
+    limits: &[Limit],
+) -> Vec<flatbuffers::WIPOffset<fb::LimitEntry<'a>>> {
+    limits
+        .iter()
+        .map(|lim| {
+            let (vtype, voff) = match lim {
+                Limit::Concurrency(cl) => {
+                    let key = builder.create_string(&cl.key);
+                    let entry = fb::ConcurrencyLimitEntry::create(
+                        builder,
+                        &fb::ConcurrencyLimitEntryArgs {
+                            key: Some(key),
+                            max_concurrency: cl.max_concurrency,
+                        },
+                    );
+                    (
+                        fb::LimitVariant::ConcurrencyLimitEntry,
+                        entry.as_union_value(),
+                    )
+                }
+                Limit::RateLimit(rl) => {
+                    let name = builder.create_string(&rl.name);
+                    let unique_key = builder.create_string(&rl.unique_key);
+                    let rp = fb::RateLimitRetryPolicy::create(
+                        builder,
+                        &fb::RateLimitRetryPolicyArgs {
+                            initial_backoff_ms: rl.retry_policy.initial_backoff_ms,
+                            max_backoff_ms: rl.retry_policy.max_backoff_ms,
+                            backoff_multiplier: rl.retry_policy.backoff_multiplier,
+                            max_retries: rl.retry_policy.max_retries,
+                        },
+                    );
+                    let entry = fb::RateLimitEntry::create(
+                        builder,
+                        &fb::RateLimitEntryArgs {
+                            name: Some(name),
+                            unique_key: Some(unique_key),
+                            limit: rl.limit,
+                            duration_ms: rl.duration_ms,
+                            hits: rl.hits,
+                            algorithm: rl.algorithm.as_u8(),
+                            behavior: rl.behavior,
+                            retry_policy: Some(rp),
+                        },
+                    );
+                    (fb::LimitVariant::RateLimitEntry, entry.as_union_value())
+                }
+                Limit::FloatingConcurrency(fl) => {
+                    let key = builder.create_string(&fl.key);
+                    let md = build_kv_pair_offsets(builder, &fl.metadata);
+                    let metadata = builder.create_vector(&md);
+                    let entry = fb::FloatingConcurrencyLimitEntry::create(
+                        builder,
+                        &fb::FloatingConcurrencyLimitEntryArgs {
+                            key: Some(key),
+                            default_max_concurrency: fl.default_max_concurrency,
+                            refresh_interval_ms: fl.refresh_interval_ms,
+                            metadata: Some(metadata),
+                        },
+                    );
+                    (
+                        fb::LimitVariant::FloatingConcurrencyLimitEntry,
+                        entry.as_union_value(),
+                    )
+                }
+            };
+            fb::LimitEntry::create(
+                builder,
+                &fb::LimitEntryArgs {
+                    variant_type: vtype,
+                    variant: Some(voff),
+                },
+            )
+        })
+        .collect()
+}
+
+pub fn fb_limit_entries_to_owned(
+    entries: Option<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<fb::LimitEntry<'_>>>>,
+) -> Vec<Limit> {
+    use crate::job::{
+        ConcurrencyLimit, FloatingConcurrencyLimit, GubernatorAlgorithm, GubernatorRateLimit,
+        RateLimitRetryPolicy,
+    };
+
+    entries
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| match entry.variant_type() {
+                    fb::LimitVariant::ConcurrencyLimitEntry => {
+                        let cl = entry.variant_as_concurrency_limit_entry()?;
+                        Some(Limit::Concurrency(ConcurrencyLimit {
+                            key: cl.key().unwrap_or_default().to_string(),
+                            max_concurrency: cl.max_concurrency(),
+                        }))
+                    }
+                    fb::LimitVariant::RateLimitEntry => {
+                        let rl = entry.variant_as_rate_limit_entry()?;
+                        let rp = rl.retry_policy();
+                        Some(Limit::RateLimit(GubernatorRateLimit {
+                            name: rl.name().unwrap_or_default().to_string(),
+                            unique_key: rl.unique_key().unwrap_or_default().to_string(),
+                            limit: rl.limit(),
+                            duration_ms: rl.duration_ms(),
+                            hits: rl.hits(),
+                            algorithm: if rl.algorithm() == 1 {
+                                GubernatorAlgorithm::LeakyBucket
+                            } else {
+                                GubernatorAlgorithm::TokenBucket
+                            },
+                            behavior: rl.behavior(),
+                            retry_policy: rp
+                                .map(|p| RateLimitRetryPolicy {
+                                    initial_backoff_ms: p.initial_backoff_ms(),
+                                    max_backoff_ms: p.max_backoff_ms(),
+                                    backoff_multiplier: p.backoff_multiplier(),
+                                    max_retries: p.max_retries(),
+                                })
+                                .unwrap_or_default(),
+                        }))
+                    }
+                    fb::LimitVariant::FloatingConcurrencyLimitEntry => {
+                        let fl = entry.variant_as_floating_concurrency_limit_entry()?;
+                        Some(Limit::FloatingConcurrency(FloatingConcurrencyLimit {
+                            key: fl.key().unwrap_or_default().to_string(),
+                            default_max_concurrency: fl.default_max_concurrency(),
+                            refresh_interval_ms: fl.refresh_interval_ms(),
+                            metadata: fb_kv_pairs_to_owned(fl.metadata()),
+                        }))
+                    }
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 #[inline]
 pub fn encode_job_info(job: &JobInfo) -> Vec<u8> {
     let mut builder = FlatBufferBuilder::with_capacity(512);
@@ -334,80 +474,7 @@ pub fn encode_job_info(job: &JobInfo) -> Vec<u8> {
     let md = build_kv_pair_offsets(&mut builder, &job.metadata);
     let metadata = builder.create_vector(&md);
 
-    let limits: Vec<_> = job
-        .limits
-        .iter()
-        .map(|lim| {
-            let (vtype, voff) = match lim {
-                Limit::Concurrency(cl) => {
-                    let key = builder.create_string(&cl.key);
-                    let entry = fb::ConcurrencyLimitEntry::create(
-                        &mut builder,
-                        &fb::ConcurrencyLimitEntryArgs {
-                            key: Some(key),
-                            max_concurrency: cl.max_concurrency,
-                        },
-                    );
-                    (
-                        fb::LimitVariant::ConcurrencyLimitEntry,
-                        entry.as_union_value(),
-                    )
-                }
-                Limit::RateLimit(rl) => {
-                    let name = builder.create_string(&rl.name);
-                    let unique_key = builder.create_string(&rl.unique_key);
-                    let rp = fb::RateLimitRetryPolicy::create(
-                        &mut builder,
-                        &fb::RateLimitRetryPolicyArgs {
-                            initial_backoff_ms: rl.retry_policy.initial_backoff_ms,
-                            max_backoff_ms: rl.retry_policy.max_backoff_ms,
-                            backoff_multiplier: rl.retry_policy.backoff_multiplier,
-                            max_retries: rl.retry_policy.max_retries,
-                        },
-                    );
-                    let entry = fb::RateLimitEntry::create(
-                        &mut builder,
-                        &fb::RateLimitEntryArgs {
-                            name: Some(name),
-                            unique_key: Some(unique_key),
-                            limit: rl.limit,
-                            duration_ms: rl.duration_ms,
-                            hits: rl.hits,
-                            algorithm: rl.algorithm.as_u8(),
-                            behavior: rl.behavior,
-                            retry_policy: Some(rp),
-                        },
-                    );
-                    (fb::LimitVariant::RateLimitEntry, entry.as_union_value())
-                }
-                Limit::FloatingConcurrency(fl) => {
-                    let key = builder.create_string(&fl.key);
-                    let md = build_kv_pair_offsets(&mut builder, &fl.metadata);
-                    let metadata = builder.create_vector(&md);
-                    let entry = fb::FloatingConcurrencyLimitEntry::create(
-                        &mut builder,
-                        &fb::FloatingConcurrencyLimitEntryArgs {
-                            key: Some(key),
-                            default_max_concurrency: fl.default_max_concurrency,
-                            refresh_interval_ms: fl.refresh_interval_ms,
-                            metadata: Some(metadata),
-                        },
-                    );
-                    (
-                        fb::LimitVariant::FloatingConcurrencyLimitEntry,
-                        entry.as_union_value(),
-                    )
-                }
-            };
-            fb::LimitEntry::create(
-                &mut builder,
-                &fb::LimitEntryArgs {
-                    variant_type: vtype,
-                    variant: Some(voff),
-                },
-            )
-        })
-        .collect();
+    let limits = build_limit_entry_offsets(&mut builder, &job.limits);
     let limits = builder.create_vector(&limits);
 
     let root = fb::JobInfo::create(
@@ -474,9 +541,21 @@ pub fn encode_concurrency_action(action: &ConcurrencyAction) -> Vec<u8> {
             attempt_number,
             relative_attempt_number,
             task_group,
+            task_id,
+            held_queues,
+            next_limit_index,
+            limits,
         } => {
             let job_id = builder.create_string(job_id);
             let task_group = builder.create_string(task_group);
+            let task_id = builder.create_string(task_id);
+            let hq: Vec<_> = held_queues
+                .iter()
+                .map(|s| builder.create_string(s))
+                .collect();
+            let held_queues = builder.create_vector(&hq);
+            let limits = build_limit_entry_offsets(&mut builder, limits);
+            let limits = builder.create_vector(&limits);
             let et = fb::EnqueueTask::create(
                 &mut builder,
                 &fb::EnqueueTaskArgs {
@@ -486,6 +565,10 @@ pub fn encode_concurrency_action(action: &ConcurrencyAction) -> Vec<u8> {
                     attempt_number: *attempt_number,
                     relative_attempt_number: *relative_attempt_number,
                     task_group: Some(task_group),
+                    task_id: Some(task_id),
+                    held_queues: Some(held_queues),
+                    next_limit_index: *next_limit_index,
+                    limits: Some(limits),
                 },
             );
             let root = fb::ConcurrencyAction::create(

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -69,7 +69,7 @@ use crate::keys::{
 };
 use crate::metrics::Metrics;
 use crate::shard_range::ShardRange;
-use crate::task::{ConcurrencyAction, HolderRecord, Task};
+use crate::task::{ConcurrencyAction, GubernatorRateLimitData, HolderRecord, Task};
 use crate::task_broker::TaskBrokerRegistry;
 
 /// Error type for concurrency operations that can fail due to storage or encoding errors.
@@ -759,6 +759,9 @@ impl ConcurrencyManager {
         attempt_number: u32,
         relative_attempt_number: u32,
         skip_try_reserve: bool,
+        held_queues: Vec<String>,
+        next_limit_index: u32,
+        all_limits: Vec<Limit>,
     ) -> Result<Option<RequestTicketOutcome>, ConcurrencyError> {
         // Only gate on the first limit (if any)
         let Some(limit) = limits.first() else {
@@ -781,19 +784,7 @@ impl ConcurrencyManager {
         {
             // Grant immediately: [SILO-ENQ-CONC-2] [SILO-ENQ-CONC-3] [SILO-IMP-CONC-2] [SILO-REIMP-CONC-2] create holder + task in DB queue
             // Note: in-memory slot is already reserved by try_reserve
-            append_grant_edits(
-                writer,
-                now_ms,
-                tenant,
-                queue,
-                task_id,
-                start_at_ms,
-                priority,
-                job_id,
-                attempt_number,
-                relative_attempt_number,
-                task_group,
-            )?;
+            append_grant_edits(writer, now_ms, tenant, queue, task_id)?;
             if let Some(ref m) = self.metrics {
                 m.record_concurrency_tickets_granted(
                     &self.shard,
@@ -819,14 +810,17 @@ impl ConcurrencyManager {
                 attempt_number,
                 relative_attempt_number,
                 task_group,
+                task_id,
+                held_queues,
+                next_limit_index,
+                all_limits,
             )?;
             Ok(Some(RequestTicketOutcome::TicketRequested {
                 queue: queue.clone(),
             }))
         } else {
             // Job scheduled for future: queue as RequestTicket task
-            let suffix = format!("{:08x}", rand::random::<u32>());
-            let request_id = format!("{job_id}:{attempt_number}:{suffix}");
+            let request_id = task_id.to_string();
             let ticket = Task::RequestTicket {
                 queue: queue.clone(),
                 start_time_ms: start_at_ms,
@@ -1084,13 +1078,16 @@ impl ConcurrencyManager {
 
         struct ScannedRequest {
             request_key: Vec<u8>,
-            request_id: String,
+            task_id: String,
             job_id: String,
             attempt_number: u32,
             relative_attempt_number: u32,
             start_time_ms: i64,
             priority: u8,
             task_group: String,
+            held_queues: Vec<String>,
+            next_limit_index: u32,
+            limits: Vec<Limit>,
         }
 
         let mut max_concurrency: Option<(usize, ConcurrencyLimitType)> = None;
@@ -1112,6 +1109,8 @@ impl ConcurrencyManager {
 
             let mut batch = WriteBatch::new();
             let mut grants: Vec<(String, String)> = Vec::new();
+            let mut reserved_slots: Vec<(String, String)> = Vec::new();
+            let mut request_counter_delta: i64 = 0;
             let mut stale_and_corrupt_count: usize = 0;
 
             // --- Scan batch of candidates ---
@@ -1137,6 +1136,7 @@ impl ConcurrencyManager {
                     Err(_) => {
                         tracing::warn!(queue = %queue, "grant scanner: failed to decode request, deleting");
                         batch.delete(&kv.key);
+                        request_counter_delta -= 1;
                         stale_and_corrupt_count += 1;
                         continue;
                     }
@@ -1145,6 +1145,7 @@ impl ConcurrencyManager {
                 let Some(et) = a.variant_as_enqueue_task() else {
                     tracing::warn!(queue = %queue, "grant scanner: unknown concurrency action variant, deleting");
                     batch.delete(&kv.key);
+                    request_counter_delta -= 1;
                     stale_and_corrupt_count += 1;
                     continue;
                 };
@@ -1157,11 +1158,33 @@ impl ConcurrencyManager {
                     break;
                 }
 
-                let Some(parsed_req) = parsed_req else {
+                if parsed_req.is_none() {
+                    batch.delete(&kv.key);
+                    request_counter_delta -= 1;
+                    stale_and_corrupt_count += 1;
                     continue;
-                };
-                let request_id = parsed_req.request_id();
-
+                }
+                let task_id = et.task_id().unwrap_or_default().to_string();
+                if task_id.is_empty() {
+                    tracing::warn!(queue = %queue, "grant scanner: request missing task_id, deleting");
+                    batch.delete(&kv.key);
+                    request_counter_delta -= 1;
+                    stale_and_corrupt_count += 1;
+                    continue;
+                }
+                let held_queues = et
+                    .held_queues()
+                    .map(|v| v.iter().map(|s| s.to_string()).collect())
+                    .unwrap_or_default();
+                let limits = crate::codec::fb_limit_entries_to_owned(et.limits());
+                let next_limit_index = et.next_limit_index();
+                if next_limit_index as usize > limits.len() {
+                    tracing::warn!(queue = %queue, "grant scanner: request next_limit_index out of bounds, deleting");
+                    batch.delete(&kv.key);
+                    request_counter_delta -= 1;
+                    stale_and_corrupt_count += 1;
+                    continue;
+                }
                 // Resolve max_concurrency from the first request whose job info is readable.
                 // Don't cache failures — a stale request's missing job shouldn't lock
                 // the limit to 1 for the rest of the scan.
@@ -1203,13 +1226,16 @@ impl ConcurrencyManager {
 
                 scanned.push(ScannedRequest {
                     request_key: kv.key.to_vec(),
-                    request_id,
+                    task_id,
                     job_id: job_id_str.to_string(),
                     attempt_number: et.attempt_number(),
                     relative_attempt_number: et.relative_attempt_number(),
                     start_time_ms,
                     priority: et.priority(),
                     task_group: et.task_group().unwrap_or_default().to_string(),
+                    held_queues,
+                    next_limit_index,
+                    limits,
                 });
             }
 
@@ -1293,11 +1319,12 @@ impl ConcurrencyManager {
                     valid_requests.push(req);
                 } else {
                     batch.delete(&req.request_key);
+                    request_counter_delta -= 1;
                     stale_and_corrupt_count += 1;
                 }
             }
 
-            // --- Reserve in-memory slots and accumulate grant edits ---
+            // --- Reserve in-memory slots and resume each admitted limit chain ---
             let limit = max_concurrency.map(|(l, _)| l).unwrap_or(1);
             for req in &valid_requests {
                 if total_granted + grants.len() >= count as usize {
@@ -1308,7 +1335,7 @@ impl ConcurrencyManager {
                 if !self.counts.try_reserve_internal(
                     tenant,
                     queue,
-                    &req.request_id,
+                    &req.task_id,
                     limit,
                     &req.job_id,
                 ) {
@@ -1316,47 +1343,172 @@ impl ConcurrencyManager {
                     break;
                 }
 
-                // [SILO-GRANT-3] Create holder
+                reserved_slots.push((queue.to_string(), req.task_id.clone()));
+
+                let mut held_queues = req.held_queues.clone();
+                if !held_queues.iter().any(|q| q == queue) {
+                    held_queues.push(queue.to_string());
+                }
+
+                // The request itself is resolved by this reservation. Further walker
+                // pauses write their own request records below.
+                batch.delete(&req.request_key);
+                request_counter_delta -= 1;
                 let holder_val = encode_holder(&HolderRecord {
                     granted_at_ms: now_ms,
                 });
                 batch.put(
-                    concurrency_holder_key(tenant, queue, &req.request_id),
+                    concurrency_holder_key(tenant, queue, &req.task_id),
                     &holder_val,
                 );
 
-                // [SILO-GRANT-4] Create RunAttempt task
-                let tval = encode_task(&Task::RunAttempt {
-                    id: req.request_id.clone(),
-                    tenant: tenant.to_string(),
-                    job_id: req.job_id.clone(),
-                    attempt_number: req.attempt_number,
-                    relative_attempt_number: req.relative_attempt_number,
-                    held_queues: vec![queue.to_string()],
-                    task_group: req.task_group.clone(),
-                });
-                batch.put(
-                    task_key(
-                        &req.task_group,
-                        req.start_time_ms,
-                        req.priority,
-                        &req.job_id,
-                        req.attempt_number,
-                    ),
-                    &tval,
-                );
-                batch.delete(&req.request_key);
+                let mut current_index = req.next_limit_index as usize;
+                let order = crate::job_store_shard::limit_processing_order(&req.limits);
+                let mut paused = false;
+                while current_index < req.limits.len() {
+                    match &req.limits[order[current_index]] {
+                        Limit::Concurrency(cl) => {
+                            if !self.counts.try_reserve_internal(
+                                tenant,
+                                &cl.key,
+                                &req.task_id,
+                                cl.max_concurrency as usize,
+                                &req.job_id,
+                            ) {
+                                append_request_batch_edits(
+                                    &mut batch,
+                                    tenant,
+                                    &cl.key,
+                                    req.start_time_ms,
+                                    req.priority,
+                                    &req.job_id,
+                                    req.attempt_number,
+                                    req.relative_attempt_number,
+                                    &req.task_group,
+                                    &req.task_id,
+                                    held_queues.clone(),
+                                    (current_index + 1) as u32,
+                                    req.limits.clone(),
+                                );
+                                paused = true;
+                                break;
+                            }
+                            reserved_slots.push((cl.key.clone(), req.task_id.clone()));
+                            let holder_val = encode_holder(&HolderRecord {
+                                granted_at_ms: now_ms,
+                            });
+                            batch.put(
+                                concurrency_holder_key(tenant, &cl.key, &req.task_id),
+                                &holder_val,
+                            );
+                            held_queues.push(cl.key.clone());
+                            current_index += 1;
+                        }
+                        Limit::FloatingConcurrency(fl) => {
+                            // Scanner resumption preserves the existing fast path by using
+                            // the durable/default floating capacity. Refresh-driven capacity
+                            // updates continue to be handled by the refresh task path.
+                            let max = fl.default_max_concurrency as usize;
+                            if !self.counts.try_reserve_internal(
+                                tenant,
+                                &fl.key,
+                                &req.task_id,
+                                max,
+                                &req.job_id,
+                            ) {
+                                append_request_batch_edits(
+                                    &mut batch,
+                                    tenant,
+                                    &fl.key,
+                                    req.start_time_ms,
+                                    req.priority,
+                                    &req.job_id,
+                                    req.attempt_number,
+                                    req.relative_attempt_number,
+                                    &req.task_group,
+                                    &req.task_id,
+                                    held_queues.clone(),
+                                    (current_index + 1) as u32,
+                                    req.limits.clone(),
+                                );
+                                paused = true;
+                                break;
+                            }
+                            reserved_slots.push((fl.key.clone(), req.task_id.clone()));
+                            let holder_val = encode_holder(&HolderRecord {
+                                granted_at_ms: now_ms,
+                            });
+                            batch.put(
+                                concurrency_holder_key(tenant, &fl.key, &req.task_id),
+                                &holder_val,
+                            );
+                            held_queues.push(fl.key.clone());
+                            current_index += 1;
+                        }
+                        Limit::RateLimit(rl) => {
+                            let task = Task::CheckRateLimit {
+                                task_id: req.task_id.clone(),
+                                tenant: tenant.to_string(),
+                                job_id: req.job_id.clone(),
+                                attempt_number: req.attempt_number,
+                                relative_attempt_number: req.relative_attempt_number,
+                                limit_index: current_index as u32,
+                                rate_limit: GubernatorRateLimitData::from(rl),
+                                retry_count: 0,
+                                started_at_ms: now_ms,
+                                priority: req.priority,
+                                held_queues: held_queues.clone(),
+                                task_group: req.task_group.clone(),
+                            };
+                            let tval = encode_task(&task);
+                            batch.put(
+                                task_key(
+                                    &req.task_group,
+                                    req.start_time_ms,
+                                    req.priority,
+                                    &req.job_id,
+                                    req.attempt_number,
+                                ),
+                                &tval,
+                            );
+                            paused = true;
+                            break;
+                        }
+                    }
+                }
 
-                grants.push((req.request_id.clone(), req.task_group.clone()));
+                if !paused {
+                    let tval = encode_task(&Task::RunAttempt {
+                        id: req.task_id.clone(),
+                        tenant: tenant.to_string(),
+                        job_id: req.job_id.clone(),
+                        attempt_number: req.attempt_number,
+                        relative_attempt_number: req.relative_attempt_number,
+                        held_queues,
+                        task_group: req.task_group.clone(),
+                    });
+                    batch.put(
+                        task_key(
+                            &req.task_group,
+                            req.start_time_ms,
+                            req.priority,
+                            &req.job_id,
+                            req.attempt_number,
+                        ),
+                        &tval,
+                    );
+                }
+
+                if !paused {
+                    grants.push((req.task_id.clone(), req.task_group.clone()));
+                }
             }
 
             // --- Per-pass commit ---
-            // Combined counter decrement for this pass's grants + stale/corrupt deletions.
-            let pass_decrement = grants.len() + stale_and_corrupt_count;
-            if pass_decrement > 0 {
+            if request_counter_delta != 0 {
                 batch.merge(
                     concurrency_requester_counter_key(tenant, queue),
-                    encode_counter(-(pass_decrement as i64)),
+                    encode_counter(request_counter_delta),
                 );
             }
 
@@ -1378,8 +1530,8 @@ impl ConcurrencyManager {
                 .await
             {
                 // Roll back only this pass's reservations; prior committed passes stand.
-                for (request_id, _) in &grants {
-                    self.counts.release_reservation(tenant, queue, request_id);
+                for (queue, task_id) in &reserved_slots {
+                    self.counts.release_reservation(tenant, queue, task_id);
                 }
                 tracing::warn!(
                     error = %e,
@@ -1415,21 +1567,14 @@ impl ConcurrencyManager {
     }
 }
 
-/// Append DB edits to grant a concurrency slot: creates holder record and RunAttempt task.
-/// Note: In-memory reservation should already be done via try_reserve before calling this.
-#[allow(clippy::too_many_arguments)]
+/// Append DB edits to grant a concurrency slot by creating only the holder record.
+/// The limit walker writes the runnable task once the full chain has resolved.
 fn append_grant_edits<W: WriteBatcher>(
     writer: &mut W,
     now_ms: i64,
     tenant: &str,
     queue: &str,
     task_id: &str,
-    start_time_ms: i64,
-    priority: u8,
-    job_id: &str,
-    attempt_number: u32,
-    relative_attempt_number: u32,
-    task_group: &str,
 ) -> Result<(), ConcurrencyError> {
     let holder = HolderRecord {
         granted_at_ms: now_ms,
@@ -1437,22 +1582,53 @@ fn append_grant_edits<W: WriteBatcher>(
     let holder_val = encode_holder(&holder);
     writer.put(concurrency_holder_key(tenant, queue, task_id), &holder_val)?;
 
-    let task = Task::RunAttempt {
-        id: task_id.to_string(),
-        tenant: tenant.to_string(),
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_request_batch_edits(
+    batch: &mut WriteBatch,
+    tenant: &str,
+    queue: &str,
+    start_time_ms: i64,
+    priority: u8,
+    job_id: &str,
+    attempt_number: u32,
+    relative_attempt_number: u32,
+    task_group: &str,
+    task_id: &str,
+    held_queues: Vec<String>,
+    next_limit_index: u32,
+    limits: Vec<Limit>,
+) {
+    let action = ConcurrencyAction::EnqueueTask {
+        start_time_ms,
+        priority,
         job_id: job_id.to_string(),
         attempt_number,
         relative_attempt_number,
-        held_queues: vec![queue.to_string()],
         task_group: task_group.to_string(),
+        task_id: task_id.to_string(),
+        held_queues,
+        next_limit_index,
+        limits,
     };
-    let task_value = encode_task(&task);
-    writer.put(
-        task_key(task_group, start_time_ms, priority, job_id, attempt_number),
-        &task_value,
-    )?;
-
-    Ok(())
+    let action_val = encode_concurrency_action(&action);
+    let suffix = format!("{:08x}", rand::random::<u32>());
+    let req_key = concurrency_request_key(
+        tenant,
+        queue,
+        start_time_ms,
+        priority,
+        job_id,
+        attempt_number,
+        &suffix,
+    );
+    batch.put(&req_key, &action_val);
+    batch.merge(
+        concurrency_requester_counter_key(tenant, queue),
+        encode_counter(1),
+    );
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1466,6 +1642,10 @@ fn append_request_edits<W: WriteBatcher>(
     attempt_number: u32,
     relative_attempt_number: u32,
     task_group: &str,
+    task_id: &str,
+    held_queues: Vec<String>,
+    next_limit_index: u32,
+    limits: Vec<Limit>,
 ) -> Result<(), ConcurrencyError> {
     let action = ConcurrencyAction::EnqueueTask {
         start_time_ms,
@@ -1474,6 +1654,10 @@ fn append_request_edits<W: WriteBatcher>(
         attempt_number,
         relative_attempt_number,
         task_group: task_group.to_string(),
+        task_id: task_id.to_string(),
+        held_queues,
+        next_limit_index,
+        limits,
     };
     let action_val = encode_concurrency_action(&action);
     let suffix = format!("{:08x}", rand::random::<u32>());

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,4 +1,6 @@
-use crate::codec::{CodecError, DecodedJobInfo, decode_job_info, fb_kv_pairs_to_owned};
+use crate::codec::{
+    CodecError, DecodedJobInfo, decode_job_info, fb_kv_pairs_to_owned, fb_limit_entries_to_owned,
+};
 use crate::fb::silo::fb;
 use crate::job_store_shard::JobStoreShardError;
 use crate::retry::RetryPolicy;
@@ -346,57 +348,6 @@ impl JobView {
 
     /// Return the ordered list of limits (concurrency, rate limits, and floating concurrency limits)
     pub fn limits(&self) -> Vec<Limit> {
-        self.fb()
-            .limits()
-            .map(|entries| {
-                entries
-                    .iter()
-                    .filter_map(|entry| match entry.variant_type() {
-                        fb::LimitVariant::ConcurrencyLimitEntry => {
-                            let cl = entry.variant_as_concurrency_limit_entry()?;
-                            Some(Limit::Concurrency(ConcurrencyLimit {
-                                key: cl.key().unwrap_or_default().to_string(),
-                                max_concurrency: cl.max_concurrency(),
-                            }))
-                        }
-                        fb::LimitVariant::RateLimitEntry => {
-                            let rl = entry.variant_as_rate_limit_entry()?;
-                            let rp = rl.retry_policy();
-                            Some(Limit::RateLimit(GubernatorRateLimit {
-                                name: rl.name().unwrap_or_default().to_string(),
-                                unique_key: rl.unique_key().unwrap_or_default().to_string(),
-                                limit: rl.limit(),
-                                duration_ms: rl.duration_ms(),
-                                hits: rl.hits(),
-                                algorithm: if rl.algorithm() == 1 {
-                                    GubernatorAlgorithm::LeakyBucket
-                                } else {
-                                    GubernatorAlgorithm::TokenBucket
-                                },
-                                behavior: rl.behavior(),
-                                retry_policy: rp
-                                    .map(|p| RateLimitRetryPolicy {
-                                        initial_backoff_ms: p.initial_backoff_ms(),
-                                        max_backoff_ms: p.max_backoff_ms(),
-                                        backoff_multiplier: p.backoff_multiplier(),
-                                        max_retries: p.max_retries(),
-                                    })
-                                    .unwrap_or_default(),
-                            }))
-                        }
-                        fb::LimitVariant::FloatingConcurrencyLimitEntry => {
-                            let fl = entry.variant_as_floating_concurrency_limit_entry()?;
-                            Some(Limit::FloatingConcurrency(FloatingConcurrencyLimit {
-                                key: fl.key().unwrap_or_default().to_string(),
-                                default_max_concurrency: fl.default_max_concurrency(),
-                                refresh_interval_ms: fl.refresh_interval_ms(),
-                                metadata: fb_kv_pairs_to_owned(fl.metadata()),
-                            }))
-                        }
-                        _ => None,
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
+        fb_limit_entries_to_owned(self.fb().limits())
     }
 }

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -524,6 +524,9 @@ impl JobStoreShard {
                             attempt_number,
                             relative_attempt_number,
                             skip_try_reserve,
+                            current_held_queues.clone(),
+                            (current_index + 1) as u32,
+                            limits.to_vec(),
                         )
                         .await?;
 
@@ -593,6 +596,9 @@ impl JobStoreShard {
                             attempt_number,
                             relative_attempt_number,
                             skip_try_reserve,
+                            current_held_queues.clone(),
+                            (current_index + 1) as u32,
+                            limits.to_vec(),
                         )
                         .await?;
 

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -25,7 +25,7 @@ pub use import::JobNotReimportableError;
 pub use lease_task::JobNotLeaseableError;
 pub use restart::JobNotRestartableError;
 
-pub(crate) use enqueue::LimitTaskParams;
+pub(crate) use enqueue::{LimitTaskParams, limit_processing_order};
 use helpers::DbWriteBatcher;
 use helpers::WriteBatcher;
 pub use helpers::now_epoch_ms;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1627,7 +1627,16 @@ impl Scan for QueuesScanner {
                         {
                             continue;
                         }
-                        let task_id = parsed.request_id();
+                        let task_id = crate::codec::decode_concurrency_action(kv.value.clone())
+                            .ok()
+                            .and_then(|decoded| {
+                                decoded
+                                    .fb()
+                                    .variant_as_enqueue_task()
+                                    .and_then(|et| et.task_id())
+                                    .map(str::to_string)
+                            })
+                            .unwrap_or_else(|| parsed.request_id());
                         let job_id = Some(parsed.job_id.clone());
                         entries.push(QueueEntry {
                             tenant: parsed.tenant,

--- a/src/task.rs
+++ b/src/task.rs
@@ -3,7 +3,7 @@
 //! This module contains the core task types that represent units of work
 //! in the system, along with associated records for leases and concurrency.
 
-use crate::job::{GubernatorRateLimit, JobView};
+use crate::job::{GubernatorRateLimit, JobView, Limit};
 use crate::job_attempt::JobAttemptView;
 
 /// Default lease duration for dequeued tasks (milliseconds)
@@ -149,6 +149,10 @@ pub enum ConcurrencyAction {
         /// Attempt number within current run (resets to 1 on job restart)
         relative_attempt_number: u32,
         task_group: String,
+        task_id: String,
+        held_queues: Vec<String>,
+        next_limit_index: u32,
+        limits: Vec<Limit>,
     },
 }
 

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -124,6 +124,10 @@ fn test_concurrency_action_roundtrip() {
         attempt_number: 1,
         relative_attempt_number: 1,
         task_group: "default".to_string(),
+        task_id: "task-1".to_string(),
+        held_queues: Vec::new(),
+        next_limit_index: 1,
+        limits: Vec::new(),
     };
     let encoded = encode_concurrency_action(&action);
     let decoded = decode_concurrency_action(encoded).unwrap();

--- a/tests/concurrency_requester_counter_tests.rs
+++ b/tests/concurrency_requester_counter_tests.rs
@@ -310,6 +310,10 @@ async fn inject_fake_request(
         attempt_number: attempt,
         relative_attempt_number: attempt,
         task_group: "default".to_string(),
+        task_id: "task-1".to_string(),
+        held_queues: Vec::new(),
+        next_limit_index: 1,
+        limits: Vec::new(),
     };
     let action_val = encode_concurrency_action(&action);
     db.put(&req_key, &action_val)

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -175,6 +175,10 @@ async fn periodic_reconcile_grants_pending_request_without_signal() {
         attempt_number: 1,
         relative_attempt_number: 1,
         task_group: "default".to_string(),
+        task_id: "task-1".to_string(),
+        held_queues: Vec::new(),
+        next_limit_index: 0,
+        limits: Vec::new(),
     };
     let request_key = concurrency_request_key(tenant, &queue, now, 10, &job_id, 1, "manual");
     let request_value = encode_concurrency_action(&action);

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -6,13 +6,20 @@
 mod test_helpers;
 
 use silo::codec::{decode_lease, encode_holder, encode_lease, encode_task};
-use silo::job::{FloatingConcurrencyLimit, Limit};
+use silo::job::{ConcurrencyLimit, FloatingConcurrencyLimit, Limit};
 use silo::job_attempt::AttemptOutcome;
 use silo::job_store_shard::JobStoreShardError;
 use silo::keys::{concurrency_holder_key, job_info_key, task_key};
 use silo::task::{GubernatorRateLimitData, HolderRecord, LeaseRecord, Task};
 
 use test_helpers::*;
+
+fn c_limit(queue: &str, max: u32) -> Limit {
+    Limit::Concurrency(ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: max,
+    })
+}
 
 fn fc_limit(queue: &str, default_max: u32) -> Limit {
     Limit::FloatingConcurrency(FloatingConcurrencyLimit {
@@ -626,5 +633,116 @@ async fn floating_concurrency_steady_state_zero_holders_after_full_cycle() {
         count_concurrency_holders_for_tenant(shard.db(), "-").await,
         0,
         "per-tenant holder count must be zero too"
+    );
+}
+
+/// A chain can grant an earlier concurrency limit immediately and then pause on
+/// a later limit. When the paused request is granted by the scanner, the
+/// terminal RunAttempt must keep the original task id and all held queues so the
+/// completion path releases every holder.
+#[silo::test]
+async fn scanner_resumes_paused_chain_with_original_task_id_and_all_holders() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+    let fixed_q = "chain-fixed-q";
+    let floating_q = "chain-floating-q";
+
+    // Job A occupies the floating slot so Job B has to pause after acquiring
+    // the fixed slot.
+    let _job_a = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": "a"})),
+            vec![fc_limit(floating_q, 1)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue a");
+
+    let job_b = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": "b"})),
+            vec![c_limit(fixed_q, 2), fc_limit(floating_q, 1)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue b");
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        2,
+        "A should hold floating_q and B should already hold fixed_q"
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        1,
+        "B should be paused on the floating queue"
+    );
+
+    let a = shard.dequeue("w-a", "default", 1).await.expect("dequeue a");
+    assert_eq!(a.tasks.len(), 1);
+    let a_task_id = a.tasks[0].attempt().task_id().to_string();
+    shard
+        .report_attempt_outcome(&a_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("complete a");
+
+    let b_ready = poll_until(
+        || async {
+            let tasks = shard.peek_tasks("default", 10).await.expect("peek tasks");
+            tasks.into_iter().find_map(|t| match t {
+                Task::RunAttempt {
+                    id,
+                    job_id,
+                    held_queues,
+                    ..
+                } if job_id == job_b => Some((id, held_queues)),
+                _ => None,
+            })
+        },
+        |found| found.is_some(),
+        5_000,
+    )
+    .await
+    .expect("job b should become runnable");
+
+    assert_eq!(
+        b_ready.1,
+        vec![fixed_q.to_string(), floating_q.to_string()],
+        "scanner-written RunAttempt should carry every acquired queue"
+    );
+
+    let b = shard.dequeue("w-b", "default", 1).await.expect("dequeue b");
+    assert_eq!(b.tasks.len(), 1);
+    assert_eq!(b.tasks[0].job().id(), job_b);
+    assert_eq!(
+        b.tasks[0].attempt().task_id(),
+        b_ready.0,
+        "lease should use the same task id as the scanner-written RunAttempt"
+    );
+    shard
+        .report_attempt_outcome(
+            b.tasks[0].attempt().task_id(),
+            AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("complete b");
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "completion should release both fixed and floating holders"
     );
 }

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -1638,6 +1638,10 @@ async fn grant_scanner_skips_stale_requests_and_grants_valid_ones() {
             attempt_number: 1,
             relative_attempt_number: 1,
             task_group: "tg".to_string(),
+            task_id: format!("stale-task-{}", i),
+            held_queues: Vec::new(),
+            next_limit_index: 1,
+            limits: Vec::new(),
         };
         let key = silo::keys::concurrency_request_key(
             tenant,
@@ -1699,6 +1703,10 @@ async fn grant_scanner_handles_all_stale_requests() {
             attempt_number: 1,
             relative_attempt_number: 1,
             task_group: "tg".to_string(),
+            task_id: format!("stale-task-{}", i),
+            held_queues: Vec::new(),
+            next_limit_index: 1,
+            limits: Vec::new(),
         };
         let key = silo::keys::concurrency_request_key(
             tenant,
@@ -1994,6 +2002,10 @@ async fn grant_scanner_interleaved_stale_and_valid_requests() {
             attempt_number: 1,
             relative_attempt_number: 1,
             task_group: "tg".to_string(),
+            task_id: format!("stale-task-{}", i),
+            held_queues: Vec::new(),
+            next_limit_index: 1,
+            limits: Vec::new(),
         };
         let key = silo::keys::concurrency_request_key(
             tenant,

--- a/tests/job_store_shard_import_tests.rs
+++ b/tests/job_store_shard_import_tests.rs
@@ -3109,6 +3109,10 @@ async fn reimport_failed_to_scheduled_ignores_stale_concurrency_requests() {
         attempt_number: 1,
         relative_attempt_number: 1,
         task_group: "default".to_string(),
+        task_id: "task-1".to_string(),
+        held_queues: Vec::new(),
+        next_limit_index: 1,
+        limits: Vec::new(),
     };
     let stale_request_key = silo::keys::concurrency_request_key(
         "-",


### PR DESCRIPTION
### Motivation
- Eliminate holder leaks and limit-bypass bugs by giving queued concurrency requests a durable chain identity so scanner resumption can continue the same limit-walk instead of inventing a synthetic id.
- Make the enqueue/scanner/ticket flows share a single resumeable walker model so immediate grants, queued requests, and future RequestTicket promotions behave consistently.
- Keep the change focused: only unify request payloads/identity and scanner resumption behavior, leaving tombstone/task-key-start-ms conflict handling to the planned follow-up.

### Description
- Persist chain resume state in request intents: added `task_id`, `held_queues`, `next_limit_index`, and serialized `limits` to `ConcurrencyAction::EnqueueTask` and the FlatBuffer schema, plus codec helpers to encode/decode limit entries.
- Stop writing interim runnable `RunAttempt` on immediate per-limit grants; `append_grant_edits` now writes only the holder record and the final `RunAttempt` is written by the unified walker once the chain fully resolves.
- Reworked grant scanner (`process_grants`) to decode the extended `EnqueueTask`, validate payload, reserve slots across possibly multiple queues while resuming the chain, emit new request edits when the resumed walk pauses on a later queue, derive per-pass request-counter deltas from walker actions, and roll back all in-memory reservations from the pass on write failure.
- Caller-side changes: `enqueue_limit_task_at_index` forwards held-queues/next-index to concurrency helpers so queued intents carry the full resume payload; query code prefers decoding the request payload's `task_id` when available; added a regression test `scanner_resumes_paused_chain_with_original_task_id_and_all_holders` and adjusted existing codec/tests to the new payload shape.
- Edge cases intentionally out of scope: tombstone / `task_key_start_ms` conflicts (handled by separate `task_key_start_ms` work), `RequestTicket` future scheduling semantics are not fully expanded to carry full chain state, cancel/reimport cleanup for EnqueueTask-held queues requires separate rework, scanner resumption uses durable/default floating capacity rather than inline floating refresh, and queue/index mismatch validations / exhaustive malformed-payload policies are minimal in this change.

### Testing
- Ran quick static checks: `git diff --check` and `cargo fmt --check` — both passed.
- Attempted `cargo check --tests` / `cargo test` but the build script invokes `flatc` (FlatBuffers compiler) and the environment lacks `flatc`, causing the build script to panic and tests to be blocked; see build error "failed to run flatc … No such file or directory".
- Added/updated regression tests and codec round-trip coverage (notably `scanner_resumes_paused_chain_with_original_task_id_and_all_holders`, codec roundtrips for the extended `EnqueueTask`), but their execution was blocked by the missing `flatc` in CI/local environment.
- Manual code-level review and local `cargo fmt`/linting performed; no formatting or obvious compile-time syntax issues remain beyond the build-tool dependency failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1874b1a2b88328bf823c198996391a)