### PR TITLE
Expose slatedb expired-entries-purged counter to prometheus

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -176,6 +176,8 @@ pub struct SlatedbShardMetrics {
     sst_filter_false_positives: CounterVec,
     bytes_compacted: CounterVec,
     flush_requests: CounterVec,
+    expired_entries_purged_value: CounterVec,
+    expired_entries_purged_merge: CounterVec,
 
     // Gauges (point-in-time)
     wal_buffer_estimated_bytes: GaugeVec,
@@ -549,6 +551,14 @@ impl SlatedbShardMetrics {
                 "slatedb_flush_requests_total",
                 "Total number of flush requests to SlateDB",
             )?,
+            expired_entries_purged_value: counter(
+                "slatedb_expired_entries_purged_value_total",
+                "Total expired value entries purged (rewritten as tombstones) by the SlateDB RetentionIterator during compaction",
+            )?,
+            expired_entries_purged_merge: counter(
+                "slatedb_expired_entries_purged_merge_total",
+                "Total expired merge entries dropped (without a tombstone) by the SlateDB RetentionIterator during compaction",
+            )?,
             wal_buffer_estimated_bytes: gauge(
                 "slatedb_wal_buffer_estimated_bytes",
                 "Estimated bytes buffered in the SlateDB WAL buffer",
@@ -636,6 +646,24 @@ impl SlatedbShardMetrics {
                 slatedb::db_stats::REQUEST_COUNT,
                 &[("op", "flush")],
                 &self.flush_requests,
+            ),
+            // RetentionIterator splits the EXPIRED_ENTRIES_PURGED counter by an
+            // `entry_type` label; map each value into its own per-shard instrument.
+            (
+                slatedb::compactor::stats::EXPIRED_ENTRIES_PURGED,
+                &[(
+                    slatedb::compactor::stats::ENTRY_TYPE_LABEL,
+                    slatedb::compactor::stats::ENTRY_TYPE_VALUE,
+                )],
+                &self.expired_entries_purged_value,
+            ),
+            (
+                slatedb::compactor::stats::EXPIRED_ENTRIES_PURGED,
+                &[(
+                    slatedb::compactor::stats::ENTRY_TYPE_LABEL,
+                    slatedb::compactor::stats::ENTRY_TYPE_MERGE,
+                )],
+                &self.expired_entries_purged_merge,
             ),
         ];
         let counter_mappings: &[(&str, &CounterVec)] = &[


### PR DESCRIPTION
## What

Wires slatedb 0.13's `RetentionIterator` expired-entries-purged stat through to Prometheus.

slatedb records purged entries to its compaction metrics recorder under `slatedb.compactor.expired_entries_purged` (`slatedb::compactor::stats::EXPIRED_ENTRIES_PURGED`), split by an `entry_type` label:
- `value` — expired value entries rewritten as tombstones (otherwise invisible to a user `CompactionFilter`)
- `merge` — expired merge entries dropped without a tombstone

This adds it to the shared `SlatedbShardMetrics`, so both the silo server and silo-compactor pick it up automatically via their existing slatedb stat poll loops.

## Changes (`src/metrics.rs`)

1. Two new counter fields on `SlatedbShardMetrics`: `expired_entries_purged_value`, `expired_entries_purged_merge`.
2. Registered as `slatedb_expired_entries_purged_value_total` / `slatedb_expired_entries_purged_merge_total` (prefixed `silo_` in the server, `silo_compactor_` in the compactor), labeled by `shard`.
3. Two entries in `labeled_counter_mappings` mapping the slatedb stat + `entry_type` label into each instrument, reusing the existing delta-tracking translation.

Follows the existing cache-counter idiom (one Prometheus instrument per slatedb label value, labeled only by `shard`).

## Notes

- The counter only increments on the compaction path, so in practice it populates under the `silo_compactor_` prefix (where compaction runs); the `silo_` series stays at 0 unless the server compacts in-process.

## Testing

- `cargo check -p silo` and `cargo check -p silo-compactor` both pass.