### PR TITLE
Add periodic leaked-holder reaper

### DIFF
--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -5,8 +5,8 @@ use slatedb::config::WriteOptions;
 use uuid::Uuid;
 
 use crate::codec::{
-    decode_floating_limit_state, decode_lease, encode_attempt, encode_floating_limit_state,
-    encode_lease,
+    decode_floating_limit_state, decode_holder_granted_at_ms, decode_lease, encode_attempt,
+    encode_floating_limit_state, encode_lease,
 };
 use crate::dst_events::{self, DstEvent};
 use crate::job::{FloatingLimitState, JobStatus, JobView};
@@ -14,9 +14,9 @@ use crate::job_attempt::{AttemptOutcome, AttemptStatus, JobAttempt};
 use crate::job_store_shard::helpers::{DbWriteBatcher, WriteBatcher, now_epoch_ms};
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
-    attempt_key, attempt_prefix, concurrency_holder_key, concurrency_holders_tenant_prefix,
-    end_bound, floating_limit_state_key, idx_metadata_key, job_cancelled_key, job_info_key,
-    leased_task_key, parse_concurrency_holder_key,
+    attempt_key, attempt_prefix, concurrency_holder_key, concurrency_holders_prefix,
+    concurrency_holders_tenant_prefix, end_bound, floating_limit_state_key, idx_metadata_key,
+    job_cancelled_key, job_info_key, leased_task_key, parse_concurrency_holder_key,
 };
 use crate::task::{DEFAULT_LEASE_MS, HeartbeatResult};
 use tracing::{debug, info_span};
@@ -669,6 +669,156 @@ impl JobStoreShard {
                 queue = %queue,
                 task_id = %task_id,
                 "purged orphaned concurrency holder during late report_outcome cleanup"
+            );
+        }
+
+        Ok(to_delete.len())
+    }
+
+    /// Scan all concurrency holders and release any orphaned ones: a holder
+    /// whose `task_id` has no lease and whose grant is older than `grace_ms`.
+    /// Releases via the full path (delete row + `atomic_release` +
+    /// `request_grant`). Skips tenants outside the shard range (split-aware).
+    /// Returns the number released.
+    ///
+    /// The invariant this repairs: every holder's `task_id` must have either a
+    /// lease (`leased_task_key`) or a still-queued `RunAttempt`. When a worker
+    /// pulls a `RunAttempt` into its in-flight buffer and its dequeue/lease
+    /// future is dropped **before a lease is durably written**, the holder was
+    /// already granted but the task is gone and no lease ever exists — so
+    /// neither the lease reaper (iterates leases) nor a late `report_outcome`
+    /// (`purge_orphaned_holders_for_task`, fires only for that exact `task_id`)
+    /// will ever reclaim it. The in-memory count stays pegged and, once ghost
+    /// holders fill the cap, the queue wedges. Nothing else iterates holders;
+    /// this does.
+    ///
+    /// Scan-then-point-get ordering avoids false positives: if a worker leases
+    /// a holder between the grace check and the point-get, the lease is
+    /// observed and the holder is skipped. The grace window covers holders
+    /// granted after the scan began. Holders are bounded (~Σ concurrency caps),
+    /// so a full `0x09` scan is cheap — comparable to the lease scan.
+    ///
+    /// At most `max_per_tick` holders are released per call; the scan stops
+    /// collecting once the cap is reached and any remainder is reclaimed on the
+    /// next tick. This bounds the durable delete batch and the post-commit
+    /// release loop so a shard with a large orphan backlog drains gradually
+    /// instead of in one giant write.
+    pub async fn reap_orphaned_holders(
+        &self,
+        grace_ms: i64,
+        max_per_tick: usize,
+    ) -> Result<usize, JobStoreShardError> {
+        let start = concurrency_holders_prefix();
+        let end = end_bound(&start);
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
+
+        let now_ms = now_epoch_ms();
+        let shard_range = self.get_range();
+
+        // (key, tenant, queue, task_id) for each orphaned holder found.
+        let mut to_delete: Vec<(Vec<u8>, String, String, String)> = Vec::new();
+
+        while let Some(kv) = iter.next().await? {
+            let Some(parsed) = parse_concurrency_holder_key(&kv.key) else {
+                continue;
+            };
+
+            // Split-aware: skip holders for tenants outside this shard's range.
+            if !shard_range.contains_tenant(&parsed.tenant) {
+                continue;
+            }
+
+            // Skip holders younger than the grace window — guards the normal
+            // grant→lease handoff and freshly granted holders whose RunAttempt
+            // is still legitimately queued.
+            let granted_at_ms = match decode_holder_granted_at_ms(&kv.value) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if now_ms - granted_at_ms < grace_ms {
+                continue;
+            }
+
+            // Healthy if a lease exists for this task_id (the lease reaper owns
+            // it). The point-get runs after the grace check, so a lease written
+            // concurrently is observed here and the holder is skipped.
+            if self
+                .db
+                .get(&leased_task_key(&parsed.task_id))
+                .await?
+                .is_some()
+            {
+                continue;
+            }
+
+            to_delete.push((kv.key.to_vec(), parsed.tenant, parsed.queue, parsed.task_id));
+
+            // Cap the per-tick batch: stop collecting once we hit the limit and
+            // let the next tick reclaim the rest. Bounds the durable write and
+            // the post-commit release loop under a large orphan backlog.
+            if to_delete.len() >= max_per_tick {
+                tracing::warn!(
+                    max_per_tick = max_per_tick,
+                    "orphaned holder reaper hit per-tick cap; remaining orphans \
+                     will be reclaimed on subsequent ticks"
+                );
+                break;
+            }
+        }
+        drop(iter);
+
+        if to_delete.is_empty() {
+            return Ok(0);
+        }
+
+        // Durable batch-delete all orphaned holder rows before touching
+        // in-memory state, mirroring report_attempt_outcome and
+        // purge_orphaned_holders_for_task.
+        let mut batch = WriteBatch::new();
+        for (key, _, _, _) in &to_delete {
+            batch.delete(key);
+        }
+        self.db
+            .write_with_options(
+                batch,
+                &WriteOptions {
+                    await_durable: true,
+                    ..Default::default()
+                },
+            )
+            .await?;
+
+        // Post-commit: drop the in-memory reservation and wake the grant
+        // scanner so queued requesters can be admitted in the orphans' place. A
+        // raw delete that skipped this would leave the count pegged and the
+        // queue wedged until the next rehydrate.
+        //
+        // `request_grant` is per-holder, but it coalesces by (tenant, queue)
+        // into a single pending-grant entry whose accumulated count the scanner
+        // drains in one `process_grants` pass — so even a queue with hundreds of
+        // orphans triggers one grant scan, not one per holder. We collapse the
+        // warn log the same way: one line per queue, not per holder.
+        let mut reaped_per_queue: std::collections::HashMap<(&str, &str), usize> =
+            std::collections::HashMap::new();
+        for (_, tenant, queue, task_id) in &to_delete {
+            self.concurrency
+                .counts()
+                .atomic_release(tenant, queue, task_id);
+            self.concurrency.request_grant(tenant, queue);
+            *reaped_per_queue
+                .entry((tenant.as_str(), queue.as_str()))
+                .or_default() += 1;
+        }
+        for ((tenant, queue), reaped) in reaped_per_queue {
+            tracing::warn!(
+                tenant = %tenant,
+                queue = %queue,
+                reaped = reaped,
+                grace_ms = grace_ms,
+                "reaped orphaned concurrency holders"
             );
         }
 

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -710,9 +710,14 @@ impl JobStoreShard {
     ) -> Result<usize, JobStoreShardError> {
         let start = concurrency_holders_prefix();
         let end = end_bound(&start);
+        // Uncached scan: this is a full-prefix sweep over every holder, run once
+        // per second. Holder blocks are not re-read from the block cache in
+        // steady state (the in-memory ConcurrencyCounts serves concurrency reads
+        // after lazy hydration), so caching them here would only evict hot
+        // blocks used by the enqueue/dequeue path.
         let mut iter = self
             .db
-            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options_uncached())
             .await?;
 
         let now_ms = now_epoch_ms();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -126,6 +126,10 @@ pub struct Metrics {
     lease_reaper_scans_total: CounterVec,
     lease_reaper_leases_reaped_total: CounterVec,
     lease_reaper_errors_total: CounterVec,
+    holder_reaper_duration: HistogramVec,
+    holder_reaper_scans_total: CounterVec,
+    holder_reaper_orphans_reaped_total: CounterVec,
+    holder_reaper_errors_total: CounterVec,
 
     // Concurrency metrics
     concurrency_tickets_granted: CounterVec,
@@ -422,6 +426,30 @@ impl Metrics {
     /// Record a lease reaper scan failure.
     pub fn record_lease_reaper_error(&self, shard: &str) {
         self.lease_reaper_errors_total
+            .with_label_values(&[shard])
+            .inc();
+    }
+
+    /// Record orphaned-holder reaper duration in seconds (and a scan).
+    pub fn record_holder_reaper_duration(&self, shard: &str, duration_secs: f64) {
+        self.holder_reaper_duration
+            .with_label_values(&[shard])
+            .observe(duration_secs);
+        self.holder_reaper_scans_total
+            .with_label_values(&[shard])
+            .inc();
+    }
+
+    /// Record the number of orphaned concurrency holders reaped during a scan.
+    pub fn record_holder_reaper_reaped(&self, shard: &str, count: u64) {
+        self.holder_reaper_orphans_reaped_total
+            .with_label_values(&[shard])
+            .inc_by(count as f64);
+    }
+
+    /// Record an orphaned-holder reaper scan failure.
+    pub fn record_holder_reaper_error(&self, shard: &str) {
+        self.holder_reaper_errors_total
             .with_label_values(&[shard])
             .inc();
     }
@@ -1208,6 +1236,51 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let holder_reaper_duration = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_holder_reaper_duration_seconds",
+                "Duration of orphaned concurrency holder reaper scan operations",
+            )
+            .buckets(SCAN_DURATION_BUCKETS.to_vec()),
+            &["shard"],
+        )?,
+    );
+
+    let holder_reaper_scans_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_holder_reaper_scans_total",
+                "Total number of orphaned holder reaper scan operations",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let holder_reaper_orphans_reaped_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_holder_reaper_orphans_reaped_total",
+                "Total number of orphaned concurrency holders reaped",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let holder_reaper_errors_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_holder_reaper_errors_total",
+                "Total number of orphaned holder reaper scan failures",
+            ),
+            &["shard"],
+        )?,
+    );
+
     // Concurrency metrics
     let concurrency_tickets_granted = register(
         &registry,
@@ -1350,6 +1423,10 @@ pub fn init() -> anyhow::Result<Metrics> {
         lease_reaper_scans_total,
         lease_reaper_leases_reaped_total,
         lease_reaper_errors_total,
+        holder_reaper_duration,
+        holder_reaper_scans_total,
+        holder_reaper_orphans_reaped_total,
+        holder_reaper_errors_total,
         concurrency_tickets_granted,
         concurrency_holders_cache_holders,
         concurrency_holders_cache_queues,

--- a/src/server.rs
+++ b/src/server.rs
@@ -2191,6 +2191,58 @@ where
         }
     });
 
+    // Periodic orphaned-holder reaper, decoupled from the lease reaper so a
+    // backpressured holder scan can't stall lease reaping. Releases concurrency
+    // holders whose task_id has no lease and whose grant predates the grace
+    // window — the wedge that the lease reaper and late report_outcome can't
+    // reach because nothing else iterates holders.
+    let holder_reaper_factory = factory.clone();
+    let holder_reaper_metrics = metrics.clone();
+    let holder_grace_ms = cfg.database.orphaned_holder_grace_ms as i64;
+    let holder_max_per_tick = cfg.database.orphaned_holder_max_reap_per_tick;
+    let mut holder_tick_rx = tick_tx.subscribe();
+    let holder_reaper: JoinHandle<()> = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+        loop {
+            tokio::select! {
+                biased;
+                _ = interval.tick() => {
+                    for (shard_id, shard) in holder_reaper_factory.instances().iter() {
+                        let reap_start = std::time::Instant::now();
+                        let result = shard
+                            .reap_orphaned_holders(holder_grace_ms, holder_max_per_tick)
+                            .await;
+                        let shard_label = shard_id.to_string();
+                        if let Some(ref m) = holder_reaper_metrics {
+                            m.record_holder_reaper_duration(
+                                &shard_label,
+                                reap_start.elapsed().as_secs_f64(),
+                            );
+                        }
+                        match result {
+                            Ok(reaped) => {
+                                if let Some(ref m) = holder_reaper_metrics {
+                                    m.record_holder_reaper_reaped(&shard_label, reaped as u64);
+                                }
+                            }
+                            Err(e) => {
+                                if let Some(ref m) = holder_reaper_metrics {
+                                    m.record_holder_reaper_error(&shard_label);
+                                }
+                                warn!(
+                                    shard = %shard_label,
+                                    error = %e,
+                                    "orphaned holder reaper failed"
+                                );
+                            }
+                        }
+                    }
+                }
+                _ = holder_tick_rx.recv() => { break; }
+            }
+        }
+    });
+
     // Periodic SlateDB metrics scrape, decoupled from the reaper so a
     // backpressured write in `reap_expired_leases` can't stall observability.
     let metrics_factory = factory.clone();
@@ -2287,6 +2339,7 @@ where
     // handles the ordered close→release-lease sequence, which is critical for
     // permanent leases. factory.close_all() in main.rs serves as a safety net.
     reaper.await.ok();
+    holder_reaper.await.ok();
     metrics_scrape.await.ok();
     if let Some(h) = compaction_ticker {
         h.await.ok();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -182,6 +182,18 @@ fn default_concurrency_reconcile_interval_ms() -> u64 {
     DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS
 }
 
+pub const DEFAULT_ORPHANED_HOLDER_GRACE_MS: u64 = 60_000;
+
+fn default_orphaned_holder_grace_ms() -> u64 {
+    DEFAULT_ORPHANED_HOLDER_GRACE_MS
+}
+
+pub const DEFAULT_ORPHANED_HOLDER_MAX_REAP_PER_TICK: usize = 1000;
+
+fn default_orphaned_holder_max_reap_per_tick() -> usize {
+    DEFAULT_ORPHANED_HOLDER_MAX_REAP_PER_TICK
+}
+
 fn default_hydrate_all_at_startup() -> bool {
     false
 }
@@ -210,6 +222,23 @@ pub struct DatabaseTemplate {
     /// to self-heal from missed in-memory notifications.
     #[serde(default = "default_concurrency_reconcile_interval_ms")]
     pub concurrency_reconcile_interval_ms: u64,
+    /// Grace window in milliseconds for the periodic orphaned-holder reaper.
+    /// A concurrency holder whose `task_id` has no lease and whose grant is
+    /// older than this window is treated as orphaned (the worker vanished
+    /// before durably writing a lease) and released. The window guards the
+    /// normal grant→lease handoff and the still-queued case; worker leases are
+    /// `DEFAULT_LEASE_MS` (10 s), so the 60 s default is 6× that — comfortably
+    /// past the gap while still reclaiming a wedged queue within a minute.
+    #[serde(default = "default_orphaned_holder_grace_ms")]
+    pub orphaned_holder_grace_ms: u64,
+    /// Maximum number of orphaned holders the periodic reaper will release in a
+    /// single per-shard scan (one tick). Bounds the size of the durable delete
+    /// batch and the post-commit release loop so a shard with a large orphan
+    /// backlog drains over several ticks instead of one giant write. Any
+    /// remainder is reclaimed on subsequent ticks. Holders are bounded by the
+    /// sum of concurrency caps, so the 1000 default rarely truncates.
+    #[serde(default = "default_orphaned_holder_max_reap_per_tick")]
+    pub orphaned_holder_max_reap_per_tick: usize,
     /// Interval in seconds for the periodic counter reconciliation background
     /// task that re-derives counter truth from JOB_INFO/JOB_STATUS to correct
     /// drift caused by the standalone compactor dropping terminal job rows.
@@ -283,6 +312,8 @@ impl Default for DatabaseTemplate {
             wal: None,
             apply_wal_on_close: default_apply_wal_on_close(),
             concurrency_reconcile_interval_ms: default_concurrency_reconcile_interval_ms(),
+            orphaned_holder_grace_ms: default_orphaned_holder_grace_ms(),
+            orphaned_holder_max_reap_per_tick: default_orphaned_holder_max_reap_per_tick(),
             counter_reconciliation_seconds: None,
             hydrate_all_at_startup: default_hydrate_all_at_startup(),
             completed_job_expire_s: None,

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -1305,3 +1305,221 @@ async fn steady_state_zero_holders_under_mixed_workload() {
     // referenced after construction; explicitly drop it here for clarity.
     let _ = MockGubernatorClient::new_arc();
 }
+
+// ---------------------------------------------------------------------------
+// Periodic orphaned-holder reaper (`reap_orphaned_holders`)
+// ---------------------------------------------------------------------------
+
+/// Positive case: a holder whose `task_id` has no lease and whose grant
+/// predates the grace window is released via the full path — the DB row is
+/// deleted and the in-memory count drops so the queue can grant again. This is
+/// the wedge that neither the lease reaper (iterates leases) nor a late
+/// `report_outcome` (`purge_orphaned_holders_for_task`) can reach.
+#[silo::test]
+async fn reap_orphaned_holders_releases_stranded_holder() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "reap-orphan-q";
+    let task_id = "orphan-task";
+
+    // Seed the in-memory reservation (no lease, no holder row yet).
+    assert!(
+        shard
+            .force_reserve_concurrency_for_test(tenant, queue, task_id, 5)
+            .await
+    );
+    assert_eq!(shard.concurrency_holder_count(tenant, queue), 1);
+
+    // Plant the durable holder row with a grant older than the grace window.
+    shard
+        .db()
+        .put(
+            &concurrency_holder_key(tenant, queue, task_id),
+            &encode_holder(&HolderRecord {
+                granted_at_ms: now_ms() - 120_000,
+            }),
+        )
+        .await
+        .expect("plant holder");
+    shard.db().flush().await.expect("flush");
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+
+    let reaped = shard
+        .reap_orphaned_holders(60_000, 1000)
+        .await
+        .expect("reap");
+    assert_eq!(reaped, 1, "stranded holder should be reaped");
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "holder row must be deleted"
+    );
+    assert_eq!(
+        shard.concurrency_holder_count(tenant, queue),
+        0,
+        "in-memory count must drop so the queue can grant again"
+    );
+}
+
+/// Negative case (a): a holder whose `task_id` still has a lease is healthy and
+/// must not be reaped, even when its grant predates the grace window — the
+/// lease reaper owns it. Exercises the scan-then-point-get path.
+#[silo::test]
+async fn reap_orphaned_holders_skips_holder_with_lease() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "reap-lease-q".to_string();
+
+    shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![fc_limit(&queue, 1)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+    let leased = shard.dequeue("w1", "default", 1).await.expect("deq").tasks;
+    let task_id = leased[0].attempt().task_id().to_string();
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+
+    // Age the holder's grant past the grace window; the lease still exists.
+    shard
+        .db()
+        .put(
+            &concurrency_holder_key(tenant, &queue, &task_id),
+            &encode_holder(&HolderRecord {
+                granted_at_ms: now_ms() - 120_000,
+            }),
+        )
+        .await
+        .expect("age holder");
+    shard.db().flush().await.expect("flush");
+
+    let reaped = shard
+        .reap_orphaned_holders(60_000, 1000)
+        .await
+        .expect("reap");
+    assert_eq!(reaped, 0, "holder with a live lease must not be reaped");
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+    assert_eq!(shard.concurrency_holder_count(tenant, &queue), 1);
+}
+
+/// Negative case (b): a holder younger than the grace window must be skipped
+/// even with no lease — this guards the normal grant→lease handoff and the
+/// still-queued `RunAttempt` case.
+#[silo::test]
+async fn reap_orphaned_holders_skips_young_holder() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "reap-young-q";
+    let task_id = "young-task";
+
+    assert!(
+        shard
+            .force_reserve_concurrency_for_test(tenant, queue, task_id, 5)
+            .await
+    );
+    shard
+        .db()
+        .put(
+            &concurrency_holder_key(tenant, queue, task_id),
+            &encode_holder(&HolderRecord {
+                granted_at_ms: now_ms(),
+            }),
+        )
+        .await
+        .expect("plant young holder");
+    shard.db().flush().await.expect("flush");
+
+    let reaped = shard
+        .reap_orphaned_holders(60_000, 1000)
+        .await
+        .expect("reap");
+    assert_eq!(reaped, 0, "holder younger than grace must not be reaped");
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+    assert_eq!(shard.concurrency_holder_count(tenant, queue), 1);
+}
+
+/// Negative case (c): a holder for a tenant outside the shard's range must be
+/// skipped — the owning shard is responsible for reaping it (split-aware).
+#[silo::test]
+async fn reap_orphaned_holders_skips_out_of_range_tenant() {
+    // Empty range: start == end, so `contains_tenant` is false for every tenant.
+    let (_tmp, shard) = open_temp_shard_with_range(silo::shard_range::ShardRange::new(
+        "zzzzz".to_string(),
+        "zzzzz".to_string(),
+    ))
+    .await;
+    let tenant = "-";
+    let queue = "reap-oor-q";
+    let task_id = "oor-task";
+
+    shard
+        .db()
+        .put(
+            &concurrency_holder_key(tenant, queue, task_id),
+            &encode_holder(&HolderRecord {
+                granted_at_ms: now_ms() - 120_000,
+            }),
+        )
+        .await
+        .expect("plant holder");
+    shard.db().flush().await.expect("flush");
+
+    let reaped = shard
+        .reap_orphaned_holders(60_000, 1000)
+        .await
+        .expect("reap");
+    assert_eq!(reaped, 0, "out-of-range holder must not be reaped");
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+}
+
+/// The per-tick cap bounds how many holders one scan releases: with three
+/// orphans and a cap of two, the first call reaps two and a follow-up tick
+/// drains the last — so a large orphan backlog is reclaimed gradually instead
+/// of in one giant durable write.
+#[silo::test]
+async fn reap_orphaned_holders_respects_per_tick_cap() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "reap-cap-q";
+    let old = now_ms() - 120_000;
+
+    for i in 0..3 {
+        let task_id = format!("cap-task-{i}");
+        assert!(
+            shard
+                .force_reserve_concurrency_for_test(tenant, queue, &task_id, 5)
+                .await
+        );
+        shard
+            .db()
+            .put(
+                &concurrency_holder_key(tenant, queue, &task_id),
+                &encode_holder(&HolderRecord { granted_at_ms: old }),
+            )
+            .await
+            .expect("plant holder");
+    }
+    shard.db().flush().await.expect("flush");
+    assert_eq!(count_concurrency_holders(shard.db()).await, 3);
+    assert_eq!(shard.concurrency_holder_count(tenant, queue), 3);
+
+    // First tick: cap of 2 releases exactly two, leaving one behind.
+    let reaped = shard.reap_orphaned_holders(60_000, 2).await.expect("reap");
+    assert_eq!(reaped, 2, "per-tick cap must bound the batch");
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+    assert_eq!(shard.concurrency_holder_count(tenant, queue), 1);
+
+    // Next tick drains the remainder.
+    let reaped = shard.reap_orphaned_holders(60_000, 2).await.expect("reap");
+    assert_eq!(reaped, 1, "remainder reclaimed on the following tick");
+    assert_eq!(count_concurrency_holders(shard.db()).await, 0);
+    assert_eq!(shard.concurrency_holder_count(tenant, queue), 0);
+}


### PR DESCRIPTION
## Problem

A tenant's concurrency queue can wedge permanently due to **orphaned concurrency holders**. A holder (KV prefix `0x09`) is granted the instant a `RunAttempt` task is created, tied to a `task_id`, and is normally released on `report_attempt_outcome`, `cancel_job`, or lease-expiry reaping. When a worker pulls a `RunAttempt` into its in-flight buffer and drops the dequeue/lease future **before a lease is durably written**, the holder is left with no lease and no task.

Nothing iterates holders to recover this:
- the lease reaper iterates *leases* — a holder with no lease is invisible to it;
- `reconcile_pending_requests` iterates *requests* and never inspects holders;
- `purge_orphaned_holders_for_task` only fires on a late `report_outcome` for that exact `task_id`, which never arrives when the worker is gone.

So the holder stays pegged until ghost holders fill the cap, `try_reserve`/`process_grants` see the queue as full, and the requester backlog starves forever.

## Change

A periodic, per-shard reaper that scans holders and releases any orphaned one — no lease for its `task_id` and a grant older than a configurable grace window — via the **full** release path (durable delete + `atomic_release` + `request_grant`), never a bare KV delete.

- **`reap_orphaned_holders(grace_ms, max_per_tick)`** (`src/job_store_shard/lease.rs`): single `0x09`-prefix scan per shard, split-aware, scan-then-point-get to avoid false positives (a lease written concurrently is observed and the holder skipped). Grant wakeups and warn logs coalesce per queue; a per-tick cap bounds the durable batch so a large backlog drains over several ticks.
- **Scheduling** (`src/server.rs`): a second 1s reaper task next to the lease reaper, decoupled via its own shutdown receiver so a backpressured holder scan can't stall lease reaping (mirrors the decoupled metrics-scrape task).
- **Settings** (`src/settings.rs`): `orphaned_holder_grace_ms` (default 60s — 6× `DEFAULT_LEASE_MS`) and `orphaned_holder_max_reap_per_tick` (default 1000).
- **Metrics** (`src/metrics.rs`): `silo_holder_reaper_{duration_seconds,scans_total,orphans_reaped_total,errors_total}`, mirroring the lease-reaper set.

## Bounding / fan-out

One scan per shard per second, sequential over shards on a single task (no overlap). Within a scan, point-gets and releases are sequential — no spawn/join. `request_grant` coalesces by `(tenant, queue)` into one pending-grant entry with an accumulated count, so a queue with hundreds of orphans triggers one `process_grants` pass, not one per holder. The per-tick cap bounds the durable write under a pathological backlog.

## Tests

`tests/holder_leak_tests.rs` — releases a stranded holder; skips holders with a lease / younger than grace / for an out-of-range tenant; respects the per-tick cap (3 orphans, cap 2 → reaps 2 then 1).

## Verification

- `cargo build` clean, `cargo fmt --check` clean
- `cargo clippy` — no new warnings in changed source
- `cargo test --test holder_leak_tests` — 15/15 pass