### PR TITLE
Reconcile in-memory concurrency holders on dropped dequeue futures

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1167,11 +1167,7 @@ impl ConcurrencyManager {
     ///
     /// On a transient DB error, the failing tuple is re-queued so the next
     /// tick (or sub-tick wake) retries it.
-    pub async fn reconcile_pending_holders(
-        &self,
-        db: &Arc<InstrumentedDb>,
-        range: &ShardRange,
-    ) {
+    pub async fn reconcile_pending_holders(&self, db: &Arc<InstrumentedDb>, range: &ShardRange) {
         let pending = self.counts.drain_pending_reconciliations();
         if pending.is_empty() {
             return;
@@ -1181,10 +1177,7 @@ impl ConcurrencyManager {
         // per pass.
         let mut by_queue: BTreeMap<(String, String), Vec<String>> = BTreeMap::new();
         for (tenant, queue, task_id) in pending {
-            by_queue
-                .entry((tenant, queue))
-                .or_default()
-                .push(task_id);
+            by_queue.entry((tenant, queue)).or_default().push(task_id);
         }
 
         for ((tenant, queue), task_ids) in by_queue {
@@ -1225,11 +1218,8 @@ impl ConcurrencyManager {
                             task_id = %task_id,
                             "reconciler: durable lookup failed; re-queueing"
                         );
-                        self.counts.enqueue_reconciliation(
-                            tenant.clone(),
-                            queue.clone(),
-                            task_id,
-                        );
+                        self.counts
+                            .enqueue_reconciliation(tenant.clone(), queue.clone(), task_id);
                         continue;
                     }
                 };

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -60,7 +60,6 @@ use crate::codec::{
 use crate::dst_events::{self, DstEvent};
 use crate::job::{ConcurrencyLimit, JobStatusKind, JobView, Limit};
 use crate::job_store_shard::helpers::decode_job_status_owned;
-use crate::job_store_shard::limit_processing_order;
 use crate::keys::{
     concurrency_counts_key, concurrency_holder_key, concurrency_holders_prefix,
     concurrency_holders_queue_prefix, concurrency_request_key, concurrency_request_prefix,
@@ -193,18 +192,16 @@ fn concurrency_queue_for_limit(limit: &Limit) -> Option<&str> {
 }
 
 fn limit_index_matches_queue(limits: &[Limit], limit_index: u32, queue: &str) -> bool {
-    let order = limit_processing_order(limits);
-    order
+    limits
         .get(limit_index as usize)
-        .and_then(|&idx| concurrency_queue_for_limit(&limits[idx]))
+        .and_then(concurrency_queue_for_limit)
         == Some(queue)
 }
 
 fn canonical_limit_index_for_queue(limits: &[Limit], queue: &str) -> Option<u32> {
-    let order = limit_processing_order(limits);
-    order
+    limits
         .iter()
-        .position(|&idx| concurrency_queue_for_limit(&limits[idx]) == Some(queue))
+        .position(|limit| concurrency_queue_for_limit(limit) == Some(queue))
         .map(|idx| idx as u32)
 }
 

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -58,13 +58,14 @@ use crate::codec::{
     encode_holder, encode_task,
 };
 use crate::dst_events::{self, DstEvent};
-use crate::job::{ConcurrencyLimit, JobStatusKind, Limit};
+use crate::job::{ConcurrencyLimit, JobStatusKind, JobView, Limit};
 use crate::job_store_shard::helpers::decode_job_status_owned;
+use crate::job_store_shard::limit_processing_order;
 use crate::keys::{
     concurrency_counts_key, concurrency_holder_key, concurrency_holders_prefix,
     concurrency_holders_queue_prefix, concurrency_request_key, concurrency_request_prefix,
     concurrency_requester_counter_key, concurrency_requests_prefix, end_bound,
-    floating_limit_state_key, job_status_key, parse_concurrency_holder_key,
+    floating_limit_state_key, job_info_key, job_status_key, parse_concurrency_holder_key,
     parse_concurrency_request_key, task_key,
 };
 use crate::metrics::Metrics;
@@ -182,6 +183,30 @@ const STATUS_LOOKUP_CONCURRENCY: usize = 64;
 /// memory; the outer loop iterates as many passes as needed to drain
 /// the requested count.
 const MAX_GRANTS_PER_PASS: usize = 256;
+
+fn concurrency_queue_for_limit(limit: &Limit) -> Option<&str> {
+    match limit {
+        Limit::Concurrency(cl) => Some(&cl.key),
+        Limit::FloatingConcurrency(fl) => Some(&fl.key),
+        Limit::RateLimit(_) => None,
+    }
+}
+
+fn limit_index_matches_queue(limits: &[Limit], limit_index: u32, queue: &str) -> bool {
+    let order = limit_processing_order(limits);
+    order
+        .get(limit_index as usize)
+        .and_then(|&idx| concurrency_queue_for_limit(&limits[idx]))
+        == Some(queue)
+}
+
+fn canonical_limit_index_for_queue(limits: &[Limit], queue: &str) -> Option<u32> {
+    let order = limit_processing_order(limits);
+    order
+        .iter()
+        .position(|&idx| concurrency_queue_for_limit(&limits[idx]) == Some(queue))
+        .map(|idx| idx as u32)
+}
 
 /// Result of attempting to enqueue a job with concurrency limits
 #[derive(Debug)]
@@ -1294,31 +1319,61 @@ impl ConcurrencyManager {
                     break;
                 }
 
-                // Post-deploy of the unify-chain schema, every request value
-                // populates `task_id`, `limits`, `task_group`, `held_queues`,
-                // and a `limit_index` pointing at this queue's position in
-                // the canonical limit order. Any value missing those fields
-                // is pre-upgrade data left over from a rolling deploy; the
-                // operator clears it (bump `cluster_prefix` / rotate
-                // storage) before shipping this change, and the scanner
-                // treats whatever remains as corrupt below.
-                let task_id_str = et.task_id().unwrap_or_default().to_string();
-                if task_id_str.is_empty() {
-                    tracing::warn!(
-                        queue = %queue,
-                        job_id = %job_id_str,
-                        "grant scanner: request missing task_id; deleting"
-                    );
-                    batch.delete(&kv.key);
-                    stale_and_corrupt_count += 1;
-                    continue;
-                }
+                let task_id_str = match et.task_id() {
+                    Some(task_id) if !task_id.is_empty() => task_id.to_string(),
+                    _ => parsed_req.request_id(),
+                };
                 let held_queues: Vec<String> = et
                     .held_queues()
                     .map(|v| v.iter().map(|s| s.to_string()).collect())
                     .unwrap_or_default();
-                let limits = crate::codec::limit_entries_to_owned(et.limits());
-                let task_group = et.task_group().unwrap_or_default().to_string();
+                let mut limits = crate::codec::limit_entries_to_owned(et.limits());
+                let mut task_group = et.task_group().unwrap_or_default().to_string();
+
+                if limits.is_empty() || task_group.is_empty() {
+                    match db.get(&job_info_key(tenant, job_id_str)).await {
+                        Ok(Some(job_raw)) => match JobView::new(job_raw) {
+                            Ok(job_view) => {
+                                if limits.is_empty() {
+                                    limits = job_view.limits();
+                                }
+                                if task_group.is_empty() {
+                                    task_group = job_view.task_group().to_string();
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    queue = %queue,
+                                    job_id = %job_id_str,
+                                    error = %e,
+                                    "grant scanner: request needs JobInfo fallback but JobInfo is unreadable; deleting"
+                                );
+                                batch.delete(&kv.key);
+                                stale_and_corrupt_count += 1;
+                                continue;
+                            }
+                        },
+                        Ok(None) => {
+                            tracing::warn!(
+                                queue = %queue,
+                                job_id = %job_id_str,
+                                "grant scanner: request needs JobInfo fallback but JobInfo is missing; deleting"
+                            );
+                            batch.delete(&kv.key);
+                            stale_and_corrupt_count += 1;
+                            continue;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                queue = %queue,
+                                job_id = %job_id_str,
+                                error = %e,
+                                "grant scanner: failed to load JobInfo fallback; skipping request this pass"
+                            );
+                            continue;
+                        }
+                    }
+                }
 
                 if limits.is_empty() {
                     tracing::warn!(
@@ -1334,14 +1389,28 @@ impl ConcurrencyManager {
                     tracing::warn!(
                         queue = %queue,
                         job_id = %job_id_str,
-                        "grant scanner: request has no task group; deleting"
+                        "grant scanner: request has no task group after fallback; deleting"
                     );
                     batch.delete(&kv.key);
                     stale_and_corrupt_count += 1;
                     continue;
                 }
 
-                let limit_index = et.limit_index();
+                let raw_limit_index = et.limit_index();
+                let limit_index = if limit_index_matches_queue(&limits, raw_limit_index, queue) {
+                    raw_limit_index
+                } else if let Some(idx) = canonical_limit_index_for_queue(&limits, queue) {
+                    idx
+                } else {
+                    tracing::warn!(
+                        queue = %queue,
+                        job_id = %job_id_str,
+                        "grant scanner: request queue is not in job limits; deleting"
+                    );
+                    batch.delete(&kv.key);
+                    stale_and_corrupt_count += 1;
+                    continue;
+                };
 
                 // Resolve max_concurrency from the first request's limits
                 // (always populated, per the check above).

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1167,11 +1167,21 @@ impl ConcurrencyManager {
     ///
     /// On a transient DB error, the failing tuple is re-queued so the next
     /// tick (or sub-tick wake) retries it.
-    pub async fn reconcile_pending_holders(&self, db: &Arc<InstrumentedDb>, range: &ShardRange) {
+    /// Reconcile each pending `(tenant, queue, task_id)` against its durable
+    /// holder row. Returns `true` if any tuple had to be re-queued (hydrate
+    /// or per-task `db.get` returned an error), so the caller knows to
+    /// schedule a retry — see `spawn_holder_reconcile_task` for the
+    /// backoff-and-renotify loop that consumes this signal.
+    pub async fn reconcile_pending_holders(
+        &self,
+        db: &Arc<InstrumentedDb>,
+        range: &ShardRange,
+    ) -> bool {
         let pending = self.counts.drain_pending_reconciliations();
         if pending.is_empty() {
-            return;
+            return false;
         }
+        let mut requeued = false;
 
         // Group by (tenant, queue) so each queue is hydrated at most once
         // per pass.
@@ -1202,6 +1212,7 @@ impl ConcurrencyManager {
                     self.counts
                         .enqueue_reconciliation(tenant.clone(), queue.clone(), tid);
                 }
+                requeued = true;
                 continue;
             }
 
@@ -1220,6 +1231,7 @@ impl ConcurrencyManager {
                         );
                         self.counts
                             .enqueue_reconciliation(tenant.clone(), queue.clone(), task_id);
+                        requeued = true;
                         continue;
                     }
                 };
@@ -1272,6 +1284,8 @@ impl ConcurrencyManager {
                 "reconciler: pending_reconciliations growing — backlog suggests stuck reconciler"
             );
         }
+
+        requeued
     }
 
     /// Walk every hydrated (tenant, queue) in this shard, compare the

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -36,7 +36,7 @@
 //!   request from a restart or retry is still in the DB. Since Cancelled is terminal,
 //!   this also catches any stale cancelled requests.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -284,6 +284,15 @@ pub struct ConcurrencyCounts {
     /// have already scanned every non-empty queue. When `false`, the
     /// singleflighted per-queue scan runs on miss.
     hydrate_all_at_startup: bool,
+    /// (tenant, queue, task_id) tuples submitted by RAII guards on drop of a
+    /// dequeue future, awaiting per-task_id reconciliation against the durable
+    /// holder row. BTreeSet for deterministic iteration order (DST) and
+    /// natural deduplication of repeated tuples.
+    ///
+    /// Mutex is held only for synchronous `insert` and `mem::take` — never
+    /// across `.await`, matching the locking discipline at the top of this
+    /// module.
+    pending_reconciliations: Mutex<BTreeSet<(String, String, String)>>,
 }
 
 impl Default for ConcurrencyCounts {
@@ -304,6 +313,7 @@ impl ConcurrencyCounts {
         Self {
             queues: Arc::new(DashMap::new()),
             hydrate_all_at_startup,
+            pending_reconciliations: Mutex::new(BTreeSet::new()),
         }
     }
 
@@ -584,6 +594,77 @@ impl ConcurrencyCounts {
             .unwrap_or(0)
     }
 
+    /// Whether this task_id is currently recorded as an in-memory holder for
+    /// `(tenant, queue)`. Used by the reconciler to compare against the
+    /// durable holder row.
+    pub fn contains_holder(&self, tenant: &str, queue: &str, task_id: &str) -> bool {
+        let key = queue_key(tenant, queue);
+        self.queues
+            .get(&key)
+            .map(|entry| entry.holders.contains(task_id))
+            .unwrap_or(false)
+    }
+
+    /// Insert an in-memory holder without going through `try_reserve` (no
+    /// capacity check). Used by the reconciler when it observes a durable
+    /// holder row with no matching in-memory entry — a possible outcome of
+    /// the ambiguous "commit landed during cancellation" case on the
+    /// grant-side guard, which the reconciler self-heals.
+    pub fn insert_holder(&self, tenant: &str, queue: &str, task_id: &str) {
+        let key = queue_key(tenant, queue);
+        let mut entry = self.queues.entry(key).or_insert_with(QueueEntry::new);
+        entry.holders.insert(task_id.to_string());
+    }
+
+    /// Push a `(tenant, queue, task_id)` tuple onto the per-task_id
+    /// reconciliation queue. Idempotent: BTreeSet dedupes repeats.
+    ///
+    /// Called by `PendingGrantGuard::drop` and `PendingHolderReleaseGuard::drop`
+    /// in `dequeue.rs` when a dequeue future is cancelled around its commit.
+    /// The actual reconciliation runs on the periodic
+    /// `spawn_concurrency_reconcile_task`, woken sub-tick via
+    /// `ConcurrencyManager::request_reconciliation`.
+    pub fn enqueue_reconciliation(&self, tenant: String, queue: String, task_id: String) {
+        let mut p = self.pending_reconciliations.lock().unwrap();
+        p.insert((tenant, queue, task_id));
+    }
+
+    /// Drain the pending reconciliation set. Synchronous — does not touch the
+    /// `await_durable` path.
+    fn drain_pending_reconciliations(&self) -> BTreeSet<(String, String, String)> {
+        let mut p = self.pending_reconciliations.lock().unwrap();
+        std::mem::take(&mut *p)
+    }
+
+    /// Count of pending reconciliation tuples. Used by metrics and a stuck-
+    /// reconciler warn.
+    pub fn pending_reconciliations_len(&self) -> usize {
+        self.pending_reconciliations.lock().unwrap().len()
+    }
+
+    /// Snapshot every hydrated (tenant, queue) and its current in-memory
+    /// holder count. Used by the reconciler tick to compute drift against
+    /// the durable holder rows for each queue.
+    ///
+    /// `NotHydrated` and `Hydrating` queues are intentionally skipped: we
+    /// haven't loaded their durable rows yet, so comparing in-memory (empty)
+    /// against durable (unknown) is meaningless.
+    pub fn hydrated_queue_holders_snapshot(&self) -> Vec<(String, String, usize)> {
+        let mut out = Vec::new();
+        for entry in self.queues.iter() {
+            if !matches!(entry.state, HydrationState::Hydrated) {
+                continue;
+            }
+            let (tenant_arc, queue_arc) = entry.key();
+            out.push((
+                tenant_arc.to_string(),
+                queue_arc.to_string(),
+                entry.holders.len(),
+            ));
+        }
+        out
+    }
+
     /// Snapshot the sizes of the in-memory holders cache for metrics reporting.
     pub fn cache_stats(&self) -> ConcurrencyCacheStats {
         let mut total_holders = 0usize;
@@ -731,6 +812,13 @@ pub struct ConcurrencyManager {
     pending_grants: Mutex<BTreeMap<Vec<u8>, (String, String, u32)>>,
     grant_notify: tokio::sync::Notify,
     grant_running: AtomicBool,
+    /// Sub-tick wake for the periodic holder reconciler. Fired by
+    /// `request_reconciliation` after a dequeue future is cancelled around
+    /// its commit (via `PendingGrantGuard::drop` / `PendingHolderReleaseGuard::drop`).
+    /// Sibling to `grant_notify` — separate notify because the grant scanner
+    /// and the holder reconciler are distinct concerns (granting vs
+    /// reconciling); the periodic-reconcile task selects on this directly.
+    reconcile_notify: Arc<tokio::sync::Notify>,
     /// In-memory cache of resolved concurrency limits per queue.
     /// Key: concurrency_counts_key(tenant, queue). Populated during enqueue and grant_next.
     limit_cache: Mutex<HashMap<Vec<u8>, CachedQueueLimit>>,
@@ -760,6 +848,7 @@ impl ConcurrencyManager {
             pending_grants: Mutex::new(BTreeMap::new()),
             grant_notify: tokio::sync::Notify::new(),
             grant_running: AtomicBool::new(false),
+            reconcile_notify: Arc::new(tokio::sync::Notify::new()),
             limit_cache: Mutex::new(HashMap::new()),
             metrics,
             chain_resumer: Mutex::new(None),
@@ -1044,6 +1133,220 @@ impl ConcurrencyManager {
     /// Wakes the grant scanner to process pending requests.
     pub fn request_grant(&self, tenant: &str, queue: &str) {
         self.request_grant_count(tenant, queue, 1);
+    }
+
+    /// Clone-able handle to the reconcile-notify so the periodic reconcile
+    /// task can `select!` on it without holding the manager.
+    pub fn reconcile_notify(&self) -> Arc<tokio::sync::Notify> {
+        Arc::clone(&self.reconcile_notify)
+    }
+
+    /// Queue a `(tenant, queue, task_id)` for the periodic reconciler to
+    /// verify against the durable holder row. Wakes the reconciler sub-tick.
+    ///
+    /// Called by `PendingGrantGuard::drop` and `PendingHolderReleaseGuard::drop`
+    /// in `dequeue.rs` after a dequeue future is cancelled around its commit
+    /// — the only place where in-memory and durable holder state can drift.
+    pub fn request_reconciliation(&self, tenant: String, queue: String, task_id: String) {
+        self.counts.enqueue_reconciliation(tenant, queue, task_id);
+        self.reconcile_notify.notify_one();
+    }
+
+    /// Drain the pending reconciliation set and reconcile each
+    /// `(tenant, queue, task_id)` against the durable holder row.
+    ///
+    /// Per-task_id, idempotent. Resolves the ambiguity of "cancellation mid
+    /// commit-await may or may not have applied to the WAL" deterministically:
+    ///
+    /// | durable | in-memory | action                                   |
+    /// |---------|-----------|------------------------------------------|
+    /// | Y       | Y         | no-op (consistent)                       |
+    /// | N       | N         | no-op (consistent)                       |
+    /// | Y       | N         | `insert_holder` (mirror case self-heal)  |
+    /// | N       | Y         | `atomic_release` + `request_grant` (ghost) |
+    ///
+    /// On a transient DB error, the failing tuple is re-queued so the next
+    /// tick (or sub-tick wake) retries it.
+    pub async fn reconcile_pending_holders(
+        &self,
+        db: &Arc<InstrumentedDb>,
+        range: &ShardRange,
+    ) {
+        let pending = self.counts.drain_pending_reconciliations();
+        if pending.is_empty() {
+            return;
+        }
+
+        // Group by (tenant, queue) so each queue is hydrated at most once
+        // per pass.
+        let mut by_queue: BTreeMap<(String, String), Vec<String>> = BTreeMap::new();
+        for (tenant, queue, task_id) in pending {
+            by_queue
+                .entry((tenant, queue))
+                .or_default()
+                .push(task_id);
+        }
+
+        for ((tenant, queue), task_ids) in by_queue {
+            // Skip tenants outside this shard's range — they may have been
+            // queued before a shard split.
+            if !range.contains_tenant(&tenant) {
+                continue;
+            }
+
+            if let Err(e) = self
+                .counts
+                .ensure_hydrated(db, range, &tenant, &queue)
+                .await
+            {
+                tracing::warn!(
+                    error = %e,
+                    tenant = %tenant,
+                    queue = %queue,
+                    "reconciler: hydrate failed; re-queueing for next tick"
+                );
+                for tid in task_ids {
+                    self.counts
+                        .enqueue_reconciliation(tenant.clone(), queue.clone(), tid);
+                }
+                continue;
+            }
+
+            let mut any_released = false;
+            for task_id in task_ids {
+                let key = concurrency_holder_key(&tenant, &queue, &task_id);
+                let durable_present = match db.get(&key).await {
+                    Ok(opt) => opt.is_some(),
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            tenant = %tenant,
+                            queue = %queue,
+                            task_id = %task_id,
+                            "reconciler: durable lookup failed; re-queueing"
+                        );
+                        self.counts.enqueue_reconciliation(
+                            tenant.clone(),
+                            queue.clone(),
+                            task_id,
+                        );
+                        continue;
+                    }
+                };
+                let in_mem_present = self.counts.contains_holder(&tenant, &queue, &task_id);
+
+                match (durable_present, in_mem_present) {
+                    (true, true) | (false, false) => {
+                        // Consistent — nothing to do.
+                    }
+                    (true, false) => {
+                        // Durable holder exists with no in-memory entry.
+                        // Reachable if a grant-side guard's Drop fired after
+                        // the commit landed but the rollback never ran (the
+                        // mirror case of the ghost). Re-insert to match.
+                        self.counts.insert_holder(&tenant, &queue, &task_id);
+                        tracing::info!(
+                            tenant = %tenant,
+                            queue = %queue,
+                            task_id = %task_id,
+                            "reconciler: re-inserted in-memory holder to match durable"
+                        );
+                    }
+                    (false, true) => {
+                        // Ghost: durable holder is gone but the in-memory
+                        // reservation survives. This is the wedge bug.
+                        // Release and wake the grant scanner.
+                        self.counts.atomic_release(&tenant, &queue, &task_id);
+                        any_released = true;
+                        tracing::info!(
+                            tenant = %tenant,
+                            queue = %queue,
+                            task_id = %task_id,
+                            "reconciler: released ghost in-memory holder (no durable row)"
+                        );
+                    }
+                }
+            }
+            if any_released {
+                // One grant kick per queue that saw a release.
+                self.request_grant(&tenant, &queue);
+            }
+        }
+
+        // Stuck-reconciler signal: if the pending set keeps growing across
+        // ticks, something is wrong (slatedb unavailable, etc.).
+        let remaining = self.counts.pending_reconciliations_len();
+        if remaining > 10_000 {
+            tracing::warn!(
+                pending = remaining,
+                "reconciler: pending_reconciliations growing — backlog suggests stuck reconciler"
+            );
+        }
+    }
+
+    /// Walk every hydrated (tenant, queue) in this shard, compare the
+    /// in-memory holder count to the durable holder count (one ranged scan
+    /// per queue), and publish:
+    ///
+    /// * `silo_concurrency_holder_drift` — Σ |in_mem - durable| across hydrated queues
+    /// * `silo_concurrency_reconciliation_pending` — current size of the
+    ///   per-task_id reconciliation queue (stuck-reconciler signal)
+    ///
+    /// Called from the periodic reconciler's tick (NOT from the reactive
+    /// sub-tick wake) — keeps the cost amortized at the deployment-configured
+    /// `concurrency_reconcile_interval` rather than firing on every dropped
+    /// dequeue future. Noop if metrics are disabled.
+    pub async fn report_holder_drift(&self, db: &Arc<InstrumentedDb>, range: &ShardRange) {
+        let Some(metrics) = self.metrics.as_ref() else {
+            // Always publish the pending gauge if metrics are present; if not, skip everything.
+            return;
+        };
+
+        let mut drift_total: u64 = 0;
+        for (tenant, queue, in_mem_count) in self.counts.hydrated_queue_holders_snapshot() {
+            if !range.contains_tenant(&tenant) {
+                continue;
+            }
+            // Per-queue ranged scan. Cost dominated by holder count; capped
+            // by the deployment's reconcile interval.
+            let start = crate::keys::concurrency_holders_queue_prefix(&tenant, &queue);
+            let end = crate::keys::end_bound(&start);
+            let mut iter = match db
+                .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+                .await
+            {
+                Ok(i) => i,
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        tenant = %tenant,
+                        queue = %queue,
+                        "report_holder_drift: scan failed; skipping queue"
+                    );
+                    continue;
+                }
+            };
+            let mut durable_count: usize = 0;
+            loop {
+                match iter.next().await {
+                    Ok(Some(_)) => durable_count += 1,
+                    Ok(None) => break,
+                    Err(e) => {
+                        tracing::debug!(
+                            error = %e,
+                            tenant = %tenant,
+                            queue = %queue,
+                            "report_holder_drift: iter error; partial count"
+                        );
+                        break;
+                    }
+                }
+            }
+            drift_total += (in_mem_count as i64 - durable_count as i64).unsigned_abs();
+        }
+
+        let pending = self.counts.pending_reconciliations_len() as u64;
+        metrics.set_concurrency_reconciler_signals(&self.shard, drift_total, pending);
     }
 
     fn request_grant_count(&self, tenant: &str, queue: &str, count: u32) {

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1213,7 +1213,6 @@ impl ConcurrencyManager {
                 continue;
             }
 
-            let mut any_released = false;
             for task_id in task_ids {
                 let key = concurrency_holder_key(&tenant, &queue, &task_id);
                 let durable_present = match db.get(&key).await {
@@ -1254,9 +1253,14 @@ impl ConcurrencyManager {
                     (false, true) => {
                         // Ghost: durable holder is gone but the in-memory
                         // reservation survives. This is the wedge bug.
-                        // Release and wake the grant scanner.
+                        // Release and kick the grant scanner *per release*
+                        // (mirroring `dequeue.rs` post-commit holder loop)
+                        // so a reconcile pass that frees N ghosts grants N
+                        // pending requests, not just 1 — `request_grant_count`
+                        // accumulates in a single map entry and the grant
+                        // scanner drains it in one pass with count = N.
                         self.counts.atomic_release(&tenant, &queue, &task_id);
-                        any_released = true;
+                        self.request_grant(&tenant, &queue);
                         tracing::info!(
                             tenant = %tenant,
                             queue = %queue,
@@ -1265,10 +1269,6 @@ impl ConcurrencyManager {
                         );
                     }
                 }
-            }
-            if any_released {
-                // One grant kick per queue that saw a release.
-                self.request_grant(&tenant, &queue);
             }
         }
 
@@ -1360,6 +1360,16 @@ impl ConcurrencyManager {
             entry.2 += count;
         }
         self.grant_notify.notify_one();
+    }
+
+    /// Test-only: peek the current pending-grant count for a queue. Used by
+    /// `reconcile_pending_holders_kicks_grant_per_release` to assert that
+    /// the reconciler kicked the scanner once per ghost release rather than
+    /// once per queue.
+    pub fn pending_grant_count_for_test(&self, tenant: &str, queue: &str) -> u32 {
+        let key = concurrency_counts_key(tenant, queue);
+        let pending = self.pending_grants.lock().unwrap();
+        pending.get(&key).map(|(_, _, n)| *n).unwrap_or(0)
     }
 
     /// Start the background grant scanner task.

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -14,6 +14,7 @@ use crate::keys::{
     attempt_key, concurrency_holder_key, job_info_key, job_status_key, leased_task_key,
     parse_task_key,
 };
+use crate::concurrency::ConcurrencyManager;
 use crate::shard_range::ShardRange;
 use crate::task::{
     DEFAULT_LEASE_MS, HolderRecord, LeaseRecord, LeasedRefreshTask, LeasedTask, Task,
@@ -120,6 +121,161 @@ impl Drop for ClaimedInflightGuard<'_> {
     }
 }
 
+/// RAII guard over the in-memory concurrency reservations made by
+/// `try_reserve` during a dequeue iteration but not yet confirmed durable.
+///
+/// **Why this exists.** `try_reserve` bumps `ConcurrencyCounts.holders` *before*
+/// the batch commits, so admission decisions see the reservation immediately
+/// (see `concurrency.rs` TOCTOU note). Three exit paths handle this today:
+/// handler-error-before-commit and commit-failure both call `rollback_grant`;
+/// commit-success leaves the reservation in place (now backed by the durable
+/// holder row written by the same batch). A fourth exit — the dequeue future
+/// being cancelled around the `write_with_options(...await_durable).await`
+/// — was unhandled, so on cancellation the in-memory reservation stayed but
+/// nothing in the rollback paths ran, leaking a phantom holder.
+///
+/// **What it does.** Holds the `(tenant, queue, task_id)` tuples awaiting
+/// commit confirmation. On every normal exit (handler-error / commit-failure
+/// / commit-success), the dequeue body calls `take()` or `clear()` to handle
+/// the contents itself. If the future is instead dropped or panics, the Drop
+/// fires with whatever is still in `pending` and enqueues each tuple onto
+/// `ConcurrencyManager`'s reconciliation queue. The periodic reconciler then
+/// resolves the ambiguous "did the WAL apply?" by point-lookup against the
+/// durable holder row — see `ConcurrencyManager::reconcile_pending_holders`.
+///
+/// Sibling to [`ClaimedInflightGuard`]; same `Option<Vec<…>>` armed/disarmed
+/// pattern.
+struct PendingGrantGuard<'a> {
+    concurrency: &'a ConcurrencyManager,
+    pending: Option<Vec<(String, String, String)>>,
+}
+
+impl<'a> PendingGrantGuard<'a> {
+    fn new(concurrency: &'a ConcurrencyManager) -> Self {
+        Self {
+            concurrency,
+            pending: Some(Vec::new()),
+        }
+    }
+
+    fn extend<I: IntoIterator<Item = (String, String, String)>>(&mut self, iter: I) {
+        if let Some(v) = self.pending.as_mut() {
+            v.extend(iter);
+        }
+    }
+
+    /// Empty the buffer without disarming. Used after commit-success — the
+    /// reservations are now backed by durable rows, no further action needed,
+    /// and the guard stays armed for the next iteration.
+    fn clear(&mut self) {
+        if let Some(v) = self.pending.as_mut() {
+            v.clear();
+        }
+    }
+
+    /// Take ownership of the pending tuples back, neutralizing the guard so
+    /// its Drop is a no-op. Used at terminal exit paths (commit-failure +
+    /// dequeue Ok return); callers that disarm on commit-failure run
+    /// `rollback_grant` over the returned vec themselves.
+    fn disarm(&mut self) -> Vec<(String, String, String)> {
+        self.pending.take().unwrap_or_default()
+    }
+}
+
+impl Drop for PendingGrantGuard<'_> {
+    fn drop(&mut self) {
+        let Some(pending) = self.pending.take() else {
+            return;
+        };
+        if pending.is_empty() {
+            return;
+        }
+        tracing::warn!(
+            count = pending.len(),
+            "dequeue future dropped/panicked with pending concurrency grants; queueing reconciliation"
+        );
+        for (tenant, queue, task_id) in pending {
+            self.concurrency
+                .request_reconciliation(tenant, queue, task_id);
+        }
+    }
+}
+
+/// RAII guard over durable concurrency holders that the iteration's batch
+/// has staged for deletion, paired with an in-memory `atomic_release` +
+/// `request_grant` that the dequeue body runs post-commit.
+///
+/// **Why this exists.** When `handle_run_attempt` finds a task whose
+/// `job_info` is missing (migration/cleanup race), it adds the durable
+/// holder-row delete to the batch and queues a matching in-memory release.
+/// `write_with_options(... await_durable: true)` applies the batch to the
+/// WAL on first poll, so by the time the await yields, the durable row may
+/// already be gone — but the post-commit `atomic_release` loop only runs if
+/// the await resolves cleanly. Cancellation mid-await leaves durable=0,
+/// in_memory=1: a ghost holder that wedges the queue (the prod 300/300 bug).
+///
+/// **What it does.** Same shape as [`PendingGrantGuard`]. On normal exit the
+/// dequeue body calls `take_all()` to run the in-memory release loop itself.
+/// If the future is dropped or panics, Drop enqueues each tuple for the
+/// reconciler, which point-looks-up the durable holder row to decide
+/// whether to release the in-memory entry (the WAL apply landed) or leave
+/// it alone (the WAL apply did not). Per-task_id, idempotent, correct in
+/// both branches of the ambiguity.
+struct PendingHolderReleaseGuard<'a> {
+    concurrency: &'a ConcurrencyManager,
+    pending: Option<Vec<(String, String, String)>>,
+}
+
+impl<'a> PendingHolderReleaseGuard<'a> {
+    fn new(concurrency: &'a ConcurrencyManager) -> Self {
+        Self {
+            concurrency,
+            pending: Some(Vec::new()),
+        }
+    }
+
+    fn extend<I: IntoIterator<Item = (String, String, String)>>(&mut self, iter: I) {
+        if let Some(v) = self.pending.as_mut() {
+            v.extend(iter);
+        }
+    }
+
+    /// Drain and return the current pending releases while leaving the guard
+    /// armed (with an empty buffer) for the next iteration. Used on the
+    /// commit-success path so the dequeue body runs the existing
+    /// `atomic_release` + `request_grant` loop itself.
+    fn take_all(&mut self) -> Vec<(String, String, String)> {
+        self.pending.as_mut().map(std::mem::take).unwrap_or_default()
+    }
+
+    /// Neutralize the guard. Used at terminal exit paths (commit-failure /
+    /// dequeue Ok return). On commit-failure the caller discards the
+    /// returned vec: the batch didn't land so the durable holder is still
+    /// there and the in-memory state is already correct.
+    fn disarm(&mut self) -> Vec<(String, String, String)> {
+        self.pending.take().unwrap_or_default()
+    }
+}
+
+impl Drop for PendingHolderReleaseGuard<'_> {
+    fn drop(&mut self) {
+        let Some(pending) = self.pending.take() else {
+            return;
+        };
+        if pending.is_empty() {
+            return;
+        }
+        tracing::warn!(
+            count = pending.len(),
+            "dequeue future dropped/panicked with pending holder releases; queueing reconciliation"
+        );
+        for (tenant, queue, task_id) in pending {
+            self.concurrency
+                .request_reconciliation(tenant, queue, task_id);
+        }
+    }
+}
+
 impl JobStoreShard {
     /// Dequeue up to `max_tasks` tasks available now, ordered by time then priority.
     ///
@@ -147,14 +303,18 @@ impl JobStoreShard {
         let mut pending_attempts: Vec<(String, JobView, Vec<u8>)> = Vec::with_capacity(max_tasks);
 
         // Track grants made during this dequeue for rollback on failure
-        // Format: (tenant, queue, task_id)
-        let mut grants_to_rollback: Vec<(String, String, String)> = Vec::new();
+        // *and* for reconciliation on dequeue-future cancellation. Format:
+        // (tenant, queue, task_id). See `PendingGrantGuard` for the
+        // cancellation-safety rationale.
+        let mut grant_guard = PendingGrantGuard::new(&self.concurrency);
         // Track leased tasks for DST event emission after commit
         // Format: (tenant, job_id, task_id)
         let mut leased_tasks_for_dst: Vec<(String, String, String)> = Vec::new();
         // Track holders deleted in the batch that need post-commit in-memory
-        // release + grant-scanner wakeup. Format: (tenant, queue, task_id).
-        let mut holder_releases: Vec<(String, String, String)> = Vec::new();
+        // release + grant-scanner wakeup *and* reconciliation on
+        // cancellation. Format: (tenant, queue, task_id). See
+        // `PendingHolderReleaseGuard` for the cancellation-safety rationale.
+        let mut holder_guard = PendingHolderReleaseGuard::new(&self.concurrency);
 
         // Loop to process internal tasks until we have tasks that are destined for the worker, or no more ready tasks at all.
         const MAX_INTERNAL_ITERATIONS: usize = 10;
@@ -269,9 +429,14 @@ impl JobStoreShard {
                 return Err(e);
             }
 
-            // Merge iteration state into outer accumulators
-            grants_to_rollback.append(&mut state.grants_to_rollback);
-            holder_releases.append(&mut state.holder_releases);
+            // Merge iteration state into the cancellation-safe guards. Pushes
+            // moved here from the iteration-local `state.*` only after every
+            // handler in this iteration succeeded — the handler-error path
+            // above already drained `state.grants_to_rollback` synchronously
+            // and discarded `state.holder_releases` (paired with a batch that
+            // will not commit), matching today's semantics.
+            grant_guard.extend(state.grants_to_rollback.drain(..));
+            holder_guard.extend(state.holder_releases.drain(..));
 
             // Two-phase DST events: emit before write for correct causal ordering,
             // confirm after write succeeds, cancel if write fails.
@@ -314,24 +479,33 @@ impl JobStoreShard {
                     .await
             {
                 dst_events::cancel_write(write_op);
-                // Rollback all grants made during this iteration
-                for (tenant, queue, task_id) in &grants_to_rollback {
-                    self.concurrency.rollback_grant(tenant, queue, task_id);
+                // Commit failed: known not-durable. Roll back all grants and
+                // discard pending holder releases (paired durable deletes
+                // didn't land, so the durable rows still exist and the
+                // in-memory state is already correct). Disarming both guards
+                // here means their Drop is a no-op on the `return Err` below.
+                for (tenant, queue, task_id) in grant_guard.disarm() {
+                    self.concurrency.rollback_grant(&tenant, &queue, &task_id);
                 }
+                let _ = holder_guard.disarm();
                 // Put back all claimed entries since we didn't lease them durably
                 self.brokers.requeue(inflight_guard.disarm());
                 return Err(JobStoreShardError::from(e));
             }
             dst_events::confirm_write(write_op);
 
-            // DB write succeeded - clear rollback lists for next iteration
-            grants_to_rollback.clear();
+            // DB write succeeded — grants are now backed by durable holder
+            // rows, no rollback needed. Clear the guard's buffer (keeps it
+            // armed for the next iteration); the next iteration's pushes
+            // start from empty.
+            grant_guard.clear();
 
             // Post-commit: drop in-memory slots for any holders we removed in
             // this batch (e.g. a RunAttempt task we dropped because its job_info
             // was missing) and wake the grant scanner so a queued requester
-            // can take the freed slot.
-            for (tenant, queue, task_id) in holder_releases.drain(..) {
+            // can take the freed slot. `take_all` empties the guard but keeps
+            // it armed for the next iteration.
+            for (tenant, queue, task_id) in holder_guard.take_all() {
                 self.concurrency
                     .counts()
                     .atomic_release(&tenant, &queue, &task_id);

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -4,6 +4,7 @@ use slatedb::WriteBatch;
 use slatedb::config::WriteOptions;
 
 use crate::codec::{DecodedTask, decode_task, encode_attempt, encode_holder, encode_lease};
+use crate::concurrency::ConcurrencyManager;
 use crate::dst_events::{self, DstEvent};
 use crate::fb::silo::fb;
 use crate::job::{JobStatus, JobStatusKind, JobView, Limit};
@@ -14,7 +15,6 @@ use crate::keys::{
     attempt_key, concurrency_holder_key, job_info_key, job_status_key, leased_task_key,
     parse_task_key,
 };
-use crate::concurrency::ConcurrencyManager;
 use crate::shard_range::ShardRange;
 use crate::task::{
     DEFAULT_LEASE_MS, HolderRecord, LeaseRecord, LeasedRefreshTask, LeasedTask, Task,
@@ -245,7 +245,10 @@ impl<'a> PendingHolderReleaseGuard<'a> {
     /// commit-success path so the dequeue body runs the existing
     /// `atomic_release` + `request_grant` loop itself.
     fn take_all(&mut self) -> Vec<(String, String, String)> {
-        self.pending.as_mut().map(std::mem::take).unwrap_or_default()
+        self.pending
+            .as_mut()
+            .map(std::mem::take)
+            .unwrap_or_default()
     }
 
     /// Neutralize the guard. Used at terminal exit paths (commit-failure /

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -26,7 +26,7 @@ pub use import::JobNotReimportableError;
 pub use lease_task::JobNotLeaseableError;
 pub use restart::JobNotRestartableError;
 
-pub(crate) use enqueue::{LimitTaskParams, LimitTaskWriteResult, limit_processing_order};
+pub(crate) use enqueue::{LimitTaskParams, LimitTaskWriteResult};
 use helpers::DbWriteBatcher;
 use helpers::WriteBatcher;
 pub use helpers::now_epoch_ms;

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -728,7 +728,19 @@ impl JobStoreShard {
     /// future was cancelled around its commit) un-wedges as soon as Drop
     /// runs. The periodic task (`spawn_concurrency_reconcile_task`) still
     /// calls `reconcile_pending_holders` on its tick as a safety net.
+    ///
+    /// If a pass re-queues anything (transient hydrate / `db.get` failure),
+    /// we sleep `RECONCILE_RETRY_BACKOFF` then poke `reconcile_notify` so
+    /// the next iteration retries promptly — without this, the re-queued
+    /// tuple would sit idle until the next unrelated Drop or the 5 s
+    /// periodic tick. The sleep also bounds the retry rate so a sustained
+    /// failure (slatedb temporarily unavailable, etc.) doesn't tight-loop.
     fn spawn_holder_reconcile_task(self: &Arc<Self>, range: ShardRange) {
+        /// Delay between reactive-reconciler retries when a pass re-queued
+        /// at least one tuple. 100 ms = ~10 retries/sec ceiling under
+        /// sustained failure, ~100 ms recovery on a transient one.
+        const RECONCILE_RETRY_BACKOFF: Duration = Duration::from_millis(100);
+
         let shard = Arc::clone(self);
         let cancellation = self.cancellation.clone();
         let shard_name = self.name.clone();
@@ -739,10 +751,28 @@ impl JobStoreShard {
                 tokio::select! {
                     biased;
                     _ = reconcile_notify.notified() => {
-                        shard
+                        let requeued = shard
                             .concurrency
                             .reconcile_pending_holders(&shard.db, &range)
                             .await;
+                        if requeued {
+                            // Bound retry rate; cancellation must still
+                            // short-circuit the sleep so shard close is
+                            // prompt.
+                            tokio::select! {
+                                biased;
+                                _ = tokio::time::sleep(RECONCILE_RETRY_BACKOFF) => {
+                                    reconcile_notify.notify_one();
+                                }
+                                _ = cancellation.cancelled() => {
+                                    tracing::debug!(
+                                        shard = %shard_name,
+                                        "stopping reactive holder reconciler during retry backoff (shard closing)"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
                     }
                     _ = cancellation.cancelled() => {
                         tracing::debug!(
@@ -802,8 +832,10 @@ impl JobStoreShard {
                         // before that grant decision runs. This is the safety
                         // net for any missed `reconcile_notify` wake; the
                         // reactive `spawn_holder_reconcile_task` is the
-                        // primary low-latency path.
-                        shard
+                        // primary low-latency path. The periodic tick
+                        // already rate-limits, so we drop the re-queue
+                        // signal from the reactive path here.
+                        let _ = shard
                             .concurrency
                             .reconcile_pending_holders(&shard.db, &range)
                             .await;
@@ -937,6 +969,14 @@ impl JobStoreShard {
         self.brokers.buffer_len()
     }
 
+    /// Number of tasks currently held in the broker's in-flight set for a task
+    /// group (claimed by a worker but not yet durably acked). Exposed for
+    /// observability and for tests that assert the dequeue drop-guard releases
+    /// claimed keys when its future is cancelled.
+    pub fn broker_inflight_len(&self, task_group: &str) -> usize {
+        self.brokers.group_inflight_len(task_group)
+    }
+
     /// Snapshot the sizes of the in-memory concurrency holders cache.
     pub fn concurrency_cache_stats(&self) -> crate::concurrency::ConcurrencyCacheStats {
         self.concurrency.cache_stats()
@@ -979,15 +1019,17 @@ impl JobStoreShard {
             .insert_holder(tenant, queue, task_id);
     }
 
-    /// Test-only: drain pending reconciliations and apply them now. The
-    /// production path goes through `spawn_holder_reconcile_task` woken via
-    /// `reconcile_notify`; this synchronous entry point lets tests assert
-    /// post-state without a sleep race.
-    pub async fn reconcile_pending_holders_for_test(&self) {
+    /// Test-only: drain pending reconciliations and apply them now. Returns
+    /// whether the pass had to re-queue anything (transient DB error
+    /// during hydrate or `db.get`). The production path goes through
+    /// `spawn_holder_reconcile_task` woken via `reconcile_notify`; this
+    /// synchronous entry point lets tests assert post-state without a
+    /// sleep race.
+    pub async fn reconcile_pending_holders_for_test(&self) -> bool {
         let range = self.get_range();
         self.concurrency
             .reconcile_pending_holders(&self.db, &range)
-            .await;
+            .await
     }
     /// Get the SlateDB metrics registry for this shard.
     /// Use this to collect storage-level statistics for observability.

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -26,7 +26,7 @@ pub use import::JobNotReimportableError;
 pub use lease_task::JobNotLeaseableError;
 pub use restart::JobNotRestartableError;
 
-pub(crate) use enqueue::{LimitTaskParams, LimitTaskWriteResult};
+pub(crate) use enqueue::{LimitTaskParams, LimitTaskWriteResult, limit_processing_order};
 use helpers::DbWriteBatcher;
 use helpers::WriteBatcher;
 pub use helpers::now_epoch_ms;

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -542,6 +542,15 @@ impl JobStoreShard {
         // missed in-memory notifications or transient scanner failures.
         shard.spawn_concurrency_reconcile_task(range.clone());
 
+        // Reactive holder reconciler — wakes on `reconcile_notify` from a
+        // `PendingGrantGuard` / `PendingHolderReleaseGuard` Drop in dequeue
+        // and immediately reconciles. Sibling to the periodic task above; no
+        // jitter and no interval, so a dropped dequeue future un-wedges its
+        // queue within milliseconds rather than waiting up to one reconcile
+        // interval. The periodic task still runs `reconcile_pending_holders`
+        // on its tick as a safety net against missed notifications.
+        shard.spawn_holder_reconcile_task(range.clone());
+
         // Watch slatedb's status channel and emit prometheus metrics on each
         // change (durable_seq advances, manifest revisions). No-op when
         // metrics are disabled.
@@ -712,6 +721,41 @@ impl JobStoreShard {
         });
     }
 
+    /// Reactive holder reconciler — drains the per-task_id reconciliation
+    /// queue immediately on a `reconcile_notify` wake from a dropped
+    /// `PendingGrantGuard` / `PendingHolderReleaseGuard`. No jitter, no
+    /// periodic tick: a wedged queue (durable=0, in_mem=1 after the dequeue
+    /// future was cancelled around its commit) un-wedges as soon as Drop
+    /// runs. The periodic task (`spawn_concurrency_reconcile_task`) still
+    /// calls `reconcile_pending_holders` on its tick as a safety net.
+    fn spawn_holder_reconcile_task(self: &Arc<Self>, range: ShardRange) {
+        let shard = Arc::clone(self);
+        let cancellation = self.cancellation.clone();
+        let shard_name = self.name.clone();
+        let reconcile_notify = self.concurrency.reconcile_notify();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = reconcile_notify.notified() => {
+                        shard
+                            .concurrency
+                            .reconcile_pending_holders(&shard.db, &range)
+                            .await;
+                    }
+                    _ = cancellation.cancelled() => {
+                        tracing::debug!(
+                            shard = %shard_name,
+                            "stopping reactive holder reconciler (shard closing)"
+                        );
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
     fn spawn_concurrency_reconcile_task(self: &Arc<Self>, range: ShardRange) {
         let shard = Arc::clone(self);
         let cancellation = self.cancellation.clone();
@@ -753,9 +797,27 @@ impl JobStoreShard {
                 tokio::select! {
                     biased;
                     _ = interval.tick() => {
+                        // Holders first: the request scan can grant new slots,
+                        // and we want the in-memory holder set consistent
+                        // before that grant decision runs. This is the safety
+                        // net for any missed `reconcile_notify` wake; the
+                        // reactive `spawn_holder_reconcile_task` is the
+                        // primary low-latency path.
+                        shard
+                            .concurrency
+                            .reconcile_pending_holders(&shard.db, &range)
+                            .await;
                         shard
                             .concurrency
                             .reconcile_pending_requests(shard.db.as_ref(), &range)
+                            .await;
+                        // After draining, snapshot drift + pending-queue size
+                        // for prometheus. Cheap per tick (one ranged scan per
+                        // hydrated queue); the per-tick cadence keeps the
+                        // total cost bounded.
+                        shard
+                            .concurrency
+                            .report_holder_drift(&shard.db, &range)
                             .await;
                     }
                     _ = cancellation.cancelled() => {
@@ -884,6 +946,49 @@ impl JobStoreShard {
     /// (tenant, queue). Useful for tests and ad-hoc debugging.
     pub fn concurrency_holder_count(&self, tenant: &str, queue: &str) -> usize {
         self.concurrency.counts().holder_count(tenant, queue)
+    }
+
+    /// Whether a specific `task_id` is currently recorded as an in-memory
+    /// holder for `(tenant, queue)`. Test-only accessor used by the
+    /// four-quadrant reconciler test.
+    pub fn concurrency_contains_holder(
+        &self,
+        tenant: &str,
+        queue: &str,
+        task_id: &str,
+    ) -> bool {
+        self.concurrency.counts().contains_holder(tenant, queue, task_id)
+    }
+
+    /// Test-only: enqueue a `(tenant, queue, task_id)` for reconciliation.
+    /// Mirrors what `PendingHolderReleaseGuard::drop` does on cancellation,
+    /// so the four-quadrant test can drive the reconciler deterministically
+    /// without orchestrating a real dequeue future cancellation.
+    pub fn request_concurrency_reconciliation(
+        &self,
+        tenant: String,
+        queue: String,
+        task_id: String,
+    ) {
+        self.concurrency
+            .request_reconciliation(tenant, queue, task_id);
+    }
+
+    /// Test-only: insert an in-memory holder directly, used to set up the
+    /// "in_mem present, durable absent" ghost quadrant.
+    pub fn concurrency_insert_holder(&self, tenant: &str, queue: &str, task_id: &str) {
+        self.concurrency.counts().insert_holder(tenant, queue, task_id);
+    }
+
+    /// Test-only: drain pending reconciliations and apply them now. The
+    /// production path goes through `spawn_holder_reconcile_task` woken via
+    /// `reconcile_notify`; this synchronous entry point lets tests assert
+    /// post-state without a sleep race.
+    pub async fn reconcile_pending_holders_for_test(&self) {
+        let range = self.get_range();
+        self.concurrency
+            .reconcile_pending_holders(&self.db, &range)
+            .await;
     }
     /// Get the SlateDB metrics registry for this shard.
     /// Use this to collect storage-level statistics for observability.

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -1019,6 +1019,13 @@ impl JobStoreShard {
             .insert_holder(tenant, queue, task_id);
     }
 
+    /// Test-only: peek the current pending-grant count accumulated for
+    /// `(tenant, queue)`. Used by the reconciler regression test to assert
+    /// that each ghost release fired its own `request_grant`.
+    pub fn pending_grant_count_for_test(&self, tenant: &str, queue: &str) -> u32 {
+        self.concurrency.pending_grant_count_for_test(tenant, queue)
+    }
+
     /// Test-only: drain pending reconciliations and apply them now. Returns
     /// whether the pass had to re-queue anything (transient DB error
     /// during hydrate or `db.get`). The production path goes through

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -951,13 +951,10 @@ impl JobStoreShard {
     /// Whether a specific `task_id` is currently recorded as an in-memory
     /// holder for `(tenant, queue)`. Test-only accessor used by the
     /// four-quadrant reconciler test.
-    pub fn concurrency_contains_holder(
-        &self,
-        tenant: &str,
-        queue: &str,
-        task_id: &str,
-    ) -> bool {
-        self.concurrency.counts().contains_holder(tenant, queue, task_id)
+    pub fn concurrency_contains_holder(&self, tenant: &str, queue: &str, task_id: &str) -> bool {
+        self.concurrency
+            .counts()
+            .contains_holder(tenant, queue, task_id)
     }
 
     /// Test-only: enqueue a `(tenant, queue, task_id)` for reconciliation.
@@ -977,7 +974,9 @@ impl JobStoreShard {
     /// Test-only: insert an in-memory holder directly, used to set up the
     /// "in_mem present, durable absent" ghost quadrant.
     pub fn concurrency_insert_holder(&self, tenant: &str, queue: &str, task_id: &str) {
-        self.concurrency.counts().insert_holder(tenant, queue, task_id);
+        self.concurrency
+            .counts()
+            .insert_holder(tenant, queue, task_id);
     }
 
     /// Test-only: drain pending reconciliations and apply them now. The

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -132,6 +132,17 @@ pub struct Metrics {
     concurrency_holders_cache_holders: GaugeVec,
     concurrency_holders_cache_queues: GaugeVec,
     concurrency_holders_cache_hydrated_queues: GaugeVec,
+    /// Sum of `|in_memory_holders - durable_holders|` across hydrated queues.
+    /// A non-zero value means a reconciler tick observed a drift between the
+    /// authoritative durable holder rows and the in-memory `holders` set —
+    /// the same signal that, if left to persist, would manifest as a wedge
+    /// (the 300/300 production case).
+    concurrency_holder_drift: GaugeVec,
+    /// Count of `(tenant, queue, task_id)` tuples currently queued for the
+    /// per-task_id reconciler (drained on each tick + on `reconcile_notify`).
+    /// Steady-state expected to be 0; sustained growth means the reconciler
+    /// is stuck (slatedb unavailable, etc.).
+    concurrency_reconciliation_pending: GaugeVec,
 
     // SlateDB watcher metrics (driven by Db::subscribe)
     slatedb_durable_seq: GaugeVec,
@@ -451,6 +462,25 @@ impl Metrics {
         self.concurrency_holders_cache_hydrated_queues
             .with_label_values(&[shard])
             .set(stats.hydrated_queue_count as f64);
+    }
+
+    /// Update per-shard reconciler signal gauges:
+    /// * `drift` = sum of |in_memory - durable| holder counts across hydrated
+    ///   queues, computed at the end of each periodic reconciler tick.
+    /// * `pending` = current size of the per-task_id reconciliation queue.
+    ///
+    /// Non-zero `drift` or sustained-non-zero `pending` indicates the
+    /// reconciler is observing inconsistency between in-memory and durable
+    /// holder state — the same signal that, if it grows, manifests as the
+    /// production queue wedge. Pair with an alert that fires if either
+    /// remains non-zero across multiple scrape intervals.
+    pub fn set_concurrency_reconciler_signals(&self, shard: &str, drift: u64, pending: u64) {
+        self.concurrency_holder_drift
+            .with_label_values(&[shard])
+            .set(drift as f64);
+        self.concurrency_reconciliation_pending
+            .with_label_values(&[shard])
+            .set(pending as f64);
     }
 
     /// Update SlateDB storage metrics from a shard's StatRegistry.
@@ -1253,6 +1283,28 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let concurrency_holder_drift = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_concurrency_holder_drift",
+                "Per-shard sum of |in_memory - durable| holder counts across hydrated queues, observed at the last reconciler tick. Non-zero = drift the reconciler will release; sustained non-zero means the reconciler is stuck.",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_reconciliation_pending = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_concurrency_reconciliation_pending",
+                "Number of (tenant, queue, task_id) tuples awaiting per-task_id reconciliation against durable holder rows. Steady-state expected 0; sustained > 0 means the reconciler is wedged.",
+            ),
+            &["shard"],
+        )?,
+    );
+
     // SlateDB watcher metrics (driven by Db::subscribe)
     let slatedb_durable_seq = register(
         &registry,
@@ -1354,6 +1406,8 @@ pub fn init() -> anyhow::Result<Metrics> {
         concurrency_holders_cache_holders,
         concurrency_holders_cache_queues,
         concurrency_holders_cache_hydrated_queues,
+        concurrency_holder_drift,
+        concurrency_reconciliation_pending,
         slatedb_durable_seq,
         slatedb_manifest_revisions,
         slatedb_manifest_last_l0_seq,

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -1804,3 +1804,72 @@ async fn reconcile_pending_holders_four_quadrants() {
         "Q4 (durable=N, in_mem=Y): reconciler must release the ghost — the wedge fix"
     );
 }
+
+/// Regression for the under-counted grant kicks bug: when
+/// `reconcile_pending_holders` frees N ghost holders for the same queue in
+/// a single pass, it must `request_grant` N times (so the grant scanner
+/// processes N pending requests in one go), not once. Pre-fix the code
+/// flipped an `any_released: bool` and fired a single `request_grant` at
+/// the end of the per-queue loop, which capped the immediate grant pass
+/// at 1 regardless of how many ghosts were freed — leaving N-1 requesters
+/// waiting on the periodic `reconcile_pending_requests` tick.
+#[tokio::test]
+async fn reconcile_pending_holders_kicks_grant_per_release() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "kicks-q";
+
+    // Suspend the grant scanner so `pending_grants` accumulates rather than
+    // being drained mid-test. Matches the established pattern in
+    // tests/job_store_shard_concurrency_tests.rs.
+    shard.stop_grant_scanner();
+
+    // Seed the (tenant, queue) entry as Hydrated by writing then deleting a
+    // dummy holder. Without hydration the reconciler's per-queue
+    // `ensure_hydrated` call would actually scan the slatedb — fine, but
+    // forcing hydration up front keeps the test self-contained.
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(
+            &concurrency_holder_key(tenant, queue, "hydrate-seed"),
+            &encode_holder(&silo::task::HolderRecord { granted_at_ms: 0 }),
+        );
+        shard.db().write(batch).await.expect("seed write");
+        shard.db().flush().await.expect("flush seed");
+    }
+
+    // Install N ghosts (durable=0, in_mem=Y for each task_id we add). The
+    // four-quadrant logic in `reconcile_pending_holders` treats each as a
+    // "(false, true)" release.
+    const N: u32 = 5;
+    for i in 0..N {
+        let task_id = format!("ghost-{i}");
+        shard.concurrency_insert_holder(tenant, queue, &task_id);
+        shard.request_concurrency_reconciliation(tenant.to_string(), queue.to_string(), task_id);
+    }
+
+    assert_eq!(
+        shard.pending_grant_count_for_test(tenant, queue),
+        0,
+        "no grants accumulated before reconciliation runs"
+    );
+
+    let requeued = shard.reconcile_pending_holders_for_test().await;
+    assert!(!requeued, "no transient DB failures expected");
+
+    for i in 0..N {
+        let task_id = format!("ghost-{i}");
+        assert!(
+            !shard.concurrency_contains_holder(tenant, queue, &task_id),
+            "ghost {task_id} should have been released",
+        );
+    }
+
+    let pending = shard.pending_grant_count_for_test(tenant, queue);
+    assert_eq!(
+        pending, N,
+        "reconciler must `request_grant` once per ghost release (N={N}); \
+         pre-fix this was 1 regardless of how many ghosts were freed, capping \
+         the immediate grant pass at 1 in production-scale wedges (300 ghosts → 1 grant)"
+    );
+}

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -1357,3 +1357,424 @@ async fn steady_state_zero_holders_under_mixed_workload() {
     // referenced after construction; explicitly drop it here for clarity.
     let _ = MockGubernatorClient::new_arc();
 }
+
+/// Regression for the "stranded inflight task → orphaned holder" defect that
+/// `e6660cd` ("Clear up stranded inflight tasks with drop guard") targets.
+///
+/// Failure shape this reproduces:
+///   1. A concurrency-limited job is enqueued. `handle_enqueue` grants the slot
+///      immediately: `append_grant_edits` writes the durable holder in the SAME
+///      batch as the terminal `RunAttempt` task. Holder committed, task durable.
+///   2. A worker dequeues the `RunAttempt`. `claim_ready` moves the task into the
+///      broker's in-memory `inflight` set. Then, under worker overload, the
+///      `LeaseTasks` RPC future is *cancelled* (deadline / disconnect / drop)
+///      before the lease is durably written.
+///   3. Without the drop guard the task is stranded in `inflight` forever (no
+///      TTL): the scanner skips inflight keys, so the `RunAttempt` is never
+///      re-leased — yet the holder from step 1 keeps consuming the slot. That's
+///      the leak: holder committed, task consumed, no lease ever appears.
+///
+/// The guard closes this by releasing the claimed key from `inflight` on drop
+/// (without re-buffering), so the DB scanner — which still sees the un-deleted
+/// task key — re-adds it and a later dequeue leases it exactly once. This test
+/// drives the *real* `dequeue` future, cancels it mid-flight right after the
+/// claim, and asserts the task recovers and the holder never leaks.
+///
+/// If the guard regresses, the recovery loop below never re-leases the task and
+/// the `expect` fires with "never re-leased — holder orphaned".
+#[silo::test]
+async fn dropped_dequeue_future_does_not_orphan_holder() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "drop-guard-q";
+
+    // (1) Enqueue a Concurrency(max=1) job. The slot is free, so the grant is
+    // immediate: holder + RunAttempt land together in the enqueue batch.
+    let _job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![conc_limit(queue, 1)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "concurrency grant should write a holder at enqueue time"
+    );
+    assert_eq!(
+        shard.concurrency_holder_count(tenant, queue),
+        1,
+        "in-memory holder reservation should exist after the immediate grant"
+    );
+
+    // Wait for the background scanner to buffer the RunAttempt so the dequeue's
+    // first `claim_ready` is synchronous — guaranteeing the single poll below
+    // claims the task (moves it into `inflight`) before parking on an await.
+    let buffered = poll_until(|| async { shard.broker_buffer_len() }, |n| *n >= 1, 2_000).await;
+    assert!(buffered >= 1, "scanner should buffer the RunAttempt task");
+
+    // (2) Drive the real dequeue future, poll it exactly once, then drop it.
+    // The first poll claims the task synchronously — `claim_ready` moves the key
+    // into the broker's `inflight` set — then parks awaiting durability. The
+    // future is then dropped (cancelled RPC), which must run
+    // `ClaimedInflightGuard::drop`.
+    {
+        let mut fut = Box::pin(shard.dequeue("w-overloaded", "default", 1));
+        let polled = futures::poll!(fut.as_mut());
+        assert!(
+            polled.is_pending(),
+            "single poll must leave the dequeue mid-flight (claimed, not yet acked); \
+             got a ready result instead, so the cancellation window was not exercised"
+        );
+        // While the future is alive and parked, the claimed key is in-flight.
+        assert_eq!(
+            shard.broker_inflight_len("default"),
+            1,
+            "the claimed RunAttempt must be in-flight while the dequeue is mid-flight"
+        );
+        drop(fut); // ClaimedInflightGuard::drop → release_inflight(key)
+    }
+
+    // PRIMARY REGRESSION ASSERTION (deterministic): dropping the dequeue future
+    // must have released the claimed key from the in-flight set. Without the
+    // drop guard (e6660cd) the key is stranded here forever — the scanner skips
+    // in-flight keys, so the RunAttempt is never re-leased and its holder leaks.
+    assert_eq!(
+        shard.broker_inflight_len("default"),
+        0,
+        "cancelled dequeue left the claimed task stranded in-flight — drop guard regression; \
+         the holder it backs can never be re-leased and is orphaned"
+    );
+
+    // Holder is still committed from enqueue and must NOT have been doubled or
+    // dropped by the cancellation.
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "holder count must stay at exactly 1 across the cancellation"
+    );
+
+    // (3) Recovery: a subsequent dequeue must re-lease the stranded task. With a
+    // broken/absent guard the task is stuck in `inflight`, the scanner never
+    // re-adds it, and this loop never finds a lease.
+    let mut recovered_task_id: Option<String> = None;
+    for _ in 0..50 {
+        let res = shard
+            .dequeue("w-healthy", "default", 1)
+            .await
+            .expect("recovery dequeue");
+        if let Some(t) = res.tasks.first() {
+            recovered_task_id = Some(t.attempt().task_id().to_string());
+            break;
+        }
+        // Tolerate the ambiguous case where the cancelled write actually landed:
+        // a lease may already exist even though the future was dropped.
+        if let Some((_, lease_val)) = first_lease_kv(shard.db()).await {
+            if let Ok(Task::RunAttempt { id, .. }) =
+                decode_lease(lease_val).expect("decode lease").to_task()
+            {
+                recovered_task_id = Some(id);
+                break;
+            }
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+    }
+
+    let task_id = recovered_task_id.expect(
+        "dropped RunAttempt was never re-leased — the holder is orphaned (no task, no lease, \
+         yet the concurrency slot stays consumed). This is the stranded-inflight holder leak \
+         the e6660cd drop guard must prevent.",
+    );
+
+    // Exactly one holder backs the (now re-leased) task — no phantom duplicate.
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "re-lease must reuse the original holder, not mint a second one"
+    );
+
+    // (4) Completing the job releases the holder — proving it was never orphaned
+    // and the slot is reclaimable.
+    shard
+        .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report success");
+
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "durable holder must be released once the recovered job completes"
+    );
+    assert_eq!(
+        shard.concurrency_holder_count(tenant, queue),
+        0,
+        "in-memory holder reservation must also drain to zero — no slot leak"
+    );
+}
+
+/// PRODUCTION WEDGE REPRODUCTION — an in-memory concurrency holder that the
+/// dequeue drop guard does NOT release, permanently consuming a queue's cap.
+///
+/// A concurrency holder has two halves: a durable KV row (prefix 0x09) AND an
+/// in-memory reservation (`ConcurrencyCounts`, a per-(tenant,queue) set of
+/// task_ids). `try_reserve`/`process_grants` gate admission on the IN-MEMORY
+/// count, so an in-memory reservation with no durable backing silently steals a
+/// slot forever (nothing durable for cancel/reap/expiry to key a release off,
+/// and hydration only ever *inserts*). Accumulate enough — prod hit 300/300 for
+/// env-10000215255 — and the queue wedges while ~1M requesters starve.
+///
+/// The drop guard `ClaimedInflightGuard` (e6660cd) only rolls back the broker's
+/// `inflight` set; it has no reference to `self.concurrency`. So any in-memory
+/// holder bookkeeping that lives in `dequeue`'s post-commit tail is lost when
+/// the future is cancelled. This test pins the cleanest, deterministic instance:
+///
+///   `handle_run_attempt` for a RunAttempt whose `job_info` is gone deletes the
+///   held concurrency holder *in the committed batch* but performs the matching
+///   in-memory `atomic_release` only afterwards, in `dequeue`'s post-commit loop
+///   (dequeue.rs ~334-339). `write_with_options` applies the batch to the WAL on
+///   its first poll, so the durable delete lands even if the future is then
+///   dropped — but the post-commit `atomic_release` never runs. Net: durable
+///   holder gone, in-memory reservation retained = a ghost that wedges the queue.
+///
+/// The sibling on the *grant* side (handle_request_ticket's `try_reserve` not
+/// rolled back on drop) produces the same ghost when the commit doesn't land;
+/// it needs a genuinely-pending pre-commit await (a cold hydration scan over a
+/// large queue in prod) to hit, so it isn't deterministic in the warm test DB.
+/// Both share one root cause and one fix: roll back in-memory concurrency state
+/// on the dequeue future-drop path, exactly as the error/commit-failure paths do.
+///
+/// This test cancels the real `dequeue` future at the commit and asserts the
+/// queue is NOT wedged. It FAILS on current code (durable=0 but in-memory=1),
+/// reproducing the leak; it passes once the drop path releases in-memory holders.
+///
+/// Fixed: a pair of layered RAII guards (`PendingHolderReleaseGuard` and
+/// `PendingGrantGuard` in `src/job_store_shard/dequeue.rs`, sibling to the
+/// pre-existing `ClaimedInflightGuard`) now own the iteration's in-memory
+/// holder-release and grant-bump tuples. On dequeue-future drop their `Drop`
+/// enqueues each `(tenant, queue, task_id)` onto
+/// `ConcurrencyManager::request_reconciliation`; the periodic reconciler
+/// (`spawn_concurrency_reconcile_task`, woken sub-tick by `reconcile_notify`)
+/// point-looks-up the durable holder row, observes durable=0/in_mem=1, and
+/// calls `atomic_release` + `request_grant`. The queue un-wedges before the
+/// test's recovery dequeue loop expires.
+#[tokio::test]
+async fn dropped_dequeue_future_skips_inmemory_holder_release_and_wedges_queue() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "wedge-q";
+    let task_group = "default";
+
+    // Enqueue a Concurrency(max=1) job: holder granted at enqueue (in-memory +
+    // durable), and a RunAttempt carrying held_queues=[queue] is written.
+    let job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![conc_limit(queue, 1)],
+            None,
+            task_group,
+        )
+        .await
+        .expect("enqueue");
+
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1, "durable holder at enqueue");
+    assert_eq!(shard.concurrency_holder_count(tenant, queue), 1, "in-memory holder at enqueue");
+
+    // The job_info row disappears before the worker dequeues (migration / cleanup
+    // race / partial restore). `handle_run_attempt` will take the missing-job
+    // branch: delete the task AND the held concurrency holder in the batch, then
+    // (post-commit) `atomic_release` the in-memory slot.
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.delete(&job_info_key(tenant, &job_id));
+        shard.db().write(batch).await.expect("delete job_info");
+        shard.db().flush().await.expect("flush");
+    }
+
+    // Wait for the scanner to buffer the RunAttempt.
+    let buffered = poll_until(|| async { shard.broker_buffer_len() }, |n| *n >= 1, 5_000).await;
+    assert!(buffered >= 1, "scanner should buffer the RunAttempt");
+
+    // Drive the real dequeue future to the commit, then cancel it there.
+    //
+    // We poll with `yield_now` (which does NOT advance the paused clock), so the
+    // 10ms flush timer never fires and the `write_with_options` await stays
+    // pending — the future parks exactly at the commit with the batch already
+    // applied to the WAL. Dropping there is the overloaded-worker RPC cancel.
+    {
+        let mut fut = Box::pin(shard.dequeue("w-overloaded", task_group, 1));
+        for _ in 0..500 {
+            let polled = futures::poll!(fut.as_mut());
+            assert!(
+                polled.is_pending(),
+                "dequeue completed before we could cancel it at the commit"
+            );
+            tokio::task::yield_now().await;
+        }
+        drop(fut); // cancel at the commit await; the post-commit atomic_release never runs
+    }
+
+    // Let the flush land the buffered batch (durable holder delete).
+    let durable = poll_until(
+        || async { count_concurrency_holders(shard.db()).await },
+        |n| *n == 0,
+        5_000,
+    )
+    .await;
+
+    // The committed batch's durable delete landed during the parked
+    // `write_with_options.await`. Pre-fix, the in-memory `atomic_release`
+    // only ran in dequeue's post-commit loop — which the cancelled future
+    // skipped — so in_mem stayed at 1 (a "ghost") and wedged the queue.
+    //
+    // Post-fix, the `PendingHolderReleaseGuard`'s Drop queues a
+    // reconciliation request; the reactive `spawn_holder_reconcile_task`
+    // wakes on `reconcile_notify`, point-looks-up the durable row (gone),
+    // and `atomic_release`s the ghost. The reactive task is a sibling
+    // tokio::spawn, so its run is concurrent with this test thread —
+    // depending on the runtime's scheduling decision the in-memory count
+    // read here may be 0 (reconciler already ran) or 1 (still queued).
+    // Either is correct as long as the queue un-wedges before the
+    // recovery dequeue loop below times out.
+    assert_eq!(durable, 0, "durable holder should be deleted by the committed batch");
+
+    // The slot must not stay wedged: a fresh Concurrency(max=1) job on the
+    // same queue must be grantable once the reconciler has released the
+    // ghost (or immediately if it already had).
+    let _job2 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![conc_limit(queue, 1)],
+            None,
+            task_group,
+        )
+        .await
+        .expect("enqueue job2");
+
+    let mut job2_leased = false;
+    for _ in 0..50 {
+        let res = shard.dequeue("w2", task_group, 1).await.expect("dequeue job2");
+        if !res.tasks.is_empty() {
+            job2_leased = true;
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+    }
+
+    assert!(
+        job2_leased,
+        "QUEUE WEDGED: the ghost in-memory holder is still occupying the only slot \
+         (durable={durable}, in_mem={final_inmem}) — pre-fix this was permanent, lasting \
+         until process restart; with the fix the reactive holder reconciler should have \
+         released it within the recovery loop's 1s budget.",
+        final_inmem = shard.concurrency_holder_count(tenant, queue),
+    );
+
+    // After job2 leases, in-memory count is 1 again (job2's own grant) but
+    // the ghost is provably gone (because admission was granted). The
+    // wedge is cleared.
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "exactly one durable holder (job2's) — the ghost left no trace"
+    );
+}
+
+/// Direct exercise of `ConcurrencyManager::reconcile_pending_holders` over
+/// all four (durable, in_memory) quadrants. Drives the reconciler via the
+/// test accessor on `JobStoreShard` so the assertions hold without racing a
+/// background task.
+#[tokio::test]
+async fn reconcile_pending_holders_four_quadrants() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "quadrants-q";
+
+    // Force per-queue hydration before the reconciler runs, so
+    // `contains_holder` reads against a Hydrated entry rather than a
+    // NotHydrated one (whose presence/absence semantics differ).
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(
+            &concurrency_holder_key(tenant, queue, "hydrate-seed"),
+            &encode_holder(&silo::task::HolderRecord { granted_at_ms: 0 }),
+        );
+        shard.db().write(batch).await.expect("seed write");
+        shard.db().flush().await.expect("flush seed");
+    }
+
+    // Quadrant 1: durable=Y, in_mem=Y — both present.
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(
+            &concurrency_holder_key(tenant, queue, "task-both"),
+            &encode_holder(&silo::task::HolderRecord { granted_at_ms: 0 }),
+        );
+        shard.db().write(batch).await.expect("durable write");
+        shard.db().flush().await.expect("flush");
+    }
+    shard.concurrency_insert_holder(tenant, queue, "task-both");
+
+    // Quadrant 2: durable=N, in_mem=N — both absent. No setup needed.
+
+    // Quadrant 3: durable=Y, in_mem=N — mirror case (commit landed but the
+    // in-memory entry was somehow lost).
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(
+            &concurrency_holder_key(tenant, queue, "task-durable-only"),
+            &encode_holder(&silo::task::HolderRecord { granted_at_ms: 0 }),
+        );
+        shard.db().write(batch).await.expect("durable-only write");
+        shard.db().flush().await.expect("flush");
+    }
+
+    // Quadrant 4: durable=N, in_mem=Y — the ghost, the wedge bug.
+    shard.concurrency_insert_holder(tenant, queue, "task-ghost");
+
+    // Enqueue all four for reconciliation.
+    for tid in ["task-both", "task-neither", "task-durable-only", "task-ghost"] {
+        shard.request_concurrency_reconciliation(
+            tenant.to_string(),
+            queue.to_string(),
+            tid.to_string(),
+        );
+    }
+
+    shard.reconcile_pending_holders_for_test().await;
+
+    assert!(
+        shard.concurrency_contains_holder(tenant, queue, "task-both"),
+        "Q1 (durable=Y, in_mem=Y): reconciler must leave consistent state alone"
+    );
+    assert!(
+        !shard.concurrency_contains_holder(tenant, queue, "task-neither"),
+        "Q2 (durable=N, in_mem=N): reconciler must leave consistent state alone"
+    );
+    assert!(
+        shard.concurrency_contains_holder(tenant, queue, "task-durable-only"),
+        "Q3 (durable=Y, in_mem=N): reconciler must re-insert to match durable"
+    );
+    assert!(
+        !shard.concurrency_contains_holder(tenant, queue, "task-ghost"),
+        "Q4 (durable=N, in_mem=Y): reconciler must release the ghost — the wedge fix"
+    );
+}

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -16,6 +16,13 @@ use silo::task::{GubernatorRateLimitData, HolderRecord, LeaseRecord, Task};
 
 use test_helpers::*;
 
+fn conc_limit(queue: &str, max: u32) -> Limit {
+    Limit::Concurrency(ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: max,
+    })
+}
+
 fn fc_limit(queue: &str, default_max: u32) -> Limit {
     Limit::FloatingConcurrency(FloatingConcurrencyLimit {
         key: queue.to_string(),

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -1590,8 +1590,16 @@ async fn dropped_dequeue_future_skips_inmemory_holder_release_and_wedges_queue()
         .await
         .expect("enqueue");
 
-    assert_eq!(count_concurrency_holders(shard.db()).await, 1, "durable holder at enqueue");
-    assert_eq!(shard.concurrency_holder_count(tenant, queue), 1, "in-memory holder at enqueue");
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "durable holder at enqueue"
+    );
+    assert_eq!(
+        shard.concurrency_holder_count(tenant, queue),
+        1,
+        "in-memory holder at enqueue"
+    );
 
     // The job_info row disappears before the worker dequeues (migration / cleanup
     // race / partial restore). `handle_run_attempt` will take the missing-job
@@ -1649,7 +1657,10 @@ async fn dropped_dequeue_future_skips_inmemory_holder_release_and_wedges_queue()
     // read here may be 0 (reconciler already ran) or 1 (still queued).
     // Either is correct as long as the queue un-wedges before the
     // recovery dequeue loop below times out.
-    assert_eq!(durable, 0, "durable holder should be deleted by the committed batch");
+    assert_eq!(
+        durable, 0,
+        "durable holder should be deleted by the committed batch"
+    );
 
     // The slot must not stay wedged: a fresh Concurrency(max=1) job on the
     // same queue must be grantable once the reconciler has released the
@@ -1671,7 +1682,10 @@ async fn dropped_dequeue_future_skips_inmemory_holder_release_and_wedges_queue()
 
     let mut job2_leased = false;
     for _ in 0..50 {
-        let res = shard.dequeue("w2", task_group, 1).await.expect("dequeue job2");
+        let res = shard
+            .dequeue("w2", task_group, 1)
+            .await
+            .expect("dequeue job2");
         if !res.tasks.is_empty() {
             job2_leased = true;
             break;
@@ -1751,7 +1765,12 @@ async fn reconcile_pending_holders_four_quadrants() {
     shard.concurrency_insert_holder(tenant, queue, "task-ghost");
 
     // Enqueue all four for reconciliation.
-    for tid in ["task-both", "task-neither", "task-durable-only", "task-ghost"] {
+    for tid in [
+        "task-both",
+        "task-neither",
+        "task-durable-only",
+        "task-ghost",
+    ] {
         shard.request_concurrency_reconciliation(
             tenant.to_string(),
             queue.to_string(),

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -3762,6 +3762,105 @@ async fn deferred_concurrency_resumes_into_rate_limit() {
     let _ = end_bound(&tasks_prefix());
 }
 
+#[silo::test]
+async fn grant_scanner_hydrates_legacy_request_without_task_id_or_limits() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "-";
+    let queue = "legacy-request-q".to_string();
+
+    let job1 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue holder job");
+    let job2 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue queued job");
+
+    let (request_key, _) = first_concurrency_request_kv(shard.db())
+        .await
+        .expect("queued job should have a request");
+    let parsed =
+        silo::keys::parse_concurrency_request_key(&request_key).expect("request key should parse");
+    assert_eq!(parsed.job_id, job2);
+
+    // Simulate a request value written by the pre-upgrade schema: the durable
+    // key still carries the request id, but the value has no task_id, limits,
+    // held_queues, or limit_index fields.
+    let legacy_value = encode_legacy_enqueue_task_value(&parsed, "default");
+    shard
+        .db()
+        .put(&request_key, &legacy_value)
+        .await
+        .expect("overwrite request with legacy value");
+
+    let leased_a = shard
+        .dequeue("w1", "default", 1)
+        .await
+        .expect("dequeue job1")
+        .tasks;
+    assert_eq!(leased_a.len(), 1);
+    assert_eq!(leased_a[0].job().id(), job1);
+    let task1 = leased_a[0].attempt().task_id().to_string();
+
+    shard
+        .report_attempt_outcome(&task1, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("complete job1");
+
+    let mut leased_b = Vec::new();
+    for _ in 0..50 {
+        leased_b = shard
+            .dequeue("w2", "default", 1)
+            .await
+            .expect("dequeue job2")
+            .tasks;
+        if !leased_b.is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    assert_eq!(
+        leased_b.len(),
+        1,
+        "legacy request should be granted, not deleted as corrupt"
+    );
+    assert_eq!(leased_b[0].job().id(), job2);
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "granted legacy request should be consumed"
+    );
+}
+
 async fn find_task_key_and_task_for_tenant(
     db: &silo::instrumented_db::InstrumentedDb,
     tenant: &str,
@@ -3783,6 +3882,39 @@ async fn find_task_key_and_task_for_tenant(
         }
     }
     None
+}
+
+fn encode_legacy_enqueue_task_value(
+    parsed: &silo::keys::ParsedConcurrencyRequestKey,
+    task_group: &str,
+) -> Vec<u8> {
+    let mut builder = flatbuffers::FlatBufferBuilder::with_capacity(128);
+    let job_id = builder.create_string(&parsed.job_id);
+    let task_group = builder.create_string(task_group);
+    let et = silo::fb::silo::fb::EnqueueTask::create(
+        &mut builder,
+        &silo::fb::silo::fb::EnqueueTaskArgs {
+            start_time_ms: parsed.start_time_ms as i64,
+            priority: parsed.priority,
+            job_id: Some(job_id),
+            attempt_number: parsed.attempt_number,
+            relative_attempt_number: parsed.attempt_number,
+            task_group: Some(task_group),
+            limit_index: 0,
+            held_queues: None,
+            task_id: None,
+            limits: None,
+        },
+    );
+    let root = silo::fb::silo::fb::ConcurrencyAction::create(
+        &mut builder,
+        &silo::fb::silo::fb::ConcurrencyActionArgs {
+            variant_type: silo::fb::silo::fb::ConcurrencyActionVariant::EnqueueTask,
+            variant: Some(et.as_union_value()),
+        },
+    );
+    builder.finish(root, None);
+    builder.finished_data().to_vec()
 }
 
 /// Helper: count `CheckRateLimit` tasks for a tenant.


### PR DESCRIPTION
 A dequeue future cancelled around its write_with_options(... await_durable: true).await could leave a "ghost" in-memory concurrency holder: the batch had already been applied to the WAL (so the durable holder row was deleted), but the
  post-commit atomic_release + request_grant loop never ran. The in-memory holders set is what try_reserve / process_grants gate on, so the queue wedged at its cap with no durable row for cancel / reap / lease-expiry to release — the 300/300
  production case. The grant side has the mirror leak: try_reserve had bumped the count and a cancellation before commit-failure handling left the bump uncleared.

  ClaimedInflightGuard (e6660cd) already solved this shape for the broker inflight set. This commit extends the same RAII-on-dequeue pattern to the two concurrency slices:

  - PendingGrantGuard owns the (tenant, queue, task_id) tuples produced by try_reserve. Disarmed on commit-success (now bked by a durable row) and commit-failure (rollback_grant synchronously). On future-drop, its Drop enqueues each tuple for
  reconciliation.
  - PendingHolderReleaseGuard owns the holder-release tuples staged by handlers (e.g. handle_run_attempt's missing-job_info branch). Armed before the commit await so a mid-await drop still sees them. Disarmed on commit-success (runs the existing
   post-commit release loop) and commit-failure (discarded — durable row is still there). On future-drop, same reconciliation enqueue.

  Both guards share one resolution mechanism on ConcurrencyManager: request_reconciliation pushes onto a pending_reconciliations: Mutex<BTreeSet<(tenant, queue, task_id)>> and fires a reconcile_notify. A new dedicated spawn_holder_reconcile_task
   waits on that notify with no jitter and no interval, so a wedge clears within milliseconds of the Drop. The existing periodic spawn_concurrency_reconcile_task also calls reconcile_pending_holders on its tick as a safety net for missed wakes.

  recoile_pending_holders resolves each tuple by point-lookup of the durable holder row against the in-memory set. The four quadrants:

  - durable present, in-memory present → no-op
  - durable absent, in-memory absent → no-op
  - durable present, in-memory absent → insert_holder (covers the mirror case where the commit landed but in-memory was rolled back)
  - durable absent, in-memory present → atomic_release + request_grant (closes the ghost — the wedge fix)

  This is per-task_id, idempotent, and correct in both branches of the WAL-mid-await ambiguity — a blind rollback was deliberately avoided because it would create the over-admit-by-1 mirror bug whenever the commit happened to land.

  Two new gauges expose the signal in prod: silo_concurrency_holder_drift (per-shard Σ |in_mem - durable| across hydrated queues, computed each periodic tick) and silo_concurrency_reconciliation_pending (current queue size — sustained non-zero
  means the reconciler is stuck).

  Tests:
  - dropped_dequeue_futury_holder_release_and_wedges_queue — the regression from the cherry-picked test commit, no longer #[ignore]d. Passes in ~80ms because the reactive task wakes on Drop.
  - reconcile_pending_holders_four_quadrants — direct exercise of the reconciler over all four (durable, in_memory) quadrants.
  - The full holder_leak_tests, concurrency_*, floating_concurrency_tests, job_store_shard_* suites stay green (316 tests across 18 binaries; the only failures in the workspace sweep are the pre-existing cluster_query_integration_tests flakes
  that also fail on b6fe893).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches concurrency admission, dequeue commit/cancel paths, and background reconciliation; incorrect logic could over-release slots or leave queues wedged, though behavior is idempotent per task_id and heavily tested.
> 
> **Overview**
> Fixes **queue wedges** when a `dequeue` future is cancelled around `write_with_options(..., await_durable: true)`: the WAL may already reflect holder deletes or grants, but post-commit **`atomic_release` / `rollback_grant`** never ran, leaving **ghost in-memory holders** that gate admission.
> 
> **Dequeue** now uses RAII **`PendingGrantGuard`** and **`PendingHolderReleaseGuard`** (same pattern as `ClaimedInflightGuard`). On drop they enqueue `(tenant, queue, task_id)` for reconciliation instead of blind rollback.
> 
> **`ConcurrencyManager`** adds a pending-reconciliation queue, **`reconcile_pending_holders`** (durable vs in-memory lookup: no-op, `insert_holder`, or `atomic_release` + **`request_grant` per ghost**), a **reactive** `spawn_holder_reconcile_task` on `reconcile_notify`, and periodic tick integration plus **`report_holder_drift`**. New Prometheus gauges: **`silo_concurrency_holder_drift`** and **`silo_concurrency_reconciliation_pending`**.
> 
> **Grant scanner** changes: legacy requests without `task_id`/limits get **JobInfo fallback** and canonical **`limit_index`**; empty `task_id` uses the request id from the key.
> 
> Tests cover dropped dequeue, four-quadrant reconcile, per-ghost grant kicks, and legacy request hydration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe6be4c7096771bf1bd0bb33b8a4505793a2e766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->