### PR TITLE
Double arm64 Docker build runner to 16 vCPUs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
             runner: blacksmith-8vcpu-ubuntu-2404
             nix_system: x86_64-linux
           - platform: arm64
-            runner: blacksmith-8vcpu-ubuntu-2404-arm
+            runner: blacksmith-16vcpu-ubuntu-2404-arm
             nix_system: aarch64-linux
     runs-on: ${{ matrix.runner }}
     permissions:


### PR DESCRIPTION
## Summary
- Bump the arm64 `build-docker` matrix runner from `blacksmith-8vcpu-ubuntu-2404-arm` to `blacksmith-16vcpu-ubuntu-2404-arm` to speed up arm64 container builds (2x CPU).

## Why
arm64 cold container builds are the slow leg of CI. Doubling the runner's CPU should meaningfully cut build time.