### PR TITLE
Stop reordering a job's Limits array server-side

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -107,9 +107,9 @@ pub struct ResumeChainParams {
     pub job_id: String,
     pub attempt_number: u32,
     pub relative_attempt_number: u32,
-    /// Index into `limit_processing_order(limits)` for the next limit to
-    /// evaluate. May equal `limits.len()` (in canonical order) — meaning the
-    /// chain is complete and the resumer should write a `RunAttempt`.
+    /// Index into the client-provided `limits` slice for the next limit to
+    /// evaluate. May equal `limits.len()` — meaning the chain is complete and
+    /// the resumer should write a `RunAttempt`.
     pub limit_index: u32,
     pub priority: u8,
     pub start_at_ms: i64,
@@ -872,10 +872,10 @@ impl ConcurrencyManager {
         attempt_number: u32,
         relative_attempt_number: u32,
         skip_try_reserve: bool,
-        // Position of this limit in the job's canonical limit order. Persisted
-        // on the deferred request/ticket so `process_grants` (or the dequeue
-        // path for future-scheduled tickets) can resume the chain at
-        // `limit_index + 1` after this slot is granted.
+        // Index of this limit in the job's `limits` list. Persisted on the
+        // deferred request/ticket so `process_grants` (or the dequeue path for
+        // future-scheduled tickets) can resume the chain at `limit_index + 1`
+        // after this slot is granted.
         limit_index: u32,
         // Concurrency queues already held by earlier chain steps. Persisted
         // alongside `limit_index` so the resumed chain knows which holders
@@ -1201,8 +1201,8 @@ impl ConcurrencyManager {
             start_time_ms: i64,
             priority: u8,
             task_group: String,
-            /// Position of the gating limit (this queue) in the job's canonical
-            /// order. Resuming the chain starts at `limit_index + 1`.
+            /// Index of the gating limit (this queue) in the job's `limits`
+            /// list. Resuming the chain starts at `limit_index + 1`.
             limit_index: u32,
             /// Holders already in place from earlier chain steps. The resumed
             /// chain appends this queue and continues from there.

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -60,26 +60,6 @@ pub(crate) struct LimitTaskParams<'a> {
     pub skip_try_reserve: bool,
 }
 
-/// Canonical processing order for a job's limits: Concurrency first, then
-/// FloatingConcurrency, then RateLimit, stable within each kind. Returns
-/// indices into the caller-provided `limits` slice. A `Limit::Concurrency`
-/// must always be processed before any `Limit::FloatingConcurrency` so a
-/// strictly-tighter Concurrency limit blocks the job *before* it acquires a
-/// FloatingConcurrency slot — otherwise the FC grant produces a leasable
-/// `RunAttempt[FC]` that bypasses the still-full Concurrency limit.
-pub(crate) fn limit_processing_order(limits: &[Limit]) -> Vec<usize> {
-    let kind_rank = |i: usize| -> u8 {
-        match &limits[i] {
-            Limit::Concurrency(_) => 0,
-            Limit::FloatingConcurrency(_) => 1,
-            Limit::RateLimit(_) => 2,
-        }
-    };
-    let mut order: Vec<usize> = (0..limits.len()).collect();
-    order.sort_by_key(|&i| kind_rank(i));
-    order
-}
-
 /// Whether a concurrency grant was obtained or the job was queued for later.
 enum GrantResult {
     /// Slot granted immediately; caller should advance to the next limit.
@@ -528,12 +508,13 @@ impl JobStoreShard {
             task_group,
             skip_try_reserve,
         } = params;
-        // Walk limits in the canonical processing order (see
-        // `limit_processing_order`). `current_index` and the `limit_index`
-        // stored in `CheckRateLimit` tasks are positions in this order — the
-        // order function is deterministic on `limits`, so dequeue's
-        // `limit_index + 1` continuation lands on the correct next entry.
-        let order = limit_processing_order(limits);
+        // Walk limits in the order the client provided them — silo no longer
+        // reorders. `current_index` and the `limit_index` stored in
+        // `CheckRateLimit` tasks are direct indices into `limits`, so
+        // dequeue's `limit_index + 1` continuation lands on the next entry.
+        // Clients are responsible for ordering their limits such that a
+        // tighter `Concurrency` limit precedes any `FloatingConcurrency` that
+        // would otherwise grant a leasable slot bypassing it.
         let mut current_index = limit_index;
         let mut current_held_queues = held_queues;
         let current_task_id = task_id.to_string();
@@ -576,7 +557,7 @@ impl JobStoreShard {
                 return Ok(());
             }
 
-            match &limits[order[current_index]] {
+            match &limits[current_index] {
                 Limit::Concurrency(cl) => {
                     // Try immediate grant for concurrency limits
                     let outcome = self

--- a/src/task.rs
+++ b/src/task.rs
@@ -40,9 +40,8 @@ pub enum Task {
         /// reachable by the same id.
         task_id: String,
         task_group: String,
-        /// Position of the gating limit in the job's canonical limit order
-        /// (see `limit_processing_order`). When granted, chain resumes at
-        /// `limit_index + 1`.
+        /// Index of the gating limit in the job's `limits` list. When granted,
+        /// chain resumes at `limit_index + 1`.
         limit_index: u32,
         /// Concurrency queues already held by earlier chain steps.
         held_queues: Vec<String>,
@@ -160,9 +159,8 @@ pub enum ConcurrencyAction {
         /// Attempt number within current run (resets to 1 on job restart)
         relative_attempt_number: u32,
         task_group: String,
-        /// Position of the gating limit in the job's canonical limit order
-        /// (see `limit_processing_order`). When granted, the chain resumes
-        /// at `limit_index + 1`.
+        /// Index of the gating limit in the job's `limits` list. When granted,
+        /// the chain resumes at `limit_index + 1`.
         limit_index: u32,
         /// Concurrency queues already held by earlier chain steps.
         held_queues: Vec<String>,


### PR DESCRIPTION
## What

Removes silo's server-side reordering of a job's `Limits` array. Limits are now processed in the exact order the client provides them. All clients have been updated to order their own limits.

## Changes

- **`src/job_store_shard/enqueue.rs`**: Deleted `limit_processing_order`, which sorted limits into a canonical order (Concurrency → FloatingConcurrency → RateLimit, stable within each kind). The enqueue walker now indexes `limits[current_index]` directly instead of through the sorted `order` indirection.
- **`src/concurrency.rs`, `src/task.rs`**: Doc-comment updates — `limit_index` is now documented as a direct index into the client-provided `limits` list rather than a position in the canonical order. No behavior change.

## Correctness note

The deleted function enforced a real invariant: a `Concurrency` limit was always processed *before* any `FloatingConcurrency`, so a strictly-tighter Concurrency limit blocks a job before it can acquire an FC slot (otherwise the FC grant yields a leasable `RunAttempt[FC]` that bypasses the still-full Concurrency limit). With sorting removed, that ordering is now the **client's responsibility** — clients have been updated accordingly. The requirement is carried forward in the walker's comment so it isn't lost.

The `limit_index + 1` chain-resume logic is unaffected: `limit_index` was always a position in `order`, which is now identity-equivalent, so direct indexing keeps every dequeue continuation landing on the correct next entry.

## Test plan

- `cargo check` passes
- `cargo fmt` applied