### PR TITLE
Double arm64 build runner to 32 vCPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
             runner: blacksmith-8vcpu-ubuntu-2404
             nix_system: x86_64-linux
           - platform: arm64
-            runner: blacksmith-16vcpu-ubuntu-2404-arm
+            runner: blacksmith-32vcpu-ubuntu-2404-arm
             nix_system: aarch64-linux
     runs-on: ${{ matrix.runner }}
     permissions:


### PR DESCRIPTION
Bumps the arm64 Docker build runner from `blacksmith-16vcpu-ubuntu-2404-arm` to `blacksmith-32vcpu-ubuntu-2404-arm` (2x the vCPUs) to speed up the arm64 image build in CI. The amd64 runner is unchanged.