### PR TITLE
Fix granted-RunAttempt back-of-queue leak via task_key epoch_ms

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -970,13 +970,12 @@ impl ConcurrencyManager {
         // request record / RequestTicket task so `process_grants` can later
         // skip future-dated requests.
         scheduled_at_ms: i64,
-        // Time component for every `task_key` / `concurrency_request_key` this
-        // call writes. For a fresh enqueue this equals `scheduled_at_ms`. For
-        // a chain *resume* this is `now_ms`, so the resumed task can't
-        // collide with a broker tombstone pinned by an earlier ack-delete at
-        // `task_key(scheduled_at_ms, …)`. See
+        // Write-time disambiguator for the trailing `epoch_ms` of any `task_key`
+        // this call writes (only the future-`RequestTicket` branch writes one).
+        // It does not affect broker ordering; it only keeps a rewritten task_key
+        // distinct from the broker tombstone of a just-deleted predecessor. See
         // `project_broker_tombstone_chain_continuation`.
-        task_key_start_ms: i64,
+        task_key_epoch_ms: i64,
         now_ms: i64,
         limits: &[ConcurrencyLimit],
         task_group: &str,
@@ -1076,17 +1075,10 @@ impl ConcurrencyManager {
             // as any prior holders accumulated by the chain (avoiding the
             // task_id mismatch that used to orphan earlier grants).
             //
-            // For a future-scheduled enqueue the broker must see this task
-            // at the user-requested time, so `task_key_start_ms ==
-            // scheduled_at_ms` on this branch. (No call site sets them apart
-            // here — resume goes through the request branch above.) If a
-            // future call site ever passes them apart, the persisted
-            // `start_time_ms` and the `task_key` would disagree and the
-            // broker would notice.
-            debug_assert_eq!(
-                scheduled_at_ms, task_key_start_ms,
-                "future RequestTicket: task_key_start_ms must equal scheduled_at_ms"
-            );
+            // For a future-scheduled enqueue the broker must see this task at
+            // the user-requested time: the `task_key` start component is
+            // `scheduled_at_ms`, matching the persisted `start_time_ms` below.
+            // `task_key_epoch_ms` is only the trailing disambiguator.
             let ticket = Task::RequestTicket {
                 queue: queue.clone(),
                 start_time_ms: scheduled_at_ms,
@@ -1105,10 +1097,11 @@ impl ConcurrencyManager {
             writer.put(
                 task_key(
                     task_group,
-                    task_key_start_ms,
+                    scheduled_at_ms,
                     priority,
                     job_id,
                     attempt_number,
+                    task_key_epoch_ms,
                 ),
                 &ticket_value,
             )?;

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -6,13 +6,13 @@ use crate::codec::{decode_cancellation_at_ms, decode_task, encode_job_cancellati
 use crate::job::{JobCancellation, JobStatus, JobStatusKind, JobView, Limit};
 use crate::job_store_shard::counters::encode_counter;
 use crate::job_store_shard::helpers::{
-    TxnWriter, decode_job_status_owned, now_epoch_ms, put_with_optional_expire,
-    retry_on_txn_conflict,
+    TxnWriter, decode_job_status_owned, find_task_by_identity, now_epoch_ms,
+    put_with_optional_expire, retry_on_txn_conflict,
 };
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
     concurrency_holder_key, concurrency_request_job_prefix, concurrency_requester_counter_key,
-    end_bound, job_cancelled_key, job_info_key, job_status_key, task_key,
+    end_bound, job_cancelled_key, job_info_key, job_status_key,
 };
 use crate::task::Task;
 
@@ -145,17 +145,26 @@ impl JobStoreShard {
                 let priority = job_view.priority();
                 let limits = job_view.limits();
 
-                // Try O(1) task key reconstruction from status fields
+                // Locate the pending task by identity (the trailing epoch_ms is
+                // write-only, so we prefix-scan instead of reconstructing the
+                // exact key).
                 let attempt_number = status.current_attempt.unwrap_or(1);
                 let start_time_ms = status.next_attempt_starts_after_ms.unwrap_or(0);
-                let computed_key =
-                    task_key(&task_group, start_time_ms, priority, id, attempt_number);
-                let task_found = match txn.get(&computed_key).await? {
-                    Some(raw) => Some((computed_key, raw)),
+                let task_found = match find_task_by_identity(
+                    &txn,
+                    &task_group,
+                    start_time_ms,
+                    priority,
+                    id,
+                    attempt_number,
+                )
+                .await?
+                {
+                    Some(found) => Some(found),
                     None => {
                         // Fallback: try with time=0 (immediate scheduling case)
-                        let zero_key = task_key(&task_group, 0, priority, id, attempt_number);
-                        txn.get(&zero_key).await?.map(|raw| (zero_key, raw))
+                        find_task_by_identity(&txn, &task_group, 0, priority, id, attempt_number)
+                            .await?
                     }
                 };
 

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -766,19 +766,23 @@ impl JobStoreShard {
         let mut new_held = stored_held_queues;
         new_held.push(queue.clone());
 
-        // task_key is `(task_group, start_time_ms, priority, job_id,
-        // attempt_number)`. The chain continues with the same task_group,
-        // priority, job_id, and attempt_number, so the *only* differentiator
-        // versus the just-tombstoned parent key is start_time_ms. `now_ms`
-        // usually exceeds the parent's start_time_ms, but for a worker that
-        // processes a future-scheduled ticket in the same millisecond it
-        // becomes ready, the two could collide and the follow-up would be
-        // silently suppressed. Bump past the parent to make the dodge
-        // unconditional.
-        let parent_start_time_ms = parse_task_key(task_key)
+        // The continuation keeps the ticket's original `start_time_ms` as its
+        // broker-ordering start time. A just-granted ticket has already waited;
+        // re-stamping it at `now_ms` would shove the holder-bearing follow-up to
+        // the back of the broker's start-time-ordered scan, where a capped scan
+        // may never reach it — the granted-RunAttempt back-of-queue leak
+        // (env-10000042940). The tombstone dodge for the just-deleted ticket's
+        // task_key moves to the trailing `epoch_ms`: all other key components
+        // (task_group, priority, job_id, attempt_number) are constant within a
+        // chain, so a fresh `epoch_ms` strictly past the parent's makes the
+        // follow-up key unique even when it reuses the parent's start_time.
+        let parent = parse_task_key(task_key);
+        let parent_start_time_ms = parent
+            .as_ref()
             .map(|p| p.start_time_ms as i64)
             .unwrap_or(now_ms);
-        let new_task_key_start_ms = now_ms.max(parent_start_time_ms + 1);
+        let parent_epoch_ms = parent.as_ref().map(|p| p.epoch_ms as i64).unwrap_or(0);
+        let task_key_epoch_ms = now_ms.max(parent_epoch_ms + 1);
 
         let mut writer = DbWriteBatcher::new(&self.db, &mut state.batch);
         let chain_result = self
@@ -793,13 +797,10 @@ impl JobStoreShard {
                     limit_index: (limit_index + 1) as usize,
                     limits: &limits,
                     priority: rt.priority(),
-                    // Future-scheduled `RequestTicket` was just granted; the
-                    // chain is past its scheduled time. Use `now_ms` for
-                    // `scheduled_at_ms`; `task_key_start_ms` may need a +1
-                    // bump versus the parent to dodge the broker tombstone
-                    // for the just-deleted ticket.
-                    scheduled_at_ms: new_task_key_start_ms,
-                    task_key_start_ms: new_task_key_start_ms,
+                    // Keep the original scheduled start (the ticket's key start);
+                    // dodge the just-deleted ticket's tombstone via epoch.
+                    scheduled_at_ms: parent_start_time_ms,
+                    task_key_epoch_ms,
                     now_ms,
                     held_queues: new_held,
                     task_group: &req_task_group,
@@ -873,12 +874,16 @@ impl JobStoreShard {
         state.batch.delete(task_key);
         state.ack_deleted(task_key);
 
-        // Parent task_key's start_time_ms — needed by both the success and
-        // retry branches to bump their follow-up task_key past the
-        // tombstone we just installed.
-        let parent_start_time_ms = parse_task_key(task_key)
+        // Parent task_key's start_time_ms / epoch_ms. Both the success and retry
+        // branches keep the parent's start_time (so the follow-up keeps its
+        // broker-ordering position) and dodge the tombstone we just installed via
+        // a fresh `epoch_ms` strictly past the parent's.
+        let parent = parse_task_key(task_key);
+        let parent_start_time_ms = parent
+            .as_ref()
             .map(|p| p.start_time_ms as i64)
             .unwrap_or(now_ms);
+        let parent_epoch_ms = parent.as_ref().map(|p| p.epoch_ms as i64).unwrap_or(0);
 
         // Terminal-status short-circuit. Symmetric with handle_request_ticket:
         // if the job is Succeeded/Failed/Cancelled there's no point calling
@@ -947,11 +952,10 @@ impl JobStoreShard {
         match rate_limit_result {
             Ok(result) if result.under_limit => {
                 // Rate limit passed! Proceed to next limit or RunAttempt.
-                // Same-millisecond tombstone dodge as handle_request_ticket:
-                // bump task_key_start_ms past the parent if necessary so
-                // the follow-up key cannot collide with the just-deleted
-                // CheckRateLimit's task_key.
-                let new_task_key_start_ms = now_ms.max(parent_start_time_ms + 1);
+                // Keep the parent's start_time so the follow-up retains its
+                // broker-ordering position; dodge the just-deleted
+                // CheckRateLimit's tombstone via a fresh `epoch_ms`.
+                let task_key_epoch_ms = now_ms.max(parent_epoch_ms + 1);
                 let chain_result = self
                     .enqueue_limit_task_at_index(
                         &mut DbWriteBatcher::new(&self.db, &mut state.batch),
@@ -964,8 +968,8 @@ impl JobStoreShard {
                             limit_index: (limit_index + 1) as usize,
                             limits: &job_view.limits(),
                             priority,
-                            scheduled_at_ms: new_task_key_start_ms,
-                            task_key_start_ms: new_task_key_start_ms,
+                            scheduled_at_ms: parent_start_time_ms,
+                            task_key_epoch_ms,
                             now_ms,
                             held_queues: held_queues.clone(),
                             task_group: check_task_group,
@@ -1038,7 +1042,7 @@ impl JobStoreShard {
                     priority,
                     held_queues,
                     retry_backoff,
-                    parent_start_time_ms,
+                    parent_epoch_ms,
                     check_task_group,
                 )?;
             }
@@ -1059,7 +1063,7 @@ impl JobStoreShard {
                     priority,
                     held_queues,
                     retry_backoff,
-                    parent_start_time_ms,
+                    parent_epoch_ms,
                     check_task_group,
                 )?;
             }
@@ -1297,7 +1301,7 @@ mod claimed_inflight_guard_tests {
             held_queues: vec![],
             task_group: task_group.to_string(),
         };
-        let key = crate::keys::task_key(task_group, 1, 0, job_id, 1);
+        let key = crate::keys::task_key(task_group, 1, 0, job_id, 1, 1);
         let decoded = decode_task_validated(encode_task(&task)).expect("decode task");
         BrokerTask { key, decoded }
     }

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -771,8 +771,9 @@ impl JobStoreShard {
         // re-stamping it at `now_ms` would shove the holder-bearing follow-up to
         // the back of the broker's start-time-ordered scan, where a capped scan
         // may never reach it — the granted-RunAttempt back-of-queue leak
-        // (env-10000042940). The tombstone dodge for the just-deleted ticket's
-        // task_key moves to the trailing `epoch_ms`: all other key components
+        // (the production back-of-queue wedge incident). The tombstone dodge
+        // for the just-deleted ticket's task_key moves to the trailing
+        // `epoch_ms`: all other key components
         // (task_group, priority, job_id, attempt_number) are constant within a
         // chain, so a fresh `epoch_ms` strictly past the parent's makes the
         // follow-up key unique even when it reuses the parent's start_time.

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -34,22 +34,24 @@ pub(crate) struct LimitTaskParams<'a> {
     pub limit_index: usize,
     pub limits: &'a [Limit],
     pub priority: u8,
-    /// The job's user-requested start time. Used purely as the "is this
-    /// future-scheduled?" predicate (`scheduled_at_ms > now_ms` ⇒ write a
-    /// `Task::RequestTicket` instead of an in-queue request record) and as
-    /// the `start_time_ms` we persist on `EnqueueTask` so `process_grants`
-    /// can skip future-dated requests on resume.
+    /// The job's user-requested start time. This is the `start_time_ms`
+    /// component baked into every `task_key` / `concurrency_request_key` this
+    /// chain step writes (so the broker orders the task by its logical schedule)
+    /// AND the predicate for "is this future-scheduled?" (`scheduled_at_ms >
+    /// now_ms` ⇒ write a `Task::RequestTicket` at that future time). It is
+    /// persisted as `start_time_ms` on `EnqueueTask` so `process_grants` can
+    /// skip future-dated requests on resume. A chain *resume* keeps the job's
+    /// original schedule here — the tombstone dodge lives in `task_key_epoch_ms`.
     pub scheduled_at_ms: i64,
-    /// The time component baked into every `task_key` / `concurrency_request_key`
-    /// this chain step writes. For a fresh enqueue this equals
-    /// `scheduled_at_ms` so a future-scheduled `RequestTicket` lands at the
-    /// future time. For a chain *resume* — `ShardChainResumer::resume_chain`
-    /// — this is `now_ms`, so the resumed task cannot collide with a broker
-    /// tombstone pinned by an earlier ack-delete at the original
-    /// `task_key(scheduled_at_ms, …)`. See
+    /// Write-time disambiguator for the trailing `epoch_ms` of every `task_key`
+    /// this chain step writes. It does NOT affect broker ordering; it only makes
+    /// a rewritten task_key unique versus the broker ack-tombstone left by an
+    /// earlier ack-delete at the same `(start_time_ms, …)`. For a fresh chain
+    /// head use `now_ms`; for a rewrite of a just-deleted predecessor use
+    /// `now_ms.max(parent_epoch_ms + 1)`. See
     /// `project_broker_tombstone_chain_continuation` and the precedent in
     /// `handle_request_ticket` (dequeue.rs).
-    pub task_key_start_ms: i64,
+    pub task_key_epoch_ms: i64,
     pub now_ms: i64,
     pub held_queues: Vec<String>,
     pub task_group: &'a str,
@@ -87,7 +89,7 @@ enum GrantResult {
 fn record_grant_outcome(
     outcome: Option<RequestTicketOutcome>,
     queue_key: &str,
-    task_key_start_ms: i64,
+    scheduled_at_ms: i64,
     grants: &mut Vec<(String, String)>,
     current_task_id: &str,
     current_held_queues: &mut Vec<String>,
@@ -126,7 +128,7 @@ fn record_grant_outcome(
             }
         }
         Some(RequestTicketOutcome::FutureRequestTaskWritten { .. }) => GrantResult::Queued {
-            pending_task_key_start_ms: Some(task_key_start_ms),
+            pending_task_key_start_ms: Some(scheduled_at_ms),
         },
     }
 }
@@ -414,12 +416,13 @@ impl JobStoreShard {
                 limit_index: 0,
                 limits: &job.limits,
                 priority,
-                // Fresh enqueue: scheduled and task_key time coincide. If the
-                // job is future-scheduled (`start_at_ms > now_ms`) the
+                // Fresh enqueue: the task_key starts at the job's schedule. If
+                // the job is future-scheduled (`start_at_ms > now_ms`) the
                 // resulting `RequestTicket` lands at the future time so the
-                // broker picks it up exactly then.
+                // broker picks it up exactly then. Fresh chain head → epoch is
+                // just the write time; no predecessor tombstone to dodge.
                 scheduled_at_ms: start_at_ms,
-                task_key_start_ms: start_at_ms,
+                task_key_epoch_ms: now_ms,
                 now_ms,
                 held_queues: Vec::new(),
                 task_group,
@@ -527,7 +530,7 @@ impl JobStoreShard {
             limits,
             priority,
             scheduled_at_ms,
-            task_key_start_ms,
+            task_key_epoch_ms,
             now_ms,
             held_queues,
             task_group,
@@ -573,13 +576,14 @@ impl JobStoreShard {
                 put_task(
                     writer,
                     task_group,
-                    task_key_start_ms,
+                    scheduled_at_ms,
                     priority,
                     job_id,
                     attempt_number,
+                    task_key_epoch_ms,
                     &run_task,
                 )?;
-                return Ok(Some(task_key_start_ms));
+                return Ok(Some(scheduled_at_ms));
             }
 
             match &limits[current_index] {
@@ -596,7 +600,7 @@ impl JobStoreShard {
                             job_id,
                             priority,
                             scheduled_at_ms,
-                            task_key_start_ms,
+                            task_key_epoch_ms,
                             now_ms,
                             std::slice::from_ref(cl),
                             task_group,
@@ -620,7 +624,7 @@ impl JobStoreShard {
                     match record_grant_outcome(
                         outcome,
                         &cl.key,
-                        task_key_start_ms,
+                        scheduled_at_ms,
                         grants,
                         &current_task_id,
                         &mut current_held_queues,
@@ -663,7 +667,7 @@ impl JobStoreShard {
                             job_id,
                             priority,
                             scheduled_at_ms,
-                            task_key_start_ms,
+                            task_key_epoch_ms,
                             now_ms,
                             std::slice::from_ref(&temp_cl),
                             task_group,
@@ -706,7 +710,7 @@ impl JobStoreShard {
                     match record_grant_outcome(
                         outcome,
                         &fl.key,
-                        task_key_start_ms,
+                        scheduled_at_ms,
                         grants,
                         &current_task_id,
                         &mut current_held_queues,
@@ -742,13 +746,14 @@ impl JobStoreShard {
                     put_task(
                         writer,
                         task_group,
-                        task_key_start_ms,
+                        scheduled_at_ms,
                         priority,
                         job_id,
                         attempt_number,
+                        task_key_epoch_ms,
                         &task,
                     )?;
-                    return Ok(Some(task_key_start_ms));
+                    return Ok(Some(scheduled_at_ms));
                 }
             }
         }

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -419,9 +419,14 @@ impl JobStoreShard {
                 // Fresh enqueue: the task_key starts at the job's schedule. If
                 // the job is future-scheduled (`start_at_ms > now_ms`) the
                 // resulting `RequestTicket` lands at the future time so the
-                // broker picks it up exactly then. Fresh chain head → epoch is
-                // just the write time; no predecessor tombstone to dodge.
-                scheduled_at_ms: start_at_ms,
+                // broker picks it up exactly then. Use `effective_start_at_ms`
+                // (not the raw `start_at_ms`) so an immediate enqueue
+                // (`start_at_ms <= 0`) keys the task at `now_ms` — matching the
+                // `effective_start_at_ms` the JobStatus stores and the import
+                // path, so identity lookups never have to fall back to time=0.
+                // Fresh chain head → epoch is just the write time; no
+                // predecessor tombstone to dodge.
+                scheduled_at_ms: effective_start_at_ms,
                 task_key_epoch_ms: now_ms,
                 now_ms,
                 held_queues: Vec::new(),

--- a/src/job_store_shard/expedite.rs
+++ b/src/job_store_shard/expedite.rs
@@ -9,7 +9,8 @@ use crate::codec::decode_task_validated;
 use crate::fb::silo::fb;
 use crate::job::JobStatusKind;
 use crate::job_store_shard::helpers::{
-    TxnWriter, decode_job_status_owned, load_job_view, now_epoch_ms, retry_on_txn_conflict,
+    TxnWriter, decode_job_status_owned, find_task_by_identity, load_job_view, now_epoch_ms,
+    retry_on_txn_conflict,
 };
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{job_cancelled_key, job_status_key, task_key};
@@ -122,9 +123,18 @@ impl JobStoreShard {
             })
         })?;
 
-        let old_task_key = task_key(&task_group, start_time_ms, priority, id, attempt_number);
-        let maybe_task_raw = txn.get(&old_task_key).await?;
-        let Some(task_raw) = maybe_task_raw else {
+        // Locate the pending task by identity (the trailing epoch_ms is
+        // write-only, so we prefix-scan instead of reconstructing the exact key).
+        let Some((old_task_key, task_raw)) = find_task_by_identity(
+            &txn,
+            &task_group,
+            start_time_ms,
+            priority,
+            id,
+            attempt_number,
+        )
+        .await?
+        else {
             return Err(JobStoreShardError::JobNotExpediteable(
                 JobNotExpediteableError {
                     job_id: id.to_string(),
@@ -161,9 +171,9 @@ impl JobStoreShard {
         // Delete the old task key
         txn.delete(&old_task_key)?;
 
-        // Create new task key with current timestamp
+        // Create new task key with current timestamp (epoch = write time).
         // Raw byte passthrough: task data is identical, only the key changes
-        let new_task_key = task_key(&task_group, now_ms, priority, id, attempt_number);
+        let new_task_key = task_key(&task_group, now_ms, priority, id, attempt_number, now_ms);
         txn.put(&new_task_key, decoded.as_bytes())?;
 
         // Update job status with new start time (keeping same attempt number)

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -135,7 +135,8 @@ impl JobStoreShard {
             now_ms,
             0, // highest priority for refresh tasks
             &synthetic_job_id,
-            0, // attempt not used for refresh tasks
+            0,      // attempt not used for refresh tasks
+            now_ms, // standalone refresh task; epoch is just the write time
         );
         writer.put(&task_key_bytes, &task_value)?;
 
@@ -310,7 +311,8 @@ impl JobStoreShard {
                 next_retry_at,
                 0, // highest priority
                 &synthetic_job_id,
-                0, // attempt not used for refresh tasks
+                0,             // attempt not used for refresh tasks
+                next_retry_at, // standalone refresh task; epoch is just the write time
             );
             batch.put(&task_key_bytes, &task_value);
         }

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -8,7 +8,7 @@ use crate::codec::encode_task;
 use crate::instrumented_db::{InstrumentedDb, InstrumentedDbIterator, InstrumentedDbTransaction};
 use crate::job::JobStatus;
 use crate::job_store_shard::JobStoreShardError;
-use crate::keys::{end_bound, task_key};
+use crate::keys::{end_bound, task_key, task_key_lookup_prefix};
 use crate::task::Task;
 
 /// A trait that abstracts over SlateDB's two ways of writing in groups: `WriteBatch` and `DbTransaction`.
@@ -239,6 +239,12 @@ pub fn now_epoch_ms() -> i64 {
 }
 
 /// Encode and write a task to a batch or transaction at the standard task key location.
+///
+/// `time_ms` is the logical start time (governs broker ordering); `epoch_ms` is
+/// the write-time disambiguator that lets a chain rewrite dodge the broker
+/// ack-tombstone of a just-deleted predecessor without perturbing ordering. See
+/// [`crate::keys::task_key`].
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn put_task<W: WriteBatcher>(
     writer: &mut W,
     task_group: &str,
@@ -246,14 +252,42 @@ pub(crate) fn put_task<W: WriteBatcher>(
     priority: u8,
     job_id: &str,
     attempt: u32,
+    epoch_ms: i64,
     task: &Task,
 ) -> Result<(), JobStoreShardError> {
     let task_value = encode_task(task);
     writer.put(
-        task_key(task_group, time_ms, priority, job_id, attempt),
+        task_key(task_group, time_ms, priority, job_id, attempt, epoch_ms),
         &task_value,
     )?;
     Ok(())
+}
+
+/// Find the single live task identified by
+/// `(task_group, start_time_ms, priority, job_id, attempt)`, ignoring the
+/// trailing write-time `epoch_ms`. Returns the task's full key bytes and encoded
+/// value, or `None` if absent.
+///
+/// Status-driven point lookups (lease, cancel, expedite, reimport) know a task's
+/// identity from `JobStatus` but not its `epoch_ms`, which is a write-only
+/// disambiguator (see [`crate::keys::task_key`]). Only one chain task is ever
+/// live per `(job_id, attempt)` — a rewrite deletes the old key and writes the
+/// new one in the same batch — so this prefix scan returns at most one row.
+pub(crate) async fn find_task_by_identity(
+    txn: &InstrumentedDbTransaction,
+    task_group: &str,
+    start_time_ms: i64,
+    priority: u8,
+    job_id: &str,
+    attempt: u32,
+) -> Result<Option<(Vec<u8>, Bytes)>, JobStoreShardError> {
+    let prefix = task_key_lookup_prefix(task_group, start_time_ms, priority, job_id, attempt);
+    let end = end_bound(&prefix);
+    let mut iter = txn.scan::<Vec<u8>, _>(prefix..end).await?;
+    match iter.next().await? {
+        Some(kv) => Ok(Some((kv.key.to_vec(), kv.value))),
+        None => Ok(None),
+    }
 }
 
 /// Retry an operation that may fail with a SlateDB transaction conflict.

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -14,13 +14,13 @@ use crate::fb::silo::fb;
 use crate::job::{JobInfo, JobStatus, JobStatusKind, JobView, Limit};
 use crate::job_attempt::{AttemptStatus, JobAttempt};
 use crate::job_store_shard::helpers::{
-    TxnWriter, decode_job_status_owned, now_epoch_ms, put_with_optional_expire,
-    retry_on_txn_conflict,
+    TxnWriter, decode_job_status_owned, find_task_by_identity, now_epoch_ms,
+    put_with_optional_expire, retry_on_txn_conflict,
 };
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
     attempt_key, attempt_prefix, concurrency_holder_key, end_bound, idx_metadata_key,
-    job_cancelled_key, job_info_key, job_status_key, task_key,
+    job_cancelled_key, job_info_key, job_status_key,
 };
 use crate::retry::{RetryPolicy, retries_exhausted};
 use crate::task::Task;
@@ -287,11 +287,11 @@ impl JobStoreShard {
                         limit_index: 0,
                         limits: &params.limits,
                         priority: params.priority,
-                        // Fresh import → fresh chain. Scheduled and task_key
-                        // time coincide; this attempt_number is unseen so no
-                        // tombstone can collide.
+                        // Fresh import → fresh chain. The task_key starts at the
+                        // scheduled time; this attempt_number is unseen so the
+                        // epoch is just the write time.
                         scheduled_at_ms: effective_start_at_ms,
-                        task_key_start_ms: effective_start_at_ms,
+                        task_key_epoch_ms: now_ms,
                         now_ms,
                         held_queues: Vec::new(),
                         task_group: &params.task_group,
@@ -593,17 +593,26 @@ impl JobStoreShard {
         let mut released_holders: Vec<(String, String)> = Vec::new();
 
         if old_status.kind == JobStatusKind::Scheduled {
-            // O(1) task key reconstruction from status fields (same pattern as cancel/expedite/lease)
+            // Locate the pending task by identity (same pattern as
+            // cancel/expedite/lease). The trailing epoch_ms is write-only, so we
+            // prefix-scan instead of reconstructing the exact key.
             let attempt_number = old_status.current_attempt.unwrap_or(1);
             let start_time_ms = old_status.next_attempt_starts_after_ms.unwrap_or(0);
-            let computed_key =
-                task_key(&task_group, start_time_ms, priority, job_id, attempt_number);
-            let task_found = match txn.get(&computed_key).await? {
-                Some(raw) => Some((computed_key, raw)),
+            let task_found = match find_task_by_identity(
+                &txn,
+                &task_group,
+                start_time_ms,
+                priority,
+                job_id,
+                attempt_number,
+            )
+            .await?
+            {
+                Some(found) => Some(found),
                 None => {
                     // Fallback: try with time=0 (immediate scheduling case)
-                    let zero_key = task_key(&task_group, 0, priority, job_id, attempt_number);
-                    txn.get(&zero_key).await?.map(|raw| (zero_key, raw))
+                    find_task_by_identity(&txn, &task_group, 0, priority, job_id, attempt_number)
+                        .await?
                 }
             };
 
@@ -715,10 +724,9 @@ impl JobStoreShard {
                         limits: &stored_limits,
                         priority,
                         // Reimport advances to a new attempt_number, so the
-                        // task_key is fresh — scheduled and task_key time
-                        // coincide.
+                        // task_key is fresh; the epoch is just the write time.
                         scheduled_at_ms: effective_start_at_ms,
-                        task_key_start_ms: effective_start_at_ms,
+                        task_key_epoch_ms: now_ms,
                         now_ms,
                         held_queues: Vec::new(),
                         task_group: &task_group,

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -256,14 +256,13 @@ impl JobStoreShard {
                                     limits: &limits,
                                     priority,
                                     // Retry: the user-requested next-run time
-                                    // is `next_time`; the task_key uses the
-                                    // same so the broker picks it up exactly
-                                    // then. `next_attempt_number` already
-                                    // differentiates this from the prior
-                                    // attempt's task_key, so no tombstone
-                                    // collision is possible here.
+                                    // is `next_time`; the task_key starts there
+                                    // so the broker picks it up exactly then.
+                                    // `next_attempt_number` already differentiates
+                                    // this from the prior attempt's task_key, so
+                                    // the epoch is just the write time.
                                     scheduled_at_ms: next_time,
-                                    task_key_start_ms: next_time,
+                                    task_key_epoch_ms: now_ms,
                                     now_ms,
                                     held_queues: Vec::new(),
                                     task_group,

--- a/src/job_store_shard/lease_task.rs
+++ b/src/job_store_shard/lease_task.rs
@@ -12,12 +12,10 @@ use crate::codec::{decode_task_validated, encode_attempt, encode_lease};
 use crate::job::{JobStatusKind, JobView};
 use crate::job_attempt::{AttemptStatus, JobAttempt, JobAttemptView};
 use crate::job_store_shard::helpers::{
-    TxnWriter, decode_job_status_owned, now_epoch_ms, retry_on_txn_conflict,
+    TxnWriter, decode_job_status_owned, find_task_by_identity, now_epoch_ms, retry_on_txn_conflict,
 };
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
-use crate::keys::{
-    attempt_key, job_cancelled_key, job_info_key, job_status_key, leased_task_key, task_key,
-};
+use crate::keys::{attempt_key, job_cancelled_key, job_info_key, job_status_key, leased_task_key};
 use crate::task::{DEFAULT_LEASE_MS, LeaseRecord, LeasedTask, Task};
 
 /// Error returned when a job cannot be leased because it's not in a leaseable state.
@@ -137,26 +135,35 @@ impl JobStoreShard {
             })
         })?;
 
-        // Read the pending task via O(1) key reconstruction.
+        // Locate the pending task by identity (the trailing epoch_ms is
+        // write-only, so we prefix-scan instead of reconstructing the exact key).
         // When start_at_ms <= 0 at enqueue time, the task key uses 0 as its time
         // component but the status stores the effective time (now_ms). Try the
         // status time first, then fall back to 0 to handle immediate jobs.
-        let old_task_key = task_key(&task_group, start_time_ms, priority, id, attempt_number);
-        let (old_task_key, task_raw) = match txn.get(&old_task_key).await? {
-            Some(raw) => (old_task_key, raw),
+        let found = match find_task_by_identity(
+            &txn,
+            &task_group,
+            start_time_ms,
+            priority,
+            id,
+            attempt_number,
+        )
+        .await?
+        {
+            Some(found) => Some(found),
             None => {
                 // Fallback: try with time=0 (immediate scheduling case)
-                let zero_key = task_key(&task_group, 0, priority, id, attempt_number);
-                match txn.get(&zero_key).await? {
-                    Some(raw) => (zero_key, raw),
-                    None => {
-                        return Err(JobStoreShardError::JobNotLeaseable(JobNotLeaseableError {
-                            job_id: id.to_string(),
-                            status: status.kind,
-                            reason: "job has no pending task in queue".to_string(),
-                        }));
-                    }
-                }
+                find_task_by_identity(&txn, &task_group, 0, priority, id, attempt_number).await?
+            }
+        };
+        let (old_task_key, task_raw) = match found {
+            Some(found) => found,
+            None => {
+                return Err(JobStoreShardError::JobNotLeaseable(JobNotLeaseableError {
+                    job_id: id.to_string(),
+                    status: status.kind,
+                    reason: "job has no pending task in queue".to_string(),
+                }));
             }
         };
         // Validate that the raw bytes decode to a valid task before replacing it

--- a/src/job_store_shard/limit_chain.rs
+++ b/src/job_store_shard/limit_chain.rs
@@ -58,7 +58,7 @@ impl LimitChainResumer for ShardChainResumer {
         // not be shoved to the back of the broker's start-time-ordered scan, or
         // the capped scan may never reach it (it holds concurrency slots that
         // then never release; see the granted-RunAttempt back-of-queue leak,
-        // env-10000042940).
+        // the production back-of-queue wedge incident).
         //
         // The tombstone dodge moves to the trailing `epoch_ms` instead. The
         // broker tombstones any task_key it ack-deleted, and an interim

--- a/src/job_store_shard/limit_chain.rs
+++ b/src/job_store_shard/limit_chain.rs
@@ -53,27 +53,25 @@ impl LimitChainResumer for ShardChainResumer {
         // baked into this batch.
         let now_ms = params.now_ms;
 
-        // `scheduled_at_ms` stays honest — the chain's original user-requested
-        // start time — so the future-scheduling check and any persisted
-        // `start_time_ms` on a follow-up request keep their semantics. But
-        // every `task_key` this walk writes lands at `now_ms`: the broker
-        // tombstones any task_key it has ack-deleted, and an LSM scan can
-        // momentarily observe the interim RunAttempt earlier chain steps
-        // wrote at `task_key(scheduled_at_ms, …)` even though that interim is
-        // deleted in the same batch. Once a worker claims and ack-deletes
-        // that key, every later write at the same task_key is silently
-        // suppressed by the tombstone, which strands the holders this
-        // resumer just granted. Mirrors the precedent in
+        // The resumed task_key keeps the job's ORIGINAL `start_at_ms` as its
+        // broker-ordering start time — a job that has waited for its slot must
+        // not be shoved to the back of the broker's start-time-ordered scan, or
+        // the capped scan may never reach it (it holds concurrency slots that
+        // then never release; see the granted-RunAttempt back-of-queue leak,
+        // env-10000042940).
+        //
+        // The tombstone dodge moves to the trailing `epoch_ms` instead. The
+        // broker tombstones any task_key it ack-deleted, and an interim
+        // RunAttempt/CheckRateLimit an earlier chain step wrote at
+        // `task_key(start_at_ms, …, epoch=earlier)` may still be observed by an
+        // in-flight LSM scan even though it's deleted; re-emitting at the same
+        // full key would be suppressed and strand the holders this resumer just
+        // granted. Stamping `now_ms` as the epoch makes the resumed key unique
+        // versus that interim (whose epoch was set at an earlier enqueue/grant,
+        // so strictly less than `now_ms`) without perturbing ordering. Mirrors
         // `handle_request_ticket` (dequeue.rs) — see
         // `project_broker_tombstone_chain_continuation`.
-        //
-        // `now_ms` typically exceeds `params.start_at_ms`, but a granted
-        // request that fires within the same millisecond would write
-        // `task_key(now_ms, …) == task_key(start_at_ms, …)` and collide
-        // with the tombstoned interim. Bump past `start_at_ms` to make the
-        // dodge unconditional. The other key components (task_group,
-        // priority, job_id, attempt_number) are constant within a chain.
-        let task_key_start_ms = now_ms.max(params.start_at_ms + 1);
+        let task_key_epoch_ms = now_ms;
         let mut writer = DbWriteBatcher::new(&shard.db, batch);
         let result = shard
             .enqueue_limit_task_at_index(
@@ -88,7 +86,7 @@ impl LimitChainResumer for ShardChainResumer {
                     limits: &params.limits,
                     priority: params.priority,
                     scheduled_at_ms: params.start_at_ms,
-                    task_key_start_ms,
+                    task_key_epoch_ms,
                     now_ms,
                     held_queues: params.held_queues.clone(),
                     task_group: &params.task_group,

--- a/src/job_store_shard/rate_limit.rs
+++ b/src/job_store_shard/rate_limit.rs
@@ -31,11 +31,16 @@ impl JobStoreShard {
         priority: u8,
         held_queues: &[String],
         retry_at_ms: i64,
-        parent_start_time_ms: i64,
+        parent_epoch_ms: i64,
         task_group: &str,
     ) -> Result<(), JobStoreShardError> {
-        let task_key_start_ms =
-            rate_limit_retry_task_key_start_ms(retry_at_ms, parent_start_time_ms);
+        // The retry's task_key keeps `retry_at_ms` as its start time (the broker
+        // must dispatch it after the backoff). `handle_check_rate_limit`
+        // ack-deleted the parent CheckRateLimit, installing a broker tombstone at
+        // its task_key; every other key component is identical to the parent's,
+        // so we dodge it with an `epoch_ms` strictly past the parent's. This
+        // holds even for zero backoff (`retry_at_ms == parent_start_time_ms`).
+        let task_key_epoch_ms = rate_limit_retry_epoch_ms(parent_epoch_ms);
         let retry_task = Task::CheckRateLimit {
             task_id: task_id.to_string(),
             tenant: tenant.to_string(),
@@ -53,10 +58,11 @@ impl JobStoreShard {
         put_task(
             writer,
             task_group,
-            task_key_start_ms,
+            retry_at_ms,
             priority,
             job_id,
             attempt_number,
+            task_key_epoch_ms,
             &retry_task,
         )
     }
@@ -109,61 +115,32 @@ impl JobStoreShard {
     }
 }
 
-/// Compute the `task_key_start_ms` for a rate-limit retry given the
-/// caller's requested `retry_at_ms` and the parent CheckRateLimit's
-/// `start_time_ms` (the value baked into the just-tombstoned task_key).
+/// Compute the trailing `epoch_ms` for a rate-limit retry's task_key.
 ///
-/// `handle_check_rate_limit` ack-deletes the parent CheckRateLimit's
-/// task_key, which installs a broker tombstone keyed by
-/// `(task_group, parent_start_time_ms, priority, job_id, attempt_number)`.
-/// All other components of the retry's task_key are identical to the
-/// parent's; the only differentiator is `start_time_ms`. If
-/// `retry_at_ms == parent_start_time_ms` — possible with zero/near-zero
-/// backoff, or with `reset_time_ms == parent.start_time_ms` — the retry
-/// write would land on the tombstoned key and be silently suppressed,
-/// stalling the chain and stranding every `held_queues` entry. Bumping
-/// past the parent by one millisecond costs nothing on the broker's
-/// dispatch ordering and makes the dodge unconditional.
+/// `handle_check_rate_limit` ack-deletes the parent CheckRateLimit's task_key,
+/// installing a broker tombstone keyed by the FULL key bytes
+/// `(task_group, start_time_ms, priority, job_id, attempt_number, epoch_ms)`.
+/// The retry keeps `retry_at_ms` as its start time (so the broker dispatches it
+/// after the backoff) and reuses the same task_group/priority/job_id/attempt, so
+/// the only field free to disambiguate from the tombstone is `epoch_ms`. One
+/// past the parent's epoch makes the dodge unconditional — even for zero backoff
+/// where `retry_at_ms == parent_start_time_ms`.
 ///
-/// Extracted as a free function so the invariant can be unit-tested
-/// without spinning up a `JobStoreShard`.
-pub(crate) fn rate_limit_retry_task_key_start_ms(
-    retry_at_ms: i64,
-    parent_start_time_ms: i64,
-) -> i64 {
-    retry_at_ms.max(parent_start_time_ms + 1)
+/// Extracted as a free function so the invariant can be unit-tested without
+/// spinning up a `JobStoreShard`.
+pub(crate) fn rate_limit_retry_epoch_ms(parent_epoch_ms: i64) -> i64 {
+    parent_epoch_ms + 1
 }
 
 #[cfg(test)]
 mod tests {
-    use super::rate_limit_retry_task_key_start_ms;
+    use super::rate_limit_retry_epoch_ms;
 
     #[test]
-    fn equal_retry_and_parent_bumps_by_one() {
-        // The exact collision case: zero backoff with the dequeue happening
-        // in the same millisecond as the parent's start_time_ms.
-        assert_eq!(rate_limit_retry_task_key_start_ms(100, 100), 101);
-    }
-
-    #[test]
-    fn retry_before_parent_jumps_to_parent_plus_one() {
-        // Clock skew or a Gubernator reset_time pointing at an earlier
-        // millisecond than the parent's start. Still must dodge the
-        // tombstone.
-        assert_eq!(rate_limit_retry_task_key_start_ms(50, 100), 101);
-    }
-
-    #[test]
-    fn retry_strictly_after_parent_is_unchanged() {
-        // The common case: backoff > 0 carries retry_at_ms past the parent.
-        // No bump needed.
-        assert_eq!(rate_limit_retry_task_key_start_ms(200, 100), 200);
-    }
-
-    #[test]
-    fn retry_one_past_parent_is_unchanged() {
-        // Boundary: retry_at_ms is exactly parent + 1. The `max` returns
-        // retry_at_ms unchanged; no double-bump.
-        assert_eq!(rate_limit_retry_task_key_start_ms(101, 100), 101);
+    fn retry_epoch_is_one_past_parent() {
+        // The retry's task_key reuses the parent's start_time (and every other
+        // component); a strictly-greater epoch dodges the parent's tombstone.
+        assert_eq!(rate_limit_retry_epoch_ms(100), 101);
+        assert_eq!(rate_limit_retry_epoch_ms(0), 1);
     }
 }

--- a/src/job_store_shard/rate_limit.rs
+++ b/src/job_store_shard/rate_limit.rs
@@ -143,4 +143,26 @@ mod tests {
         assert_eq!(rate_limit_retry_epoch_ms(100), 101);
         assert_eq!(rate_limit_retry_epoch_ms(0), 1);
     }
+
+    #[test]
+    fn retry_epoch_strictly_increases_across_a_multi_hop_chain() {
+        // A rate-limited job can retry many times. Each hop feeds the prior
+        // hop's epoch back through this function (handle_check_rate_limit parses
+        // the parent CheckRateLimit's key and passes its `epoch_ms`), so the
+        // chain's epochs must form a strictly increasing sequence. Under zero
+        // backoff every hop reuses the same `start_time`, so this epoch growth is
+        // the *only* thing keeping each retry clear of the previous hop's broker
+        // ack-tombstone — a single non-increasing step would silently suppress a
+        // retry and strand the chain's held_queues.
+        let mut epoch = 7; // arbitrary starting epoch from the initial CheckRateLimit
+        for _ in 0..10 {
+            let next = rate_limit_retry_epoch_ms(epoch);
+            assert!(
+                next > epoch,
+                "retry epoch must strictly exceed the parent's: {next} !> {epoch}",
+            );
+            epoch = next;
+        }
+        assert_eq!(epoch, 17, "10 hops from epoch 7 should land at 17");
+    }
 }

--- a/src/job_store_shard/rate_limit.rs
+++ b/src/job_store_shard/rate_limit.rs
@@ -38,8 +38,9 @@ impl JobStoreShard {
         // must dispatch it after the backoff). `handle_check_rate_limit`
         // ack-deleted the parent CheckRateLimit, installing a broker tombstone at
         // its task_key; every other key component is identical to the parent's,
-        // so we dodge it with an `epoch_ms` strictly past the parent's. This
-        // holds even for zero backoff (`retry_at_ms == parent_start_time_ms`).
+        // so we dodge it with an `epoch_ms` strictly past the parent's —
+        // `rate_limit_retry_epoch_ms` returns `parent_epoch_ms + 1`. This holds
+        // even for zero backoff (`retry_at_ms == parent_start_time_ms`).
         let task_key_epoch_ms = rate_limit_retry_epoch_ms(parent_epoch_ms);
         let retry_task = Task::CheckRateLimit {
             task_id: task_id.to_string(),

--- a/src/job_store_shard/restart.rs
+++ b/src/job_store_shard/restart.rs
@@ -165,8 +165,15 @@ impl JobStoreShard {
 
         // Use a temporary WriteBatch to encode the task, then extract and put via txn
         let task_value = crate::codec::encode_task(&new_task);
-        let task_key =
-            crate::keys::task_key(&task_group, start_at_ms, priority, id, next_attempt_number);
+        // Fresh attempt_number → fresh task_key; epoch is just the write time.
+        let task_key = crate::keys::task_key(
+            &task_group,
+            start_at_ms,
+            priority,
+            id,
+            next_attempt_number,
+            now_ms,
+        );
         txn.put(&task_key, &task_value)?;
 
         // Two-phase DST event: emit before commit for correct causal ordering,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -229,7 +229,39 @@ pub fn parse_metadata_index_key(key: &[u8]) -> Option<ParsedMetadataIndexKey> {
 }
 
 /// Construct the key for a task, ordered by task group then start time.
+///
+/// `epoch_ms` is a trailing write-time disambiguator that does NOT participate
+/// in cross-job ordering (it sorts after every other field). It exists so a
+/// chain rewrite can re-emit a task at the same logical `start_time_ms` without
+/// colliding with the broker ack-tombstone left by the just-deleted prior key.
+/// No reader reconstructs it — point lookups use [`task_key_lookup_prefix`].
 pub fn task_key(
+    task_group: &str,
+    start_time_ms: i64,
+    priority: u8,
+    job_id: &str,
+    attempt: u32,
+    epoch_ms: i64,
+) -> Vec<u8> {
+    encode_with_prefix(
+        prefix::TASK,
+        &(
+            task_group,
+            start_time_ms.max(0) as u64,
+            priority,
+            job_id,
+            attempt,
+            epoch_ms.max(0) as u64,
+        ),
+    )
+}
+
+/// Prefix that uniquely identifies the at-most-one live task for a given
+/// `(task_group, start_time_ms, priority, job_id, attempt)`, omitting the
+/// trailing `epoch_ms`. Scanning `[P, end_bound(P))` yields that single task
+/// regardless of which `epoch_ms` it carries — the lookup path for callers that
+/// know a task's identity but not its (write-only) epoch.
+pub fn task_key_lookup_prefix(
     task_group: &str,
     start_time_ms: i64,
     priority: u8,
@@ -266,6 +298,8 @@ pub struct ParsedTaskKey {
     pub priority: u8,
     pub job_id: String,
     pub attempt: u32,
+    /// Write-time disambiguator; see [`task_key`]. Not part of task identity.
+    pub epoch_ms: u64,
 }
 
 /// Parse a task key back to its components.
@@ -273,14 +307,21 @@ pub fn parse_task_key(key: &[u8]) -> Option<ParsedTaskKey> {
     if key.first() != Some(&prefix::TASK) {
         return None;
     }
-    let (task_group, start_time_ms, priority, job_id, attempt): (String, u64, u8, String, u32) =
-        decode(&key[1..]).ok()?;
+    let (task_group, start_time_ms, priority, job_id, attempt, epoch_ms): (
+        String,
+        u64,
+        u8,
+        String,
+        u32,
+        u64,
+    ) = decode(&key[1..]).ok()?;
     Some(ParsedTaskKey {
         task_group,
         start_time_ms,
         priority,
         job_id,
         attempt,
+        epoch_ms,
     })
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -2333,8 +2333,8 @@ impl Scan for TasksScanner {
                     ..
                 } => {
                     let start = if let Some(lower) = start_time_lower {
-                        // Encode a key with the lower time bound (priority=0, empty job_id, attempt=0)
-                        crate::keys::task_key(task_group, *lower, 0, "", 0)
+                        // Encode a key with the lower time bound (priority=0, empty job_id, attempt=0, epoch=0)
+                        crate::keys::task_key(task_group, *lower, 0, "", 0, 0)
                     } else {
                         crate::keys::task_group_prefix(task_group)
                     };

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -726,7 +726,7 @@ mod inflight_release_tests {
             held_queues: vec![],
             task_group: "tg".to_string(),
         };
-        let key = crate::keys::task_key("tg", 1, 0, job_id, 1);
+        let key = crate::keys::task_key("tg", 1, 0, job_id, 1, 1);
         let decoded = decode_task_validated(encode_task(&task)).expect("decode task");
         BrokerTask { key, decoded }
     }

--- a/summary.md
+++ b/summary.md
@@ -1,0 +1,432 @@
+# Lifecycle of a job in silo: `[Concurrency, FloatingConcurrency]`, not immediately grantable
+
+A naming correction up front, since it changes how you read everything below: there is **no `GrantOutcome` enum**. The concurrency layer returns `RequestTicketOutcome` (`src/concurrency.rs:210`); the shard chain-walker has a tiny internal `GrantResult { Granted, Queued }` (`src/job_store_shard/enqueue.rs:75`). Your instinct ("it does `GrantOutcome::Queued`") maps to the chain-walker's `GrantResult::Queued`, produced when the concurrency layer returns `RequestTicketOutcome::TicketRequested`.
+
+Also key to the whole trace: **limits are walked in client order, one at a time, and the walk stops at the first limit that can't be granted.** Each granted limit writes its own holder; only when *all* limits are satisfied does a terminal `RunAttempt` task get written. So with `[Concurrency, FloatingConcurrency]` and the concurrency limit full, the walk stops at index 0 and the floating limit is never even looked at yet.
+
+---
+
+## 1. The enqueue RPC — what gets written, and the `Queued` outcome
+
+The gRPC handler is `src/server.rs:812`. It converts proto limits into domain `Limit`s **preserving client order**, then calls `shard.enqueue(...)`:
+
+```rust
+// src/server.rs:812
+let limits: Vec<crate::job::Limit> = r.limits.into_iter()
+    .filter_map(proto_limit_to_job_limit).collect();
+let id = shard.enqueue(&tenant, /*id*/, r.priority as u8, r.start_at_ms,
+                       retry, payload_bytes, limits, metadata, &r.task_group).await?;
+```
+
+`shard.enqueue` (`src/job_store_shard/enqueue.rs:144`) writes the **durable job facts** via `write_enqueue_data` (`enqueue.rs:359`), in one `WriteBatch` (auto-UUID) or `SerializableSnapshot` txn (caller-supplied id, with a dedup check):
+
+- `job_info_key(tenant, job_id)` → encoded `JobInfo`, **including the full `limits` list** (`enqueue.rs:396`). This is the record everything later reads back from.
+- metadata secondary-index rows (`enqueue.rs:400`).
+- `JobStatus::scheduled(...)` plus its status-time index (`enqueue.rs:404`).
+- a total-jobs counter bump, and a two-phase `DstEvent::JobEnqueued`.
+
+Then, in the *same* batch, it begins the **limit chain walk** at `limit_index: 0` — this is where tickets/holders get written.
+
+**The chain walker** is `walk_limit_chain` (`enqueue.rs:514`). The control structure is the spine of the whole system:
+
+```rust
+// src/job_store_shard/enqueue.rs:561
+loop {
+    if current_index >= limits.len() {
+        // No more limits - enqueue RunAttempt
+        let run_task = Task::RunAttempt { id: current_task_id, tenant, job_id,
+            attempt_number, relative_attempt_number,
+            held_queues: current_held_queues, task_group };
+        put_task(writer, task_group, task_key_start_ms, priority, job_id, attempt_number, &run_task)?;
+        return Ok(Some(task_key_start_ms));
+    }
+    match &limits[current_index] {
+        Limit::Concurrency(cl) => { /* try immediate grant */ }
+        Limit::FloatingConcurrency(fl) => { /* ... */ }
+        Limit::RateLimit(rl) => { /* write CheckRateLimit task, return */ }
+    }
+}
+```
+
+- The `if current_index >= limits.len()` branch is the **terminal exit**: only reached when every limit has been granted; it writes the `RunAttempt` and stops. This is the single place a `RunAttempt` is born.
+- Otherwise it dispatches on the limit *at the current index* — the walk is strictly ordered and resumable, because `current_index` is a direct index into the persisted `limits` array.
+
+For your scenario, `current_index = 0` hits `Limit::Concurrency(cl)` (`enqueue.rs:586`). It calls `handle_enqueue` with **a single-element slice** `std::slice::from_ref(cl)` (`enqueue.rs:601`) — that's why `handle_enqueue` only ever gates on `limits.first()`.
+
+Inside `handle_enqueue` (`src/concurrency.rs:958`), the not-grantable decision:
+
+```rust
+// src/concurrency.rs:1013
+if !skip_try_reserve
+    && self.counts.try_reserve(db, range, tenant, queue, task_id, max_allowed, job_id).await?
+{
+    if scheduled_at_ms > now_ms { self.rollback_grant(tenant, queue, task_id); }
+    else { /* GrantedImmediately: append_grant_edits + return */ }
+}
+if scheduled_at_ms <= now_ms {
+    // src/concurrency.rs:1054  Queue is at capacity → create request record
+    append_request_edits(writer, tenant, queue, scheduled_at_ms, priority, job_id,
+        attempt_number, relative_attempt_number, task_group,
+        limit_index, held_queues, task_id, all_limits)?;
+    Ok(Some(RequestTicketOutcome::TicketRequested { queue: queue.clone() }))
+}
+```
+
+- `try_reserve` is the atomic capacity gate. Since the queue is full, it returns `false`, so the whole `if` is skipped.
+- `scheduled_at_ms <= now_ms` (present-time job at capacity) → `append_request_edits` writes a **request record** and returns `TicketRequested`. **This is your "Queued" path.** (If the job were future-scheduled, the `else` branch writes a `Task::RequestTicket` into the task queue instead, returning `FutureRequestTaskWritten`.)
+
+**Where the request ticket is written** — `append_request_edits` (`src/concurrency.rs:2044`):
+
+```rust
+// src/concurrency.rs:2059
+let action = ConcurrencyAction::EnqueueTask {
+    start_time_ms, priority, job_id, attempt_number, relative_attempt_number,
+    task_group, limit_index, held_queues, task_id, limits: all_limits };
+let req_key = concurrency_request_key(tenant, queue, start_time_ms, priority, job_id, attempt_number, &suffix);
+writer.put(&req_key, &encode_concurrency_action(&action))?;
+writer.merge(&concurrency_requester_counter_key(tenant, queue), encode_counter(1))?;
+```
+
+- The **keyspace is `CONCURRENCY_REQUEST`, prefix byte `0x08`** (`src/keys.rs:23`). Key ordering is `(tenant, queue, start_time_ms, priority, job_id, attempt_number, suffix)` (`concurrency_request_key`, `keys.rs:350`) — so requests in a queue sort by start-time then priority, which is the grant order.
+- Critically, the value `ConcurrencyAction::EnqueueTask` **carries `limit_index`, `held_queues`, `task_id`, and the full `limits` list**. That's the entire state needed to *resume the chain* later without re-reading `JobInfo`.
+- A per-queue requester counter (`COUNTER_CONCURRENCY_REQUESTERS`, `0xF7`) is bumped so the system knows the queue has waiters.
+
+So to answer Q1 directly: yes — `RequestTicketOutcome::TicketRequested` → `GrantResult::Queued`, and a request record is written to the **`CONCURRENCY_REQUEST` (0x08) keyspace**, *not* to the task broker. The chain-walker then returns early (`enqueue.rs:630–637`); the floating limit is untouched.
+
+---
+
+## 2. What dequeues that request ticket and re-attempts the grant
+
+The present-time request record (0x08) is **not** picked up by the broker. It is drained by a dedicated **grant scanner** that wakes when a holder frees up. The loop is `start_grant_scanner` (`src/concurrency.rs:1378`):
+
+```rust
+// src/concurrency.rs:1390
+loop {
+    mgr.grant_notify.notified().await;            // woken by request_grant()
+    ...
+    for (_key, (tenant, queue, count)) in work {
+        let groups = mgr.process_grants(&db, &range, &tenant, &queue, count).await;
+        granted_groups.extend(groups);
+    }
+    if !granted_groups.is_empty() { brokers.wakeup_groups(&granted_groups); }
+}
+```
+
+- The scanner blocks on `grant_notify`. It's nudged by `request_grant` → `request_grant_count` (`concurrency.rs:1353`), which is called whenever a holder is released (more on that in Q9). `count` is how many slots opened up.
+- `process_grants` (`concurrency.rs:1496`) scans the `concurrency_request_prefix(tenant, queue)` range and grants up to `count` of the oldest requests. For a **plain concurrency limit**, "granting" means: `try_reserve` a slot, write the holder, delete the request record, and **resume the chain at `limit_index + 1`** so the next limit (or the terminal RunAttempt) gets processed. After granting, it wakes the affected task-group brokers.
+
+(There's a second dequeue path for *future-scheduled* `Task::RequestTicket`s — those go through the broker's `handle_request_ticket`, `src/job_store_shard/dequeue.rs:639`. Same shape: `capacity_for_queue` → `try_reserve` → holder → chain continuation. I cover its continuation mechanics in Q7 because that's where the tombstone subtlety lives.)
+
+---
+
+## 3. Where the holder is written, and how it's reserved in memory
+
+**Two-layer reservation.** A grant is *first* reserved in memory (atomically, to win the race), *then* persisted as a durable holder row in the same batch.
+
+**In-memory reservation** lives in `ConcurrencyCounts.queues`, a `DashMap<(tenant, queue), QueueEntry>` where each `QueueEntry` holds a `HashSet<String>` of `task_id`s:
+
+```rust
+// src/concurrency.rs:243
+struct QueueEntry { state: HydrationState, holders: HashSet<String> }
+// src/concurrency.rs:277
+pub struct ConcurrencyCounts { queues: Arc<DashMap<QueueKey, QueueEntry>>, ... }
+```
+
+The reservation itself is `try_reserve_internal` (`concurrency.rs:486`), executed under the DashMap shard lock so check-and-insert is atomic:
+
+```rust
+// src/concurrency.rs:486
+let mut entry = self.queues.entry(key).or_insert_with(QueueEntry::new);
+if entry.holders.len() >= limit { return false; }   // at capacity → caller queues
+entry.holders.insert(task_id.to_string());          // reserve the slot
+```
+
+- This is the TOCTOU-safe gate: capacity check and slot insert happen as one critical section. A `true` means *you own a slot*; the caller must now make it durable or roll it back.
+
+**Durable holder row** — written to the **`CONCURRENCY_HOLDER` keyspace, prefix `0x09`** (`keys.rs:24`), keyed `(tenant, queue, task_id)` (`concurrency_holder_key`, `keys.rs:449`). Value is a `HolderRecord { granted_at_ms }` (`task.rs:144`). The grant-scanner / dequeue write site:
+
+```rust
+// src/job_store_shard/dequeue.rs:751
+let holder_val = encode_holder(&HolderRecord { granted_at_ms: now_ms });
+state.batch.put(concurrency_holder_key(&tenant, &queue, &task_id), &holder_val);
+```
+
+- The `task_id` keying matters: **all holders in a chain share the one `task_id`**, so when the job finishes, every held queue's holder can be deleted by that single id (and the chain's earlier grants never orphan when a later limit is granted in a different code path).
+- The pairing of in-memory `holders.insert` + durable `0x09` put is what "reserved in memory" means: the `HashSet` is the source of truth for the live count; the `0x09` row is the durable mirror for crash recovery.
+
+---
+
+## 4. Floating concurrency — is a RefreshTask enqueued?
+
+Once the concurrency slot frees and the chain resumes to `current_index = 1`, the walker hits `Limit::FloatingConcurrency(fl)` (`enqueue.rs:641`). The important thing: **the floating limit grants synchronously against its *current* cached max — it never blocks on a refresh.** The refresh is a *separate, throttled, side-channel* to keep that max fresh.
+
+```rust
+// src/job_store_shard/enqueue.rs:643
+let state = self.get_or_create_floating_limit_state(writer, tenant, fl).await?;
+let refresh_ready = JobStoreShard::floating_limit_refresh_ready(&state, now_ms);
+let current_max = state.current_max_concurrency();
+let temp_cl = ConcurrencyLimit { key: fl.key.clone(), max_concurrency: current_max };
+let outcome = self.concurrency.handle_enqueue(/* ... */ std::slice::from_ref(&temp_cl), /* ... */).await?;
+```
+
+- `get_or_create_floating_limit_state` loads (or seeds) the floating state row. On cold creation it seeds `current_max_concurrency = fl.default_max_concurrency` (`src/job_store_shard/floating.rs:68`) — **this is the default you asked about in Q5: the floating limit always has a usable value on the immediate path, even before any refresh runs.**
+- It builds a *temporary* fixed `ConcurrencyLimit` from `current_max` and grants through the exact same `handle_enqueue` machinery as a normal concurrency limit. So floating concurrency is "ordinary concurrency with a periodically-updated ceiling."
+
+Then, conditionally, the refresh is scheduled:
+
+```rust
+// src/job_store_shard/enqueue.rs:687
+let mut has_waiters = matches!(outcome, Some(RequestTicketOutcome::TicketRequested { .. }));
+if refresh_ready && !has_waiters {
+    has_waiters = self.has_waiting_concurrency_requests(tenant, &fl.key).await?;
+}
+if refresh_ready {
+    self.maybe_schedule_floating_limit_refresh(writer, tenant, fl, &state, now_ms, task_group, has_waiters)?;
+}
+```
+
+- `refresh_ready` (`floating.rs:19`) gates on: no refresh already in flight, the refresh interval has elapsed, and not in backoff.
+- `maybe_schedule_floating_limit_refresh` (`floating.rs:89`) writes a **`Task::RefreshFloatingLimit` broker task** and flips `refresh_task_scheduled = true` on the state row so only one is ever outstanding:
+
+```rust
+// src/job_store_shard/floating.rs:119
+let refresh_task = Task::RefreshFloatingLimit { task_id, tenant, queue_key: fl.key.clone(),
+    current_max_concurrency: state.current_max_concurrency(),
+    last_refreshed_at_ms: state.last_refreshed_at_ms(), metadata: state.metadata(), task_group };
+let synthetic_job_id = format!("floating_refresh:{}", fl.key);
+let task_key_bytes = crate::keys::task_key(task_group, now_ms, 0 /*highest priority*/, &synthetic_job_id, 0);
+writer.put(&task_key_bytes, &task_value)?;
+let new_state = FloatingLimitState { refresh_task_scheduled: true, ..state.to_owned() };
+```
+
+So to answer Q4 directly: **yes, a `Task::RefreshFloatingLimit` is enqueued into the task broker** (prefix `0x05`, highest priority, synthetic job id) — but it is *orthogonal* to granting this job. This job grants against the existing `current_max`; the refresh just updates that number for *future* grants, and only when the interval has elapsed and there are waiters.
+
+---
+
+## 5. How the RefreshTask is leased; the "second RequestTicket" question
+
+The broker dequeue loop dispatches `RefreshFloatingLimit` → `handle_refresh_floating_limit` (`dequeue.rs:1072`). Leasing means: write a **lease record** keyed by the refresh task's id and delete the broker task, atomically:
+
+```rust
+// src/job_store_shard/dequeue.rs:1086
+let lease_key = leased_task_key(task_id);                     // LEASE keyspace, 0x06
+let record = LeaseRecord { worker_id, task, expiry_ms, started_at_ms: 0 };
+state.batch.put(&lease_key, &encode_lease(&record));
+state.batch.delete(task_key);
+...
+refresh_out.push(LeasedRefreshTask { task_id, tenant_id, queue_key,
+    current_max_concurrency, last_refreshed_at_ms, metadata, task_group });
+state.ack_deleted(task_key);
+```
+
+- The lease lives in the **`LEASE` keyspace, prefix `0x06`** (`keys.rs:21`), keyed by `task_id` (`leased_task_key`, `keys.rs:288`). Same leasing primitive used for run attempts.
+- The task is then surfaced to the worker over gRPC as a `RefreshFloatingLimitTask` (`server.rs:1212`). The worker computes the new ceiling and calls back `report_refresh_success` (`floating.rs:163`) or `report_refresh_failure` (`floating.rs:229`).
+- On success (`floating.rs:194`): the lease is deleted, the state row is updated (`current_max_concurrency = new_max`, `last_refreshed_at_ms = now`, `refresh_task_scheduled = false`), and the in-memory limit cache is updated. On failure: an exponential-backoff retry is scheduled, *only if there are still waiters*.
+
+**Your two sub-questions for Q5:**
+
+- *Is there another RequestTicket written after the floating limit is found?* **No.** The refresh round-trip only updates the floating *state row* + in-memory cache — it writes no request/ticket and does not re-enqueue the waiting job. Previously-queued requesters are admitted the normal way: when a holder frees, `request_grant` wakes the scanner, which re-reads the now-larger `current_max` via `capacity_for_queue` and grants.
+- *Is there a default floating value for the immediate path?* **Yes** — `fl.default_max_concurrency`, used in two places: it seeds a cold state row (`floating.rs:68`), and it's the fallback in `capacity_for_queue` if the state row is missing/undecodable (`concurrency.rs:933`):
+
+```rust
+// src/concurrency.rs:933
+Limit::FloatingConcurrency(fl) if fl.key == queue => {
+    let state_capacity = /* decode floating_limit_state_key(tenant, queue) */;
+    return (state_capacity.unwrap_or(fl.default_max_concurrency as usize),
+            ConcurrencyLimitType::Floating);
+}
+```
+
+---
+
+## 6. After the floating limit is granted — how the RunAttempt is written
+
+When the floating limit grants, `record_grant_outcome` pushes its `(queue, task_id)` into `grants`, appends the queue to `current_held_queues`, and **increments `current_index` to 2**. The `loop` re-enters, `current_index (2) >= limits.len() (2)` is now true, and the terminal branch fires — the **same** code shown in Q1:
+
+```rust
+// src/job_store_shard/enqueue.rs:564
+let run_task = Task::RunAttempt { id: current_task_id, tenant, job_id,
+    attempt_number, relative_attempt_number,
+    held_queues: current_held_queues, task_group };
+put_task(writer, task_group, task_key_start_ms, priority, job_id, attempt_number, &run_task)?;
+return Ok(Some(task_key_start_ms));
+```
+
+- `RunAttempt` is **not a struct — it's a `Task` enum variant** (`task.rs:14`) persisted as an ordinary task row. It carries `held_queues` = the accumulated list of every queue this chain holds (the concurrency queue *and* the floating queue), so cleanup later knows exactly which holders to release.
+- `put_task` (`helpers.rs:242`) encodes it and writes it under the **`TASK` keyspace, prefix `0x05`**, at `task_key(task_group, task_key_start_ms, priority, job_id, attempt)` (`keys.rs:232`). The time component is a plain ascending `u64`, so within a task group, tasks sort by ready-time.
+- Note `task_key_start_ms` here is `now_ms` on a resumed chain (not the original `scheduled_at_ms`) — that +1-style bump is exactly the tombstone-dodge described in Q7.
+
+The `RunAttempt` row is the handoff from the *limit/concurrency* subsystem to the *execution/broker* subsystem.
+
+---
+
+## 7. What dequeues the RunAttempt into the task broker — and why tombstones
+
+The **task broker** (`src/task_broker.rs:38`, one per task group) is an in-memory buffer fed by a background scanner that prefix-scans the `TASK` keyspace. Writing the `RunAttempt` row does **not** push it to the broker directly; the scanner discovers it.
+
+**Buffer + scan:**
+
+```rust
+// src/task_broker.rs:44
+buffer: Arc<SkipMap<Vec<u8>, BrokerTask>>,
+```
+
+```rust
+// src/task_broker.rs:130 (scan_tasks)
+let start = task_group_prefix(&self.task_group);
+let mut iter = self.db.scan_with_options(start..end_bound(&start), ...).await?;
+...
+let Some(parsed_key) = parse_task_key(&kv.key) else { continue; };
+if parsed_key.start_time_ms > now_ms as u64 { break; }    // skip not-yet-ready
+if self.buffer.get(&key_bytes).is_none() { self.buffer.insert(key_bytes, entry); }
+```
+
+- The scanner walks `TASK/<task_group>/…` in key order, drops future-dated rows, and inserts ready ones into the sorted skiplist `buffer`. It runs with hysteresis (refill below 4096, stop at 8192) and is nudged early via `wakeup()` after an enqueue. So: `put_task` writes the row → scanner finds it → it lands in the buffer as a `BrokerTask`.
+
+**Why tombstones are needed.** SlateDB is an LSM store. When a worker claims a task and durably **deletes** its key, a concurrent or slightly-stale broker scan can still observe the just-deleted key (the delete may not have compacted over the old value yet). Without protection, the scanner would re-insert an already-leased task and it would be dispatched **twice**. The broker keeps **in-memory tombstones** (not DB tombstones) to suppress re-insert for a bounded window:
+
+```rust
+// src/task_broker.rs:47
+ack_tombstones: Arc<Mutex<HashMap<Vec<u8>, u64>>>,
+```
+
+```rust
+// src/task_broker.rs:183 (inside scan)
+let suppress_due_to_tombstone = {
+    let mut tombstones = self.ack_tombstones.lock().unwrap();
+    if let Some(last_seen_generation) = tombstones.get_mut(&key_bytes) {
+        *last_seen_generation = generation; true     // refresh → extend suppression
+    } else { false }
+};
+if suppress_due_to_tombstone { skipped_tombstone += 1; continue; }
+```
+
+- A tombstone is installed only on a **durable delete**, recorded via `ack_deleted` (which appends to both `release_keys` and `tombstone_keys`), versus `ack_release` (release-only, no tombstone — used when a ticket is *left in place* to be re-scanned). See `dequeue.rs:55`.
+
+**The chain-continuation gotcha.** A `task_key` is `(task_group, start_time_ms, priority, job_id, attempt_number)`. A chain continuation keeps *every* component constant except `start_time_ms`. So a follow-up task written at the **same** `start_time_ms` as the just-tombstoned parent would be silently suppressed — stranding the holders just granted. The fix bumps the follow-up's time past the parent (`dequeue.rs:778`):
+
+```rust
+// src/job_store_shard/dequeue.rs:778
+let parent_start_time_ms = parse_task_key(task_key).map(|p| p.start_time_ms as i64).unwrap_or(now_ms);
+let new_task_key_start_ms = now_ms.max(parent_start_time_ms + 1);
+```
+
+- `now_ms` *usually* already exceeds the parent's `start_time_ms`, but a worker processing a future-scheduled ticket in the same millisecond it becomes ready could collide — hence `max(parent + 1)` makes the dodge unconditional. (This is the "trailing task_key `epoch_ms`"; the field is named `start_time_ms` in `task_key`.)
+
+---
+
+## 8. How a job is leased from the broker buffer
+
+Two stages: an **in-memory claim** from the skiplist, then a **durable lease write**.
+
+**Claim from buffer** — `claim_ready` (`task_broker.rs:395`): walk the sorted skiplist, mark each key `inflight`, remove it from the buffer:
+
+```rust
+// src/task_broker.rs:395
+for entry in self.buffer.iter() {
+    if keys.len() >= max { break; }
+    if inflight.contains(entry.key()) { continue; }
+    inflight.insert(entry.key().clone());
+    keys.push(entry.key().clone());
+}
+...
+for key in candidate_keys { if let Some(entry) = self.buffer.remove(&key) { claimed.push(entry.value().clone()); } }
+```
+
+- The `inflight` set prevents the scanner from re-buffering a task that's mid-dequeue (complementing the tombstone, which covers the post-delete window).
+
+**Drive loop + durable lease** — `dequeue` (`dequeue.rs:289`) claims a batch (`claim_ready_or_nudge`, `dequeue.rs:331`), wraps it in a cancellation-safe `ClaimedInflightGuard`, dispatches `RunAttempt → handle_run_attempt`, commits durably (`await_durable: true`), then `ack_durable` installs tombstones + evicts. `handle_run_attempt` deletes the task key and writes three durable records (`write_lease_and_attempt`, `dequeue.rs:582`):
+
+```rust
+// src/job_store_shard/dequeue.rs:582
+let lease_key = leased_task_key(task_id);                              // LEASE 0x06
+batch.put(&lease_key, &encode_lease(&LeaseRecord { worker_id, task, expiry_ms, started_at_ms: now_ms }));
+self.set_job_status_with_index(..., JobStatus::running(now_ms)).await?; // JOB_STATUS
+batch.put(&attempt_key(tenant, job_id, attempt_number), &encode_attempt(&attempt)); // ATTEMPT 0x07
+```
+
+- The lease (`0x06`, keyed by `task_id`) is what a worker crash recovery and `report_outcome` later look up. Default lease is `DEFAULT_LEASE_MS = 10_000` (`task.rs:10`); expiry `now_ms + 10s`. The job status flips to `running`, and an `ATTEMPT` row (`0x07`) records this attempt. After commit, the task becomes a `LeasedTask` (tenant + `JobView` + `JobAttemptView`) returned to the worker.
+
+A lease reaper (`reap_expired_leases`) sweeps leases past expiry and synthesizes a `WORKER_CRASHED` error outcome — feeding the same failure path as Q9.
+
+---
+
+## 9. `report_outcome` — success and failure
+
+The RPC is `report_outcome` (`server.rs:1249`), mapping proto outcome → `AttemptOutcome::{Success, Error, Cancelled}` (`job_attempt.rs:11`) and delegating to `report_attempt_outcome` (`src/job_store_shard/lease.rs:93`). It loads the lease (errors `LeaseNotFound` if gone — which triggers a self-heal of orphaned holders), and **always** starts the batch by deleting the lease:
+
+```rust
+// src/job_store_shard/lease.rs:161
+batch.delete(&leased_task_key);
+```
+
+**Success** (`lease.rs:176`):
+
+```rust
+AttemptOutcome::Success { .. } => {
+    let job_status = JobStatus::succeeded(now_ms);
+    terminal_expire_ts = self.terminal_expire_ts(JobStatusKind::Succeeded, now_ms);
+    self.set_job_status_with_index_opts(..., job_status, terminal_expire_ts).await?;
+    self.increment_completed_jobs_counter(...)?;
+    reached_terminal = true;
+}
+```
+
+- Lease deleted, job status → `Succeeded` (with a terminal TTL `completed_job_expire_s`), completed-jobs counter bumped, and a terminal `Succeeded` `ATTEMPT` row written with `Ttl::ExpireAt`. `reached_terminal` triggers `expire_terminal_job_records` to stamp the TTL on `JobInfo`/metadata/prior attempts. (Cancelled is structurally identical.)
+
+**Failure** (`lease.rs:216`) — the "bump an attempt, maybe make a new RunAttempt" path:
+
+```rust
+// src/job_store_shard/lease.rs:239
+let next_attempt_number = attempt_number + 1;
+let next_relative_attempt_number = relative_attempt_number + 1;
+let next_task_id = Uuid::new_v4().to_string();
+retry_grants = self.enqueue_limit_task_at_index(..., LimitTaskParams {
+    attempt_number: next_attempt_number,
+    relative_attempt_number: next_relative_attempt_number,
+    limit_index: 0,
+    limits: &limits,
+    scheduled_at_ms: next_time, task_key_start_ms: next_time,
+    held_queues: Vec::new(),       // retry re-acquires all tickets from scratch
+    skip_try_reserve: true,        // old holder still in memory → must queue
+}).await?.grants;
+let job_status = JobStatus::scheduled(now_ms, next_time, next_attempt_number);
+```
+
+- If the retry policy yields a `next_time` (`retry::next_retry_time_ms`), the attempt counter is bumped (`+1`), a **fresh `task_id`** is minted, and the **whole limit chain is re-walked from `limit_index: 0`** — so the retry must re-acquire both the concurrency and floating holders from scratch (`held_queues: Vec::new()`). Job status goes back to `Scheduled(n+1)`; the job is *not* terminal.
+- `skip_try_reserve: true` is the subtle invariant: the *current* attempt's holders are still in memory (released only post-commit, below), so the retry can't grab an immediate grant or it would double-count the slot. It is forced through the request queue. This is why `walk_limit_chain` consumes the flag with `std::mem::replace(&mut skip_try_reserve, false)` after the first limit — a compile-checked guard so no downstream limit silently bypasses its reservation.
+- If retries are exhausted (or no policy), job status → `Failed` (terminal, with TTL), completed counter bumped.
+
+**Holder release — identical for all outcomes** (outside the match). Durable delete in the batch, then in-memory release post-commit:
+
+```rust
+// src/job_store_shard/lease.rs:361
+for queue in &held_queues_local { batch.delete(concurrency_holder_key(&tenant, queue, task_id)); }
+// ... commit batch durably ...
+// src/job_store_shard/lease.rs:412 (post-commit)
+for queue in &held_queues_local {
+    self.concurrency.counts().atomic_release(&tenant, queue, task_id);   // free in-memory slot
+    self.concurrency.request_grant(&tenant, queue);                      // wake grant scanner
+}
+```
+
+- Every queue in `held_queues` (the concurrency queue **and** the floating queue) has its `0x09` holder row deleted and its in-memory `HashSet` slot freed via `atomic_release` (`concurrency.rs:568`).
+- Then `request_grant` (`concurrency.rs:1131`) wakes the grant scanner from Q2 — closing the loop, since the freed slot is exactly what lets the *next* queued requester be granted. This is the linkage between one job finishing and the next starting.
+
+---
+
+## The loop, in one breath
+
+`enqueue` writes `JobInfo` + walks limits → concurrency full ⇒ **request record** in `0x08`, walk stops → a holder frees, `request_grant` wakes the **grant scanner** → it grants the concurrency slot (in-memory `HashSet` + `0x09` holder), resumes the chain → **floating limit** grants against `current_max` (refreshed out-of-band by a throttled `RefreshFloatingLimit` broker task) → all limits held ⇒ terminal **`RunAttempt`** task written to `0x05` → broker **scanner** buffers it (tombstones guard against LSM re-reads; chain continuations bump `start_time_ms` to dodge them) → worker **claims + leases** it (`0x06` lease, `0x07` attempt, status→running) → **`report_outcome`**: success → terminal + holders released; failure → attempt bumped, new chain re-walked from index 0, holders released → release wakes the grant scanner for the next waiter.
+
+## Keyspace prefix reference
+
+| Prefix | Name | Key | Holds |
+|--------|------|-----|-------|
+| `0x05` | `TASK` | `(task_group, start_time_ms, priority, job_id, attempt)` | broker tasks (RunAttempt, RequestTicket, CheckRateLimit, RefreshFloatingLimit) |
+| `0x06` | `LEASE` | `(task_id)` | active leases |
+| `0x07` | `ATTEMPT` | `(tenant, job_id, attempt)` | per-attempt records |
+| `0x08` | `CONCURRENCY_REQUEST` | `(tenant, queue, start_time_ms, priority, job_id, attempt, suffix)` | queued request records |
+| `0x09` | `CONCURRENCY_HOLDER` | `(tenant, queue, task_id)` | durable holder rows |
+| `0x0B` | `FLOATING_LIMIT` | `(tenant, queue_key)` | floating-limit state |
+| `0xF7` | `COUNTER_CONCURRENCY_REQUESTERS` | `(tenant, queue)` | per-queue waiter counter |

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -718,10 +718,10 @@ async fn floating_concurrency_steady_state_zero_holders_after_full_cycle() {
 /// The original dodge bumped the task_key's `start_time_ms` to `now_ms`. That
 /// dodged the tombstone but shoved the holder-bearing RunAttempt to the back of
 /// the broker's start-time-ordered scan; under load a capped scan never reached
-/// it, so it never ran, never released its slot, and wedged the tenant
-/// (env-10000042940). The fix keeps the job's ORIGINAL `start_at_ms` as the
-/// task_key start time (so it sorts by its true schedule) and moves the dodge to
-/// the trailing write-only `epoch_ms`. See
+/// it, so it never ran, never released its slot, and wedged the tenant (the
+/// production back-of-queue wedge incident). The fix keeps the job's ORIGINAL
+/// `start_at_ms` as the task_key start time (so it sorts by its true schedule)
+/// and moves the dodge to the trailing write-only `epoch_ms`. See
 /// `project_broker_tombstone_chain_continuation`.
 ///
 /// This test pins both halves of that invariant: after a queued job is granted
@@ -844,7 +844,7 @@ async fn resume_chain_writes_run_attempt_at_original_start_with_fresh_epoch() {
         "resumed RunAttempt must keep the job's ORIGINAL start_at_ms as its \
          task_key start_time so it sorts by its true schedule — got start_time_ms={} \
          vs original={}. A regression to now_ms here re-introduces the \
-         back-of-queue leak (env-10000042940).",
+         back-of-queue leak (the production back-of-queue wedge incident).",
         b_start, original_enqueue_ms,
     );
     assert!(

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -355,7 +355,14 @@ async fn check_rate_limit_max_retries_releases_held_queues() {
         held_queues: vec![queue.to_string()],
         task_group: task_group.to_string(),
     };
-    let crl_key = task_key(task_group, now_ms(), priority, &job_id, attempt_number);
+    let crl_key = task_key(
+        task_group,
+        now_ms(),
+        priority,
+        &job_id,
+        attempt_number,
+        now_ms(),
+    );
     shard
         .db()
         .put(&crl_key, &encode_task(&crl))
@@ -448,7 +455,14 @@ async fn check_rate_limit_missing_job_info_releases_held_queues() {
         held_queues: vec![queue.to_string()],
         task_group: task_group.to_string(),
     };
-    let crl_key = task_key(task_group, now_ms(), priority, &job_id, attempt_number);
+    let crl_key = task_key(
+        task_group,
+        now_ms(),
+        priority,
+        &job_id,
+        attempt_number,
+        now_ms(),
+    );
     shard
         .db()
         .put(&crl_key, &encode_task(&crl))
@@ -693,29 +707,30 @@ async fn floating_concurrency_steady_state_zero_holders_after_full_cycle() {
     );
 }
 
-/// Regression test for the broker-tombstone collision in process_grants' chain
-/// resumer.
+/// Regression test for the broker-tombstone dodge in process_grants' chain
+/// resumer — and for the back-of-queue leak that the original dodge caused.
 ///
-/// Before the fix, `ShardChainResumer::resume_chain` re-emitted the resumed
-/// chain's `RunAttempt` task at `task_key(params.start_at_ms, …)` — the same
-/// task_key the original enqueue's chain had written (and the same batch had
-/// then deleted) when the job first queued. If the broker's scan happened to
-/// observe the interim RunAttempt before the delete won in the LSM, a worker
-/// could lease and ack-delete it, installing a tombstone for that task_key.
-/// The resumed chain's subsequent write at the same key was then silently
-/// suppressed, stranding the holders the resumer had just granted.
+/// `ShardChainResumer::resume_chain` re-emits the resumed chain's terminal
+/// `RunAttempt`. It must dodge the broker tombstone of any interim chain task
+/// that was claimed and ack-deleted at the same task_key — otherwise the write
+/// is silently suppressed and the holders the resumer just granted are stranded.
 ///
-/// The fix lands the resumed task at `task_key(now_ms, …)` so the broker
-/// tombstone for the original key cannot suppress it — mirroring the
-/// long-standing precedent in `handle_request_ticket`. See
+/// The original dodge bumped the task_key's `start_time_ms` to `now_ms`. That
+/// dodged the tombstone but shoved the holder-bearing RunAttempt to the back of
+/// the broker's start-time-ordered scan; under load a capped scan never reached
+/// it, so it never ran, never released its slot, and wedged the tenant
+/// (env-10000042940). The fix keeps the job's ORIGINAL `start_at_ms` as the
+/// task_key start time (so it sorts by its true schedule) and moves the dodge to
+/// the trailing write-only `epoch_ms`. See
 /// `project_broker_tombstone_chain_continuation`.
 ///
-/// This test pins down the simpler invariant the fix introduces: after a
-/// queued job is granted by `process_grants`, its terminal `RunAttempt` lives
-/// at a `task_key` whose `start_time_ms` is strictly greater than the job's
-/// original enqueue `start_at_ms`, provided enough wall-clock has passed.
+/// This test pins both halves of that invariant: after a queued job is granted
+/// by `process_grants`, its terminal `RunAttempt` lives at a `task_key` whose
+/// `start_time_ms` equals the original enqueue `start_at_ms`, while its
+/// `epoch_ms` is strictly greater (the tombstone dodge), provided enough
+/// wall-clock has passed.
 #[silo::test]
-async fn resume_chain_writes_run_attempt_at_now_not_original_start_at_ms() {
+async fn resume_chain_writes_run_attempt_at_original_start_with_fresh_epoch() {
     use silo::job::ConcurrencyLimit;
     use silo::keys::{parse_task_key, tasks_prefix};
 
@@ -794,7 +809,7 @@ async fn resume_chain_writes_run_attempt_at_now_not_original_start_at_ms() {
     // Poll for B's RunAttempt task to appear; the grant scanner runs
     // asynchronously after the release.
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    let mut b_task_start_time_ms: Option<u64> = None;
+    let mut b_task: Option<silo::keys::ParsedTaskKey> = None;
     while std::time::Instant::now() < deadline {
         let start = tasks_prefix();
         let end = silo::keys::end_bound(&start);
@@ -810,34 +825,37 @@ async fn resume_chain_writes_run_attempt_at_now_not_original_start_at_ms() {
             };
             // The leased Job A's task_key has already been ack-deleted, so any
             // surviving task at this point is Job B's resumed RunAttempt.
-            found = Some(parsed.start_time_ms);
+            found = Some(parsed);
             break;
         }
-        if let Some(t) = found {
-            b_task_start_time_ms = Some(t);
+        if found.is_some() {
+            b_task = found;
             break;
         }
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
     }
 
-    let b_start = b_task_start_time_ms
-        .expect("grant scanner failed to write Job B's RunAttempt within the deadline");
+    let b_task =
+        b_task.expect("grant scanner failed to write Job B's RunAttempt within the deadline");
+    let b_start = b_task.start_time_ms;
 
-    assert!(
-        b_start >= before_release_ms as u64,
-        "resumed chain must write at task_key(now_ms, …), not at the original \
-         enqueue's start_at_ms — got start_time_ms={} which is not >= now-at-release={}. \
-         A regression here re-introduces the broker-tombstone collision tracked in \
-         project_broker_tombstone_chain_continuation.",
-        b_start,
-        before_release_ms,
+    assert_eq!(
+        b_start, original_enqueue_ms as u64,
+        "resumed RunAttempt must keep the job's ORIGINAL start_at_ms as its \
+         task_key start_time so it sorts by its true schedule — got start_time_ms={} \
+         vs original={}. A regression to now_ms here re-introduces the \
+         back-of-queue leak (env-10000042940).",
+        b_start, original_enqueue_ms,
     );
     assert!(
-        b_start > original_enqueue_ms as u64,
-        "resumed RunAttempt's task_key still encodes the original enqueue time \
-         ({}), so any tombstone planted at that key would silently suppress this \
-         task — exactly the leak the fix is meant to prevent.",
-        original_enqueue_ms,
+        b_task.epoch_ms >= before_release_ms as u64,
+        "resumed RunAttempt must carry a fresh epoch_ms (the tombstone dodge) \
+         strictly past the interim task's epoch — got epoch_ms={} which is not \
+         >= now-at-release={}. Without this the broker tombstone for the \
+         interim key would silently suppress this task. See \
+         project_broker_tombstone_chain_continuation.",
+        b_task.epoch_ms,
+        before_release_ms,
     );
 
     let b_status = shard
@@ -849,7 +867,8 @@ async fn resume_chain_writes_run_attempt_at_now_not_original_start_at_ms() {
     assert_eq!(
         b_status.next_attempt_starts_after_ms,
         Some(b_start as i64),
-        "Scheduled status must point at the retargeted resumed RunAttempt key"
+        "Scheduled status must point at the resumed RunAttempt's start_time \
+         (the original schedule) so status-derived lookups locate it"
     );
 
     shard

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2668,6 +2668,160 @@ async fn two_concurrency_limits_chain_resumes_correctly() {
     );
 }
 
+/// Scan a task group's keyspace for the (single) pending RunAttempt task of
+/// `job_id` and return its parsed task key. Returns `None` if no such task is
+/// currently in the DB queue.
+async fn find_run_attempt_task_key(
+    shard: &std::sync::Arc<silo::job_store_shard::JobStoreShard>,
+    task_group: &str,
+    job_id: &str,
+) -> Option<silo::keys::ParsedTaskKey> {
+    let prefix = silo::keys::task_group_prefix(task_group);
+    let end = silo::keys::end_bound(&prefix);
+    let mut iter = shard
+        .db()
+        .scan_with_options::<Vec<u8>, _>(prefix..end, &silo::scan_options())
+        .await
+        .ok()?;
+    while let Ok(Some(kv)) = iter.next().await {
+        if let Ok(Task::RunAttempt { job_id: jid, .. }) = decode_task(&kv.value)
+            && jid == job_id
+        {
+            return silo::keys::parse_task_key(&kv.key);
+        }
+    }
+    None
+}
+
+/// Regression for the granted-RunAttempt back-of-queue leak (env-10000042940).
+///
+/// When the grant scanner resumes a waiting job's limit-chain, the terminal
+/// `RunAttempt` must be written at a task_key whose `start_time_ms` is the job's
+/// ORIGINAL scheduled time — not the grant time. The chain resumer historically
+/// bumped `task_key_start_ms` to `now_ms` to dodge the broker's ack tombstone,
+/// which shoved freshly-granted RunAttempts to the back of the broker's
+/// start-time-ordered scan. Behind a wall of old, ungrantable RequestTickets the
+/// capped scan never reached them, so they never ran, never released their
+/// holders, and wedged the whole tenant.
+#[silo::test]
+async fn granted_run_attempt_keeps_original_start_time() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    // Original schedule is well in the past, so a grant-time (now_ms) stamp is
+    // unmistakably distinguishable from the scheduled-time stamp.
+    let old_start = now_ms() - 3_600_000; // 1h ago
+    let queue_a = "oldstart-a".to_string();
+    let queue_b = "oldstart-b".to_string();
+    let limits = |n: i64| {
+        (
+            n,
+            vec![
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_a.clone(),
+                    max_concurrency: 1,
+                }),
+                Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: queue_b.clone(),
+                    max_concurrency: 1,
+                }),
+            ],
+        )
+    };
+
+    // job1 holds both A and B (both limits capped at 1).
+    let (_, l1) = limits(1);
+    let _job1 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            old_start,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            l1,
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue job1");
+    let job1_tasks = shard.dequeue("w1", "default", 1).await.unwrap().tasks;
+    assert_eq!(job1_tasks.len(), 1);
+    let job1_task_id = job1_tasks[0].attempt().task_id().to_string();
+
+    // job2 waits on A, scheduled at the SAME old start time.
+    let (_, l2) = limits(2);
+    let job2 = shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            old_start,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            l2,
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue job2");
+
+    // Release job1 — the grant scanner resumes job2's chain across A and B and
+    // writes job2's terminal RunAttempt into the task keyspace.
+    shard
+        .report_attempt_outcome(&job1_task_id, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report job1 success");
+
+    // Poll until job2's terminal RunAttempt appears in the DB (grant scanner is
+    // async). Inspect it in place — do NOT dequeue it, or it leaves the keyspace.
+    let mut parsed = None;
+    for _ in 0..50 {
+        if let Some(p) = find_run_attempt_task_key(&shard, "default", &job2).await {
+            parsed = Some(p);
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    let parsed = parsed.expect("job2's terminal RunAttempt should be written after job1 completes");
+
+    // THE INVARIANT: the granted RunAttempt keeps its original scheduled start
+    // time. Pre-fix this is ~now_ms (≈1h after old_start), pushing it to the
+    // back of the broker scan.
+    assert_eq!(
+        parsed.start_time_ms, old_start as u64,
+        "granted RunAttempt must keep the job's original scheduled start_time \
+         ({old_start}); got {} (≈grant time = back of the broker queue)",
+        parsed.start_time_ms
+    );
+
+    // Sanity: it must also actually be runnable and hold both queues.
+    let mut job2_tasks = vec![];
+    for _ in 0..50 {
+        let t = shard.dequeue("w2", "default", 1).await.unwrap().tasks;
+        if !t.is_empty() {
+            job2_tasks = t;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert_eq!(job2_tasks.len(), 1, "job2 should be dequeuable");
+    let job2_task_id = job2_tasks[0].attempt().task_id().to_string();
+    let lease_bytes = shard
+        .db()
+        .get(&silo::keys::leased_task_key(&job2_task_id))
+        .await
+        .expect("read lease")
+        .expect("lease present");
+    let held = silo::codec::decode_lease(lease_bytes)
+        .expect("decode lease")
+        .held_queues();
+    assert!(
+        held.iter().any(|q| q == &queue_a) && held.iter().any(|q| q == &queue_b),
+        "job2 must hold both A and B; got {:?}",
+        held
+    );
+}
+
 /// When the chain resumer hits a STILL-FULL downstream concurrency limit, it
 /// must write a fresh deferred request rather than fabricating a RunAttempt.
 /// The fresh request must carry the partial chain state (limit_index pointing

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2693,7 +2693,8 @@ async fn find_run_attempt_task_key(
     None
 }
 
-/// Regression for the granted-RunAttempt back-of-queue leak (env-10000042940).
+/// Regression for the granted-RunAttempt back-of-queue leak (the production
+/// back-of-queue wedge incident).
 ///
 /// When the grant scanner resumes a waiting job's limit-chain, the terminal
 /// `RunAttempt` must be written at a task_key whose `start_time_ms` is the job's

--- a/tests/job_store_shard_dequeue_tests.rs
+++ b/tests/job_store_shard_dequeue_tests.rs
@@ -607,6 +607,26 @@ async fn dequeue_ignores_recently_acked_task_keys() {
             .await
             .expect("enqueue");
 
+        // Capture the actual task key before dequeue. Its trailing `epoch_ms` is
+        // assigned at enqueue time (a write-only disambiguator), so we can't
+        // reconstruct it — read it from the queue so we reinject the SAME key the
+        // dequeue will ack-delete (and thus tombstone).
+        let real_key = {
+            let prefix = silo::keys::task_group_prefix("default");
+            let end = silo::keys::end_bound(&prefix);
+            let mut iter = shard
+                .db()
+                .scan::<Vec<u8>, _>(prefix..end)
+                .await
+                .expect("scan tasks");
+            iter.next()
+                .await
+                .expect("iter")
+                .expect("task present before dequeue")
+                .key
+                .to_vec()
+        };
+
         let first = shard
             .dequeue("worker-1", "default", 1)
             .await
@@ -631,10 +651,9 @@ async fn dequeue_ignores_recently_acked_task_keys() {
             task_group: "default".to_string(),
         };
         let task_bytes = encode_task(&reinjected);
-        let task_key = silo::keys::task_key("default", 0, 1, &job_id, 1);
 
         let mut batch = WriteBatch::new();
-        batch.put(&task_key, &task_bytes);
+        batch.put(&real_key, &task_bytes);
         shard
             .db()
             .write(batch)

--- a/tests/keys_tests.rs
+++ b/tests/keys_tests.rs
@@ -18,29 +18,36 @@ fn test_job_info_key_roundtrip() {
 
 #[test]
 fn test_task_key_roundtrip() {
-    let key = task_key("group1", 1000, 10, "job123", 1);
+    let key = task_key("group1", 1000, 10, "job123", 1, 1234);
     let parsed = parse_task_key(&key).unwrap();
     assert_eq!(parsed.task_group, "group1");
     assert_eq!(parsed.start_time_ms, 1000);
     assert_eq!(parsed.priority, 10);
     assert_eq!(parsed.job_id, "job123");
     assert_eq!(parsed.attempt, 1);
+    assert_eq!(parsed.epoch_ms, 1234);
 }
 
 #[test]
 fn test_task_key_ordering() {
-    // Tasks should sort by task_group, then time, then priority
-    let key1 = task_key("group1", 1000, 10, "job1", 1);
-    let key2 = task_key("group1", 1001, 10, "job2", 1);
-    let key3 = task_key("group1", 1000, 20, "job3", 1);
-    let key4 = task_key("group2", 500, 5, "job4", 1);
+    // Tasks should sort by task_group, then time, then priority. epoch_ms is the
+    // trailing field and must NOT perturb any of those orderings.
+    let key1 = task_key("group1", 1000, 10, "job1", 1, 9999);
+    let key2 = task_key("group1", 1001, 10, "job2", 1, 0);
+    let key3 = task_key("group1", 1000, 20, "job3", 1, 0);
+    let key4 = task_key("group2", 500, 5, "job4", 1, 0);
 
     // group1 < group2
     assert!(key1 < key4);
-    // Same group, earlier time comes first
+    // Same group, earlier time comes first (even with a larger epoch_ms)
     assert!(key1 < key2);
-    // Same group and time, lower priority comes first
+    // Same group and time, lower priority comes first (even with larger epoch_ms)
     assert!(key1 < key3);
+
+    // epoch_ms only breaks ties among otherwise-identical keys, and sorts last.
+    let early_epoch = task_key("group1", 1000, 10, "job1", 1, 100);
+    let late_epoch = task_key("group1", 1000, 10, "job1", 1, 200);
+    assert!(early_epoch < late_epoch);
 }
 
 #[test]
@@ -93,14 +100,14 @@ fn test_prefix_scanning() {
 
 #[test]
 fn test_task_group_prefix_scanning() {
-    let key1 = task_key("mygroup", 1000, 10, "job1", 1);
-    let key2 = task_key("mygroup", 2000, 20, "job2", 2);
+    let key1 = task_key("mygroup", 1000, 10, "job1", 1, 0);
+    let key2 = task_key("mygroup", 2000, 20, "job2", 2, 0);
     let prefix = task_group_prefix("mygroup");
 
     assert!(key1.starts_with(&prefix));
     assert!(key2.starts_with(&prefix));
 
-    let key3 = task_key("othergroup", 1000, 10, "job3", 1);
+    let key3 = task_key("othergroup", 1000, 10, "job3", 1, 0);
     assert!(!key3.starts_with(&prefix));
 }
 
@@ -427,9 +434,26 @@ fn test_parse_empty_slice_returns_none() {
 fn test_large_numeric_values() {
     // Test with large timestamp values near u64::MAX
     let large_time: i64 = i64::MAX;
-    let key = task_key("group", large_time, 255, "job", u32::MAX);
+    let key = task_key("group", large_time, 255, "job", u32::MAX, large_time);
     let parsed = parse_task_key(&key).unwrap();
     assert_eq!(parsed.start_time_ms, large_time as u64);
     assert_eq!(parsed.priority, 255);
     assert_eq!(parsed.attempt, u32::MAX);
+    assert_eq!(parsed.epoch_ms, large_time as u64);
+}
+
+#[test]
+fn test_task_key_lookup_prefix_matches_any_epoch() {
+    // The identity prefix (omitting epoch_ms) must be a proper prefix of the
+    // full key regardless of which epoch_ms the task carries — that's what lets
+    // status-driven lookups find a task without knowing its epoch.
+    let prefix = silo::keys::task_key_lookup_prefix("group1", 1000, 10, "job123", 1);
+    let key_a = task_key("group1", 1000, 10, "job123", 1, 0);
+    let key_b = task_key("group1", 1000, 10, "job123", 1, 9_999_999);
+    assert!(key_a.starts_with(&prefix));
+    assert!(key_b.starts_with(&prefix));
+
+    // A different identity must NOT match the prefix.
+    let other = task_key("group1", 1000, 10, "job124", 1, 0);
+    assert!(!other.starts_with(&prefix));
 }


### PR DESCRIPTION
## Problem

The wedge incident: a tenant wedged — every queue pinned at max holders, **0 running jobs**, holders 17–30h old and surviving restarts (durable, not in-memory ghosts).

When the grant scanner resumes a waiting job's limit-chain, the terminal `RunAttempt` was stamped into the broker at `now_ms` (grant time) instead of the job's original `scheduled_at_ms`, in order to dodge the broker **ack-tombstone** of the just-deleted predecessor `task_key`. Because it sorted at grant time, the granted RunAttempt landed at the **back** of the broker's `start_time_ms`-ascending order — behind the tenant's wall of old, ungrantable `RequestTicket`s.

The broker doesn't scan straight to dispatch: it refills an in-memory buffer (`target_buffer`, ordered by `start_time_ms` ascending) by re-scanning the task keyspace **from the front every generation**, and dispatches from the front of that buffer. So this wasn't a one-shot "capped scan stopped short" — it was steady-state starvation. The old `RequestTicket`s sit at the front (old `start_time`s) and never leave: a ticket whose queue is full fails to reserve and is *left in place* (`ack_release`, not deleted/tombstoned), so every generation re-buffers the same front-most wall. The broker spent its cycles endlessly re-dispatching those tickets — work that could never complete, because the slots they needed were held by the grant-time RunAttempt itself stranded *behind* the wall. With more than `target_buffer` live tickets ahead of it, the RunAttempt never entered the buffer → never ran → never released its concurrency holders → the wall stayed ungrantable → self-reinforcing wedge.

## Fix

Decouple the tombstone dodge from broker ordering by adding a trailing `epoch_ms` field to `task_key`:

```
(task_group, start_time_ms, priority, job_id, attempt, epoch_ms)
              ^^ = scheduled_at_ms (logical)            ^^ = now_ms-style dodge
```

- `start_time_ms` always equals the logical `scheduled_at_ms` (governs broker ordering) — so a granted RunAttempt sorts by its true schedule and stays reachable.
- `epoch_ms` is a **write-only** disambiguator (`now_ms`, or `now_ms.max(parent_epoch_ms + 1)` on a rewrite). It sorts last, so it never perturbs cross-job ordering or the scan's early-break.
- The deleted predecessor's tombstone stays intact for its real purpose (suppressing stale-scan re-inserts of a just-deleted interim).

### Who needs `epoch_ms` for lookups? Nobody — it's write-only
- The broker / dequeue / delete / ack path is already key-agnostic (it parses discovered keys and carries raw bytes).
- The four "reconstruct-exact-key + `get`" control-plane sites (expedite, cancel, lease_task, import) now use `helpers::find_task_by_identity` — a single-result prefix scan on the 5 identity fields (`keys::task_key_lookup_prefix`), omitting `epoch_ms`. Only one chain task is live per `(job, attempt)`, so the scan returns ≤1.

## Changes
- **`keys.rs`**: `epoch_ms` on `task_key` / `parse_task_key` / `ParsedTaskKey`; new `task_key_lookup_prefix`.
- **Write path**: replace `LimitTaskParams.task_key_start_ms` with `task_key_epoch_ms`; thread through `put_task`, `handle_enqueue`, `walk_limit_chain`, `limit_chain::resume_chain`, `handle_request_ticket`, `handle_check_rate_limit`, `schedule_rate_limit_retry`, and fresh-chain / refresh / restart / range-bound sites.
- **Read path**: the four point-lookup sites switch to `find_task_by_identity` prefix scans.

**Pre-launch:** old-layout task keys are flushed on deploy — no migration / decode fallback.

## Tests
- `granted_run_attempt_keeps_original_start_time` (concurrency suite) — **fails on `main`**, passes here. Verified the pre-fix key carried grant time (~1h after the original schedule).
- Rewrote `holder_leak` resume test → `resume_chain_writes_run_attempt_at_original_start_with_fresh_epoch` (asserts original start + a fresh epoch). The old test asserted the now-fixed buggy behavior.
- Fixed `dequeue_ignores_recently_acked_task_keys` to reinject the real key (it hardcoded `epoch=0`).
- Extended `keys_tests` for epoch ordering + the lookup prefix.

`cargo fmt`, `cargo check --tests`, and `cargo clippy --lib` are clean. Full suite green except `k8s_coordination_tests` (pre-existing environmental: `auth exec` binary absent).

