### PR TITLE
Fix gRPC decode limit on cluster query path (32MB)

### DIFF
--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -233,8 +233,8 @@ pub fn create_silo_client_lazy(
     let channel = endpoint.connect_lazy();
     let interceptor = AuthInterceptor::new(config.auth_token.clone());
     Ok(SiloClient::with_interceptor(channel, interceptor)
-        .max_decoding_message_size(128 * 1024 * 1024)
-        .max_encoding_message_size(128 * 1024 * 1024))
+        .max_decoding_message_size(32 * 1024 * 1024)
+        .max_encoding_message_size(32 * 1024 * 1024))
 }
 
 /// Helper to create a SiloClient with an eager connection and retry logic.
@@ -276,8 +276,8 @@ pub async fn create_silo_client(
             Ok(Ok(channel)) => {
                 let interceptor = AuthInterceptor::new(config.auth_token.clone());
                 return Ok(SiloClient::with_interceptor(channel, interceptor)
-                    .max_decoding_message_size(128 * 1024 * 1024)
-                    .max_encoding_message_size(128 * 1024 * 1024));
+                    .max_decoding_message_size(32 * 1024 * 1024)
+                    .max_encoding_message_size(32 * 1024 * 1024));
             }
             Ok(Err(e)) => {
                 trace!(

--- a/src/cluster_query.rs
+++ b/src/cluster_query.rs
@@ -665,7 +665,9 @@ async fn query_remote_shard_batches(
         };
 
         let interceptor = AuthInterceptor::new(auth_token.map(|s| s.to_string()));
-        let mut client = SiloClient::with_interceptor(channel, interceptor);
+        let mut client = SiloClient::with_interceptor(channel, interceptor)
+            .max_decoding_message_size(32 * 1024 * 1024)
+            .max_encoding_message_size(32 * 1024 * 1024);
 
         // Make streaming query
         let request = QueryArrowRequest {

--- a/src/server.rs
+++ b/src/server.rs
@@ -2129,8 +2129,8 @@ where
     let svc = SiloService::new(factory.clone(), coordinator, cfg.clone(), metrics.clone());
     let interceptor = make_auth_interceptor(cfg.server.auth_token.clone());
     let silo_server = SiloServer::new(svc)
-        .max_decoding_message_size(128 * 1024 * 1024)
-        .max_encoding_message_size(128 * 1024 * 1024);
+        .max_decoding_message_size(32 * 1024 * 1024)
+        .max_encoding_message_size(32 * 1024 * 1024);
     let server = tonic::service::interceptor::InterceptedService::new(silo_server, interceptor);
 
     // Create health service for gRPC health probes


### PR DESCRIPTION
## Problem

Loading the tenant UI failed with:

```
Waiting jobs query failed: External error: status: OutOfRange,
message: "Error, decoded message length too large: found 5617293 bytes, the limit is: 4194304 bytes"
```

`4194304` is tonic's **default 4MB** message limit. The tenant UI's "Waiting jobs" query fans out to remote shards via the `QueryArrow` RPC through `ClusterQueryEngine`. The client for that call (`cluster_query.rs`) was constructed **without** the `max_decoding_message_size` / `max_encoding_message_size` overrides that every other `SiloClient` and the server already set — so it kept the 4MB default. A streamed Arrow batch above 4MB (a tenant with many waiting jobs) is rejected before decode, breaking the page.

## Fix

- Add the encode/decode size overrides to the remote-shard query client in `cluster_query.rs`, which was the missing site.
- Set the limit to **32MB** across all client and server construction sites (was 128MB) so client and server stay symmetric — `cluster_query.rs`, `cluster_client.rs` (2 sites), and `server.rs`.

32MB gives ample headroom over the ~5.6MB seen here while staying more conservative than the previous 128MB.

## Notes

`QueryArrow` is a streaming RPC; if a single tenant ever exceeds even 32MB per message, the right follow-up is server-side batch-size capping in the `query_arrow` handler rather than raising the limit again.

## Verification

`cargo fmt`, `cargo check --lib`, and `cargo clippy --lib` all pass clean.