### PR TITLE
Make grant-scanner throughput clamps configurable

### DIFF
--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -616,6 +616,8 @@ pub async fn clone_golden_shard(
             hydrate_all_at_startup: false,
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
+            grant_scanner_batch_size: silo::settings::DEFAULT_GRANT_SCANNER_BATCH_SIZE,
+            grant_scanner_buffer_size: silo::settings::DEFAULT_GRANT_SCANNER_BUFFER_SIZE,
         },
         ShardRange::full(),
     )

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -166,23 +166,6 @@ impl From<crate::codec::CodecError> for ConcurrencyError {
     }
 }
 
-/// Max in-flight `db.get(job_status_key)` lookups during a single
-/// `process_grants` pass. Caps slatedb-side block-fetch fan-out so the
-/// scanner can't pin unbounded `Bytes` while validating a large pending
-/// backlog. Mirrors the `CONCURRENCY = 64` pattern used in
-/// `job_store_shard::get_jobs_status_batch` for the same reason.
-const STATUS_LOOKUP_CONCURRENCY: usize = 64;
-
-/// Max grants written in a single `process_grants` pass. A single
-/// `request_grant_count` accumulation can be arbitrarily large (every
-/// release between scanner wakeups adds to it), and without a per-pass
-/// cap the scanner would materialize `count` `ScannedRequest`s, issue
-/// `count` buffered status gets, and accumulate `count` edits in a
-/// single `WriteBatch` before committing. Capping per pass bounds peak
-/// memory; the outer loop iterates as many passes as needed to drain
-/// the requested count.
-const MAX_GRANTS_PER_PASS: usize = 256;
-
 fn concurrency_queue_for_limit(limit: &Limit) -> Option<&str> {
     match limit {
         Limit::Concurrency(cl) => Some(&cl.key),
@@ -831,6 +814,24 @@ pub struct ConcurrencyManager {
     /// `take_chain_resumer_for_test` to exercise the not-installed bailout
     /// path; production code calls `set_chain_resumer` once and never clears.
     chain_resumer: Mutex<Option<Arc<dyn LimitChainResumer>>>,
+    /// Max grants written in a single `process_grants` pass. A single
+    /// `request_grant_count` accumulation can be arbitrarily large (every
+    /// release between scanner wakeups adds to it), and without a per-pass
+    /// cap the scanner would materialize `count` `ScannedRequest`s, issue
+    /// `count` buffered status gets, and accumulate `count` edits in a
+    /// single `WriteBatch` before committing. Capping per pass bounds peak
+    /// memory; the outer loop iterates as many passes as needed to drain
+    /// the requested count. Configurable via `grant_scanner_batch_size`
+    /// (default 256); stored already clamped to `>= 1`.
+    grant_scanner_batch_size: usize,
+    /// Max in-flight `db.get(job_status_key)` lookups during a single
+    /// `process_grants` pass. Caps slatedb-side block-fetch fan-out so the
+    /// scanner can't pin unbounded `Bytes` while validating a large pending
+    /// backlog. Mirrors the `CONCURRENCY = 64` pattern used in
+    /// `job_store_shard::get_jobs_status_batch` for the same reason.
+    /// Configurable via `grant_scanner_buffer_size` (default 64); stored
+    /// already clamped to `>= 1`.
+    grant_scanner_buffer_size: usize,
 }
 
 impl ConcurrencyManager {
@@ -838,6 +839,8 @@ impl ConcurrencyManager {
         shard: impl Into<String>,
         metrics: Option<Metrics>,
         hydrate_all_at_startup: bool,
+        grant_scanner_batch_size: usize,
+        grant_scanner_buffer_size: usize,
     ) -> Self {
         Self {
             shard: shard.into(),
@@ -849,6 +852,10 @@ impl ConcurrencyManager {
             limit_cache: Mutex::new(HashMap::new()),
             metrics,
             chain_resumer: Mutex::new(None),
+            // Clamp to >= 1: a 0 batch would stall the drain loop and
+            // `.buffered(0)` is invalid.
+            grant_scanner_batch_size: grant_scanner_batch_size.max(1),
+            grant_scanner_buffer_size: grant_scanner_buffer_size.max(1),
         }
     }
 
@@ -1554,14 +1561,14 @@ impl ConcurrencyManager {
 
         // Scan→validate→grant loop: keeps pulling from the iterator until we've
         // granted `count` requests, or hit the end / capacity limit. Each pass
-        // scans up to `MAX_GRANTS_PER_PASS` candidates, validates them concurrently,
+        // scans up to `grant_scanner_batch_size` candidates, validates them concurrently,
         // reserves slots for valid ones, and commits the batch. Stale/corrupt entries
         // are cleaned up along the way. Bounding per-pass scan size caps peak memory
         // (the scanned Vec, buffered status results, and WriteBatch all scale with it),
         // so a large accumulated `count` is drained over multiple bounded passes
         // rather than one unbounded one.
         while total_granted < count as usize && !iter_exhausted && !capacity_exhausted {
-            let needed = (count as usize - total_granted).min(MAX_GRANTS_PER_PASS);
+            let needed = (count as usize - total_granted).min(self.grant_scanner_batch_size);
 
             let mut batch = WriteBatch::new();
             let mut grants: Vec<(String, String)> = Vec::new();
@@ -1753,7 +1760,7 @@ impl ConcurrencyManager {
             //
             // --- Batch validate status ---
             // Use `buffered` (order-preserving) rather than `join_all` so that
-            // we cap in-flight slatedb reads at STATUS_LOOKUP_CONCURRENCY. Each
+            // we cap in-flight slatedb reads at grant_scanner_buffer_size. Each
             // db.get() can fan out to many SST block fetches; with thousands of
             // pending requests, an unbounded join_all pinned multi-GB of Bytes.
             // `buffered` (not `buffer_unordered`) keeps results in scanned-order
@@ -1768,7 +1775,7 @@ impl ConcurrencyManager {
                     .into_iter()
                     .map(|key| async move { db.get(&key).await }),
             )
-            .buffered(STATUS_LOOKUP_CONCURRENCY)
+            .buffered(self.grant_scanner_buffer_size)
             .collect()
             .await;
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -193,6 +193,8 @@ impl ShardFactory {
                         ),
                         counter_reconciliation_seconds: template.counter_reconciliation_seconds,
                         hydrate_all_at_startup: template.hydrate_all_at_startup,
+                        grant_scanner_batch_size: template.grant_scanner_batch_size,
+                        grant_scanner_buffer_size: template.grant_scanner_buffer_size,
                         completed_job_expire_s: template.completed_job_expire_s,
                         terminal_job_expire_s: template.terminal_job_expire_s,
                     },

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -100,6 +100,12 @@ pub struct OpenShardOptions {
     /// Populated from `DatabaseConfig::hydrate_all_at_startup` /
     /// `DatabaseTemplate::hydrate_all_at_startup`; tests set it explicitly.
     pub hydrate_all_at_startup: bool,
+    /// Max grants the background grant scanner commits per `process_grants`
+    /// pass. Populated from `grant_scanner_batch_size` in the database config.
+    pub grant_scanner_batch_size: usize,
+    /// Max in-flight status lookups the grant scanner buffers per pass.
+    /// Populated from `grant_scanner_buffer_size` in the database config.
+    pub grant_scanner_buffer_size: usize,
     /// When set, jobs that reach Succeeded have their associated KV records
     /// re-put with a SlateDB row TTL of this many seconds. `None` disables
     /// the feature for successful jobs.
@@ -382,6 +388,8 @@ impl JobStoreShard {
                 ),
                 counter_reconciliation_seconds: cfg.counter_reconciliation_seconds,
                 hydrate_all_at_startup: cfg.hydrate_all_at_startup,
+                grant_scanner_batch_size: cfg.grant_scanner_batch_size,
+                grant_scanner_buffer_size: cfg.grant_scanner_buffer_size,
                 completed_job_expire_s: cfg.completed_job_expire_s,
                 terminal_job_expire_s: cfg.terminal_job_expire_s,
             },
@@ -422,6 +430,8 @@ impl JobStoreShard {
             concurrency_reconcile_interval,
             counter_reconciliation_seconds,
             hydrate_all_at_startup,
+            grant_scanner_batch_size,
+            grant_scanner_buffer_size,
             completed_job_expire_s,
             terminal_job_expire_s,
         } = options;
@@ -479,6 +489,8 @@ impl JobStoreShard {
             name.clone(),
             metrics.clone(),
             hydrate_all_at_startup,
+            grant_scanner_batch_size,
+            grant_scanner_buffer_size,
         ));
 
         // Eagerly hydrate the in-memory holders cache from durable storage so

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -186,6 +186,22 @@ fn default_hydrate_all_at_startup() -> bool {
     false
 }
 
+/// Default for `grant_scanner_batch_size`: max grants the scanner materializes,
+/// status-gets, and commits in a single `process_grants` pass.
+pub const DEFAULT_GRANT_SCANNER_BATCH_SIZE: usize = 256;
+
+fn default_grant_scanner_batch_size() -> usize {
+    DEFAULT_GRANT_SCANNER_BATCH_SIZE
+}
+
+/// Default for `grant_scanner_buffer_size`: max in-flight status lookups the
+/// scanner buffers concurrently within a single `process_grants` pass.
+pub const DEFAULT_GRANT_SCANNER_BUFFER_SIZE: usize = 64;
+
+fn default_grant_scanner_buffer_size() -> usize {
+    DEFAULT_GRANT_SCANNER_BUFFER_SIZE
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseTemplate {
     pub backend: Backend,
@@ -225,6 +241,19 @@ pub struct DatabaseTemplate {
     /// access. Defaults to false.
     #[serde(default = "default_hydrate_all_at_startup")]
     pub hydrate_all_at_startup: bool,
+    /// Max grants the background grant scanner materializes, status-checks, and
+    /// commits in a single `process_grants` pass. A single accumulated grant
+    /// request can be arbitrarily large; this caps peak per-pass memory, and the
+    /// scanner iterates as many passes as needed to drain the backlog. Defaults
+    /// to 256. Values below 1 are treated as 1.
+    #[serde(default = "default_grant_scanner_batch_size")]
+    pub grant_scanner_batch_size: usize,
+    /// Max in-flight job-status lookups the grant scanner buffers concurrently
+    /// within a single `process_grants` pass. Caps slatedb-side block-fetch
+    /// fan-out while the scanner validates a large pending backlog. Defaults to
+    /// 64. Values below 1 are treated as 1.
+    #[serde(default = "default_grant_scanner_buffer_size")]
+    pub grant_scanner_buffer_size: usize,
     /// When set, jobs that finished successfully (Succeeded) have all of their
     /// associated KV records re-put with a SlateDB row TTL expiring this many
     /// seconds in the future. `None` (the default) disables the behaviour for
@@ -285,6 +314,8 @@ impl Default for DatabaseTemplate {
             concurrency_reconcile_interval_ms: default_concurrency_reconcile_interval_ms(),
             counter_reconciliation_seconds: None,
             hydrate_all_at_startup: default_hydrate_all_at_startup(),
+            grant_scanner_batch_size: default_grant_scanner_batch_size(),
+            grant_scanner_buffer_size: default_grant_scanner_buffer_size(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             periodic_full_compaction_s: None,
@@ -547,6 +578,14 @@ pub struct DatabaseConfig {
     /// details. Defaults to false.
     #[serde(default = "default_hydrate_all_at_startup")]
     pub hydrate_all_at_startup: bool,
+    /// Max grants the grant scanner commits per `process_grants` pass. See
+    /// `DatabaseTemplate::grant_scanner_batch_size` for details. Defaults to 256.
+    #[serde(default = "default_grant_scanner_batch_size")]
+    pub grant_scanner_batch_size: usize,
+    /// Max in-flight status lookups the grant scanner buffers per pass. See
+    /// `DatabaseTemplate::grant_scanner_buffer_size` for details. Defaults to 64.
+    #[serde(default = "default_grant_scanner_buffer_size")]
+    pub grant_scanner_buffer_size: usize,
     /// TTL (seconds) applied to Succeeded jobs' associated records. See
     /// `DatabaseTemplate::completed_job_expire_s` for details.
     #[serde(default)]
@@ -579,6 +618,8 @@ impl Default for DatabaseConfig {
             apply_wal_on_close: default_apply_wal_on_close(),
             counter_reconciliation_seconds: None,
             hydrate_all_at_startup: default_hydrate_all_at_startup(),
+            grant_scanner_batch_size: default_grant_scanner_batch_size(),
+            grant_scanner_buffer_size: default_grant_scanner_buffer_size(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             slatedb: None,

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -571,6 +571,38 @@ concurrency_reconcile_interval_ms = 25
 }
 
 #[silo::test]
+fn parse_toml_grant_scanner_clamps_default() {
+    let toml_str = r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+"#;
+    let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
+    assert_eq!(
+        cfg.database.grant_scanner_batch_size, 256,
+        "missing grant_scanner_batch_size should use default"
+    );
+    assert_eq!(
+        cfg.database.grant_scanner_buffer_size, 64,
+        "missing grant_scanner_buffer_size should use default"
+    );
+}
+
+#[silo::test]
+fn parse_toml_with_custom_grant_scanner_clamps() {
+    let toml_str = r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+grant_scanner_batch_size = 8
+grant_scanner_buffer_size = 4
+"#;
+    let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
+    assert_eq!(cfg.database.grant_scanner_batch_size, 8);
+    assert_eq!(cfg.database.grant_scanner_buffer_size, 4);
+}
+
+#[silo::test]
 fn parse_toml_counter_reconciliation_seconds_defaults_off() {
     let toml_str = r#"
 [database]
@@ -622,6 +654,14 @@ path = "/tmp/silo-%shard%"
         from_default.counter_reconciliation_seconds,
         from_toml.database.counter_reconciliation_seconds
     );
+    assert_eq!(
+        from_default.grant_scanner_batch_size,
+        from_toml.database.grant_scanner_batch_size
+    );
+    assert_eq!(
+        from_default.grant_scanner_buffer_size,
+        from_toml.database.grant_scanner_buffer_size
+    );
     assert!(from_default.wal.is_none() && from_toml.database.wal.is_none());
     assert!(from_default.slatedb.is_none() && from_toml.database.slatedb.is_none());
     assert!(from_default.memory_cache.is_none() && from_toml.database.memory_cache.is_none());
@@ -649,6 +689,14 @@ path = "/tmp/silo-shard"
     assert_eq!(
         from_default.counter_reconciliation_seconds,
         from_toml.counter_reconciliation_seconds
+    );
+    assert_eq!(
+        from_default.grant_scanner_batch_size,
+        from_toml.grant_scanner_batch_size
+    );
+    assert_eq!(
+        from_default.grant_scanner_buffer_size,
+        from_toml.grant_scanner_buffer_size
     );
     assert!(from_default.wal.is_none() && from_toml.wal.is_none());
     assert!(from_default.slatedb.is_none() && from_toml.slatedb.is_none());

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2054,14 +2054,14 @@ async fn grant_scanner_interleaved_stale_and_valid_requests() {
 /// that drove production OOMs (heap profile showed ~5.5 GB pinned in
 /// `CachedObjectStore::read_part` from concurrent slatedb reads).
 ///
-/// Exercises the bounded `buffered(STATUS_LOOKUP_CONCURRENCY)` path with a
-/// pending backlog larger than the in-flight cap (currently 64). Verifies
+/// Exercises the bounded `buffered(grant_scanner_buffer_size)` path with a
+/// pending backlog larger than the in-flight cap (default 64). Verifies
 /// correctness — order-preserving validation must still pair each result
 /// with the right request — across more than one buffered batch.
 #[silo::test]
 async fn grant_scanner_handles_backlog_larger_than_status_lookup_concurrency() {
-    // Sized to be a multiple of STATUS_LOOKUP_CONCURRENCY (64) plus extras
-    // so we cross at least two buffered windows. Kept modest to keep the
+    // Sized to be a multiple of the default grant_scanner_buffer_size (64) plus
+    // extras so we cross at least two buffered windows. Kept modest to keep the
     // test fast while still beating the in-flight cap meaningfully.
     const N: usize = 200;
 
@@ -2132,7 +2132,7 @@ async fn grant_scanner_handles_backlog_larger_than_status_lookup_concurrency() {
 
     // One process_grants call should drain all N waiters. Internally this
     // runs the buffered status-lookup pipeline across multiple batches of
-    // up to STATUS_LOOKUP_CONCURRENCY (64) in-flight db.gets.
+    // up to grant_scanner_buffer_size (default 64) in-flight db.gets.
     let granted = shard
         .process_concurrency_grants(tenant, queue, N as u32)
         .await;
@@ -2151,7 +2151,7 @@ async fn grant_scanner_handles_backlog_larger_than_status_lookup_concurrency() {
     assert_eq!(count_concurrency_holders(shard.db()).await, N);
 }
 
-/// Regression test for `MAX_GRANTS_PER_PASS` bounding in `process_grants`.
+/// Regression test for `grant_scanner_batch_size` bounding in `process_grants`.
 ///
 /// A single `request_grant_count` accumulation can be arbitrarily large (every
 /// release between scanner wakeups adds to it). Without a per-pass cap, the
@@ -2159,7 +2159,7 @@ async fn grant_scanner_handles_backlog_larger_than_status_lookup_concurrency() {
 /// status gets, and accumulate `count` edits in one `WriteBatch` before
 /// committing. The cap forces the scanner to drain a large `count` over multiple
 /// bounded passes — this test verifies that an end-to-end drain of a backlog
-/// larger than `MAX_GRANTS_PER_PASS` (256) still grants every waiter.
+/// larger than the default `grant_scanner_batch_size` (256) still grants every waiter.
 #[silo::test]
 async fn grant_scanner_drains_backlog_larger_than_max_per_pass() {
     // Sized to cross the per-pass cap (256) by enough to require at least three
@@ -2231,7 +2231,7 @@ async fn grant_scanner_drains_backlog_larger_than_max_per_pass() {
     }
 
     // One process_grants call asks for N grants. Internally this must run as
-    // multiple bounded passes (each ≤ MAX_GRANTS_PER_PASS = 256) and still
+    // multiple bounded passes (each ≤ grant_scanner_batch_size = 256) and still
     // return all N grants.
     let granted = shard
         .process_concurrency_grants(tenant, queue, N as u32)

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -153,6 +153,8 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             concurrency_reconcile_interval: Duration::from_millis(interval_ms.max(1)),
             counter_reconciliation_seconds: None,
             hydrate_all_at_startup: false,
+            grant_scanner_batch_size: silo::settings::DEFAULT_GRANT_SCANNER_BATCH_SIZE,
+            grant_scanner_buffer_size: silo::settings::DEFAULT_GRANT_SCANNER_BUFFER_SIZE,
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
         },


### PR DESCRIPTION
When we have a huge job backlog we see that the grant scanner can't fill the task broker fast enough, but there are still outstanding jobs:

<img width="547" height="345" alt="image" src="https://github.com/user-attachments/assets/a5f1716f-c7a0-4030-b585-c5a96fa4ffd8" />

We want to be able to tune these values in config.


## What

The grant scanner (`ConcurrencyManager::process_grants`) bounds its per-pass throughput with two hardcoded constants. This moves both into the TOML database settings so they can be tuned per deployment without a rebuild. **Defaults are unchanged.**

| Setting (TOML, under `[database]`) | Type | Default | Replaces |
|---|---|---|---|
| `grant_scanner_batch_size` | `usize` | `256` | `MAX_GRANTS_PER_PASS` — max grants materialized / status-checked / committed in a single pass |
| `grant_scanner_buffer_size` | `usize` | `64` | `STATUS_LOOKUP_CONCURRENCY` — max in-flight `db.get(job_status_key)` lookups via `.buffered(N)` |

## How

Mirrors the existing `hydrate_all_at_startup` numeric-setting pattern:

- **`src/settings.rs`** — `pub const` defaults + `default_*` fns; fields added to both `DatabaseTemplate` and `DatabaseConfig` and their `Default` impls.
- **`src/job_store_shard/mod.rs`** — fields on `OpenShardOptions`, threaded into `ConcurrencyManager::new`; populated from `cfg` in the `open` path.
- **`src/factory.rs`** — populated from `template` in the production shard-open path.
- **`src/concurrency.rs`** — consts removed, rationale moved onto two new `ConcurrencyManager` fields; constructor params clamped with `.max(1)` (a `0` batch would stall the drain loop and `.buffered(0)` is invalid).

## Testing

- `direnv exec . cargo build` / `--tests` — clean, no dead-code warnings.
- Existing `grant_scanner_drains_backlog_larger_than_max_per_pass` regression test passes with the preserved 256 default.
- Added config round-trip tests (defaults + custom values) and extended both `*_default_matches_toml_defaults` drift guards.