### PR TITLE
Update slatedb to upstream rev with transaction bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1116,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,7 +1342,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.3",
  "parking_lot",
  "parquet",
  "rand 0.9.2",
@@ -1357,7 +1377,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.3",
  "parking_lot",
  "tokio",
 ]
@@ -1381,7 +1401,7 @@ dependencies = [
  "datafusion-session",
  "futures",
  "log",
- "object_store",
+ "object_store 0.12.3",
  "tokio",
 ]
 
@@ -1401,7 +1421,7 @@ dependencies = [
  "indexmap 2.11.4",
  "libc",
  "log",
- "object_store",
+ "object_store 0.12.3",
  "parquet",
  "paste",
  "recursive",
@@ -1447,7 +1467,7 @@ dependencies = [
  "glob",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.3",
  "parquet",
  "rand 0.9.2",
  "tempfile",
@@ -1478,7 +1498,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "object_store",
+ "object_store 0.12.3",
  "regex",
  "tokio",
 ]
@@ -1503,7 +1523,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "object_store",
+ "object_store 0.12.3",
  "serde_json",
  "tokio",
 ]
@@ -1534,7 +1554,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.3",
  "parking_lot",
  "parquet",
  "rand 0.9.2",
@@ -1560,7 +1580,7 @@ dependencies = [
  "datafusion-expr",
  "futures",
  "log",
- "object_store",
+ "object_store 0.12.3",
  "parking_lot",
  "rand 0.9.2",
  "tempfile",
@@ -1902,7 +1922,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.3",
  "parking_lot",
  "tokio",
 ]
@@ -2492,9 +2512,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2928,7 +2962,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3047,6 +3081,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,6 +3131,8 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3369,6 +3411,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexical-core"
@@ -3834,11 +3882,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc4f07659e11cd45a341cd24d71e683e3be65d9ff1f8150061678fe60437496"
 dependencies = [
  "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "http 1.3.1",
+ "humantime",
+ "itertools 0.14.0",
+ "parking_lot",
+ "percent-encoding",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http 1.3.1",
  "http-body-util",
  "humantime",
@@ -3848,10 +3922,10 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.2",
+ "rand 0.10.1",
  "reqwest",
  "ring",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4052,7 +4126,7 @@ dependencies = [
  "lz4_flex",
  "num",
  "num-bigint",
- "object_store",
+ "object_store 0.12.3",
  "paste",
  "ring",
  "seq-macro",
@@ -4450,7 +4524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -4483,7 +4557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -4588,9 +4662,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.3"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -4609,7 +4683,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.32",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -4646,7 +4720,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4667,6 +4741,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4685,6 +4765,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4724,6 +4815,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -5321,7 +5418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5332,7 +5429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5393,7 +5490,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "mad-turmoil",
- "object_store",
+ "object_store 0.13.2",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -5472,7 +5569,7 @@ dependencies = [
  "humantime",
  "k8s-openapi",
  "kube",
- "object_store",
+ "object_store 0.13.2",
  "prometheus",
  "serde",
  "serde_json",
@@ -5537,8 +5634,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 [[package]]
 name = "slatedb"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286ec5657d17f3ba70c060becd57a5550ad43973b8480811ad27d3fa4d620a49"
+source = "git+https://github.com/slatedb/slatedb?rev=a9ab64507e677ba1ab18576e7e86fb15b971a233#a9ab64507e677ba1ab18576e7e86fb15b971a233"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -5558,8 +5654,7 @@ dependencies = [
  "futures",
  "log",
  "lru",
- "object_store",
- "once_cell",
+ "object_store 0.13.2",
  "ouroboros",
  "parking_lot",
  "rand 0.9.2",
@@ -5584,8 +5679,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9caca0e37a5bc4c65c61143cdd9674faa6b9f69f76a02e1edc94d8e2a6da414a"
+source = "git+https://github.com/slatedb/slatedb?rev=a9ab64507e677ba1ab18576e7e86fb15b971a233#a9ab64507e677ba1ab18576e7e86fb15b971a233"
 dependencies = [
  "chrono",
  "log",
@@ -5596,15 +5690,15 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9bd80ee7b7f7da1fd4ada17fcf6ee564e76af71254e8189e68bf497856557aa"
+source = "git+https://github.com/slatedb/slatedb?rev=a9ab64507e677ba1ab18576e7e86fb15b971a233#a9ab64507e677ba1ab18576e7e86fb15b971a233"
 dependencies = [
  "async-trait",
  "bytes",
  "chrono",
  "futures",
  "log",
- "object_store",
+ "object_store 0.13.2",
+ "parking_lot",
  "slatedb-common",
  "thiserror 1.0.69",
 ]
@@ -6570,6 +6664,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6737,7 +6837,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -6813,6 +6922,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.11.4",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6823,6 +6954,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.9.4",
+ "hashbrown 0.15.5",
+ "indexmap 2.11.4",
+ "semver",
 ]
 
 [[package]]
@@ -7118,6 +7261,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.11.4",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.4",
+ "indexmap 2.11.4",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.11.4",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ version = "0.3.0"
 [dependencies]
 clap = { version = "4.3.14", features = ["derive", "env"] }
 futures = "0.3"
-slatedb = "0.13"
-slatedb-common = "0.13"
-object_store = { version = "0.12", features = ["gcp"] }
+slatedb = { git = "https://github.com/slatedb/slatedb", rev = "a9ab64507e677ba1ab18576e7e86fb15b971a233" }
+slatedb-common = { git = "https://github.com/slatedb/slatedb", rev = "a9ab64507e677ba1ab18576e7e86fb15b971a233" }
+object_store = { version = "0.13", features = ["gcp"] }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 rmp = "0.8"

--- a/silo-compactor/Cargo.toml
+++ b/silo-compactor/Cargo.toml
@@ -9,9 +9,9 @@ name = "silo-compactor"
 path = "src/main.rs"
 
 [dependencies]
-slatedb = "0.13"
-slatedb-common = "0.13"
-object_store = { version = "0.12", features = ["gcp"] }
+slatedb = { git = "https://github.com/slatedb/slatedb", rev = "a9ab64507e677ba1ab18576e7e86fb15b971a233" }
+slatedb-common = { git = "https://github.com/slatedb/slatedb", rev = "a9ab64507e677ba1ab18576e7e86fb15b971a233" }
+object_store = { version = "0.13", features = ["gcp"] }
 prometheus = "0.13"
 
 # silo provides the counter merge operator and shared metrics/storage helpers.

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1,7 +1,7 @@
 use dashmap::DashMap;
 use futures::TryStreamExt;
-use slatedb::object_store::ObjectStore;
 use slatedb::object_store::path::Path as ObjectPath;
+use slatedb::object_store::{ObjectStore, ObjectStoreExt};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/turmoil_object_store.rs
+++ b/src/turmoil_object_store.rs
@@ -18,9 +18,9 @@ use futures::stream::BoxStream;
 use rand::Rng;
 use slatedb::object_store::path::Path;
 use slatedb::object_store::{
-    Attributes, Error as ObjectStoreError, GetOptions, GetRange, GetResult, GetResultPayload,
-    ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions,
-    PutPayload, PutResult, Result as ObjectStoreResult, UploadPart,
+    Attributes, CopyMode, CopyOptions, Error as ObjectStoreError, GetOptions, GetRange, GetResult,
+    GetResultPayload, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOptions,
+    PutOptions, PutPayload, PutResult, Result as ObjectStoreResult, UploadPart,
 };
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Display, Formatter};
@@ -225,25 +225,41 @@ impl ObjectStore for TurmoilObjectStore {
         })
     }
 
-    async fn delete(&self, location: &Path) -> ObjectStoreResult<()> {
-        // Simulate network latency for delete operations (1-3ms)
-        simulate_latency(1, 3).await;
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, ObjectStoreResult<Path>>,
+    ) -> BoxStream<'static, ObjectStoreResult<Path>> {
+        // object_store 0.13 made `delete_stream` the required primitive; the
+        // convenience `delete` is now provided by `ObjectStoreExt` on top of it.
+        // Process locations sequentially (via `then`, not `buffered`) so deletion
+        // order stays deterministic under turmoil's seeded simulation.
+        let root = self.root.clone();
+        locations
+            .then(move |location| {
+                let root = root.clone();
+                async move {
+                    let location = location?;
 
-        let full_path = self.full_path(location);
+                    // Simulate network latency for delete operations (1-3ms)
+                    simulate_latency(1, 3).await;
 
-        let removed = get_shared_storage().lock().unwrap().remove(&full_path);
+                    let full_path = root.join(location.as_ref());
+                    let removed = get_shared_storage().lock().unwrap().remove(&full_path);
 
-        if removed.is_none() {
-            return Err(ObjectStoreError::NotFound {
-                path: location.to_string(),
-                source: Box::new(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "file not found",
-                )),
-            });
-        }
+                    if removed.is_none() {
+                        return Err(ObjectStoreError::NotFound {
+                            path: location.to_string(),
+                            source: Box::new(std::io::Error::new(
+                                std::io::ErrorKind::NotFound,
+                                "file not found",
+                            )),
+                        });
+                    }
 
-        Ok(())
+                    Ok(location)
+                }
+            })
+            .boxed()
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
@@ -365,7 +381,16 @@ impl ObjectStore for TurmoilObjectStore {
         })
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> ObjectStoreResult<()> {
+        // object_store 0.13 collapsed `copy`/`copy_if_not_exists` into a single
+        // `copy_opts` primitive parameterized by `CopyMode`; the old convenience
+        // methods are now provided by `ObjectStoreExt`.
+        //
         // Simulate network latency for copy operations (1-5ms)
         simulate_latency(1, 5).await;
 
@@ -374,6 +399,18 @@ impl ObjectStore for TurmoilObjectStore {
 
         let entry = {
             let storage = get_shared_storage().lock().unwrap();
+
+            // Create mode (copy_if_not_exists): fail if the destination exists.
+            if options.mode == CopyMode::Create && storage.contains_key(&to_path) {
+                return Err(ObjectStoreError::AlreadyExists {
+                    path: to.to_string(),
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::AlreadyExists,
+                        "destination already exists",
+                    )),
+                });
+            }
+
             storage
                 .get(&from_path)
                 .cloned()
@@ -398,26 +435,6 @@ impl ObjectStore for TurmoilObjectStore {
             .insert(to_path, new_entry);
 
         Ok(())
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-        let to_path = self.full_path(to);
-
-        // Check if destination exists
-        {
-            let storage = get_shared_storage().lock().unwrap();
-            if storage.contains_key(&to_path) {
-                return Err(ObjectStoreError::AlreadyExists {
-                    path: to.to_string(),
-                    source: Box::new(std::io::Error::new(
-                        std::io::ErrorKind::AlreadyExists,
-                        "destination already exists",
-                    )),
-                });
-            }
-        }
-
-        self.copy(from, to).await
     }
 }
 
@@ -475,6 +492,8 @@ impl MultipartUpload for TurmoilMultipartUpload {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // object_store 0.13 moved the `put`/`get` convenience methods onto `ObjectStoreExt`.
+    use slatedb::object_store::ObjectStoreExt;
 
     #[tokio::test]
     async fn test_basic_put_get() {


### PR DESCRIPTION
## What

Points `slatedb` / `slatedb-common` at git rev [`a9ab645`](https://github.com/slatedb/slatedb/commit/a9ab64507e677ba1ab18576e7e86fb15b971a233) — slatedb/slatedb#1710, _"Track the entire scanned range in `DbIteratorRangeTracker` to fix some phantom reads and write skew"_ — to pick up the transaction bug fixes merged upstream.

## Why the extra changes

This rev bumps slatedb's re-exported `object_store` from **0.12 → 0.13.2**, which forced two small adaptations:

- **Bump our direct `object_store` dep 0.12 → 0.13** (root + `silo-compactor`). Silo registers GCS through slatedb's `Db::resolve_object_store`, so the `gcp` feature must unify with slatedb's `object_store` version; with our dep stuck at 0.12 that unification silently broke. Bumping it also avoids carrying a duplicate `object_store` purely for slatedb. `datafusion v50` still pulls `object_store 0.12.3` transitively, but silo never crosses a slatedb store into datafusion, so the split is harmless.
- **`use slatedb::object_store::ObjectStoreExt` in `factory.rs`** — object_store 0.13 moved `delete` onto an extension trait.

## Sanity check

Brought up a fresh dev cluster (`dev`) against a brand-new slatedb on disk and ran `silo-bench`:

```
Total completed: 591
Total enqueued:  591
Backlog (enqueued - completed): 0
Post-bench holder audit: holders=0 requests=0 across all 8 shards (clean)
```

Reads and writes against the new slatedb work, and the freshly-created on-disk format (WAL / manifests / SSTs / compactions) was verified across all shards.

`cargo fmt --check`, `cargo clippy --workspace --all-targets`, and `cargo check --workspace` all pass (clippy warnings are pre-existing test-file lints, untouched by this change).