### PR TITLE
Create metrics for ops dashboard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ turmoil = { version = "0.7", features = ["unstable-fs"], optional = true }
 tracing-opentelemetry = "0.27"
 opentelemetry = { version = "0.26" }
 opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.26", features = ["http-json", "trace", "reqwest-client", "reqwest-rustls"] }
+opentelemetry-otlp = { version = "0.26", features = ["http-json", "http-proto", "trace", "metrics", "reqwest-client", "reqwest-rustls"] }
 prometheus = { version = "0.13", features = ["process"] }
 usdt = "0.6.0"
 tempfile = "3"

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -4,7 +4,7 @@ use slatedb::IsolationLevel;
 
 use crate::codec::{decode_cancellation_at_ms, decode_task, encode_job_cancellation};
 use crate::job::{JobCancellation, JobStatus, JobStatusKind, JobView, Limit};
-use crate::job_store_shard::counters::encode_counter;
+use crate::job_store_shard::counters::{BackgroundActionMetricTransition, encode_counter};
 use crate::job_store_shard::helpers::{
     TxnWriter, decode_job_status_owned, find_task_by_identity, now_epoch_ms,
     put_with_optional_expire, retry_on_txn_conflict,
@@ -117,6 +117,20 @@ impl JobStoreShard {
         // by task_id, and the grant scanner is woken per queue.
         let mut holders_to_release: Vec<(String, String)> = Vec::new();
         let mut deleted_task_key: Option<Vec<u8>> = None;
+        let mut background_action_transition: Option<BackgroundActionMetricTransition> = None;
+        macro_rules! try_after_status {
+            ($expr:expr) => {
+                match $expr {
+                    Ok(value) => value,
+                    Err(e) => {
+                        if let Some(transition) = &background_action_transition {
+                            self.rollback_background_action_metric_gauge_transition(transition);
+                        }
+                        return Err(e.into());
+                    }
+                }
+            };
+        }
 
         // [SILO-CXL-3] For Scheduled jobs, eagerly delete task and concurrency state
         if was_scheduled {
@@ -128,19 +142,20 @@ impl JobStoreShard {
                 status.next_attempt_starts_after_ms,
                 status.current_attempt,
             );
-            self.set_job_status_with_index_opts(
-                &mut TxnWriter(&txn),
-                tenant,
-                id,
-                cancelled_status,
-                terminal_expire_ts,
-            )
-            .await?;
+            background_action_transition = self
+                .set_job_status_with_index_opts(
+                    &mut TxnWriter(&txn),
+                    tenant,
+                    id,
+                    cancelled_status,
+                    terminal_expire_ts,
+                )
+                .await?;
 
             // Read job info to get task_group, priority, and limits for task key reconstruction
             let job_key = job_info_key(tenant, id);
-            if let Some(job_bytes) = txn.get(&job_key).await? {
-                let job_view = JobView::new(job_bytes)?;
+            if let Some(job_bytes) = try_after_status!(txn.get(&job_key).await) {
+                let job_view = try_after_status!(JobView::new(job_bytes));
                 let task_group = job_view.task_group().to_string();
                 let priority = job_view.priority();
                 let limits = job_view.limits();
@@ -150,31 +165,41 @@ impl JobStoreShard {
                 // exact key).
                 let attempt_number = status.current_attempt.unwrap_or(1);
                 let start_time_ms = status.next_attempt_starts_after_ms.unwrap_or(0);
-                let task_found = match find_task_by_identity(
-                    &txn,
-                    &task_group,
-                    start_time_ms,
-                    priority,
-                    id,
-                    attempt_number,
-                )
-                .await?
-                {
+                let task_found = match try_after_status!(
+                    find_task_by_identity(
+                        &txn,
+                        &task_group,
+                        start_time_ms,
+                        priority,
+                        id,
+                        attempt_number
+                    )
+                    .await
+                ) {
                     Some(found) => Some(found),
                     None => {
                         // Fallback: try with time=0 (immediate scheduling case)
-                        find_task_by_identity(&txn, &task_group, 0, priority, id, attempt_number)
-                            .await?
+                        try_after_status!(
+                            find_task_by_identity(
+                                &txn,
+                                &task_group,
+                                0,
+                                priority,
+                                id,
+                                attempt_number
+                            )
+                            .await
+                        )
                     }
                 };
 
                 if let Some((found_key, task_raw)) = task_found {
-                    let decoded = decode_task(&task_raw).map_err(|e| {
+                    let decoded = try_after_status!(decode_task(&task_raw).map_err(|e| {
                         JobStoreShardError::Codec(format!("cancel task decode: {e}"))
-                    })?;
+                    }));
 
                     // Delete the task from the DB queue
-                    txn.delete(&found_key)?;
+                    try_after_status!(txn.delete(&found_key));
                     deleted_task_key = Some(found_key);
 
                     match decoded {
@@ -185,7 +210,9 @@ impl JobStoreShard {
                         } => {
                             // Delete concurrency holders for each held queue
                             for queue in held_queues {
-                                txn.delete(concurrency_holder_key(tenant, &queue, &tid))?;
+                                try_after_status!(
+                                    txn.delete(concurrency_holder_key(tenant, &queue, &tid))
+                                );
                                 holders_to_release.push((tid.clone(), queue));
                             }
                         }
@@ -201,7 +228,9 @@ impl JobStoreShard {
                             // granted (carried on the ticket's `held_queues`);
                             // those must be released or the slots leak.
                             for queue in held_queues {
-                                txn.delete(concurrency_holder_key(tenant, &queue, &tid))?;
+                                try_after_status!(
+                                    txn.delete(concurrency_holder_key(tenant, &queue, &tid))
+                                );
                                 holders_to_release.push((tid.clone(), queue));
                             }
                         }
@@ -216,7 +245,9 @@ impl JobStoreShard {
                             // chain, but the holders must be released too or
                             // those slots leak.
                             for queue in held_queues {
-                                txn.delete(concurrency_holder_key(tenant, &queue, &tid))?;
+                                try_after_status!(
+                                    txn.delete(concurrency_holder_key(tenant, &queue, &tid))
+                                );
                                 holders_to_release.push((tid.clone(), queue));
                             }
                         }
@@ -242,7 +273,8 @@ impl JobStoreShard {
                             start_time_ms,
                             priority,
                         )
-                        .await?;
+                        .await;
+                    let released = try_after_status!(released);
                     holders_to_release.extend(released);
                 }
             }
@@ -253,7 +285,7 @@ impl JobStoreShard {
 
         // Include counter in the transaction (unmark_write excludes it from conflict detection)
         if was_scheduled {
-            self.increment_completed_jobs_counter(&mut TxnWriter(&txn))?;
+            try_after_status!(self.increment_completed_jobs_counter(&mut TxnWriter(&txn)));
         }
 
         // Re-put the job's prior associated records (JOB_INFO, IDX_METADATA,
@@ -271,14 +303,25 @@ impl JobStoreShard {
         // prior ATTEMPT rows were written by earlier transactions; re-putting
         // them here tags them with the row TTL.
         if let Some(ts) = terminal_expire_ts {
-            self.expire_terminal_job_records(&mut TxnWriter(&txn), tenant, id, ts)
-                .await?;
+            let expire_result = self
+                .expire_terminal_job_records(&mut TxnWriter(&txn), tenant, id, ts)
+                .await;
+            try_after_status!(expire_result);
         }
 
         // Commit the transaction - this will detect conflicts with concurrent modifications
-        txn.commit().await?;
+        if let Err(e) = txn.commit().await {
+            if let Some(transition) = &background_action_transition {
+                self.rollback_background_action_metric_gauge_transition(transition);
+            }
+            return Err(e.into());
+        }
 
         // ---- Post-commit: update in-memory state ----
+
+        if let Some(transition) = &background_action_transition {
+            self.apply_background_action_metric_transition(transition);
+        }
 
         // Evict the deleted task from the broker buffer
         if let Some(ref key) = deleted_task_key {

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -324,10 +324,6 @@ impl JobStoreShard {
 
         // ---- Post-commit: update in-memory state ----
 
-        if let Some(transition) = &background_action_transition {
-            self.apply_background_action_metric_transition(transition);
-        }
-
         // Evict the deleted task from the broker buffer
         if let Some(ref key) = deleted_task_key {
             self.brokers.evict_keys(std::slice::from_ref(key));

--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -142,6 +142,10 @@ impl JobStoreShard {
                 status.next_attempt_starts_after_ms,
                 status.current_attempt,
             );
+            // JobView is loaded just below for task-key reconstruction; that
+            // ordering predates the metric helper. Pass None for now and let
+            // the helper fall back to its own JOB_INFO lookup — cancel is not
+            // a hot path. Re-ordering the load is the deferred refactor.
             background_action_transition = self
                 .set_job_status_with_index_opts(
                     &mut TxnWriter(&txn),
@@ -149,6 +153,7 @@ impl JobStoreShard {
                     id,
                     cancelled_status,
                     terminal_expire_ts,
+                    None,
                 )
                 .await?;
 

--- a/src/job_store_shard/counters.rs
+++ b/src/job_store_shard/counters.rs
@@ -359,18 +359,6 @@ impl JobStoreShard {
         }
     }
 
-    pub(crate) fn apply_background_action_metric_transition(
-        &self,
-        transition: &BackgroundActionMetricTransition,
-    ) {
-        self.record_background_action_terminal_counter_transition(
-            &transition.tenant,
-            &transition.task_group,
-            transition.new_status,
-            &transition.metadata,
-        );
-    }
-
     pub(crate) fn rollback_background_action_metric_gauge_transition(
         &self,
         transition: &BackgroundActionMetricTransition,
@@ -391,21 +379,6 @@ impl JobStoreShard {
         for transition in transitions {
             self.rollback_background_action_metric_gauge_transition(transition);
         }
-    }
-
-    pub(crate) fn record_background_action_terminal_counter_transition(
-        &self,
-        tenant: &str,
-        task_group: &str,
-        new_status: JobStatusKind,
-        metadata: &[(String, String)],
-    ) {
-        let Some(metrics) = self.metrics.as_ref() else {
-            return;
-        };
-        metrics.record_background_action_terminal_event(
-            &self.name, tenant, task_group, new_status, metadata,
-        );
     }
 
     fn apply_background_action_queue_counter_delta_for_key(

--- a/src/job_store_shard/counters.rs
+++ b/src/job_store_shard/counters.rs
@@ -21,12 +21,14 @@ use slatedb::bytes::Bytes;
 use slatedb::{MergeOperator, MergeOperatorError};
 
 use crate::codec::decode_job_status_owned;
+use crate::job::{JobStatusKind, JobView};
 use crate::job_store_shard::helpers::WriteBatcher;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
     concurrency_requester_counter_key, concurrency_requester_counter_tenant_prefix, end_bound,
-    parse_concurrency_requester_counter_key, parse_job_info_key, parse_job_status_key, prefix,
-    shard_completed_jobs_counter_key, shard_total_jobs_counter_key, tenant_status_counter_key,
+    job_info_key, parse_concurrency_requester_counter_key, parse_job_info_key,
+    parse_job_status_key, prefix, shard_completed_jobs_counter_key, shard_total_jobs_counter_key,
+    tenant_status_counter_key,
 };
 use crate::shard_range::ShardRange;
 
@@ -37,6 +39,31 @@ pub struct ShardCounters {
     pub total_jobs: i64,
     /// Number of jobs in terminal states (Succeeded, Failed, Cancelled).
     pub completed_jobs: i64,
+}
+
+pub(crate) const BACKGROUND_ACTION_QUEUE_SIZE_BUCKET: &str = "queue_size";
+pub(crate) const BACKGROUND_ACTION_RUNNING_SIZE_BUCKET: &str = "running_size";
+pub(crate) const BACKGROUND_ACTION_EXPLICIT_QUEUE_KIND: &str = "explicit";
+pub(crate) const BACKGROUND_ACTION_PLATFORM_QUEUE_KIND: &str = "platform";
+
+/// Stored queue counter row for background action metrics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundActionQueueCounter {
+    pub tenant: String,
+    pub task_group: String,
+    pub status_bucket: String,
+    pub queue_kind: String,
+    pub queue: String,
+    pub count: i64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BackgroundActionMetricTransition {
+    pub tenant: String,
+    pub task_group: String,
+    pub old_status: Option<JobStatusKind>,
+    pub new_status: JobStatusKind,
+    pub metadata: Vec<(String, String)>,
 }
 
 /// Optional lexicographic tenant bounds for scanning tenant status counters.
@@ -152,6 +179,33 @@ pub(crate) fn decode_counter(bytes: &[u8]) -> i64 {
     }
 }
 
+pub(crate) fn background_action_status_bucket(status: JobStatusKind) -> Option<&'static str> {
+    match status {
+        JobStatusKind::Scheduled => Some(BACKGROUND_ACTION_QUEUE_SIZE_BUCKET),
+        JobStatusKind::Running => Some(BACKGROUND_ACTION_RUNNING_SIZE_BUCKET),
+        JobStatusKind::Succeeded | JobStatusKind::Failed | JobStatusKind::Cancelled => None,
+    }
+}
+
+pub(crate) fn background_action_queue_counter_transition_is_relevant(
+    old_status: Option<JobStatusKind>,
+    new_status: JobStatusKind,
+) -> bool {
+    old_status
+        .and_then(background_action_status_bucket)
+        .is_some()
+        || background_action_status_bucket(new_status).is_some()
+}
+
+fn background_action_metadata_value<'a>(
+    metadata: &'a [(String, String)],
+    key: &str,
+) -> Option<&'a str> {
+    metadata
+        .iter()
+        .find_map(|(k, v)| (k == key).then_some(v.as_str()))
+}
+
 impl JobStoreShard {
     /// Get the current job counters for this shard.
     pub async fn get_counters(&self) -> Result<ShardCounters, JobStoreShardError> {
@@ -212,6 +266,199 @@ impl JobStoreShard {
         let key = shard_completed_jobs_counter_key();
         writer.merge(&key, encode_counter(-1))?;
         Ok(())
+    }
+
+    /// Apply a signed delta to background action queue counters for this job
+    /// metadata and status. Terminal statuses are intentionally not
+    /// represented as gauges.
+    pub(crate) fn apply_background_action_queue_counter_delta(
+        &self,
+        tenant: &str,
+        task_group: &str,
+        status: JobStatusKind,
+        metadata: &[(String, String)],
+        delta: i64,
+    ) {
+        let Some(status_bucket) = background_action_status_bucket(status) else {
+            return;
+        };
+
+        if let Some(queue) = background_action_metadata_value(metadata, "queue") {
+            self.apply_background_action_queue_counter_delta_for_key(
+                tenant,
+                task_group,
+                status_bucket,
+                BACKGROUND_ACTION_EXPLICIT_QUEUE_KIND,
+                queue,
+                delta,
+            );
+        }
+
+        if let Some(queue) = background_action_metadata_value(metadata, "platformConcurrencyQueue")
+        {
+            self.apply_background_action_queue_counter_delta_for_key(
+                tenant,
+                task_group,
+                status_bucket,
+                BACKGROUND_ACTION_PLATFORM_QUEUE_KIND,
+                queue,
+                delta,
+            );
+        }
+    }
+
+    /// Apply the background-action queue counter movement for one status
+    /// transition. Terminal statuses are intentionally not represented in the
+    /// gauges; failure/cancellation visibility is emitted as event counters.
+    pub(crate) fn apply_background_action_queue_counter_transition(
+        &self,
+        tenant: &str,
+        task_group: &str,
+        old_status: Option<JobStatusKind>,
+        new_status: JobStatusKind,
+        metadata: &[(String, String)],
+    ) {
+        if old_status
+            .and_then(background_action_status_bucket)
+            .is_some()
+        {
+            let old_status = old_status.expect("checked above");
+            self.apply_background_action_queue_counter_delta(
+                tenant, task_group, old_status, metadata, -1,
+            );
+        }
+        if background_action_status_bucket(new_status).is_some() {
+            self.apply_background_action_queue_counter_delta(
+                tenant, task_group, new_status, metadata, 1,
+            );
+        }
+    }
+
+    /// Reverse a previously applied background-action queue counter transition.
+    pub(crate) fn rollback_background_action_queue_counter_transition(
+        &self,
+        tenant: &str,
+        task_group: &str,
+        old_status: Option<JobStatusKind>,
+        new_status: JobStatusKind,
+        metadata: &[(String, String)],
+    ) {
+        if background_action_status_bucket(new_status).is_some() {
+            self.apply_background_action_queue_counter_delta(
+                tenant, task_group, new_status, metadata, -1,
+            );
+        }
+        if old_status
+            .and_then(background_action_status_bucket)
+            .is_some()
+        {
+            let old_status = old_status.expect("checked above");
+            self.apply_background_action_queue_counter_delta(
+                tenant, task_group, old_status, metadata, 1,
+            );
+        }
+    }
+
+    pub(crate) fn apply_background_action_metric_transition(
+        &self,
+        transition: &BackgroundActionMetricTransition,
+    ) {
+        self.record_background_action_terminal_counter_transition(
+            &transition.tenant,
+            &transition.task_group,
+            transition.new_status,
+            &transition.metadata,
+        );
+    }
+
+    pub(crate) fn rollback_background_action_metric_gauge_transition(
+        &self,
+        transition: &BackgroundActionMetricTransition,
+    ) {
+        self.rollback_background_action_queue_counter_transition(
+            &transition.tenant,
+            &transition.task_group,
+            transition.old_status,
+            transition.new_status,
+            &transition.metadata,
+        );
+    }
+
+    pub(crate) fn rollback_background_action_metric_gauge_transitions(
+        &self,
+        transitions: &[BackgroundActionMetricTransition],
+    ) {
+        for transition in transitions {
+            self.rollback_background_action_metric_gauge_transition(transition);
+        }
+    }
+
+    pub(crate) fn record_background_action_terminal_counter_transition(
+        &self,
+        tenant: &str,
+        task_group: &str,
+        new_status: JobStatusKind,
+        metadata: &[(String, String)],
+    ) {
+        let Some(metrics) = self.metrics.as_ref() else {
+            return;
+        };
+        metrics.record_background_action_terminal_event(
+            &self.name, tenant, task_group, new_status, metadata,
+        );
+    }
+
+    fn apply_background_action_queue_counter_delta_for_key(
+        &self,
+        tenant: &str,
+        task_group: &str,
+        status_bucket: &str,
+        queue_kind: &str,
+        queue: &str,
+        delta: i64,
+    ) {
+        let key = (
+            tenant.to_string(),
+            task_group.to_string(),
+            status_bucket.to_string(),
+            queue_kind.to_string(),
+            queue.to_string(),
+        );
+        let mut entry = self
+            .background_action_queue_counts
+            .entry(key.clone())
+            .or_insert(0);
+        *entry = entry.saturating_add(delta);
+        if *entry <= 0 {
+            drop(entry);
+            self.background_action_queue_counts
+                .remove_if(&key, |_, value| *value <= 0);
+        }
+    }
+
+    /// Snapshot sparse in-memory background action queue counters for this shard.
+    ///
+    /// Entries with count <= 0 are excluded. The metric layer derives
+    /// synthetic `<no queue>` values from explicit/platform rows per
+    /// `(tenant, task_group)`.
+    pub fn snapshot_background_action_queue_counters(&self) -> Vec<BackgroundActionQueueCounter> {
+        let mut results = Vec::new();
+        for entry in self.background_action_queue_counts.iter() {
+            let count = *entry.value();
+            if count <= 0 {
+                continue;
+            }
+            let (tenant, task_group, status_bucket, queue_kind, queue) = entry.key();
+            results.push(BackgroundActionQueueCounter {
+                tenant: tenant.clone(),
+                task_group: task_group.clone(),
+                status_bucket: status_bucket.clone(),
+                queue_kind: queue_kind.clone(),
+                queue: queue.clone(),
+                count,
+            });
+        }
+        results
     }
 
     /// Scan all tenant status counters for this shard.
@@ -422,7 +669,7 @@ impl JobStoreShard {
                     }
                     *truth
                         .per_tenant_status
-                        .entry((parsed.tenant, status.kind.as_str().to_owned()))
+                        .entry((parsed.tenant.clone(), status.kind.as_str().to_owned()))
                         .or_insert(0) += 1;
                 }
                 Err(e) => {
@@ -535,6 +782,79 @@ impl JobStoreShard {
         }
         self.db.merge(&key, &encode_counter(delta)).await?;
         Ok(1)
+    }
+
+    /// Rebuild the sparse in-memory background action queue counters from
+    /// current Scheduled/Running job rows. This runs at shard open so
+    /// process-local counters recover after a restart without durable queue
+    /// counter state.
+    pub async fn rebuild_background_action_queue_counters(
+        &self,
+        range: &ShardRange,
+    ) -> Result<(), JobStoreShardError> {
+        self.background_action_queue_counts.clear();
+
+        let status_prefix = vec![prefix::JOB_STATUS];
+        let status_end = end_bound(&status_prefix);
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(status_prefix..status_end, &crate::scan_options())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let Some(parsed) = parse_job_status_key(&kv.key) else {
+                continue;
+            };
+            if !range.contains_tenant(&parsed.tenant) {
+                continue;
+            }
+
+            let status = match decode_job_status_owned(&kv.value) {
+                Ok(status) => status,
+                Err(e) => {
+                    tracing::warn!(
+                        shard = %self.name,
+                        tenant = %parsed.tenant,
+                        job_id = %parsed.job_id,
+                        error = %e,
+                        "background action queue counter rebuild: failed to decode job status, skipping row"
+                    );
+                    continue;
+                }
+            };
+            if background_action_status_bucket(status.kind).is_none() {
+                continue;
+            }
+
+            let Some(raw_info) = self
+                .db
+                .get(&job_info_key(&parsed.tenant, &parsed.job_id))
+                .await?
+            else {
+                continue;
+            };
+            let view = match JobView::new(raw_info) {
+                Ok(view) => view,
+                Err(e) => {
+                    tracing::warn!(
+                        shard = %self.name,
+                        tenant = %parsed.tenant,
+                        job_id = %parsed.job_id,
+                        error = %e,
+                        "background action queue counter rebuild: failed to decode job info, skipping row"
+                    );
+                    continue;
+                }
+            };
+            self.apply_background_action_queue_counter_delta(
+                &parsed.tenant,
+                view.task_group(),
+                status.kind,
+                &view.metadata(),
+                1,
+            );
+        }
+
+        Ok(())
     }
 }
 

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -9,6 +9,7 @@ use crate::dst_events::{self, DstEvent};
 use crate::fb::silo::fb;
 use crate::job::{JobStatus, JobStatusKind, JobView, Limit};
 use crate::job_attempt::{AttemptStatus, JobAttempt, JobAttemptView};
+use crate::job_store_shard::counters::BackgroundActionMetricTransition;
 use crate::job_store_shard::helpers::{DbWriteBatcher, decode_job_status_owned, now_epoch_ms};
 use crate::job_store_shard::{DequeueResult, JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
@@ -29,6 +30,7 @@ struct DequeueIterationState {
     release_keys: Vec<Vec<u8>>,
     tombstone_keys: Vec<Vec<u8>>,
     grants_to_rollback: Vec<(String, String, String)>,
+    background_action_transitions: Vec<BackgroundActionMetricTransition>,
     leased_tasks_for_dst: Vec<(String, String, String)>,
     pending_attempts: Vec<(String, JobView, Vec<u8>)>,
     /// Holders that were deleted in this iteration's batch and need their
@@ -45,6 +47,7 @@ impl DequeueIterationState {
             release_keys: Vec::with_capacity(claimed_len),
             tombstone_keys: Vec::with_capacity(claimed_len),
             grants_to_rollback: Vec::new(),
+            background_action_transitions: Vec::new(),
             leased_tasks_for_dst: Vec::new(),
             pending_attempts: Vec::new(),
             holder_releases: Vec::new(),
@@ -427,6 +430,9 @@ impl JobStoreShard {
                 }
             }
             if let Some(e) = handler_err {
+                for transition in &state.background_action_transitions {
+                    self.rollback_background_action_metric_gauge_transition(transition);
+                }
                 // Known not-committed state: re-buffer for immediate re-pickup.
                 self.brokers.requeue(inflight_guard.disarm());
                 return Err(e);
@@ -489,6 +495,9 @@ impl JobStoreShard {
                 // here means their Drop is a no-op on the `return Err` below.
                 for (tenant, queue, task_id) in grant_guard.disarm() {
                     self.concurrency.rollback_grant(&tenant, &queue, &task_id);
+                }
+                for transition in &state.background_action_transitions {
+                    self.rollback_background_action_metric_gauge_transition(transition);
                 }
                 let _ = holder_guard.disarm();
                 // Put back all claimed entries since we didn't lease them durably
@@ -578,7 +587,7 @@ impl JobStoreShard {
         relative_attempt_number: u32,
         now_ms: i64,
         expiry_ms: i64,
-    ) -> Result<Vec<u8>, JobStoreShardError> {
+    ) -> Result<(Vec<u8>, Option<BackgroundActionMetricTransition>), JobStoreShardError> {
         // [SILO-DEQ-4] Create lease record
         let lease_key = leased_task_key(task_id);
         let record = LeaseRecord {
@@ -592,13 +601,14 @@ impl JobStoreShard {
 
         // [SILO-DEQ-6] Mark job as running
         let job_status = JobStatus::running(now_ms);
-        self.set_job_status_with_index(
-            &mut DbWriteBatcher::new(&self.db, batch),
-            tenant,
-            job_id,
-            job_status,
-        )
-        .await?;
+        let background_action_transition = self
+            .set_job_status_with_index(
+                &mut DbWriteBatcher::new(&self.db, batch),
+                tenant,
+                job_id,
+                job_status,
+            )
+            .await?;
 
         // [SILO-DEQ-5] Create attempt record
         let attempt = JobAttempt {
@@ -613,7 +623,7 @@ impl JobStoreShard {
         let akey = attempt_key(tenant, job_id, attempt_number);
         batch.put(&akey, &attempt_val);
 
-        Ok(attempt_val)
+        Ok((attempt_val, background_action_transition))
     }
 
     /// Process a RequestTicket task.
@@ -815,15 +825,18 @@ impl JobStoreShard {
         for (q, tid) in chain_result.grants {
             state.grants_to_rollback.push((tenant.clone(), q, tid));
         }
-        if let Some(task_key_start_ms) = chain_result.pending_task_key_start_ms {
-            self.retarget_scheduled_task_key(
-                &mut writer,
-                &tenant,
-                &job_id,
-                attempt_number,
-                task_key_start_ms,
-            )
-            .await?;
+        if let Some(task_key_start_ms) = chain_result.pending_task_key_start_ms
+            && let Some(transition) = self
+                .retarget_scheduled_task_key(
+                    &mut writer,
+                    &tenant,
+                    &job_id,
+                    attempt_number,
+                    task_key_start_ms,
+                )
+                .await?
+        {
+            state.background_action_transitions.push(transition);
         }
 
         // Metrics: account the grant as a Scanned-path ticket.
@@ -984,15 +997,18 @@ impl JobStoreShard {
                         .grants_to_rollback
                         .push((tenant.clone(), queue, task_id));
                 }
-                if let Some(task_key_start_ms) = chain_result.pending_task_key_start_ms {
-                    self.retarget_scheduled_task_key(
-                        &mut DbWriteBatcher::new(&self.db, &mut state.batch),
-                        tenant,
-                        job_id,
-                        attempt_number,
-                        task_key_start_ms,
-                    )
-                    .await?;
+                if let Some(task_key_start_ms) = chain_result.pending_task_key_start_ms
+                    && let Some(transition) = self
+                        .retarget_scheduled_task_key(
+                            &mut DbWriteBatcher::new(&self.db, &mut state.batch),
+                            tenant,
+                            job_id,
+                            attempt_number,
+                            task_key_start_ms,
+                        )
+                        .await?
+                {
+                    state.background_action_transitions.push(transition);
                 }
             }
             Ok(result) => {
@@ -1180,7 +1196,7 @@ impl JobStoreShard {
         state.batch.delete(task_key);
 
         let task = decoded.to_task()?;
-        let attempt_val = self
+        let (attempt_val, background_action_transition) = self
             .write_lease_and_attempt(
                 &mut state.batch,
                 worker_id,
@@ -1194,6 +1210,9 @@ impl JobStoreShard {
                 expiry_ms,
             )
             .await?;
+        if let Some(transition) = background_action_transition {
+            state.background_action_transitions.push(transition);
+        }
 
         // Construct AttemptView directly from encoded bytes (no DB readback needed)
         state

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -587,6 +587,7 @@ impl JobStoreShard {
         relative_attempt_number: u32,
         now_ms: i64,
         expiry_ms: i64,
+        job_metric_info: Option<&JobView>,
     ) -> Result<(Vec<u8>, Option<BackgroundActionMetricTransition>), JobStoreShardError> {
         // [SILO-DEQ-4] Create lease record
         let lease_key = leased_task_key(task_id);
@@ -607,6 +608,7 @@ impl JobStoreShard {
                 tenant,
                 job_id,
                 job_status,
+                job_metric_info,
             )
             .await?;
 
@@ -1208,6 +1210,7 @@ impl JobStoreShard {
                 relative_attempt_number,
                 now_ms,
                 expiry_ms,
+                Some(&view),
             )
             .await?;
         if let Some(transition) = background_action_transition {

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use crate::codec::{encode_job_info, encode_job_status};
 use crate::concurrency::RequestTicketOutcome;
 use crate::dst_events::{self, DstEvent};
-use crate::job::{JobInfo, JobStatus, JobStatusKind, Limit};
+use crate::job::{JobInfo, JobStatus, JobStatusKind, JobView, Limit};
 use crate::job_store_shard::JobStoreShard;
 use crate::job_store_shard::JobStoreShardError;
 use crate::job_store_shard::counters::{
@@ -800,9 +800,17 @@ impl JobStoreShard {
         tenant: &str,
         job_id: &str,
         new_status: JobStatus,
+        job_metric_info: Option<&JobView>,
     ) -> Result<Option<BackgroundActionMetricTransition>, JobStoreShardError> {
-        self.set_job_status_with_index_opts(writer, tenant, job_id, new_status, None)
-            .await
+        self.set_job_status_with_index_opts(
+            writer,
+            tenant,
+            job_id,
+            new_status,
+            None,
+            job_metric_info,
+        )
+        .await
     }
 
     /// Update job status with optional row TTL on the new status/index records.
@@ -810,6 +818,14 @@ impl JobStoreShard {
     /// When `expire_ts` is `Some`, the new `JOB_STATUS` and `IDX_STATUS_TIME`
     /// rows are written with a SlateDB TTL expiring at `expire_ts` (epoch ms).
     /// Used by the terminal-job expiration path; pass `None` everywhere else.
+    ///
+    /// `job_metric_info` is an optional `JobView` reference supplied by the
+    /// caller when one is already in scope. When provided, it short-circuits
+    /// the `JOB_INFO` lookup that this helper would otherwise issue to derive
+    /// the task_group and metadata needed for background-action queue gauges —
+    /// the lookup is on the hot path for callers like dequeue and
+    /// `report_attempt_outcome`. Callers without a `JobView` in scope pass
+    /// `None` and the helper falls back to reading `JOB_INFO` itself.
     pub(crate) async fn set_job_status_with_index_opts<W: WriteBatcher>(
         &self,
         writer: &mut W,
@@ -817,6 +833,7 @@ impl JobStoreShard {
         job_id: &str,
         new_status: JobStatus,
         expire_ts: Option<i64>,
+        job_metric_info: Option<&JobView>,
     ) -> Result<Option<BackgroundActionMetricTransition>, JobStoreShardError> {
         // Delete old index entries if present
         let old_status = if let Some(old_raw) = writer.get(&job_status_key(tenant, job_id)).await? {
@@ -838,21 +855,25 @@ impl JobStoreShard {
         let new_kind = new_status.kind;
         let needs_background_action_counters =
             background_action_queue_counter_transition_is_relevant(old_kind, new_kind);
-        let job_metric_info = if needs_background_action_counters {
-            writer
-                .get(&job_info_key(tenant, job_id))
-                .await?
-                .map(|raw| {
-                    crate::job::JobView::new(raw)
-                        .map(|view| (view.task_group().to_string(), view.metadata()))
-                        .map_err(|e| JobStoreShardError::Codec(e.to_string()))
-                })
-                .transpose()?
-        } else {
-            None
-        };
+        let derived_metric_info: Option<(String, Vec<(String, String)>)> =
+            if needs_background_action_counters {
+                match job_metric_info {
+                    Some(view) => Some((view.task_group().to_string(), view.metadata())),
+                    None => writer
+                        .get(&job_info_key(tenant, job_id))
+                        .await?
+                        .map(|raw| {
+                            JobView::new(raw)
+                                .map(|view| (view.task_group().to_string(), view.metadata()))
+                                .map_err(|e| JobStoreShardError::Codec(e.to_string()))
+                        })
+                        .transpose()?,
+                }
+            } else {
+                None
+            };
         let background_action_transition =
-            job_metric_info.as_ref().map(|(task_group, metadata)| {
+            derived_metric_info.as_ref().map(|(task_group, metadata)| {
                 BackgroundActionMetricTransition {
                     tenant: tenant.to_string(),
                     task_group: task_group.clone(),
@@ -861,7 +882,7 @@ impl JobStoreShard {
                     metadata: metadata.clone(),
                 }
             });
-        if let Some((task_group, metadata)) = job_metric_info.as_ref() {
+        if let Some((task_group, metadata)) = derived_metric_info.as_ref() {
             self.apply_background_action_queue_counter_transition(
                 tenant, task_group, old_kind, new_kind, metadata,
             );
@@ -870,7 +891,7 @@ impl JobStoreShard {
         if let Err(e) = Self::write_job_status_with_index_opts_and_metadata(
             writer, tenant, job_id, new_status, expire_ts,
         ) {
-            if let Some((task_group, metadata)) = job_metric_info.as_ref() {
+            if let Some((task_group, metadata)) = derived_metric_info.as_ref() {
                 self.rollback_background_action_queue_counter_transition(
                     tenant, task_group, old_kind, new_kind, metadata,
                 );
@@ -960,7 +981,10 @@ impl JobStoreShard {
             Some(task_key_start_ms),
             old.current_attempt,
         );
-        self.set_job_status_with_index(writer, tenant, job_id, new_status)
+        // No JobView is loaded on the retarget path (Scheduled→Scheduled is
+        // not a gauge-relevant transition either), so let the helper's
+        // fallback handle the rare case where the predicate ever does fire.
+        self.set_job_status_with_index(writer, tenant, job_id, new_status, None)
             .await
     }
 }

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -11,7 +11,10 @@ use crate::dst_events::{self, DstEvent};
 use crate::job::{JobInfo, JobStatus, JobStatusKind, Limit};
 use crate::job_store_shard::JobStoreShard;
 use crate::job_store_shard::JobStoreShardError;
-use crate::job_store_shard::counters::encode_counter;
+use crate::job_store_shard::counters::{
+    BackgroundActionMetricTransition, background_action_queue_counter_transition_is_relevant,
+    encode_counter,
+};
 use crate::job_store_shard::helpers::{
     DbWriteBatcher, TxnWriter, WriteBatcher, decode_job_status_owned, now_epoch_ms, put_task,
     retry_on_txn_conflict,
@@ -202,6 +205,7 @@ impl JobStoreShard {
         task_group: &str,
     ) -> Result<(), JobStoreShardError> {
         let mut batch = WriteBatch::new();
+        let background_action_metadata = metadata.clone().unwrap_or_default();
         let grants = self
             .write_enqueue_data(
                 &mut DbWriteBatcher::new(&self.db, &mut batch),
@@ -244,6 +248,13 @@ impl JobStoreShard {
         {
             dst_events::cancel_write(write_op);
             self.rollback_grants(tenant, &grants);
+            self.rollback_background_action_queue_counter_transition(
+                tenant,
+                task_group,
+                None,
+                JobStatusKind::Scheduled,
+                &background_action_metadata,
+            );
             return Err(e.into());
         }
         dst_events::confirm_write(write_op);
@@ -300,6 +311,7 @@ impl JobStoreShard {
     ) -> Result<(), JobStoreShardError> {
         // Start a transaction with SerializableSnapshot isolation for conflict detection
         let txn = self.db.begin(IsolationLevel::SerializableSnapshot).await?;
+        let background_action_metadata = metadata.clone().unwrap_or_default();
 
         // [SILO-ENQ-1] If caller provided an id, ensure it doesn't already exist
         let info_key = job_info_key(tenant, job_id);
@@ -347,6 +359,13 @@ impl JobStoreShard {
         {
             dst_events::cancel_write(write_op);
             self.rollback_grants(tenant, &grants);
+            self.rollback_background_action_queue_counter_transition(
+                tenant,
+                task_group,
+                None,
+                JobStatusKind::Scheduled,
+                &background_action_metadata,
+            );
             return Err(e.into());
         }
         dst_events::confirm_write(write_op);
@@ -394,6 +413,7 @@ impl JobStoreShard {
 
         // [SILO-ENQ-2] Create job with status Scheduled, with next attempt time
         let job_status = JobStatus::scheduled(now_ms, effective_start_at_ms, 1);
+        let job_status_kind = job_status.kind;
 
         writer.put(job_info_key(tenant, job_id), &job_value)?;
 
@@ -403,39 +423,48 @@ impl JobStoreShard {
             writer.put(&mkey, [])?;
         }
 
-        Self::write_job_status_with_index(writer, tenant, job_id, job_status)?;
+        Self::write_job_status_with_index_and_metadata(writer, tenant, job_id, job_status)?;
 
-        self.enqueue_limit_task_at_index(
-            writer,
-            LimitTaskParams {
-                tenant,
-                task_id: &first_task_id,
-                job_id,
-                attempt_number: 1,
-                relative_attempt_number: 1,
-                limit_index: 0,
-                limits: &job.limits,
-                priority,
-                // Fresh enqueue: the task_key starts at the job's schedule. If
-                // the job is future-scheduled (`start_at_ms > now_ms`) the
-                // resulting `RequestTicket` lands at the future time so the
-                // broker picks it up exactly then. Use `effective_start_at_ms`
-                // (not the raw `start_at_ms`) so an immediate enqueue
-                // (`start_at_ms <= 0`) keys the task at `now_ms` — matching the
-                // `effective_start_at_ms` the JobStatus stores and the import
-                // path, so identity lookups never have to fall back to time=0.
-                // Fresh chain head → epoch is just the write time; no
-                // predecessor tombstone to dodge.
-                scheduled_at_ms: effective_start_at_ms,
-                task_key_epoch_ms: now_ms,
-                now_ms,
-                held_queues: Vec::new(),
-                task_group,
-                skip_try_reserve: false,
-            },
-        )
-        .await
-        .map(|result| result.grants)
+        let result = self
+            .enqueue_limit_task_at_index(
+                writer,
+                LimitTaskParams {
+                    tenant,
+                    task_id: &first_task_id,
+                    job_id,
+                    attempt_number: 1,
+                    relative_attempt_number: 1,
+                    limit_index: 0,
+                    limits: &job.limits,
+                    priority,
+                    // Fresh enqueue: the task_key starts at the job's schedule. If
+                    // the job is future-scheduled (`start_at_ms > now_ms`) the
+                    // resulting `RequestTicket` lands at the future time so the
+                    // broker picks it up exactly then. Use `effective_start_at_ms`
+                    // (not the raw `start_at_ms`) so an immediate enqueue
+                    // (`start_at_ms <= 0`) keys the task at `now_ms` — matching the
+                    // `effective_start_at_ms` the JobStatus stores and the import
+                    // path, so identity lookups never have to fall back to time=0.
+                    // Fresh chain head → epoch is just the write time; no
+                    // predecessor tombstone to dodge.
+                    scheduled_at_ms: effective_start_at_ms,
+                    task_key_epoch_ms: now_ms,
+                    now_ms,
+                    held_queues: Vec::new(),
+                    task_group,
+                    skip_try_reserve: false,
+                },
+            )
+            .await
+            .map(|result| result.grants)?;
+        self.apply_background_action_queue_counter_transition(
+            tenant,
+            task_group,
+            None,
+            job_status_kind,
+            &job.metadata,
+        );
+        Ok(result)
     }
 
     /// Complete an enqueue after successful write/commit and DST event emission.
@@ -771,7 +800,7 @@ impl JobStoreShard {
         tenant: &str,
         job_id: &str,
         new_status: JobStatus,
-    ) -> Result<(), JobStoreShardError> {
+    ) -> Result<Option<BackgroundActionMetricTransition>, JobStoreShardError> {
         self.set_job_status_with_index_opts(writer, tenant, job_id, new_status, None)
             .await
     }
@@ -788,9 +817,9 @@ impl JobStoreShard {
         job_id: &str,
         new_status: JobStatus,
         expire_ts: Option<i64>,
-    ) -> Result<(), JobStoreShardError> {
+    ) -> Result<Option<BackgroundActionMetricTransition>, JobStoreShardError> {
         // Delete old index entries if present
-        if let Some(old_raw) = writer.get(&job_status_key(tenant, job_id)).await? {
+        let old_status = if let Some(old_raw) = writer.get(&job_status_key(tenant, job_id)).await? {
             let old = decode_job_status_owned(&old_raw)?;
             let old_ts = status_index_timestamp(&old);
             let old_time = idx_status_time_key(tenant, old.kind.as_str(), old_ts, job_id);
@@ -800,24 +829,70 @@ impl JobStoreShard {
                 tenant_status_counter_key(tenant, old.kind.as_str()),
                 encode_counter(-1),
             )?;
+            Some(old)
+        } else {
+            None
+        };
+
+        let old_kind = old_status.as_ref().map(|old| old.kind);
+        let new_kind = new_status.kind;
+        let needs_background_action_counters =
+            background_action_queue_counter_transition_is_relevant(old_kind, new_kind);
+        let job_metric_info = if needs_background_action_counters {
+            writer
+                .get(&job_info_key(tenant, job_id))
+                .await?
+                .map(|raw| {
+                    crate::job::JobView::new(raw)
+                        .map(|view| (view.task_group().to_string(), view.metadata()))
+                        .map_err(|e| JobStoreShardError::Codec(e.to_string()))
+                })
+                .transpose()?
+        } else {
+            None
+        };
+        let background_action_transition =
+            job_metric_info.as_ref().map(|(task_group, metadata)| {
+                BackgroundActionMetricTransition {
+                    tenant: tenant.to_string(),
+                    task_group: task_group.clone(),
+                    old_status: old_kind,
+                    new_status: new_kind,
+                    metadata: metadata.clone(),
+                }
+            });
+        if let Some((task_group, metadata)) = job_metric_info.as_ref() {
+            self.apply_background_action_queue_counter_transition(
+                tenant, task_group, old_kind, new_kind, metadata,
+            );
         }
 
-        Self::write_job_status_with_index_opts(writer, tenant, job_id, new_status, expire_ts)
+        if let Err(e) = Self::write_job_status_with_index_opts_and_metadata(
+            writer, tenant, job_id, new_status, expire_ts,
+        ) {
+            if let Some((task_group, metadata)) = job_metric_info.as_ref() {
+                self.rollback_background_action_queue_counter_transition(
+                    tenant, task_group, old_kind, new_kind, metadata,
+                );
+            }
+            return Err(e);
+        }
+        Ok(background_action_transition)
     }
 
     /// Shared helper: write status value and index entry.
-    pub(crate) fn write_job_status_with_index<W: WriteBatcher>(
+    pub(crate) fn write_job_status_with_index_and_metadata<W: WriteBatcher>(
         writer: &mut W,
         tenant: &str,
         job_id: &str,
         new_status: JobStatus,
     ) -> Result<(), JobStoreShardError> {
-        Self::write_job_status_with_index_opts(writer, tenant, job_id, new_status, None)
+        Self::write_job_status_with_index_opts_and_metadata(
+            writer, tenant, job_id, new_status, None,
+        )
     }
 
-    /// Shared helper variant that accepts an optional `expire_ts` for the new
-    /// status and index rows.
-    pub(crate) fn write_job_status_with_index_opts<W: WriteBatcher>(
+    pub(crate) fn write_job_status_with_index_opts_and_metadata<W: WriteBatcher>(
         writer: &mut W,
         tenant: &str,
         job_id: &str,
@@ -867,16 +942,16 @@ impl JobStoreShard {
         job_id: &str,
         attempt_number: u32,
         task_key_start_ms: i64,
-    ) -> Result<(), JobStoreShardError> {
+    ) -> Result<Option<BackgroundActionMetricTransition>, JobStoreShardError> {
         let Some(old_raw) = writer.get(&job_status_key(tenant, job_id)).await? else {
-            return Ok(());
+            return Ok(None);
         };
         let old = decode_job_status_owned(&old_raw)?;
         if old.kind != JobStatusKind::Scheduled
             || old.current_attempt != Some(attempt_number)
             || old.next_attempt_starts_after_ms == Some(task_key_start_ms)
         {
-            return Ok(());
+            return Ok(None);
         }
 
         let new_status = JobStatus::new(

--- a/src/job_store_shard/expedite.rs
+++ b/src/job_store_shard/expedite.rs
@@ -178,11 +178,17 @@ impl JobStoreShard {
 
         // Update job status with new start time (keeping same attempt number)
         let new_status = crate::job::JobStatus::scheduled(now_ms, now_ms, attempt_number);
-        self.set_job_status_with_index(&mut TxnWriter(&txn), tenant, id, new_status)
+        let background_action_transition = self
+            .set_job_status_with_index(&mut TxnWriter(&txn), tenant, id, new_status)
             .await?;
 
         // Commit the transaction
-        txn.commit().await?;
+        if let Err(e) = txn.commit().await {
+            if let Some(transition) = &background_action_transition {
+                self.rollback_background_action_metric_gauge_transition(transition);
+            }
+            return Err(e.into());
+        }
 
         // Wake the broker to pick up the expedited task promptly
         self.brokers.wakeup(&task_group);

--- a/src/job_store_shard/expedite.rs
+++ b/src/job_store_shard/expedite.rs
@@ -179,7 +179,13 @@ impl JobStoreShard {
         // Update job status with new start time (keeping same attempt number)
         let new_status = crate::job::JobStatus::scheduled(now_ms, now_ms, attempt_number);
         let background_action_transition = self
-            .set_job_status_with_index(&mut TxnWriter(&txn), tenant, id, new_status)
+            .set_job_status_with_index(
+                &mut TxnWriter(&txn),
+                tenant,
+                id,
+                new_status,
+                Some(&job_view),
+            )
             .await?;
 
         // Commit the transaction

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -13,6 +13,7 @@ use crate::dst_events::{self, DstEvent};
 use crate::fb::silo::fb;
 use crate::job::{JobInfo, JobStatus, JobStatusKind, JobView, Limit};
 use crate::job_attempt::{AttemptStatus, JobAttempt};
+use crate::job_store_shard::counters::BackgroundActionMetricTransition;
 use crate::job_store_shard::helpers::{
     TxnWriter, decode_job_status_owned, find_task_by_identity, now_epoch_ms,
     put_with_optional_expire, retry_on_txn_conflict,
@@ -254,7 +255,7 @@ impl JobStoreShard {
 
         // Write status + index (TTL applied when the import lands terminal)
         let mut writer = TxnWriter(&txn);
-        Self::write_job_status_with_index_opts(
+        Self::write_job_status_with_index_opts_and_metadata(
             &mut writer,
             tenant,
             job_id,
@@ -307,6 +308,27 @@ impl JobStoreShard {
         if is_terminal {
             self.increment_completed_jobs_counter(&mut writer)?;
         }
+        let background_action_transition = if matches!(
+            status_kind,
+            JobStatusKind::Failed | JobStatusKind::Cancelled
+        ) {
+            Some(BackgroundActionMetricTransition {
+                tenant: tenant.to_string(),
+                task_group: params.task_group.clone(),
+                old_status: None,
+                new_status: status_kind,
+                metadata: job.metadata.clone(),
+            })
+        } else {
+            None
+        };
+        self.apply_background_action_queue_counter_transition(
+            tenant,
+            &params.task_group,
+            None,
+            status_kind,
+            &job.metadata,
+        );
 
         let write_op = if !is_terminal {
             let op = dst_events::next_write_op();
@@ -333,10 +355,20 @@ impl JobStoreShard {
                 dst_events::cancel_write(op);
             }
             self.rollback_grants(tenant, &grants);
+            self.rollback_background_action_queue_counter_transition(
+                tenant,
+                &params.task_group,
+                None,
+                status_kind,
+                &job.metadata,
+            );
             return Err(e.into());
         }
         if let Some(op) = write_op {
             dst_events::confirm_write(op);
+        }
+        if let Some(transition) = &background_action_transition {
+            self.apply_background_action_metric_transition(transition);
         }
 
         // For non-terminal, finish enqueue (flush + broker wakeup)
@@ -574,6 +606,7 @@ impl JobStoreShard {
             limits: existing_job.limits(),
             task_group: existing_job.task_group().to_string(),
         };
+        let background_action_metadata = updated_job.metadata.clone();
         let updated_job_value = encode_job_info(&updated_job);
         let info_key = job_info_key(tenant, job_id);
         put_with_optional_expire(&txn, &info_key, &updated_job_value, terminal_expire_ts)?;
@@ -687,19 +720,25 @@ impl JobStoreShard {
         // === Update status, scheduling state, and counters ===
         let mut writer = TxnWriter(&txn);
 
-        self.set_job_status_with_index_opts(
-            &mut writer,
-            tenant,
-            job_id,
-            new_job_status,
-            terminal_expire_ts,
-        )
-        .await?;
+        let background_action_transition = self
+            .set_job_status_with_index_opts(
+                &mut writer,
+                tenant,
+                job_id,
+                new_job_status,
+                terminal_expire_ts,
+            )
+            .await?;
 
         // Clean up cancelled key: cancel_job writes a separate cancelled key that blocks
         // lease creation. The marker can outlive Cancelled status (for example when a
         // running cancelled job later reports Error), so always delete it on reimport.
-        txn.delete(job_cancelled_key(tenant, job_id))?;
+        if let Err(e) = txn.delete(job_cancelled_key(tenant, job_id)) {
+            if let Some(transition) = &background_action_transition {
+                self.rollback_background_action_metric_gauge_transition(transition);
+            }
+            return Err(e.into());
+        }
 
         // Create new scheduling state if non-terminal
         let mut grants = Vec::new();
@@ -711,7 +750,7 @@ impl JobStoreShard {
             // [SILO-REIMP-9] new task in DB queue, old tasks for j removed
             // [SILO-REIMP-CONC-1/2] concurrency granted path
             // [SILO-REIMP-CONC-3/4] concurrency queued path
-            grants = self
+            grants = match self
                 .enqueue_limit_task_at_index(
                     &mut writer,
                     LimitTaskParams {
@@ -733,18 +772,42 @@ impl JobStoreShard {
                         skip_try_reserve: false,
                     },
                 )
-                .await?
-                .grants;
+                .await
+            {
+                Ok(result) => result.grants,
+                Err(e) => {
+                    self.rollback_background_action_queue_counter_transition(
+                        tenant,
+                        &task_group,
+                        Some(old_status.kind),
+                        status_kind,
+                        &background_action_metadata,
+                    );
+                    return Err(e);
+                }
+            };
         }
         // [SILO-REIMP-7] If terminal: status is terminal, no new tasks
 
         // Update counters
         let was_terminal = old_status.is_terminal();
-        if !was_terminal && is_terminal {
-            self.increment_completed_jobs_counter(&mut writer)?;
+        if !was_terminal
+            && is_terminal
+            && let Err(e) = self.increment_completed_jobs_counter(&mut writer)
+        {
+            if let Some(transition) = &background_action_transition {
+                self.rollback_background_action_metric_gauge_transition(transition);
+            }
+            return Err(e);
         }
-        if was_terminal && !is_terminal {
-            self.decrement_completed_jobs_counter(&mut writer)?;
+        if was_terminal
+            && !is_terminal
+            && let Err(e) = self.decrement_completed_jobs_counter(&mut writer)
+        {
+            if let Some(transition) = &background_action_transition {
+                self.rollback_background_action_metric_gauge_transition(transition);
+            }
+            return Err(e);
         }
         // total_jobs counter unchanged (job already counted)
 
@@ -775,10 +838,20 @@ impl JobStoreShard {
             }
             // Rollback new grants
             self.rollback_grants(tenant, &grants);
+            self.rollback_background_action_queue_counter_transition(
+                tenant,
+                &task_group,
+                Some(old_status.kind),
+                status_kind,
+                &background_action_metadata,
+            );
             return Err(e.into());
         }
         if let Some(op) = write_op {
             dst_events::confirm_write(op);
+        }
+        if let Some(transition) = &background_action_transition {
+            self.apply_background_action_metric_transition(transition);
         }
 
         // [SILO-REIMP-6] Remove buffered tasks for this job.

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -13,7 +13,6 @@ use crate::dst_events::{self, DstEvent};
 use crate::fb::silo::fb;
 use crate::job::{JobInfo, JobStatus, JobStatusKind, JobView, Limit};
 use crate::job_attempt::{AttemptStatus, JobAttempt};
-use crate::job_store_shard::counters::BackgroundActionMetricTransition;
 use crate::job_store_shard::helpers::{
     TxnWriter, decode_job_status_owned, find_task_by_identity, now_epoch_ms,
     put_with_optional_expire, retry_on_txn_conflict,
@@ -308,27 +307,12 @@ impl JobStoreShard {
         if is_terminal {
             self.increment_completed_jobs_counter(&mut writer)?;
         }
-        let background_action_transition = if matches!(
-            status_kind,
-            JobStatusKind::Failed | JobStatusKind::Cancelled
-        ) {
-            Some(BackgroundActionMetricTransition {
-                tenant: tenant.to_string(),
-                task_group: params.task_group.clone(),
-                old_status: None,
-                new_status: status_kind,
-                metadata: job.metadata.clone(),
-            })
-        } else {
-            None
-        };
-        self.apply_background_action_queue_counter_transition(
-            tenant,
-            &params.task_group,
-            None,
-            status_kind,
-            &job.metadata,
-        );
+        // Imported jobs intentionally don't move the background-action queue
+        // gauges or terminal event counters: imports are admin-driven and
+        // represent historical state being seeded, not live enqueues. The
+        // reimport path goes through `set_job_status_with_index_opts` and
+        // therefore still updates the gauges as part of a normal status
+        // transition.
 
         let write_op = if !is_terminal {
             let op = dst_events::next_write_op();
@@ -355,20 +339,10 @@ impl JobStoreShard {
                 dst_events::cancel_write(op);
             }
             self.rollback_grants(tenant, &grants);
-            self.rollback_background_action_queue_counter_transition(
-                tenant,
-                &params.task_group,
-                None,
-                status_kind,
-                &job.metadata,
-            );
             return Err(e.into());
         }
         if let Some(op) = write_op {
             dst_events::confirm_write(op);
-        }
-        if let Some(transition) = &background_action_transition {
-            self.apply_background_action_metric_transition(transition);
         }
 
         // For non-terminal, finish enqueue (flush + broker wakeup)
@@ -720,6 +694,9 @@ impl JobStoreShard {
         // === Update status, scheduling state, and counters ===
         let mut writer = TxnWriter(&txn);
 
+        // `existing_job` is the pre-reimport JobView; reimport copies its
+        // metadata + task_group into the new JobInfo unchanged, so passing it
+        // to the metric helper short-circuits the JOB_INFO refetch.
         let background_action_transition = self
             .set_job_status_with_index_opts(
                 &mut writer,
@@ -727,6 +704,7 @@ impl JobStoreShard {
                 job_id,
                 new_job_status,
                 terminal_expire_ts,
+                Some(&existing_job),
             )
             .await?;
 

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -828,9 +828,6 @@ impl JobStoreShard {
         if let Some(op) = write_op {
             dst_events::confirm_write(op);
         }
-        if let Some(transition) = &background_action_transition {
-            self.apply_background_action_metric_transition(transition);
-        }
 
         // [SILO-REIMP-6] Remove buffered tasks for this job.
         // Must happen after commit so the scanner cannot re-buffer old tasks from DB.

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -457,9 +457,6 @@ impl JobStoreShard {
             return Err(e.into());
         }
         dst_events::confirm_write(write_op);
-        for transition in &background_action_transitions {
-            self.apply_background_action_metric_transition(transition);
-        }
 
         // Post-commit: release in-memory concurrency counts and signal grant scanner.
         for queue in &held_queues_local {

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -11,6 +11,7 @@ use crate::codec::{
 use crate::dst_events::{self, DstEvent};
 use crate::job::{FloatingLimitState, JobStatus, JobView};
 use crate::job_attempt::{AttemptOutcome, AttemptStatus, JobAttempt};
+use crate::job_store_shard::counters::BackgroundActionMetricTransition;
 use crate::job_store_shard::helpers::{DbWriteBatcher, WriteBatcher, now_epoch_ms};
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
@@ -164,6 +165,7 @@ impl JobStoreShard {
         let mut followup_next_time: Option<i64> = None;
         // Track grants from retry scheduling for rollback if DB write fails
         let mut retry_grants: Vec<(String, String)> = Vec::new();
+        let mut background_action_transitions: Vec<BackgroundActionMetricTransition> = Vec::new();
         // Track the new job status for DST event emission
         let mut new_job_status_for_dst: Option<String> = None;
         // Whether the job reached a terminal status during this call. Drives
@@ -177,18 +179,27 @@ impl JobStoreShard {
                 let job_status = JobStatus::succeeded(now_ms);
                 terminal_expire_ts =
                     self.terminal_expire_ts(crate::job::JobStatusKind::Succeeded, now_ms);
-                self.set_job_status_with_index_opts(
-                    &mut DbWriteBatcher::new(&self.db, &mut batch),
-                    &tenant,
-                    &job_id,
-                    job_status,
-                    terminal_expire_ts,
-                )
-                .await?;
+                if let Some(transition) = self
+                    .set_job_status_with_index_opts(
+                        &mut DbWriteBatcher::new(&self.db, &mut batch),
+                        &tenant,
+                        &job_id,
+                        job_status,
+                        terminal_expire_ts,
+                    )
+                    .await?
+                {
+                    background_action_transitions.push(transition);
+                }
                 // Job reached terminal state - include counter in batch
-                self.increment_completed_jobs_counter(&mut DbWriteBatcher::new(
+                if let Err(e) = self.increment_completed_jobs_counter(&mut DbWriteBatcher::new(
                     &self.db, &mut batch,
-                ))?;
+                )) {
+                    self.rollback_background_action_metric_gauge_transitions(
+                        &background_action_transitions,
+                    );
+                    return Err(e);
+                }
                 new_job_status_for_dst = Some("Succeeded".to_string());
                 reached_terminal = true;
             }
@@ -197,18 +208,27 @@ impl JobStoreShard {
                 let job_status = JobStatus::cancelled(now_ms);
                 terminal_expire_ts =
                     self.terminal_expire_ts(crate::job::JobStatusKind::Cancelled, now_ms);
-                self.set_job_status_with_index_opts(
-                    &mut DbWriteBatcher::new(&self.db, &mut batch),
-                    &tenant,
-                    &job_id,
-                    job_status,
-                    terminal_expire_ts,
-                )
-                .await?;
+                if let Some(transition) = self
+                    .set_job_status_with_index_opts(
+                        &mut DbWriteBatcher::new(&self.db, &mut batch),
+                        &tenant,
+                        &job_id,
+                        job_status,
+                        terminal_expire_ts,
+                    )
+                    .await?
+                {
+                    background_action_transitions.push(transition);
+                }
                 // Job reached terminal state - include counter in batch
-                self.increment_completed_jobs_counter(&mut DbWriteBatcher::new(
+                if let Err(e) = self.increment_completed_jobs_counter(&mut DbWriteBatcher::new(
                     &self.db, &mut batch,
-                ))?;
+                )) {
+                    self.rollback_background_action_metric_gauge_transitions(
+                        &background_action_transitions,
+                    );
+                    return Err(e);
+                }
                 new_job_status_for_dst = Some("Cancelled".to_string());
                 reached_terminal = true;
             }
@@ -275,13 +295,17 @@ impl JobStoreShard {
                         // [SILO-RETRY-3] Set job status to Scheduled with next attempt time
                         let job_status =
                             JobStatus::scheduled(now_ms, next_time, next_attempt_number);
-                        self.set_job_status_with_index(
-                            &mut DbWriteBatcher::new(&self.db, &mut batch),
-                            &tenant,
-                            &job_id,
-                            job_status,
-                        )
-                        .await?;
+                        if let Some(transition) = self
+                            .set_job_status_with_index(
+                                &mut DbWriteBatcher::new(&self.db, &mut batch),
+                                &tenant,
+                                &job_id,
+                                job_status,
+                            )
+                            .await?
+                        {
+                            background_action_transitions.push(transition);
+                        }
                         scheduled_followup = true;
                         followup_next_time = Some(next_time);
                         new_job_status_for_dst = Some("Scheduled".to_string());
@@ -291,18 +315,27 @@ impl JobStoreShard {
                         let job_status = JobStatus::failed(now_ms);
                         terminal_expire_ts =
                             self.terminal_expire_ts(crate::job::JobStatusKind::Failed, now_ms);
-                        self.set_job_status_with_index_opts(
-                            &mut DbWriteBatcher::new(&self.db, &mut batch),
-                            &tenant,
-                            &job_id,
-                            job_status,
-                            terminal_expire_ts,
-                        )
-                        .await?;
+                        if let Some(transition) = self
+                            .set_job_status_with_index_opts(
+                                &mut DbWriteBatcher::new(&self.db, &mut batch),
+                                &tenant,
+                                &job_id,
+                                job_status,
+                                terminal_expire_ts,
+                            )
+                            .await?
+                        {
+                            background_action_transitions.push(transition);
+                        }
                         // Job reached terminal state (failed permanently) - include counter in batch
-                        self.increment_completed_jobs_counter(&mut DbWriteBatcher::new(
-                            &self.db, &mut batch,
-                        ))?;
+                        if let Err(e) = self.increment_completed_jobs_counter(
+                            &mut DbWriteBatcher::new(&self.db, &mut batch),
+                        ) {
+                            self.rollback_background_action_metric_gauge_transitions(
+                                &background_action_transitions,
+                            );
+                            return Err(e);
+                        }
                         new_job_status_for_dst = Some("Failed".to_string());
                         reached_terminal = true;
                     }
@@ -328,14 +361,21 @@ impl JobStoreShard {
         // just deleted earlier in this batch, no other attempt for this
         // job_id can be Running, and the job's terminal status will block
         // dequeue / restart / reimport, so the scan sees a stable view.
-        if reached_terminal && let Some(ts) = terminal_expire_ts {
-            self.expire_terminal_job_records(
-                &mut DbWriteBatcher::new(&self.db, &mut batch),
-                &tenant,
-                &job_id,
-                ts,
-            )
-            .await?;
+        if reached_terminal
+            && let Some(ts) = terminal_expire_ts
+            && let Err(e) = self
+                .expire_terminal_job_records(
+                    &mut DbWriteBatcher::new(&self.db, &mut batch),
+                    &tenant,
+                    &job_id,
+                    ts,
+                )
+                .await
+        {
+            self.rollback_background_action_metric_gauge_transitions(
+                &background_action_transitions,
+            );
+            return Err(e);
         }
 
         // [SILO-SUCC-4][SILO-FAIL-4][SILO-RETRY-4] Update attempt status.
@@ -404,9 +444,15 @@ impl JobStoreShard {
                 self.concurrency
                     .rollback_grant(&tenant, queue, grant_task_id);
             }
+            self.rollback_background_action_metric_gauge_transitions(
+                &background_action_transitions,
+            );
             return Err(e.into());
         }
         dst_events::confirm_write(write_op);
+        for transition in &background_action_transitions {
+            self.apply_background_action_metric_transition(transition);
+        }
 
         // Post-commit: release in-memory concurrency counts and signal grant scanner.
         for queue in &held_queues_local {

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -179,6 +179,9 @@ impl JobStoreShard {
                 let job_status = JobStatus::succeeded(now_ms);
                 terminal_expire_ts =
                     self.terminal_expire_ts(crate::job::JobStatusKind::Succeeded, now_ms);
+                // No JobView is loaded on the Success/Cancelled branches; the
+                // helper falls back to its own JOB_INFO get. The Error branch
+                // below already loads `view` and threads it through.
                 if let Some(transition) = self
                     .set_job_status_with_index_opts(
                         &mut DbWriteBatcher::new(&self.db, &mut batch),
@@ -186,6 +189,7 @@ impl JobStoreShard {
                         &job_id,
                         job_status,
                         terminal_expire_ts,
+                        None,
                     )
                     .await?
                 {
@@ -215,6 +219,7 @@ impl JobStoreShard {
                         &job_id,
                         job_status,
                         terminal_expire_ts,
+                        None,
                     )
                     .await?
                 {
@@ -301,6 +306,7 @@ impl JobStoreShard {
                                 &tenant,
                                 &job_id,
                                 job_status,
+                                Some(&view),
                             )
                             .await?
                         {
@@ -322,6 +328,7 @@ impl JobStoreShard {
                                 &job_id,
                                 job_status,
                                 terminal_expire_ts,
+                                Some(&view),
                             )
                             .await?
                         {

--- a/src/job_store_shard/lease_task.rs
+++ b/src/job_store_shard/lease_task.rs
@@ -217,6 +217,7 @@ impl JobStoreShard {
                 tenant,
                 id,
                 crate::job::JobStatus::running(now_ms),
+                Some(&job_view),
             )
             .await?;
 

--- a/src/job_store_shard/lease_task.rs
+++ b/src/job_store_shard/lease_task.rs
@@ -211,20 +211,28 @@ impl JobStoreShard {
 
         // Update job status to Running
         let mut writer = TxnWriter(&txn);
-        self.set_job_status_with_index(
-            &mut writer,
-            tenant,
-            id,
-            crate::job::JobStatus::running(now_ms),
-        )
-        .await?;
+        let background_action_transition = self
+            .set_job_status_with_index(
+                &mut writer,
+                tenant,
+                id,
+                crate::job::JobStatus::running(now_ms),
+            )
+            .await?;
 
         // Commit the transaction with durable writes
-        txn.commit_with_options(&WriteOptions {
-            await_durable: true,
-            ..Default::default()
-        })
-        .await?;
+        if let Err(e) = txn
+            .commit_with_options(&WriteOptions {
+                await_durable: true,
+                ..Default::default()
+            })
+            .await
+        {
+            if let Some(transition) = &background_action_transition {
+                self.rollback_background_action_metric_gauge_transition(transition);
+            }
+            return Err(e.into());
+        }
 
         // Post-commit: evict old task key from broker buffer and wake broker
         self.brokers.evict_keys(&[old_task_key]);

--- a/src/job_store_shard/limit_chain.rs
+++ b/src/job_store_shard/limit_chain.rs
@@ -121,7 +121,7 @@ async fn retarget_if_concrete_task(
     if task_key_start_ms == params.start_at_ms {
         return Ok(());
     }
-    shard
+    let _ = shard
         .retarget_scheduled_task_key(
             writer,
             &params.tenant,
@@ -129,7 +129,8 @@ async fn retarget_if_concrete_task(
             params.attempt_number,
             task_key_start_ms,
         )
-        .await
+        .await?;
+    Ok(())
 }
 
 fn into_concurrency_error(e: JobStoreShardError) -> ConcurrencyError {

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -56,6 +56,7 @@ use crate::shard_range::ShardRange;
 use crate::storage::resolve_object_store;
 use crate::task::{LeasedRefreshTask, LeasedTask};
 use crate::task_broker::TaskBrokerRegistry;
+use dashmap::DashMap;
 
 /// Configuration for WAL cleanup during shard close
 #[derive(Debug, Clone)]
@@ -197,6 +198,10 @@ pub struct JobStoreShard {
     range: ShardRange,
     /// Metrics recorder for SlateDB, passed to DbBuilder and used for stats collection.
     slatedb_metrics_recorder: Arc<DefaultMetricsRecorder>,
+    /// Sparse in-memory counters for background action queue metrics.
+    /// Keyed by `(tenant, task_group, status_bucket, queue_kind, queue)`.
+    pub(crate) background_action_queue_counts:
+        DashMap<(String, String, String, String, String), i64>,
     /// TTL (seconds) applied to Succeeded jobs' associated records. `None`
     /// disables the feature for successful jobs.
     pub(crate) completed_job_expire_s: Option<u64>,
@@ -517,6 +522,7 @@ impl JobStoreShard {
             db_path: db_path.to_string(),
             range: range.clone(),
             slatedb_metrics_recorder,
+            background_action_queue_counts: DashMap::new(),
             completed_job_expire_s,
             terminal_job_expire_s,
         });
@@ -528,6 +534,10 @@ impl JobStoreShard {
         shard
             .concurrency
             .set_chain_resumer(limit_chain::ShardChainResumer::install(&shard));
+
+        shard
+            .rebuild_background_action_queue_counters(&range)
+            .await?;
 
         // Start the grant scanner after both ConcurrencyManager and TaskBrokerRegistry are ready,
         // and after the chain resumer is installed. It takes the instrumented db so its writes
@@ -1392,13 +1402,16 @@ impl JobStoreShard {
             batch.delete(&timek);
         }
         // Clean up metadata index entries (load job info to enumerate metadata)
-        if let Some(raw) = self.db.get(&job_info_key_bytes).await? {
+        let job_metric_info = if let Some(raw) = self.db.get(&job_info_key_bytes).await? {
             let view = JobView::new(raw)?;
             for (mk, mv) in view.metadata().into_iter() {
                 let mkey = idx_metadata_key(tenant, &mk, &mv, id);
                 batch.delete(&mkey);
             }
-        }
+            Some((view.task_group().to_string(), view.metadata()))
+        } else {
+            None
+        };
         batch.delete(&job_info_key_bytes);
         batch.delete(&job_status_key_bytes);
         // Also delete cancellation record if present
@@ -1418,7 +1431,32 @@ impl JobStoreShard {
             )?;
         }
 
-        self.db.write(batch).await?;
+        if let (Some(status), Some((task_group, metadata))) =
+            (status.as_ref(), job_metric_info.as_ref())
+        {
+            self.apply_background_action_queue_counter_transition(
+                tenant,
+                task_group,
+                Some(status.kind),
+                JobStatusKind::Succeeded,
+                metadata,
+            );
+        }
+
+        if let Err(e) = self.db.write(batch).await {
+            if let (Some(status), Some((task_group, metadata))) =
+                (status.as_ref(), job_metric_info.as_ref())
+            {
+                self.rollback_background_action_queue_counter_transition(
+                    tenant,
+                    task_group,
+                    Some(status.kind),
+                    JobStatusKind::Succeeded,
+                    metadata,
+                );
+            }
+            return Err(e.into());
+        }
 
         Ok(())
     }

--- a/src/job_store_shard/restart.rs
+++ b/src/job_store_shard/restart.rs
@@ -148,7 +148,13 @@ impl JobStoreShard {
         // [SILO-RESTART-6] Post: Set status to Scheduled with next attempt time and attempt number
         let new_status = JobStatus::scheduled(now_ms, start_at_ms, next_attempt_number);
         let background_action_transition = self
-            .set_job_status_with_index(&mut TxnWriter(&txn), tenant, id, new_status)
+            .set_job_status_with_index(
+                &mut TxnWriter(&txn),
+                tenant,
+                id,
+                new_status,
+                Some(&job_view),
+            )
             .await?;
 
         // [SILO-RESTART-5] Post: Create new task in DB queue with next attempt number

--- a/src/job_store_shard/restart.rs
+++ b/src/job_store_shard/restart.rs
@@ -147,7 +147,8 @@ impl JobStoreShard {
 
         // [SILO-RESTART-6] Post: Set status to Scheduled with next attempt time and attempt number
         let new_status = JobStatus::scheduled(now_ms, start_at_ms, next_attempt_number);
-        self.set_job_status_with_index(&mut TxnWriter(&txn), tenant, id, new_status)
+        let background_action_transition = self
+            .set_job_status_with_index(&mut TxnWriter(&txn), tenant, id, new_status)
             .await?;
 
         // [SILO-RESTART-5] Post: Create new task in DB queue with next attempt number
@@ -174,7 +175,12 @@ impl JobStoreShard {
             next_attempt_number,
             now_ms,
         );
-        txn.put(&task_key, &task_value)?;
+        if let Err(e) = txn.put(&task_key, &task_value) {
+            if let Some(transition) = &background_action_transition {
+                self.rollback_background_action_metric_gauge_transition(transition);
+            }
+            return Err(e.into());
+        }
 
         // Two-phase DST event: emit before commit for correct causal ordering,
         // confirm after commit succeeds.
@@ -189,13 +195,21 @@ impl JobStoreShard {
         );
 
         // Include counter in the transaction (unmark_write excludes it from conflict detection)
-        self.decrement_completed_jobs_counter(&mut TxnWriter(&txn))?;
+        if let Err(e) = self.decrement_completed_jobs_counter(&mut TxnWriter(&txn)) {
+            if let Some(transition) = &background_action_transition {
+                self.rollback_background_action_metric_gauge_transition(transition);
+            }
+            return Err(e);
+        }
 
         // Commit the transaction
         match txn.commit().await {
             Ok(_) => dst_events::confirm_write(write_op),
             Err(e) => {
                 dst_events::cancel_write(write_op);
+                if let Some(transition) = &background_action_transition {
+                    self.rollback_background_action_metric_gauge_transition(transition);
+                }
                 return Err(e.into());
             }
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -22,7 +22,7 @@
 //! metrics.jobs_enqueued.with_label_values(&["0", "default"]).inc();
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
@@ -30,6 +30,9 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use axum::{Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::Counter as OtelCounter;
+use opentelemetry::metrics::Gauge as OtelGauge;
 use prometheus::{
     CounterVec, Encoder, Gauge, GaugeVec, HistogramOpts, HistogramVec, Opts, Registry, TextEncoder,
     core::Collector,
@@ -38,6 +41,13 @@ use slatedb_common::metrics::{DefaultMetricsRecorder, LATENCY_BOUNDARIES, Metric
 use tokio::sync::broadcast;
 use tower::{Layer, Service};
 use tracing::{debug, error};
+
+use crate::job::JobStatusKind;
+use crate::job_store_shard::counters::{
+    BACKGROUND_ACTION_EXPLICIT_QUEUE_KIND, BACKGROUND_ACTION_PLATFORM_QUEUE_KIND,
+    BACKGROUND_ACTION_QUEUE_SIZE_BUCKET, BACKGROUND_ACTION_RUNNING_SIZE_BUCKET,
+};
+use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 
 /// Default histogram buckets for request latencies (in seconds)
 const LATENCY_BUCKETS: &[f64] = &[
@@ -89,6 +99,9 @@ impl GrantPath {
     }
 }
 
+type BackgroundActionMetricKey = (String, String, String, String);
+type BackgroundActionLabelSet = Arc<Mutex<HashSet<BackgroundActionMetricKey>>>;
+
 /// Silo metrics handle containing all metric instruments.
 #[derive(Clone)]
 pub struct Metrics {
@@ -100,6 +113,12 @@ pub struct Metrics {
     jobs_completed: CounterVec,
     job_attempts: CounterVec,
     job_wait_time: HistogramVec,
+    background_actions_queue_size: OtelGauge<u64>,
+    background_actions_running_size: OtelGauge<u64>,
+    background_actions_failed_total: OtelCounter<u64>,
+    background_actions_cancelled_total: OtelCounter<u64>,
+    previous_background_actions_queue_labels: BackgroundActionLabelSet,
+    previous_background_actions_running_labels: BackgroundActionLabelSet,
 
     // gRPC metrics
     grpc_requests: CounterVec,
@@ -163,6 +182,32 @@ pub struct Metrics {
     /// Jemalloc allocator stats driven by a periodic scraper spawned in `main.rs`.
     #[cfg(unix)]
     pub jemalloc: crate::jemalloc_metrics::JemallocMetrics,
+}
+
+/// Computed status gauges for Gadget background actions.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BackgroundActionMetricSnapshot {
+    pub queue_size: HashMap<(String, String, String, String), u64>,
+    pub running_size: HashMap<(String, String, String, String), u64>,
+}
+
+impl BackgroundActionMetricSnapshot {
+    pub fn merge(&mut self, other: BackgroundActionMetricSnapshot) {
+        for (key, value) in other.queue_size {
+            increment(&mut self.queue_size, key, value);
+        }
+        for (key, value) in other.running_size {
+            increment(&mut self.running_size, key, value);
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct BackgroundActionStatusCounts {
+    explicit_by_queue: HashMap<(String, String, String, String), u64>,
+    platform_by_queue: HashMap<(String, String, String, String), u64>,
+    explicit_by_shard_tenant_task_group: HashMap<(String, String, String), u64>,
+    platform_by_shard_tenant_task_group: HashMap<(String, String, String), u64>,
 }
 
 /// SlateDB per-shard metric instruments plus the previous-value map needed
@@ -262,6 +307,82 @@ impl Metrics {
         self.job_wait_time
             .with_label_values(&[shard, task_group])
             .observe(wait_time_secs);
+    }
+
+    /// Record background action status gauge values for the current scrape.
+    pub fn record_background_action_metrics(&self, snapshot: BackgroundActionMetricSnapshot) {
+        self.record_background_action_gauge(
+            &self.background_actions_queue_size,
+            &self.previous_background_actions_queue_labels,
+            &snapshot.queue_size,
+        );
+        self.record_background_action_gauge(
+            &self.background_actions_running_size,
+            &self.previous_background_actions_running_labels,
+            &snapshot.running_size,
+        );
+    }
+
+    fn record_background_action_gauge(
+        &self,
+        gauge: &OtelGauge<u64>,
+        previous_labels: &BackgroundActionLabelSet,
+        values: &HashMap<BackgroundActionMetricKey, u64>,
+    ) {
+        let current: HashSet<BackgroundActionMetricKey> = values.keys().cloned().collect();
+        let stale: Vec<BackgroundActionMetricKey> = {
+            let mut previous = previous_labels.lock().unwrap();
+            let stale = previous
+                .difference(&current)
+                .cloned()
+                .collect::<Vec<(String, String, String, String)>>();
+            *previous = current;
+            stale
+        };
+
+        for (shard_id, tenant, task_group, queue) in stale {
+            record_background_action_gauge_value(gauge, &shard_id, &tenant, &task_group, &queue, 0);
+        }
+        for ((shard_id, tenant, task_group, queue), value) in values {
+            record_background_action_gauge_value(
+                gauge, shard_id, tenant, task_group, queue, *value,
+            );
+        }
+    }
+
+    pub fn record_background_action_terminal_event(
+        &self,
+        shard_id: &str,
+        tenant: &str,
+        task_group: &str,
+        status: JobStatusKind,
+        metadata: &[(String, String)],
+    ) {
+        let counter = match status {
+            JobStatusKind::Failed => &self.background_actions_failed_total,
+            JobStatusKind::Cancelled => &self.background_actions_cancelled_total,
+            JobStatusKind::Scheduled | JobStatusKind::Running | JobStatusKind::Succeeded => return,
+        };
+
+        let explicit_queue = background_action_metadata_value(metadata, "queue");
+        let platform_queue = background_action_metadata_value(metadata, "platformConcurrencyQueue");
+
+        if let Some(queue) = explicit_queue {
+            record_background_action_counter_value(counter, shard_id, tenant, task_group, queue, 1);
+        }
+        if let Some(queue) = platform_queue {
+            record_background_action_counter_value(counter, shard_id, tenant, task_group, queue, 1);
+        }
+        if explicit_queue.is_none() && platform_queue.is_some() {
+            record_background_action_counter_value(
+                counter,
+                shard_id,
+                tenant,
+                task_group,
+                "<no queue>",
+                1,
+            );
+        }
     }
 
     /// Record a gRPC request.
@@ -490,6 +611,318 @@ impl Metrics {
     /// since Prometheus counters only support `inc_by()`, not `set()`.
     pub fn update_slatedb_stats(&self, shard: &str, recorder: &DefaultMetricsRecorder) {
         self.slatedb.update(shard, recorder);
+    }
+}
+
+fn record_background_action_gauge_value(
+    gauge: &OtelGauge<u64>,
+    shard_id: &str,
+    tenant: &str,
+    task_group: &str,
+    queue: &str,
+    value: u64,
+) {
+    gauge.record(
+        value,
+        &[
+            KeyValue::new("shard_id", shard_id.to_string()),
+            KeyValue::new("tenant", tenant.to_string()),
+            KeyValue::new("task_group", task_group.to_string()),
+            KeyValue::new("queue", queue.to_string()),
+        ],
+    );
+}
+
+fn record_background_action_counter_value(
+    counter: &OtelCounter<u64>,
+    shard_id: &str,
+    tenant: &str,
+    task_group: &str,
+    queue: &str,
+    value: u64,
+) {
+    counter.add(
+        value,
+        &[
+            KeyValue::new("shard_id", shard_id.to_string()),
+            KeyValue::new("tenant", tenant.to_string()),
+            KeyValue::new("task_group", task_group.to_string()),
+            KeyValue::new("queue", queue.to_string()),
+        ],
+    );
+}
+
+fn background_action_metadata_value<'a>(
+    metadata: &'a [(String, String)],
+    key: &str,
+) -> Option<&'a str> {
+    metadata
+        .iter()
+        .find_map(|(k, v)| (k == key).then_some(v.as_str()))
+}
+
+/// Build background action status gauges from all represented jobs in a shard.
+pub async fn collect_background_action_metrics_for_shard(
+    shard_id: &str,
+    shard: &JobStoreShard,
+) -> Result<BackgroundActionMetricSnapshot, JobStoreShardError> {
+    let mut queued = BackgroundActionStatusCounts::default();
+    let mut running = BackgroundActionStatusCounts::default();
+
+    for counter in shard.snapshot_background_action_queue_counters() {
+        match counter.status_bucket.as_str() {
+            BACKGROUND_ACTION_QUEUE_SIZE_BUCKET => queued.add_counter(
+                shard_id,
+                &counter.tenant,
+                &counter.task_group,
+                &counter.queue_kind,
+                &counter.queue,
+                counter.count,
+            ),
+            BACKGROUND_ACTION_RUNNING_SIZE_BUCKET => running.add_counter(
+                shard_id,
+                &counter.tenant,
+                &counter.task_group,
+                &counter.queue_kind,
+                &counter.queue,
+                counter.count,
+            ),
+            _ => {}
+        }
+    }
+
+    let mut snapshot = BackgroundActionMetricSnapshot::default();
+    queued.finish_into(&mut snapshot.queue_size);
+    running.finish_into(&mut snapshot.running_size);
+    Ok(snapshot)
+}
+
+impl BackgroundActionStatusCounts {
+    fn add_counter(
+        &mut self,
+        shard_id: &str,
+        tenant: &str,
+        task_group: &str,
+        queue_kind: &str,
+        queue: &str,
+        count: i64,
+    ) {
+        let Ok(count) = u64::try_from(count) else {
+            return;
+        };
+        if count == 0 {
+            return;
+        }
+
+        match queue_kind {
+            BACKGROUND_ACTION_EXPLICIT_QUEUE_KIND => {
+                increment(
+                    &mut self.explicit_by_queue,
+                    (
+                        shard_id.to_string(),
+                        tenant.to_string(),
+                        task_group.to_string(),
+                        queue.to_string(),
+                    ),
+                    count,
+                );
+                increment(
+                    &mut self.explicit_by_shard_tenant_task_group,
+                    (
+                        shard_id.to_string(),
+                        tenant.to_string(),
+                        task_group.to_string(),
+                    ),
+                    count,
+                );
+            }
+            BACKGROUND_ACTION_PLATFORM_QUEUE_KIND => {
+                increment(
+                    &mut self.platform_by_queue,
+                    (
+                        shard_id.to_string(),
+                        tenant.to_string(),
+                        task_group.to_string(),
+                        queue.to_string(),
+                    ),
+                    count,
+                );
+                increment(
+                    &mut self.platform_by_shard_tenant_task_group,
+                    (
+                        shard_id.to_string(),
+                        tenant.to_string(),
+                        task_group.to_string(),
+                    ),
+                    count,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn finish_into(self, output: &mut HashMap<(String, String, String, String), u64>) {
+        for (key, count) in self.explicit_by_queue {
+            increment(output, key, count);
+        }
+        for (key, count) in self.platform_by_queue {
+            increment(output, key, count);
+        }
+
+        let shard_tenant_task_groups: HashSet<(String, String, String)> = self
+            .platform_by_shard_tenant_task_group
+            .keys()
+            .chain(self.explicit_by_shard_tenant_task_group.keys())
+            .cloned()
+            .collect();
+        for (shard_id, tenant, task_group) in shard_tenant_task_groups {
+            let key = (shard_id.clone(), tenant.clone(), task_group.clone());
+            let platform = self
+                .platform_by_shard_tenant_task_group
+                .get(&key)
+                .copied()
+                .unwrap_or(0);
+            let explicit = self
+                .explicit_by_shard_tenant_task_group
+                .get(&key)
+                .copied()
+                .unwrap_or(0);
+            let unqueued = platform.saturating_sub(explicit);
+            if unqueued > 0 {
+                output.insert(
+                    (shard_id, tenant, task_group, "<no queue>".to_string()),
+                    unqueued,
+                );
+            }
+        }
+    }
+}
+
+fn increment<K: Eq + std::hash::Hash>(map: &mut HashMap<K, u64>, key: K, amount: u64) {
+    *map.entry(key).or_insert(0) += amount;
+}
+
+#[cfg(test)]
+mod background_action_metric_tests {
+    use super::*;
+
+    #[test]
+    fn explicit_and_platform_queues_are_reported_with_synthetic_unqueued() {
+        let mut counts = BackgroundActionStatusCounts::default();
+
+        counts.add_counter(
+            "shard-a",
+            "env-env-1",
+            "default",
+            BACKGROUND_ACTION_EXPLICIT_QUEUE_KIND,
+            "user-a",
+            1,
+        );
+        counts.add_counter(
+            "shard-a",
+            "env-env-1",
+            "default",
+            BACKGROUND_ACTION_EXPLICIT_QUEUE_KIND,
+            "user-b",
+            1,
+        );
+        counts.add_counter(
+            "shard-a",
+            "env-env-1",
+            "default",
+            BACKGROUND_ACTION_PLATFORM_QUEUE_KIND,
+            "platform-a",
+            3,
+        );
+        counts.add_counter(
+            "shard-b",
+            "tenant-env-1",
+            "background",
+            BACKGROUND_ACTION_PLATFORM_QUEUE_KIND,
+            "x",
+            1,
+        );
+        let mut output = HashMap::new();
+        counts.finish_into(&mut output);
+
+        assert_eq!(
+            output.get(&(
+                "shard-a".to_string(),
+                "env-env-1".to_string(),
+                "default".to_string(),
+                "user-a".to_string()
+            )),
+            Some(&1)
+        );
+        assert_eq!(
+            output.get(&(
+                "shard-a".to_string(),
+                "env-env-1".to_string(),
+                "default".to_string(),
+                "user-b".to_string()
+            )),
+            Some(&1)
+        );
+        assert_eq!(
+            output.get(&(
+                "shard-a".to_string(),
+                "env-env-1".to_string(),
+                "default".to_string(),
+                "platform-a".to_string()
+            )),
+            Some(&3)
+        );
+        assert_eq!(
+            output.get(&(
+                "shard-a".to_string(),
+                "env-env-1".to_string(),
+                "default".to_string(),
+                "<no queue>".to_string()
+            )),
+            Some(&1)
+        );
+        assert_eq!(
+            output.get(&(
+                "shard-b".to_string(),
+                "tenant-env-1".to_string(),
+                "background".to_string(),
+                "x".to_string()
+            )),
+            Some(&1)
+        );
+    }
+
+    #[test]
+    fn synthetic_unqueued_never_goes_negative() {
+        let mut counts = BackgroundActionStatusCounts::default();
+
+        counts.add_counter(
+            "shard-a",
+            "env-env-1",
+            "default",
+            BACKGROUND_ACTION_EXPLICIT_QUEUE_KIND,
+            "user-a",
+            1,
+        );
+
+        let mut output = HashMap::new();
+        counts.finish_into(&mut output);
+
+        assert_eq!(
+            output.get(&(
+                "shard-a".to_string(),
+                "env-env-1".to_string(),
+                "default".to_string(),
+                "user-a".to_string()
+            )),
+            Some(&1)
+        );
+        assert!(!output.contains_key(&(
+            "shard-a".to_string(),
+            "env-env-1".to_string(),
+            "default".to_string(),
+            "<no queue>".to_string()
+        )));
     }
 }
 
@@ -1042,6 +1475,23 @@ pub fn init() -> anyhow::Result<Metrics> {
             &["shard", "task_group"],
         )?,
     );
+    let meter = opentelemetry::global::meter("silo");
+    let background_actions_queue_size = meter
+        .u64_gauge("background_actions.queue_size")
+        .with_description("Number of Silo background action jobs waiting or scheduled to run")
+        .init();
+    let background_actions_running_size = meter
+        .u64_gauge("background_actions.running_size")
+        .with_description("Number of Silo background action jobs currently running")
+        .init();
+    let background_actions_failed_total = meter
+        .u64_counter("background_actions.failed_total")
+        .with_description("Total number of Silo background action jobs that failed")
+        .init();
+    let background_actions_cancelled_total = meter
+        .u64_counter("background_actions.cancelled_total")
+        .with_description("Total number of Silo background action jobs that were cancelled")
+        .init();
 
     // gRPC metrics
     let grpc_requests = register(
@@ -1384,6 +1834,12 @@ pub fn init() -> anyhow::Result<Metrics> {
         jobs_completed,
         job_attempts,
         job_wait_time,
+        background_actions_queue_size,
+        background_actions_running_size,
+        background_actions_failed_total,
+        background_actions_cancelled_total,
+        previous_background_actions_queue_labels: Arc::new(Mutex::new(HashSet::new())),
+        previous_background_actions_running_labels: Arc::new(Mutex::new(HashSet::new())),
         grpc_requests,
         grpc_request_duration,
         shards_owned,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,7 +31,6 @@ use std::task::{Context, Poll};
 
 use axum::{Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
 use opentelemetry::KeyValue;
-use opentelemetry::metrics::Counter as OtelCounter;
 use opentelemetry::metrics::Gauge as OtelGauge;
 use prometheus::{
     CounterVec, Encoder, Gauge, GaugeVec, HistogramOpts, HistogramVec, Opts, Registry, TextEncoder,
@@ -42,7 +41,6 @@ use tokio::sync::broadcast;
 use tower::{Layer, Service};
 use tracing::{debug, error};
 
-use crate::job::JobStatusKind;
 use crate::job_store_shard::counters::{
     BACKGROUND_ACTION_EXPLICIT_QUEUE_KIND, BACKGROUND_ACTION_PLATFORM_QUEUE_KIND,
     BACKGROUND_ACTION_QUEUE_SIZE_BUCKET, BACKGROUND_ACTION_RUNNING_SIZE_BUCKET,
@@ -115,8 +113,6 @@ pub struct Metrics {
     job_wait_time: HistogramVec,
     background_actions_queue_size: OtelGauge<u64>,
     background_actions_running_size: OtelGauge<u64>,
-    background_actions_failed_total: OtelCounter<u64>,
-    background_actions_cancelled_total: OtelCounter<u64>,
     previous_background_actions_queue_labels: BackgroundActionLabelSet,
     previous_background_actions_running_labels: BackgroundActionLabelSet,
 
@@ -346,41 +342,6 @@ impl Metrics {
         for ((shard_id, tenant, task_group, queue), value) in values {
             record_background_action_gauge_value(
                 gauge, shard_id, tenant, task_group, queue, *value,
-            );
-        }
-    }
-
-    pub fn record_background_action_terminal_event(
-        &self,
-        shard_id: &str,
-        tenant: &str,
-        task_group: &str,
-        status: JobStatusKind,
-        metadata: &[(String, String)],
-    ) {
-        let counter = match status {
-            JobStatusKind::Failed => &self.background_actions_failed_total,
-            JobStatusKind::Cancelled => &self.background_actions_cancelled_total,
-            JobStatusKind::Scheduled | JobStatusKind::Running | JobStatusKind::Succeeded => return,
-        };
-
-        let explicit_queue = background_action_metadata_value(metadata, "queue");
-        let platform_queue = background_action_metadata_value(metadata, "platformConcurrencyQueue");
-
-        if let Some(queue) = explicit_queue {
-            record_background_action_counter_value(counter, shard_id, tenant, task_group, queue, 1);
-        }
-        if let Some(queue) = platform_queue {
-            record_background_action_counter_value(counter, shard_id, tenant, task_group, queue, 1);
-        }
-        if explicit_queue.is_none() && platform_queue.is_some() {
-            record_background_action_counter_value(
-                counter,
-                shard_id,
-                tenant,
-                task_group,
-                "<no queue>",
-                1,
             );
         }
     }
@@ -631,34 +592,6 @@ fn record_background_action_gauge_value(
             KeyValue::new("queue", queue.to_string()),
         ],
     );
-}
-
-fn record_background_action_counter_value(
-    counter: &OtelCounter<u64>,
-    shard_id: &str,
-    tenant: &str,
-    task_group: &str,
-    queue: &str,
-    value: u64,
-) {
-    counter.add(
-        value,
-        &[
-            KeyValue::new("shard_id", shard_id.to_string()),
-            KeyValue::new("tenant", tenant.to_string()),
-            KeyValue::new("task_group", task_group.to_string()),
-            KeyValue::new("queue", queue.to_string()),
-        ],
-    );
-}
-
-fn background_action_metadata_value<'a>(
-    metadata: &'a [(String, String)],
-    key: &str,
-) -> Option<&'a str> {
-    metadata
-        .iter()
-        .find_map(|(k, v)| (k == key).then_some(v.as_str()))
 }
 
 /// Build background action status gauges from all represented jobs in a shard.
@@ -1484,14 +1417,6 @@ pub fn init() -> anyhow::Result<Metrics> {
         .u64_gauge("background_actions.running_size")
         .with_description("Number of Silo background action jobs currently running")
         .init();
-    let background_actions_failed_total = meter
-        .u64_counter("background_actions.failed_total")
-        .with_description("Total number of Silo background action jobs that failed")
-        .init();
-    let background_actions_cancelled_total = meter
-        .u64_counter("background_actions.cancelled_total")
-        .with_description("Total number of Silo background action jobs that were cancelled")
-        .init();
 
     // gRPC metrics
     let grpc_requests = register(
@@ -1836,8 +1761,6 @@ pub fn init() -> anyhow::Result<Metrics> {
         job_wait_time,
         background_actions_queue_size,
         background_actions_running_size,
-        background_actions_failed_total,
-        background_actions_cancelled_total,
         previous_background_actions_queue_labels: Arc::new(Mutex::new(HashSet::new())),
         previous_background_actions_running_labels: Arc::new(Mutex::new(HashSet::new())),
         grpc_requests,

--- a/src/server.rs
+++ b/src/server.rs
@@ -2203,6 +2203,8 @@ where
                 biased;
                 _ = interval.tick() => {
                     if let Some(ref m) = metrics_for_scrape {
+                        let mut background_action_snapshot =
+                            crate::metrics::BackgroundActionMetricSnapshot::default();
                         for (shard_id, shard) in metrics_factory.instances().iter() {
                             let shard_label = shard_id.to_string();
                             let recorder = shard.slatedb_metrics_recorder();
@@ -2211,7 +2213,23 @@ where
                                 &shard_label,
                                 shard.concurrency_cache_stats(),
                             );
+                            match crate::metrics::collect_background_action_metrics_for_shard(
+                                &shard_label,
+                                shard.as_ref(),
+                            )
+                            .await
+                            {
+                                Ok(snapshot) => background_action_snapshot.merge(snapshot),
+                                Err(e) => {
+                                    warn!(
+                                        shard = %shard_label,
+                                        error = %e,
+                                        "failed to collect background action metrics"
+                                    );
+                                }
+                            }
                         }
+                        m.record_background_action_metrics(background_action_snapshot);
                     }
                 }
                 _ = metrics_tick_rx.recv() => { break; }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex, Once};
 use opentelemetry::KeyValue;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::{Resource, runtime, trace as sdktrace};
 use tracing_subscriber::fmt::MakeWriter;
@@ -11,6 +12,8 @@ use tracing_subscriber::{EnvFilter, filter::LevelFilter, prelude::*};
 use crate::settings::LogFormat;
 
 static INIT: Once = Once::new();
+static METER_PROVIDER: std::sync::OnceLock<Mutex<Option<SdkMeterProvider>>> =
+    std::sync::OnceLock::new();
 
 fn build_env_filter() -> EnvFilter {
     EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
@@ -148,6 +151,27 @@ where
             tracing_perfetto::PerfettoLayer::new(Mutex::new(file)).with_filter(LevelFilter::DEBUG);
         base.with(perfetto_layer).init();
     } else if let Ok(endpoint) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+        let resource = Resource::new(vec![KeyValue::new("service.name", "silo")]);
+        match opentelemetry_otlp::new_pipeline()
+            .metrics(runtime::Tokio)
+            .with_exporter(
+                opentelemetry_otlp::new_exporter()
+                    .http()
+                    .with_endpoint(endpoint.clone()),
+            )
+            .with_resource(resource.clone())
+            .build()
+        {
+            Ok(provider) => {
+                opentelemetry::global::set_meter_provider(provider.clone());
+                let store = METER_PROVIDER.get_or_init(|| Mutex::new(None));
+                *store.lock().unwrap() = Some(provider);
+            }
+            Err(err) => {
+                eprintln!("otlp metrics init failed, continuing without otlp metrics: {err}");
+            }
+        }
+
         match opentelemetry_otlp::new_pipeline()
             .tracing()
             .with_exporter(
@@ -155,10 +179,7 @@ where
                     .http()
                     .with_endpoint(endpoint),
             )
-            .with_trace_config(
-                sdktrace::Config::default()
-                    .with_resource(Resource::new(vec![KeyValue::new("service.name", "silo")])),
-            )
+            .with_trace_config(sdktrace::Config::default().with_resource(resource))
             .install_batch(runtime::Tokio)
         {
             Ok(provider) => {
@@ -209,6 +230,12 @@ where
 
 /// Flush OTLP exporter if configured.
 pub fn shutdown() {
+    if let Some(store) = METER_PROVIDER.get()
+        && let Some(provider) = store.lock().unwrap().take()
+        && let Err(err) = provider.shutdown()
+    {
+        eprintln!("otlp metrics shutdown failed: {err}");
+    }
     opentelemetry::global::shutdown_tracer_provider();
 }
 

--- a/tests/tenant_status_counter_tests.rs
+++ b/tests/tenant_status_counter_tests.rs
@@ -25,6 +25,28 @@ async fn get_status_counts(
         .collect()
 }
 
+async fn get_background_action_queue_counts(
+    shard: &std::sync::Arc<silo::job_store_shard::JobStoreShard>,
+    tenant: &str,
+) -> std::collections::HashMap<(String, String, String, String), i64> {
+    shard
+        .snapshot_background_action_queue_counters()
+        .into_iter()
+        .filter(|counter| counter.tenant == tenant)
+        .map(|counter| {
+            (
+                (
+                    counter.task_group,
+                    counter.status_bucket,
+                    counter.queue_kind,
+                    counter.queue,
+                ),
+                counter.count,
+            )
+        })
+        .collect()
+}
+
 #[silo::test]
 async fn counter_increments_on_enqueue() {
     let (_tmp, shard) = open_temp_shard().await;
@@ -113,6 +135,220 @@ async fn counter_transitions_through_lifecycle() {
             .expect("get status")
             .expect("exists");
         assert_eq!(status.kind, JobStatusKind::Succeeded);
+    });
+}
+
+#[silo::test]
+async fn background_action_queue_counters_transition_through_lifecycle() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let job_id = shard
+            .enqueue(
+                "env-tenant-1",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                msgpack_payload(&serde_json::json!({"test": "background counters"})),
+                vec![],
+                Some(vec![
+                    ("queue".to_string(), "user-queue".to_string()),
+                    (
+                        "platformConcurrencyQueue".to_string(),
+                        "platform-queue".to_string(),
+                    ),
+                ]),
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        let counts = get_background_action_queue_counts(&shard, "env-tenant-1").await;
+        assert_eq!(
+            counts
+                .get(&(
+                    "default".to_string(),
+                    "queue_size".to_string(),
+                    "explicit".to_string(),
+                    "user-queue".to_string()
+                ))
+                .copied()
+                .unwrap_or(0),
+            1
+        );
+        assert_eq!(
+            counts
+                .get(&(
+                    "default".to_string(),
+                    "queue_size".to_string(),
+                    "platform".to_string(),
+                    "platform-queue".to_string()
+                ))
+                .copied()
+                .unwrap_or(0),
+            1
+        );
+
+        let tasks = shard
+            .dequeue("w", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        assert_eq!(tasks.len(), 1);
+
+        let counts = get_background_action_queue_counts(&shard, "env-tenant-1").await;
+        assert_eq!(
+            counts
+                .get(&(
+                    "default".to_string(),
+                    "queue_size".to_string(),
+                    "explicit".to_string(),
+                    "user-queue".to_string()
+                ))
+                .copied()
+                .unwrap_or(0),
+            0
+        );
+        assert_eq!(
+            counts
+                .get(&(
+                    "default".to_string(),
+                    "running_size".to_string(),
+                    "explicit".to_string(),
+                    "user-queue".to_string()
+                ))
+                .copied()
+                .unwrap_or(0),
+            1
+        );
+        assert_eq!(
+            counts
+                .get(&(
+                    "default".to_string(),
+                    "running_size".to_string(),
+                    "platform".to_string(),
+                    "platform-queue".to_string()
+                ))
+                .copied()
+                .unwrap_or(0),
+            1
+        );
+
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .expect("report success");
+
+        let counts = get_background_action_queue_counts(&shard, "env-tenant-1").await;
+        assert!(
+            counts.is_empty(),
+            "terminal job counters should be removed, got {counts:?}"
+        );
+
+        let status = shard
+            .get_job_status("env-tenant-1", &job_id)
+            .await
+            .expect("get status")
+            .expect("exists");
+        assert_eq!(status.kind, JobStatusKind::Succeeded);
+    });
+}
+
+#[silo::test]
+async fn background_action_queue_counters_drop_failed_and_cancelled_gauges() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        let failed_job_id = shard
+            .enqueue(
+                "env-tenant-1",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                msgpack_payload(&serde_json::json!({"test": "background failed"})),
+                vec![],
+                Some(vec![
+                    ("queue".to_string(), "user-queue".to_string()),
+                    (
+                        "platformConcurrencyQueue".to_string(),
+                        "platform-queue".to_string(),
+                    ),
+                ]),
+                "default",
+            )
+            .await
+            .expect("enqueue failed job");
+
+        let tasks = shard
+            .dequeue("w", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        assert_eq!(tasks.len(), 1);
+
+        let task_id = tasks[0].attempt().task_id().to_string();
+        shard
+            .report_attempt_outcome(
+                &task_id,
+                AttemptOutcome::Error {
+                    error_code: "TEST".to_string(),
+                    error: vec![],
+                },
+            )
+            .await
+            .expect("report error");
+
+        let counts = get_background_action_queue_counts(&shard, "env-tenant-1").await;
+        assert!(
+            counts.is_empty(),
+            "failed jobs should emit event counters, not retained gauges: {counts:?}"
+        );
+
+        let cancelled_job_id = shard
+            .enqueue(
+                "env-tenant-1",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                msgpack_payload(&serde_json::json!({"test": "background cancelled"})),
+                vec![],
+                Some(vec![
+                    ("queue".to_string(), "cancel-queue".to_string()),
+                    (
+                        "platformConcurrencyQueue".to_string(),
+                        "cancel-platform".to_string(),
+                    ),
+                ]),
+                "default",
+            )
+            .await
+            .expect("enqueue cancelled job");
+
+        shard
+            .cancel_job("env-tenant-1", &cancelled_job_id)
+            .await
+            .expect("cancel");
+
+        let counts = get_background_action_queue_counts(&shard, "env-tenant-1").await;
+        assert!(
+            counts.is_empty(),
+            "cancelled jobs should emit event counters, not retained gauges: {counts:?}"
+        );
+
+        shard
+            .delete_job("env-tenant-1", &failed_job_id)
+            .await
+            .expect("delete failed job");
+
+        let counts = get_background_action_queue_counts(&shard, "env-tenant-1").await;
+        assert!(
+            counts.is_empty(),
+            "deleted failed job should not reintroduce gauges: {counts:?}"
+        );
     });
 }
 


### PR DESCRIPTION
- Adds Silo background action metrics for queued and running jobs using OTel gauges:
      - background_actions.queue_size
      - background_actions.running_size

  - Emits metrics from the scheduled/background metrics path so the existing ops dashboard can read them from ClickHouse without frontend changes.
  - Tracks sparse in-memory queue/running counts by shard_id, tenant, task_group, and queue.
  - Attributes jobs to explicit user queues via metadata.queue, platform queues via metadata.platformConcurrencyQueue, and synthetic "<no queue>" values for unqueued dashboard visibility.
  - Maps Waiting/Scheduled jobs to queued gauges and Running jobs to running gauges; terminal jobs are excluded from gauges.
  - Adds failed/cancelled terminal event counters and emits them only after the backing write commits.
  - Rebuilds in-memory background action counters on shard open from persisted job status/job info.
  - Fixes a DashMap zero-removal race so concurrent queue counter increments are not accidentally erased.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many job lifecycle write paths (enqueue, dequeue, cancel, outcomes) with rollback logic; incorrect gauge drift could mislead ops but does not affect job execution correctness.
> 
> **Overview**
> Adds **background-action queue visibility** for the ops dashboard by tracking sparse in-memory counts per shard (`DashMap`) keyed by tenant, task_group, status bucket (`queue_size` / `running_size`), queue kind (explicit `metadata.queue` vs `metadata.platformConcurrencyQueue`), and queue name. **Scheduled** and **Running** jobs move counts on status transitions; terminal statuses drop out of gauges. Counts are updated from `set_job_status_with_index` (with optional `JobView` to avoid extra `JOB_INFO` reads on hot paths), rolled back when transactions or writes fail, rebuilt from `JOB_STATUS` + `JOB_INFO` at shard open, and **not** updated on admin import (only normal transitions / reimport).
> 
> Exports **`background_actions.queue_size`** and **`background_actions.running_size`** as OpenTelemetry gauges (labels: `shard_id`, `tenant`, `task_group`, `queue`), with stale label sets zeroed on scrape. The metrics loop merges per-shard snapshots and derives synthetic **`<no queue>`** from platform minus explicit totals. Enables OTLP **metrics** export alongside traces (`opentelemetry-otlp` features, `SdkMeterProvider` in `trace.rs`). Integration tests cover lifecycle, failed/cancelled gauge removal, and concurrent counter safety via `remove_if` when counts hit zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e7e011414cf1dcd13b2579937183aae4d9fc06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->