### PR TITLE
Raise gRPC max message size back to 128MB for large job payloads

### DIFF
--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -234,8 +234,8 @@ pub fn create_silo_client_lazy(
     let channel = endpoint.connect_lazy();
     let interceptor = AuthInterceptor::new(config.auth_token.clone());
     Ok(SiloClient::with_interceptor(channel, interceptor)
-        .max_decoding_message_size(32 * 1024 * 1024)
-        .max_encoding_message_size(32 * 1024 * 1024))
+        .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE))
 }
 
 /// Helper to create a SiloClient with an eager connection and retry logic.
@@ -277,8 +277,8 @@ pub async fn create_silo_client(
             Ok(Ok(channel)) => {
                 let interceptor = AuthInterceptor::new(config.auth_token.clone());
                 return Ok(SiloClient::with_interceptor(channel, interceptor)
-                    .max_decoding_message_size(32 * 1024 * 1024)
-                    .max_encoding_message_size(32 * 1024 * 1024));
+                    .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+                    .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE));
             }
             Ok(Err(e)) => {
                 trace!(

--- a/src/cluster_query.rs
+++ b/src/cluster_query.rs
@@ -666,8 +666,8 @@ async fn query_remote_shard_batches(
 
         let interceptor = AuthInterceptor::new(auth_token.map(|s| s.to_string()));
         let mut client = SiloClient::with_interceptor(channel, interceptor)
-            .max_decoding_message_size(32 * 1024 * 1024)
-            .max_encoding_message_size(32 * 1024 * 1024);
+            .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
 
         // Make streaming query
         let request = QueryArrowRequest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,11 @@ pub mod pb {
 #[cfg(feature = "server")]
 pub mod server;
 
+/// Max gRPC message size for all silo servers and clients (tonic defaults to 4MB).
+/// Gadget background action payloads can be up to 100MB (matching the bigtable-backed
+/// store's payload ceiling), so this must comfortably clear that plus request overhead.
+pub const MAX_GRPC_MESSAGE_SIZE: usize = 128 * 1024 * 1024;
+
 #[cfg(unix)]
 #[global_allocator]
 static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/src/server.rs
+++ b/src/server.rs
@@ -2147,8 +2147,8 @@ where
     let svc = SiloService::new(factory.clone(), coordinator, cfg.clone(), metrics.clone());
     let interceptor = make_auth_interceptor(cfg.server.auth_token.clone());
     let silo_server = SiloServer::new(svc)
-        .max_decoding_message_size(32 * 1024 * 1024)
-        .max_encoding_message_size(32 * 1024 * 1024);
+        .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
     let server = tonic::service::interceptor::InterceptedService::new(silo_server, interceptor);
 
     // Create health service for gRPC health probes

--- a/typescript_client/test/client-integration.test.ts
+++ b/typescript_client/test/client-integration.test.ts
@@ -1218,16 +1218,17 @@ describe.skipIf(!RUN_INTEGRATION)("SiloGRPCClient integration", () => {
 
   describe("large payloads", () => {
     it(
-      "enqueues and retrieves a 10MB payload",
-      { timeout: 30_000 },
+      "enqueues and retrieves a 100MB payload",
+      { timeout: 60_000 },
       async () => {
         const tenant = "large-payload-tenant";
 
-        // Build a ~10MB payload using a raw Buffer.
+        // Build a ~100MB payload using a raw Buffer.
         // msgpack encodes Buffers as binary data without base64 expansion,
-        // so the wire size stays close to 10MB. This validates we're above
-        // the default 4MB gRPC limit without overwhelming CI resources.
-        const sizeBytes = 10 * 1024 * 1024;
+        // so the wire size stays close to 100MB. Gadget background action
+        // payloads can be up to 100MB, so this validates the gRPC message
+        // size limit clears the largest payload the platform allows.
+        const sizeBytes = 100 * 1024 * 1024;
         const largeBuffer = Buffer.alloc(sizeBytes, 0x42);
         const payload = { data: largeBuffer };
 


### PR DESCRIPTION
Gadget background action payloads can be up to 100MB (the bigtable-backed store's payload ceiling), and enqueue requests for environments on the silo backend were failing with tonic's 'decoded message length too large' once the encoded request crossed the 32MB cap introduced in 7e99abd.

Extract the limit into a shared MAX_GRPC_MESSAGE_SIZE constant used by the tonic server, the Rust cluster client, and the cluster query client, and set it to 128MB to comfortably clear the largest payload the platform allows. The TypeScript client already defaults to 128MB. Bump the round-trip integration test to 100MB to lock the ceiling in.