### PR TITLE
Convert at-capacity RequestTickets into deferred concurrency requests

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -2040,8 +2040,19 @@ fn append_grant_edits<W: WriteBatcher>(
     Ok(())
 }
 
+/// Append a deferred concurrency request record (plus the +1 requester
+/// counter merge) for a chain parked at an at-capacity queue.
+///
+/// Two callers: the at-capacity immediate-enqueue path ([SILO-ENQ-CONC-6])
+/// and the dequeue-time ticket-conversion path in `job_store_shard::dequeue`
+/// (`handle_request_ticket`). Callers must pass the chain's ORIGINAL
+/// `start_time_ms` and `priority`: cancel/reimport locate request records by
+/// the narrow `(tenant, queue, start_time_ms, priority, job_id, attempt)`
+/// prefix derived from job status, and `process_grants` grants in
+/// start-time order, so a rewritten time would orphan the record from
+/// cleanup and forfeit the job's queue position.
 #[allow(clippy::too_many_arguments)]
-fn append_request_edits<W: WriteBatcher>(
+pub(crate) fn append_request_edits<W: WriteBatcher>(
     writer: &mut W,
     tenant: &str,
     queue: &str,

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -4,7 +4,7 @@ use slatedb::WriteBatch;
 use slatedb::config::WriteOptions;
 
 use crate::codec::{DecodedTask, decode_task, encode_attempt, encode_holder, encode_lease};
-use crate::concurrency::ConcurrencyManager;
+use crate::concurrency::{ConcurrencyManager, append_request_edits};
 use crate::dst_events::{self, DstEvent};
 use crate::fb::silo::fb;
 use crate::job::{JobStatus, JobStatusKind, JobView, Limit};
@@ -37,6 +37,12 @@ struct DequeueIterationState {
     /// in-memory slot released + the grant scanner notified after commit.
     /// Format: (tenant, queue, task_id).
     holder_releases: Vec<(String, String, String)>,
+    /// (tenant, queue) pairs whose at-capacity RequestTicket was converted
+    /// into a deferred concurrency request in this iteration's batch. The
+    /// grant scanner is nudged for each after commit so a slot freed between
+    /// `try_reserve` failing and the batch committing is picked up
+    /// immediately instead of waiting for the periodic reconcile.
+    converted_requests: Vec<(String, String)>,
     processed_internal: bool,
 }
 
@@ -51,12 +57,9 @@ impl DequeueIterationState {
             leased_tasks_for_dst: Vec::new(),
             pending_attempts: Vec::new(),
             holder_releases: Vec::new(),
+            converted_requests: Vec::new(),
             processed_internal: false,
         }
-    }
-
-    fn ack_release(&mut self, key: &[u8]) {
-        self.release_keys.push(key.to_vec());
     }
 
     fn ack_deleted(&mut self, key: &[u8]) {
@@ -524,6 +527,24 @@ impl JobStoreShard {
                 self.concurrency.request_grant(&tenant, &queue);
             }
 
+            // Post-commit: nudge the grant scanner for every queue whose
+            // parked ticket we just converted into a deferred request.
+            // Closes the race where the gating slot
+            // freed between try_reserve failing and this batch committing;
+            // without the nudge the request waits for the periodic reconcile.
+            // No cancellation guard is needed (unlike holder_releases): a
+            // missed nudge self-heals via that same reconcile, and a spurious
+            // nudge is harmless (process_grants re-checks capacity). The
+            // metric is recorded here rather than in the handler so it only
+            // counts durable conversions.
+            let converted = state.converted_requests.len() as u64;
+            for (tenant, queue) in state.converted_requests.drain(..) {
+                self.concurrency.request_grant(&tenant, &queue);
+            }
+            if let Some(ref m) = self.metrics {
+                m.record_concurrency_tickets_converted(self.name(), converted);
+            }
+
             // Collect pending attempts from this iteration
             pending_attempts.append(&mut state.pending_attempts);
 
@@ -636,8 +657,10 @@ impl JobStoreShard {
     /// 1. Sanity-check that the job still exists (cheap status check; no
     ///    JobInfo fetch — the limits we need ride on the ticket itself).
     /// 2. Resolve the gating queue's capacity from the persisted limits.
-    /// 3. `try_reserve` the slot. If at capacity, leave the ticket in place
-    ///    (`ack_release`) so a later scan reattempts.
+    /// 3. `try_reserve` the slot. If at capacity, delete the ticket and
+    ///    convert it into a deferred concurrency request record (drained by
+    ///    the grant scanner; nudged post-commit) — leaving at-capacity
+    ///    tickets in place head-of-line-blocks the broker scan.
     /// 4. On grant: write the holder, delete the ticket, and call
     ///    `enqueue_limit_task_at_index` with `limit_index + 1` to write the
     ///    follow-up task. Use `now_ms` for the follow-up's task_key — the
@@ -750,8 +773,46 @@ impl JobStoreShard {
             .await?;
 
         if !reserved {
-            // Out of capacity — leave the ticket in place for a later scan.
-            state.ack_release(task_key);
+            // Out of capacity. Do NOT leave the ticket in
+            // the task keyspace — the broker rescans the group from the front
+            // every pass and claims in key order, so a pile of permanently
+            // unconsumable tickets head-of-line blocks every later-keyed task
+            // in the group (tests/broker_head_of_line_blocking_tests.rs).
+            // Convert it into a deferred concurrency request record instead:
+            // the same durable shape an at-capacity immediate enqueue writes
+            // ([SILO-ENQ-CONC-6]), drained by the grant scanner when a slot
+            // frees.
+            //
+            // The request keeps the ticket's ORIGINAL start_time_ms and
+            // priority: cancel/reimport locate request records by the narrow
+            // (tenant, queue, start_time, priority, job_id, attempt) prefix
+            // derived from job status, and process_grants grants in
+            // start-time order, so the job keeps its fair queue position.
+            //
+            // No rollback handling is needed: nothing was reserved in memory
+            // (try_reserve failed), and if the batch never commits the ticket
+            // survives durably and is re-converted on the next claim.
+            state.batch.delete(task_key);
+            state.ack_deleted(task_key);
+            let mut writer = DbWriteBatcher::new(&self.db, &mut state.batch);
+            append_request_edits(
+                &mut writer,
+                &tenant,
+                &queue,
+                rt.start_time_ms(),
+                rt.priority(),
+                &job_id,
+                attempt_number,
+                relative_attempt_number,
+                &req_task_group,
+                limit_index,
+                &stored_held_queues,
+                &task_id,
+                &limits,
+            )?;
+            state
+                .converted_requests
+                .push((tenant.clone(), queue.clone()));
             return Ok(());
         }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -152,6 +152,7 @@ pub struct Metrics {
 
     // Concurrency metrics
     concurrency_tickets_granted: CounterVec,
+    concurrency_tickets_converted: CounterVec,
     concurrency_holders_cache_holders: GaugeVec,
     concurrency_holders_cache_queues: GaugeVec,
     concurrency_holders_cache_hydrated_queues: GaugeVec,
@@ -528,6 +529,17 @@ impl Metrics {
         }
         self.concurrency_tickets_granted
             .with_label_values(&[shard, path.as_str()])
+            .inc_by(n as f64);
+    }
+
+    /// Record `n` at-capacity RequestTicket tasks converted into deferred
+    /// concurrency request records at dequeue time on `shard`.
+    pub fn record_concurrency_tickets_converted(&self, shard: &str, n: u64) {
+        if n == 0 {
+            return;
+        }
+        self.concurrency_tickets_converted
+            .with_label_values(&[shard])
             .inc_by(n as f64);
     }
 
@@ -1964,6 +1976,17 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let concurrency_tickets_converted = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_concurrency_tickets_converted_total",
+                "Total number of at-capacity RequestTicket tasks converted into deferred concurrency request records at dequeue time",
+            ),
+            &["shard"],
+        )?,
+    );
+
     let concurrency_holders_cache_holders = register(
         &registry,
         GaugeVec::new(
@@ -2121,6 +2144,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         lease_reaper_leases_reaped_total,
         lease_reaper_errors_total,
         concurrency_tickets_granted,
+        concurrency_tickets_converted,
         concurrency_holders_cache_holders,
         concurrency_holders_cache_queues,
         concurrency_holders_cache_hydrated_queues,

--- a/tests/broker_head_of_line_blocking_tests.rs
+++ b/tests/broker_head_of_line_blocking_tests.rs
@@ -1,0 +1,203 @@
+//! Regression test for broker head-of-line blocking by parked RequestTickets.
+//!
+//! Production incident (2026-06): one tenant enqueued ~29k future-scheduled jobs
+//! gated by a user queue with max_concurrency=1. One job won the only slot; the
+//! rest became `Task::RequestTicket` entries parked at the front of the task
+//! group's key range. An at-capacity ticket is left in place by
+//! `handle_request_ticket` (ack_release) to be retried on a later scan, so the
+//! tickets never leave the DB while the slot is held. The broker scan always
+//! restarts from the front of the group's key range and claims in key order,
+//! so with more unconsumable tickets than a scan batch (4096) the broker never
+//! makes progress past them — starving every other tenant's tasks in the same
+//! task group on the same shard, even tasks that already hold all their
+//! concurrency slots and are ready to run.
+//!
+//! This test reproduces the wedge with two tenants on one shard and asserts
+//! the desired behavior: tenant B's runnable jobs must be dequeued even while
+//! tenant A's parked tickets clog the front of the task group.
+
+mod test_helpers;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use silo::job::{ConcurrencyLimit, FloatingConcurrencyLimit, Limit};
+use test_helpers::*;
+
+const TASK_GROUP: &str = "shared-actions";
+const TENANT_A: &str = "tenant-a";
+const TENANT_B: &str = "tenant-b";
+
+/// Must exceed the broker's scan_batch (4096) so a single scan pass can never
+/// read past tenant A's parked tickets.
+const TENANT_A_JOBS: usize = 4_300;
+const TENANT_B_JOBS: usize = 3;
+
+/// How far in the future tenant A's jobs are scheduled. Enqueueing all of
+/// TENANT_A_JOBS must finish within this window so every job takes the
+/// future-scheduled path and writes a parked `Task::RequestTicket` (an
+/// immediate-start enqueue writes a deferred request record instead, which
+/// does not occupy the task-group key range).
+const START_DELAY_MS: i64 = 15_000;
+
+/// Long enough that no RefreshFloatingLimit task fires during the test.
+const REFRESH_INTERVAL_MS: i64 = 3_600_000;
+
+fn limits(queue: &str, max_concurrency: u32, floating_queue: &str) -> Vec<Limit> {
+    vec![
+        // The tight fixed limit must precede the floating limit — silo walks
+        // limits in client order (see walk_limit_chain), matching production.
+        Limit::Concurrency(ConcurrencyLimit {
+            key: queue.to_string(),
+            max_concurrency,
+        }),
+        Limit::FloatingConcurrency(FloatingConcurrencyLimit {
+            key: floating_queue.to_string(),
+            default_max_concurrency: 360,
+            refresh_interval_ms: REFRESH_INTERVAL_MS,
+            metadata: vec![],
+        }),
+    ]
+}
+
+#[silo::test]
+async fn tenant_b_is_not_starved_by_tenant_a_parked_request_tickets() {
+    with_timeout!(150_000, {
+        let (_tmp, shard) = open_temp_shard().await;
+
+        // Both tenants must land on the same shard — the wedge is per
+        // (shard, task_group). The temp shard owns the full tenant range.
+        let range = shard.get_range();
+        assert!(
+            range.contains_tenant(TENANT_A) && range.contains_tenant(TENANT_B),
+            "test setup: both tenants must map to this shard"
+        );
+
+        let payload = msgpack_payload(&serde_json::json!({"k": "v"}));
+        let start_a = now_ms() + START_DELAY_MS;
+
+        // Tenant A: future-scheduled jobs gated by a queue with
+        // max_concurrency=1. Each enqueue writes a parked RequestTicket task
+        // keyed at start_a in the shared task group. Enqueue concurrently so
+        // commits share SlateDB flush windows.
+        let mut enqueued = 0usize;
+        while enqueued < TENANT_A_JOBS {
+            let chunk = (TENANT_A_JOBS - enqueued).min(512);
+            let mut join_set = tokio::task::JoinSet::new();
+            for _ in 0..chunk {
+                let shard = Arc::clone(&shard);
+                let payload = payload.clone();
+                join_set.spawn(async move {
+                    shard
+                        .enqueue(
+                            TENANT_A,
+                            None,
+                            10u8,
+                            start_a,
+                            None,
+                            payload,
+                            limits("queue-a", 1, "surge-a"),
+                            None,
+                            TASK_GROUP,
+                        )
+                        .await
+                });
+            }
+            while let Some(res) = join_set.join_next().await {
+                res.expect("enqueue task panicked").expect("enqueue A");
+            }
+            enqueued += chunk;
+        }
+        assert!(
+            now_ms() < start_a,
+            "test setup too slow: tenant A enqueues overran the future start \
+             time, so some jobs missed the RequestTicket path; increase \
+             START_DELAY_MS"
+        );
+
+        // Every tenant A job must be a parked RequestTicket in the task group.
+        let parked = count_with_binary_prefix(
+            shard.db(),
+            &silo::keys::task_group_prefix(TASK_GROUP),
+        )
+        .await;
+        assert_eq!(
+            parked, TENANT_A_JOBS,
+            "expected one parked RequestTicket per tenant A job"
+        );
+
+        // Wait until tenant A's tickets become ready (scannable).
+        let wait = (start_a - now_ms()).max(0) as u64 + 200;
+        tokio::time::sleep(Duration::from_millis(wait)).await;
+
+        // Tenant B: immediate jobs on its own queue (max_concurrency=3). All
+        // three are granted their fixed + floating slots at enqueue time; the
+        // resulting RunAttempt tasks land in the same task group *behind*
+        // tenant A's tickets (later start time). They are fully runnable —
+        // only the broker stands between them and a worker.
+        for i in 0..TENANT_B_JOBS {
+            shard
+                .enqueue(
+                    TENANT_B,
+                    Some(format!("b-{i}")),
+                    10u8,
+                    0, // immediate
+                    None,
+                    payload.clone(),
+                    limits("queue-b", TENANT_B_JOBS as u32, "surge-b"),
+                    None,
+                    TASK_GROUP,
+                )
+                .await
+                .expect("enqueue B");
+        }
+        assert_eq!(
+            count_concurrency_holders_for_tenant(shard.db(), TENANT_B).await,
+            TENANT_B_JOBS * 2,
+            "tenant B jobs should hold both their fixed and floating slots \
+             immediately after enqueue"
+        );
+
+        // Drive dequeues like production workers. The first granted tenant A
+        // ticket takes queue-a's only slot and its RunAttempt is leased (we
+        // never complete it, so the slot is held for the rest of the test and
+        // all remaining tenant A tickets stay at capacity, recycling through
+        // the broker scan window). Tenant B's three RunAttempts must still be
+        // dequeued.
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        let mut a_leased = 0usize;
+        let mut b_leased = 0usize;
+        while std::time::Instant::now() < deadline {
+            let result = shard
+                .dequeue("worker-1", TASK_GROUP, 10)
+                .await
+                .expect("dequeue");
+            for task in &result.tasks {
+                if task.job().id().starts_with("b-") {
+                    b_leased += 1;
+                } else {
+                    a_leased += 1;
+                }
+            }
+            if b_leased >= TENANT_B_JOBS && a_leased >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(
+            b_leased, TENANT_B_JOBS,
+            "tenant B's granted, runnable jobs were starved behind tenant A's \
+             {} parked at-capacity RequestTickets: the broker scan restarts \
+             from the front of the task group every pass and the tickets are \
+             never consumed (handle_request_ticket leaves at-capacity tickets \
+             in place), so tasks keyed behind them are never claimed",
+            TENANT_A_JOBS
+        );
+        assert_eq!(
+            a_leased, 1,
+            "exactly one tenant A job should run (queue-a max_concurrency=1, \
+             never completed)"
+        );
+    });
+}

--- a/tests/broker_head_of_line_blocking_tests.rs
+++ b/tests/broker_head_of_line_blocking_tests.rs
@@ -116,11 +116,8 @@ async fn tenant_b_is_not_starved_by_tenant_a_parked_request_tickets() {
         );
 
         // Every tenant A job must be a parked RequestTicket in the task group.
-        let parked = count_with_binary_prefix(
-            shard.db(),
-            &silo::keys::task_group_prefix(TASK_GROUP),
-        )
-        .await;
+        let parked =
+            count_with_binary_prefix(shard.db(), &silo::keys::task_group_prefix(TASK_GROUP)).await;
         assert_eq!(
             parked, TENANT_A_JOBS,
             "expected one parked RequestTicket per tenant A job"

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -2188,3 +2188,234 @@ async fn future_scheduled_burst_into_quiet_queue_holds_zero_slots() {
         tasks.len(),
     );
 }
+
+/// A future-scheduled job's RequestTicket processed at an
+/// at-capacity queue must be converted into a deferred concurrency request
+/// (task deleted, request record + requester counter written) rather than
+/// left parked in the task keyspace, and the grant scanner must drain the
+/// converted request once the slot frees.
+#[silo::test]
+async fn at_capacity_ticket_converts_to_deferred_request() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+        let now = now_ms();
+        let queue = "convert-q".to_string();
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let limits = vec![Limit::Concurrency(ConcurrencyLimit {
+            key: queue.clone(),
+            max_concurrency: 1,
+        })];
+
+        // Job 1: immediate, takes the only slot and is leased (held until we
+        // complete it).
+        let job1 = shard
+            .enqueue(
+                "-",
+                Some("convert-job-1".to_string()),
+                10u8,
+                now,
+                None,
+                payload.clone(),
+                limits.clone(),
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue job1");
+        let tasks = shard.dequeue("w", "default", 1).await.expect("deq1").tasks;
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].job().id(), job1);
+        let t1_id = tasks[0].attempt().task_id().to_string();
+
+        // Job 2: future-scheduled on the same queue → persisted RequestTicket.
+        let job2 = shard
+            .enqueue(
+                "-",
+                Some("convert-job-2".to_string()),
+                10u8,
+                now + 500,
+                None,
+                payload.clone(),
+                limits.clone(),
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue job2");
+        assert_eq!(
+            count_task_keys(shard.db()).await,
+            1,
+            "future job should be a parked RequestTicket task"
+        );
+        assert_eq!(
+            count_concurrency_requests(shard.db()).await,
+            0,
+            "no deferred request before the ticket is processed"
+        );
+
+        // Let the start time pass, then dequeue: the broker claims the
+        // ticket, try_reserve fails (job1 holds the slot), and the ticket is
+        // converted. The dequeue returns nothing leasable.
+        tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+        let converted = poll_until(
+            || async {
+                let r = shard.dequeue("w", "default", 1).await.expect("deq2");
+                assert!(r.tasks.is_empty(), "no slot available, nothing leasable");
+                (
+                    count_task_keys(shard.db()).await,
+                    count_concurrency_requests(shard.db()).await,
+                )
+            },
+            |(tasks, requests)| *tasks == 0 && *requests == 1,
+            5000,
+        )
+        .await;
+        assert_eq!(
+            converted,
+            (0, 1),
+            "at-capacity ticket should be deleted and replaced by exactly one \
+             deferred request (got (task_keys, requests) = {:?})",
+            converted
+        );
+        let requesters = shard
+            .get_concurrency_requester_count("-", &queue)
+            .await
+            .expect("requester count");
+        assert_eq!(requesters, 1, "converted job counts as a requester");
+
+        // Job 2 is still Scheduled and cannot have run.
+        let status2 = shard
+            .get_job_status("-", &job2)
+            .await
+            .expect("status job2")
+            .expect("job2 exists");
+        assert_eq!(status2.kind, silo::job::JobStatusKind::Scheduled);
+
+        // Complete job 1 → holder released → grant scanner drains the
+        // converted request → job 2 becomes leasable.
+        shard
+            .report_attempt_outcome(&t1_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .expect("report job1 success");
+        let tasks2 = poll_until(
+            || async {
+                shard
+                    .dequeue("w", "default", 1)
+                    .await
+                    .expect("deq job2")
+                    .tasks
+            },
+            |t| !t.is_empty(),
+            5000,
+        )
+        .await;
+        assert_eq!(tasks2.len(), 1, "converted request should grant and run");
+        assert_eq!(tasks2[0].job().id(), job2);
+        let final_requesters = shard
+            .get_concurrency_requester_count("-", &queue)
+            .await
+            .expect("requester count after grant");
+        assert_eq!(final_requesters, 0, "requester counter drains on grant");
+    });
+}
+
+/// Cancelling a job whose at-capacity ticket was converted to a deferred
+/// request must remove the request record and drain the requester counter,
+/// without disturbing the slot holder, and must not produce a phantom grant
+/// when the holder later releases.
+#[silo::test]
+async fn cancel_after_ticket_conversion_cleans_up_request() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+        let now = now_ms();
+        let queue = "convert-cancel-q".to_string();
+        let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+        let limits = vec![Limit::Concurrency(ConcurrencyLimit {
+            key: queue.clone(),
+            max_concurrency: 1,
+        })];
+
+        let _job1 = shard
+            .enqueue(
+                "-",
+                Some("cc-job-1".to_string()),
+                10u8,
+                now,
+                None,
+                payload.clone(),
+                limits.clone(),
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue job1");
+        let tasks = shard.dequeue("w", "default", 1).await.expect("deq1").tasks;
+        assert_eq!(tasks.len(), 1);
+        let t1_id = tasks[0].attempt().task_id().to_string();
+
+        let job2 = shard
+            .enqueue(
+                "-",
+                Some("cc-job-2".to_string()),
+                10u8,
+                now + 500,
+                None,
+                payload.clone(),
+                limits.clone(),
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue job2");
+
+        // Drive the conversion.
+        tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+        let converted = poll_until(
+            || async {
+                let _ = shard.dequeue("w", "default", 1).await.expect("deq2");
+                count_concurrency_requests(shard.db()).await
+            },
+            |requests| *requests == 1,
+            5000,
+        )
+        .await;
+        assert_eq!(converted, 1, "ticket should convert to a deferred request");
+
+        // Cancel the waiting job: request record and requester counter must
+        // be cleaned up; job1's holder must be untouched.
+        shard.cancel_job("-", &job2).await.expect("cancel job2");
+        assert_eq!(
+            count_concurrency_requests(shard.db()).await,
+            0,
+            "cancel should delete the converted request record"
+        );
+        let requesters = shard
+            .get_concurrency_requester_count("-", &queue)
+            .await
+            .expect("requester count");
+        assert_eq!(requesters, 0, "cancel should drain the requester counter");
+        assert_eq!(
+            count_concurrency_holders(shard.db()).await,
+            1,
+            "job1's holder must survive the cancel"
+        );
+
+        // Releasing job1's slot must not grant anything (no phantom grant
+        // for the cancelled requester).
+        shard
+            .report_attempt_outcome(&t1_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .expect("report job1 success");
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        let r = shard.dequeue("w", "default", 1).await.expect("deq final");
+        assert!(
+            r.tasks.is_empty(),
+            "cancelled job must not run after the slot frees"
+        );
+        assert_eq!(
+            count_concurrency_holders(shard.db()).await,
+            0,
+            "no phantom holder after cancelled requester's queue drains"
+        );
+    });
+}


### PR DESCRIPTION
## Problem

When a future-scheduled job's `RequestTicket` is processed at an at-capacity queue, `handle_request_ticket` left the ticket in the task keyspace (`ack_release`) to be retried by a later scan. The broker rescans each task group from the front of its key range every pass and claims in key order, so more than ~one scan batch (4096) of permanently-unconsumable tickets head-of-line-blocks **every later-keyed task in the (shard, task_group)** — including other tenants' fully-granted, runnable work.

This is the root cause of the staging incident where one tenant's ~29k jobs behind a `max_concurrency=1` queue wedged a task group on shard `14ec7869` for ~46h: 9,864 parked tickets recycled through the scan window forever (202M broker re-inserts, zero successful dequeues), starving an unrelated tenant's 360 granted RunAttempts and its `RefreshFloatingLimit` task.

## Fix

Ticket creation is unchanged (immediate-start jobs never create tickets). Only the at-capacity branch of `handle_request_ticket` changes: instead of leaving the ticket in place, it deletes the ticket and atomically (same batch) writes a **deferred concurrency request record** — the same durable shape an at-capacity immediate enqueue creates — which the grant scanner drains when a slot frees. A one-way transition, at most once per future-scheduled gate.

Key invariants:
- The request keeps the ticket's **original `start_time_ms` and `priority`**: cancel/reimport locate request records by the narrow `(tenant, queue, start_time, priority, job_id, attempt)` prefix, and `process_grants` grants in start-time order, so the job keeps its fair queue position.
- No new rollback paths: the conversion makes zero in-memory mutations (`try_reserve` failed). If the batch never commits, the ticket survives and re-converts on the next claim.
- Post-commit, the grant scanner is nudged per converted queue, closing the race where the slot freed between `try_reserve` failing and the commit (worst case otherwise: the 5s periodic reconcile).
- New `silo_concurrency_tickets_converted_total{shard}` counter records durable conversions.

No migration needed: wedged shards self-drain — every parked ticket converts the first time the broker processes it after deploy.

## Tests

- `broker_head_of_line_blocking_tests` (first commit): two tenants on one shard; tenant A parks 4,300 at-capacity tickets, tenant B has 3 fully-granted runnable jobs keyed behind them. **Red before the fix** (B leased 0/3 in 30s of polling), green after (B leases within seconds).
- `at_capacity_ticket_converts_to_deferred_request`: ticket → request record + requester counter, then holder release → grant scanner → job runs.
- `cancel_after_ticket_conversion_cleans_up_request`: cancel removes the request and drains the counter without disturbing the slot holder; no phantom grant when the slot later frees.
- Full `cargo test` green (cluster_query_integration_tests requires a local etcd; passes with one running).