### PR TITLE
Populate the job view Limits section from the jobs scanner

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -610,6 +610,9 @@ impl JobsScanner {
                 ),
                 true,
             ),
+            // Job-level limits (concurrency/rate/floating) serialized as a JSON array
+            // of {limit_type, key, value} objects for display purposes.
+            Field::new("limits", DataType::Utf8, true),
         ]))
     }
 }
@@ -639,7 +642,7 @@ fn analyze_projection(projection: &SchemaRef, strategy: &JobsScanStrategy) -> Pr
     let need_job_info = projection.fields().iter().any(|f| {
         matches!(
             f.name().as_str(),
-            "priority" | "enqueue_time_ms" | "payload" | "task_group" | "metadata"
+            "priority" | "enqueue_time_ms" | "payload" | "task_group" | "metadata" | "limits"
         )
     });
     // status_kind and status_changed_at_ms are encoded in the status/time index key, so
@@ -1219,6 +1222,12 @@ fn build_job_pairs_batch(
                     .collect::<Vec<Option<i64>>>(),
             )),
             "metadata" => build_metadata_column(pairs, jobs_map)?,
+            "limits" => Arc::new(StringArray::from(
+                pairs
+                    .iter()
+                    .map(|p| jobs_map.get(&p.1).map(|v| limits_to_json(&v.limits())))
+                    .collect::<Vec<Option<String>>>(),
+            )),
             other => {
                 return Err(DataFusionError::Execution(format!(
                     "unknown column {}",
@@ -1230,6 +1239,33 @@ fn build_job_pairs_batch(
     }
     RecordBatch::try_new(Arc::clone(projection), cols)
         .map_err(|e| DataFusionError::Execution(e.to_string()))
+}
+
+/// Serialize a job's limits into a JSON array of `{limit_type, key, value}` objects
+/// for display in the web UI. Each limit variant is flattened into a single display row.
+fn limits_to_json(limits: &[crate::job::Limit]) -> String {
+    use crate::job::Limit;
+    let rows: Vec<serde_json::Value> = limits
+        .iter()
+        .map(|limit| match limit {
+            Limit::Concurrency(c) => serde_json::json!({
+                "limit_type": "Concurrency",
+                "key": c.key,
+                "value": c.max_concurrency.to_string(),
+            }),
+            Limit::RateLimit(r) => serde_json::json!({
+                "limit_type": "Rate",
+                "key": r.unique_key,
+                "value": format!("{} per {}ms", r.limit, r.duration_ms),
+            }),
+            Limit::FloatingConcurrency(f) => serde_json::json!({
+                "limit_type": "Floating Concurrency",
+                "key": f.key,
+                "value": f.default_max_concurrency.to_string(),
+            }),
+        })
+        .collect();
+    serde_json::Value::Array(rows).to_string()
 }
 
 /// Build the Arrow `Map<Utf8, Utf8>` column for job metadata key/value pairs.

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -85,7 +85,7 @@ pub struct TenantQueueRow {
     pub total: usize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Deserialize)]
 pub struct LimitRow {
     pub limit_type: String,
     pub key: String,
@@ -611,6 +611,7 @@ struct JobQueryResult {
     status_kind: String,
     status_changed_at_ms: i64,
     metadata: Vec<(String, String)>,
+    limits: Vec<LimitRow>,
 }
 
 async fn job_handler(
@@ -627,7 +628,7 @@ async fn job_handler(
         where_clauses.push(format!("tenant = '{}'", tenant.replace('\'', "''")));
     }
     let sql = format!(
-        "SELECT shard_id, priority, enqueue_time_ms, payload, status_kind, status_changed_at_ms, metadata FROM jobs WHERE {} LIMIT 1",
+        "SELECT shard_id, priority, enqueue_time_ms, payload, status_kind, status_changed_at_ms, metadata, limits FROM jobs WHERE {} LIMIT 1",
         where_clauses.join(" AND ")
     );
 
@@ -751,6 +752,18 @@ async fn job_handler(
                         })
                         .unwrap_or_default();
 
+                    // Limits are serialized as a JSON array of {limit_type, key, value}
+                    // objects by the jobs scanner (see query.rs `limits_to_json`).
+                    let limits = batch
+                        .column_by_name("limits")
+                        .and_then(|c| {
+                            c.as_any()
+                                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                        })
+                        .filter(|a| !a.is_null(0))
+                        .and_then(|a| serde_json::from_str::<Vec<LimitRow>>(a.value(0)).ok())
+                        .unwrap_or_default();
+
                     result = Some(JobQueryResult {
                         shard_id,
                         priority,
@@ -759,6 +772,7 @@ async fn job_handler(
                         status_kind,
                         status_changed_at_ms,
                         metadata,
+                        limits,
                     });
                     break;
                 }
@@ -794,8 +808,7 @@ async fn job_handler(
         "Succeeded" | "Failed" | "Cancelled"
     );
 
-    // Limits are not available from the query engine - would need to be added to the jobs scanner
-    let limits: Vec<LimitRow> = Vec::new();
+    let limits = job.limits;
 
     // Pretty-print the payload JSON
     let payload_str = serde_json::from_str::<serde_json::Value>(&job.payload)

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -793,8 +793,8 @@ async fn sql_select_all_columns() {
         .expect("collect");
 
     assert!(!batches.is_empty());
-    // Should have all 12 columns: shard_id, tenant, id, priority, enqueue_time_ms, payload, status_kind, status_changed_at_ms, task_group, current_attempt, next_attempt_starts_after_ms, metadata
-    assert_eq!(batches[0].num_columns(), 12);
+    // Should have all 13 columns: shard_id, tenant, id, priority, enqueue_time_ms, payload, status_kind, status_changed_at_ms, task_group, current_attempt, next_attempt_starts_after_ms, metadata, limits
+    assert_eq!(batches[0].num_columns(), 13);
     assert_eq!(batches[0].num_rows(), 1);
 }
 

--- a/tests/webui_tests.rs
+++ b/tests/webui_tests.rs
@@ -695,14 +695,26 @@ async fn test_job_view_renders_limits_section() {
         !body.contains("No limits"),
         "Limits section should not be empty"
     );
-    assert!(body.contains("conc-key"), "should show concurrency limit key");
-    assert!(body.contains("float-key-a"), "should show first floating key");
-    assert!(body.contains("float-key-b"), "should show second floating key");
+    assert!(
+        body.contains("conc-key"),
+        "should show concurrency limit key"
+    );
+    assert!(
+        body.contains("float-key-a"),
+        "should show first floating key"
+    );
+    assert!(
+        body.contains("float-key-b"),
+        "should show second floating key"
+    );
     assert!(
         body.contains("Floating Concurrency"),
         "should label floating concurrency limits"
     );
-    assert!(body.contains("Concurrency"), "should label concurrency limits");
+    assert!(
+        body.contains("Concurrency"),
+        "should label concurrency limits"
+    );
 }
 
 #[silo::test]

--- a/tests/webui_tests.rs
+++ b/tests/webui_tests.rs
@@ -644,6 +644,68 @@ async fn test_queues_page_shows_unavailable_shards_and_partial_results() {
 }
 
 #[silo::test]
+async fn test_job_view_renders_limits_section() {
+    use silo::job::{ConcurrencyLimit, FloatingConcurrencyLimit, Limit};
+
+    let (_tmp, state, shard_map) = setup_multi_shard_state(1).await;
+
+    let shard_id = shard_map.shards()[0].id;
+    let shard = state.factory.get(&shard_id).expect("shard 0");
+    let job_id = shard
+        .enqueue(
+            "-",
+            Some("job-with-limits".to_string()),
+            30,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![
+                Limit::Concurrency(ConcurrencyLimit {
+                    key: "conc-key".to_string(),
+                    max_concurrency: 7,
+                }),
+                Limit::FloatingConcurrency(FloatingConcurrencyLimit {
+                    key: "float-key-a".to_string(),
+                    default_max_concurrency: 11,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+                Limit::FloatingConcurrency(FloatingConcurrencyLimit {
+                    key: "float-key-b".to_string(),
+                    default_max_concurrency: 13,
+                    refresh_interval_ms: 60_000,
+                    metadata: vec![],
+                }),
+            ],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue job with limits");
+
+    let (status, body) = make_request(
+        state,
+        "GET",
+        &format!("/job?shard={}&tenant=-&id={}", shard_id, job_id),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        !body.contains("No limits"),
+        "Limits section should not be empty"
+    );
+    assert!(body.contains("conc-key"), "should show concurrency limit key");
+    assert!(body.contains("float-key-a"), "should show first floating key");
+    assert!(body.contains("float-key-b"), "should show second floating key");
+    assert!(
+        body.contains("Floating Concurrency"),
+        "should label floating concurrency limits"
+    );
+    assert!(body.contains("Concurrency"), "should label concurrency limits");
+}
+
+#[silo::test]
 async fn test_job_view_with_correct_shard_and_tenant_hint() {
     // Test that providing correct shard and tenant makes job lookup work efficiently
     let (_tmp, state, shard_map) = setup_multi_shard_state(3).await;


### PR DESCRIPTION
## Problem

The `/job` webui page's **Limits** section was always empty. The handler in `src/webui.rs` hardcoded `let limits: Vec<LimitRow> = Vec::new();` with a comment noting limits weren't available from the query engine. The data existed in storage (`JobView::limits()`) and over gRPC (`GetJob`), but the SQL jobs scanner never exposed a `limits` column, so the webui — which reads jobs via the query engine — had nothing to render.

## Fix

- **`src/query.rs`**: Add a nullable `limits` Utf8 column to `JobsScanner::base_schema()`, mark it as a `need_job_info` projection, and add a `limits_to_json` helper that flattens each `Limit` variant (Concurrency / Rate / Floating Concurrency) into `{limit_type, key, value}` JSON built from `JobView::limits()`.
- **`src/webui.rs`**: Add `limits` to the job query's `SELECT`, parse the JSON column into `Vec<LimitRow>` (made `LimitRow` `Deserialize`), and feed it to the template instead of the empty vector.
- **`tests/webui_tests.rs`**: Add `test_job_view_renders_limits_section`, which enqueues a job with one concurrency + two floating-concurrency limits and asserts they render.

## Verification

- `cargo check` and the new test pass.
- Verified end-to-end against a live local cluster: enqueued a job with 1 concurrency + 2 floating-concurrency limits (mirroring `SiloMirror.ts`) and confirmed all three rows render in the Limits table:

  | Type | Key | Limit |
  |------|-----|-------|
  | Concurrency | user-queue:my-queue | 5 |
  | Floating Concurrency | platform-floating:env-... | 100 |
  | Floating Concurrency | per-shop-floating:env-...:shop-123 | 50 |