### PR TITLE
Prevent orphaned jobs when dropping tenant holders & run attempts

### DIFF
--- a/src/job_store_shard/drop_tenant_holders.rs
+++ b/src/job_store_shard/drop_tenant_holders.rs
@@ -8,6 +8,7 @@ use slatedb::WriteBatch;
 use tracing::warn;
 
 use crate::codec::{decode_lease, decode_task};
+use crate::job_attempt::AttemptOutcome;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
     concurrency_holders_tenant_prefix, end_bound, leases_prefix, parse_concurrency_holder_key,
@@ -25,36 +26,60 @@ const DROP_BATCH_SIZE: usize = 1000;
 pub struct DropTenantStats {
     /// Number of concurrency holder records deleted.
     pub holders_dropped: usize,
-    /// Number of in-flight `RunAttempt`s deleted — both queued task-queue
-    /// entries and running (leased) attempts.
+    /// Number of in-flight `RunAttempt`s finalized — both queued task-queue
+    /// entries (cancelled) and running (leased) attempts (failed as if the
+    /// worker crashed).
     pub run_attempts_dropped: usize,
 }
 
 impl JobStoreShard {
-    /// Forcibly drop **all** concurrency holders and in-flight `RunAttempt`
-    /// tasks (plus their leases) for `tenant` on this shard.
+    /// Forcibly clear **all** concurrency holders and finalize every in-flight
+    /// `RunAttempt` (queued or running) for `tenant` on this shard, returning
+    /// every affected job to a consistent terminal/runnable state.
     ///
-    /// This is intentionally **destructive and non-transactional**, mirroring
-    /// the bulk-delete pattern in [`cleanup`](super::cleanup): it scans
-    /// read-only, then deletes the collected keys via plain write batches. It
-    /// does *not* use a serializable transaction, because the run-attempt /
-    /// lease scans aren't tenant-scoped (those keys aren't tenant-keyed) and
-    /// would pull the whole shard's task/lease activity into an SSI read set —
-    /// on a live, busy shard that conflicts on every other tenant's work and
-    /// never commits. The batched-delete approach always commits regardless of
-    /// concurrent activity, so it can fix a stuck tenant on a live env with no
+    /// This is intentionally **non-transactional at the tenant level**,
+    /// mirroring the bulk-scan pattern in [`cleanup`](super::cleanup): it scans
+    /// the (non-tenant-keyed) task/lease keyspaces read-only, then finalizes
+    /// each collected attempt via a **per-attempt** call to the same code paths
+    /// the system already uses live. It does *not* wrap the whole operation in
+    /// one serializable transaction, because the run-attempt / lease scans
+    /// aren't tenant-scoped and would pull the whole shard's task/lease activity
+    /// into an SSI read set — on a live, busy shard that conflicts on every
+    /// other tenant's work and never commits. Each per-attempt finalization is
+    /// itself atomic and tenant/job-scoped (exactly like a normal worker
+    /// outcome report or user-initiated cancel), so it commits regardless of
+    /// concurrent activity and can fix a stuck tenant on a live env with no
     /// downtime.
     ///
+    /// Finalization (NOT raw deletion — raw-deleting a lease while leaving
+    /// `JOB_STATUS = Running` orphans the job, because the lease reaper only
+    /// acts on leases and would never see it again):
+    /// - **Running (leased) attempts** are finalized through
+    ///   [`report_attempt_outcome`](Self::report_attempt_outcome) — the same
+    ///   call the lease reaper makes — as `Cancelled` if the job was cancelled,
+    ///   otherwise as a `WORKER_CRASHED` error (which fails the job or schedules
+    ///   a retry per its policy). This atomically deletes the lease, transitions
+    ///   `JOB_STATUS` off `Running`, releases the attempt's concurrency holders,
+    ///   and updates the status/time index and counters.
+    /// - **Queued (granted, not yet leased) attempts** are finalized through
+    ///   [`cancel_job`](Self::cancel_job), which deletes the pending task,
+    ///   transitions the `Scheduled` job to `Cancelled`, evicts the broker
+    ///   buffer, and releases any chain-accumulated holders. (A cancelled or
+    ///   failed job is restartable, so dropped work is recoverable.)
+    ///
     /// Semantics:
-    /// - **Point-in-time / best-effort.** Holders or run attempts created for
-    ///   the tenant *after* the scans are not caught; re-run if needed (the
-    ///   operation is idempotent — re-deleting a missing key is a no-op).
-    /// - **Partial progress is safe.** Each holder / task / lease delete is
-    ///   independent; a holder without its lease (or vice versa) self-heals on
-    ///   the worker's next heartbeat.
-    /// - **Clean release.** After the deletes land, the in-memory concurrency
-    ///   counts are updated and the grant scanner is woken so pending requests
-    ///   can be re-granted.
+    /// - **Point-in-time / best-effort.** Holders or attempts created for the
+    ///   tenant *after* the scans (including retries scheduled by the
+    ///   finalizations above) are not caught; re-run if needed (the operation is
+    ///   idempotent — finalizing an already-finalized attempt is a no-op, and
+    ///   re-deleting a missing holder is a no-op).
+    /// - **Partial progress is safe.** Each finalization and holder delete is
+    ///   independent; a failure on one attempt is logged and the sweep
+    ///   continues with the rest.
+    /// - **Clean release.** After finalizing attempts, any *remaining*
+    ///   orphaned holder rows (rows with no corresponding live attempt) are
+    ///   deleted and their in-memory counts released, and the grant scanner is
+    ///   woken so pending requests can be re-granted.
     /// - Historical `ATTEMPT` records and concurrency *requests* are
     ///   deliberately left untouched.
     #[tracing::instrument(skip_all, fields(shard = %self.name, tenant))]
@@ -62,12 +87,14 @@ impl JobStoreShard {
         &self,
         tenant: &str,
     ) -> Result<DropTenantStats, JobStoreShardError> {
-        // ---- Collect keys to delete (read-only scans; no conflict set) ----
+        // ---- Collect work via read-only scans (a point-in-time snapshot; no
+        // SSI read set, so the scans never conflict with concurrent activity) ----
 
         // Holders are tenant-prefixed, so a single prefix scan captures every
-        // holder for the tenant. Track (task_id, queue) for the post-delete
-        // in-memory release. Holder counts have no persisted counter (in-memory
-        // only), so deleting the rows is all that's needed durably.
+        // holder for the tenant. Track (task_id, queue) for the post-finalize
+        // in-memory release of any rows not already released by an attempt
+        // finalization below. Holder counts have no persisted counter
+        // (in-memory only), so deleting the rows is all that's needed durably.
         let mut holders_to_release: Vec<(String, String)> = Vec::new();
         let mut holder_keys: Vec<Vec<u8>> = Vec::new();
         {
@@ -85,8 +112,9 @@ impl JobStoreShard {
 
         // Queued (granted, not yet leased) RunAttempts live in the TASK queue,
         // keyed by task_group (not tenant) — full-shard scan + filter by the
-        // tenant carried inside the RunAttempt.
-        let mut deleted_task_keys: Vec<Vec<u8>> = Vec::new();
+        // tenant carried inside the RunAttempt. Collect the job ids so we can
+        // cancel each (which deletes the task and transitions the job).
+        let mut queued_job_ids: Vec<String> = Vec::new();
         {
             let start = tasks_prefix();
             let end = end_bound(&start);
@@ -99,10 +127,12 @@ impl JobStoreShard {
                         continue;
                     }
                 };
-                if let Task::RunAttempt { tenant: t, .. } = task
+                if let Task::RunAttempt {
+                    tenant: t, job_id, ..
+                } = task
                     && t == tenant
                 {
-                    deleted_task_keys.push(kv.key.to_vec());
+                    queued_job_ids.push(job_id);
                 }
             }
         }
@@ -110,10 +140,10 @@ impl JobStoreShard {
         // Running (leased) RunAttempts: the TASK entry was removed at lease time
         // and a LeaseRecord (which embeds the Task) was written under the LEASE
         // prefix, keyed by task_id — full-shard scan + filter on the embedded
-        // task. Deleting the lease orphans the worker's attempt (it discovers
-        // the missing lease on heartbeat), mirroring cancel semantics. The two
-        // RunAttempt sets are disjoint (a leased task is no longer in TASK).
-        let mut deleted_lease_keys: Vec<Vec<u8>> = Vec::new();
+        // task. Collect (task_id, job_id) so we can finalize each via the lease
+        // reaper's path. The two RunAttempt sets are disjoint (a leased task is
+        // no longer in TASK).
+        let mut leased_attempts: Vec<(String, String)> = Vec::new();
         {
             let start = leases_prefix();
             let end = end_bound(&start);
@@ -126,25 +156,78 @@ impl JobStoreShard {
                         continue;
                     }
                 };
-                if let Task::RunAttempt { tenant: t, .. } = task
+                if let Task::RunAttempt {
+                    id: task_id,
+                    tenant: t,
+                    job_id,
+                    ..
+                } = task
                     && t == tenant
                 {
-                    deleted_lease_keys.push(kv.key.to_vec());
+                    leased_attempts.push((task_id, job_id));
                 }
             }
         }
 
-        // ---- Delete via chunked, non-transactional write batches ----
-        // Each batch is atomic on its own; chunking across batches is safe
-        // because the operation is idempotent. `db.write` has no read set, so
-        // it commits regardless of concurrent activity on the shard.
+        let mut run_attempts_dropped = 0usize;
+
+        // ---- Finalize running (leased) attempts via the reaper's path ----
+        // Mirrors `reap_expired_leases`: a cancelled job reports Cancelled,
+        // otherwise WORKER_CRASHED (fail or retry per policy). This deletes the
+        // lease and transitions JOB_STATUS off Running atomically, so the job is
+        // never left orphaned in Running with no lease.
+        for (task_id, job_id) in &leased_attempts {
+            let was_cancelled = self.is_job_cancelled(tenant, job_id).await.unwrap_or(false);
+            let outcome = if was_cancelled {
+                AttemptOutcome::Cancelled
+            } else {
+                AttemptOutcome::Error {
+                    error_code: "WORKER_CRASHED".to_string(),
+                    error: b"run attempt force-dropped via drop_tenant_holders admin action"
+                        .to_vec(),
+                }
+            };
+            match self.report_attempt_outcome(task_id, outcome).await {
+                Ok(()) => run_attempts_dropped += 1,
+                Err(e) => {
+                    // Best-effort: a concurrent reaper/worker may have already
+                    // finalized this lease. Log and continue.
+                    warn!(
+                        task_id = %task_id,
+                        job_id = %job_id,
+                        error = %e,
+                        "failed to finalize leased run attempt during tenant drop"
+                    );
+                }
+            }
+        }
+
+        // ---- Finalize queued (Scheduled) attempts via cancel_job ----
+        // Deletes the pending task and transitions the job to Cancelled, so the
+        // job is never left orphaned in Scheduled with no task to run it.
+        for job_id in &queued_job_ids {
+            match self.cancel_job(tenant, job_id).await {
+                Ok(()) => run_attempts_dropped += 1,
+                Err(e) => {
+                    warn!(
+                        job_id = %job_id,
+                        error = %e,
+                        "failed to cancel queued run attempt during tenant drop"
+                    );
+                }
+            }
+        }
+
+        // ---- Delete any remaining orphaned holder rows ----
+        // Attempt finalizations above already released the holders for the
+        // attempts they handled; what remains are holder rows with no
+        // corresponding live attempt (genuine leaks). Deleting the snapshot is
+        // idempotent — already-released rows are no-ops — and only touches rows
+        // observed before finalization, so holders granted by retries scheduled
+        // above (new task ids) are left intact.
         let mut batch = WriteBatch::new();
         let mut batch_count = 0usize;
-        for key in holder_keys
-            .iter()
-            .chain(deleted_task_keys.iter())
-            .chain(deleted_lease_keys.iter())
-        {
+        for key in &holder_keys {
             batch.delete(key);
             batch_count += 1;
             if batch_count >= DROP_BATCH_SIZE {
@@ -157,15 +240,10 @@ impl JobStoreShard {
             self.db.write(batch).await?;
         }
 
-        // ---- Post-delete: reconcile in-memory state ----
-
-        // Evict deleted queued tasks from the broker buffers.
-        if !deleted_task_keys.is_empty() {
-            self.brokers.evict_keys(&deleted_task_keys);
-        }
-
-        // Release concurrency holders from in-memory counts and wake the grant
-        // scanner per freed queue so pending requests get re-granted.
+        // Release holders from in-memory counts and wake the grant scanner per
+        // freed queue so pending requests get re-granted. `atomic_release` is a
+        // set removal (idempotent), so re-releasing a holder already released by
+        // a finalization above is harmless.
         for (task_id, queue) in &holders_to_release {
             self.concurrency
                 .counts()
@@ -175,7 +253,7 @@ impl JobStoreShard {
 
         Ok(DropTenantStats {
             holders_dropped: holder_keys.len(),
-            run_attempts_dropped: deleted_task_keys.len() + deleted_lease_keys.len(),
+            run_attempts_dropped,
         })
     }
 }

--- a/tests/job_store_shard_drop_tenant_holders_tests.rs
+++ b/tests/job_store_shard_drop_tenant_holders_tests.rs
@@ -92,6 +92,70 @@ async fn drop_tenant_clears_holders_runattempts_and_leases() {
     assert_eq!(shard.concurrency_holder_count("tenant-b", "qC"), 1);
 }
 
+/// Regression: dropping a tenant's *running* (leased) attempt must finalize the
+/// job to a terminal status — it must never be left orphaned in `Running` with
+/// no lease. The lease reaper is lease-driven, so a Running job with no lease
+/// would never be cleaned up (this is exactly the bug raw lease-deletion caused).
+#[silo::test]
+async fn drop_tenant_finalizes_running_job_instead_of_orphaning() {
+    use silo::job::JobStatusKind;
+
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    let job_id = enqueue_with_holder(&shard, "tenant-a", "qA", now).await;
+
+    // Lease it so the job is Running, backed by a durable lease.
+    let leased = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(leased.len(), 1, "exactly one task leased");
+    let status = shard
+        .get_job_status("tenant-a", &job_id)
+        .await
+        .expect("status")
+        .expect("job exists");
+    assert_eq!(
+        status.kind,
+        JobStatusKind::Running,
+        "job is Running pre-drop"
+    );
+    assert!(count_lease_keys(shard.db()).await >= 1, "a lease exists");
+
+    // Act.
+    let stats = shard
+        .drop_tenant_holders_and_runattempts("tenant-a")
+        .await
+        .expect("drop tenant state");
+    assert_eq!(stats.run_attempts_dropped, 1);
+
+    // The job must be finalized to a terminal status — NOT left in Running —
+    // and its lease must be gone, so nothing is orphaned beyond the reaper's reach.
+    let status = shard
+        .get_job_status("tenant-a", &job_id)
+        .await
+        .expect("status")
+        .expect("job exists");
+    assert!(
+        status.is_terminal(),
+        "job must be terminal after drop, got {:?}",
+        status.kind
+    );
+    assert_ne!(
+        status.kind,
+        JobStatusKind::Running,
+        "job must not be orphaned in Running"
+    );
+    assert_eq!(
+        count_lease_keys(shard.db()).await,
+        0,
+        "no lease may be left behind"
+    );
+    assert_eq!(shard.concurrency_holder_count("tenant-a", "qA"), 0);
+}
+
 /// Dropping a tenant with no holders/run attempts is a no-op that returns zeros.
 #[silo::test]
 async fn drop_tenant_with_no_state_is_a_noop() {

--- a/tests/job_store_shard_drop_tenant_holders_tests.rs
+++ b/tests/job_store_shard_drop_tenant_holders_tests.rs
@@ -156,6 +156,127 @@ async fn drop_tenant_finalizes_running_job_instead_of_orphaning() {
     assert_eq!(shard.concurrency_holder_count("tenant-a", "qA"), 0);
 }
 
+/// Regression: dropping a tenant's *queued* (Scheduled, not yet leased) attempt
+/// must finalize the job to `Cancelled` — it must never be left orphaned in
+/// `Scheduled` with no task to run it. (Raw task-deletion left it stuck in
+/// `Scheduled` with nothing in the queue, invisible to every recovery path.)
+#[silo::test]
+async fn drop_tenant_cancels_queued_job_instead_of_orphaning() {
+    use silo::job::JobStatusKind;
+
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Enqueue but do NOT lease — the job stays Scheduled with a queued RunAttempt.
+    let job_id = enqueue_with_holder(&shard, "tenant-a", "qA", now).await;
+    let status = shard
+        .get_job_status("tenant-a", &job_id)
+        .await
+        .expect("status")
+        .expect("job exists");
+    assert_eq!(
+        status.kind,
+        JobStatusKind::Scheduled,
+        "job is Scheduled pre-drop"
+    );
+
+    // Act.
+    let stats = shard
+        .drop_tenant_holders_and_runattempts("tenant-a")
+        .await
+        .expect("drop tenant state");
+    assert_eq!(stats.run_attempts_dropped, 1);
+
+    // The queued job must be transitioned to Cancelled — not left orphaned in
+    // Scheduled — and its holder released.
+    let status = shard
+        .get_job_status("tenant-a", &job_id)
+        .await
+        .expect("status")
+        .expect("job exists");
+    assert_eq!(
+        status.kind,
+        JobStatusKind::Cancelled,
+        "queued job must be Cancelled after drop, got {:?}",
+        status.kind
+    );
+    assert_eq!(shard.concurrency_holder_count("tenant-a", "qA"), 0);
+}
+
+/// Dropping a *running* attempt whose job was already cancelled must finalize it
+/// as `Cancelled` (the `was_cancelled` branch), not as a `WORKER_CRASHED`
+/// failure. This mirrors what the lease reaper does for a cancelled job and
+/// preserves the user's intent through the forced drop.
+#[silo::test]
+async fn drop_tenant_finalizes_cancelled_running_job_as_cancelled() {
+    use silo::job::JobStatusKind;
+
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    let job_id = enqueue_with_holder(&shard, "tenant-a", "qA", now).await;
+
+    // Lease it so the job is Running, backed by a durable lease.
+    let leased = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(leased.len(), 1, "exactly one task leased");
+
+    // Cancel the running job: this only records the cancellation flag (the
+    // worker would normally ack it on heartbeat), leaving the job in Running
+    // with a live lease — exactly the state the drop must finalize correctly.
+    shard
+        .cancel_job("tenant-a", &job_id)
+        .await
+        .expect("cancel running job");
+    let status = shard
+        .get_job_status("tenant-a", &job_id)
+        .await
+        .expect("status")
+        .expect("job exists");
+    assert_eq!(
+        status.kind,
+        JobStatusKind::Running,
+        "cancel of a Running job only sets the flag; status stays Running"
+    );
+    assert!(
+        shard
+            .is_job_cancelled("tenant-a", &job_id)
+            .await
+            .expect("cancellation lookup"),
+        "cancellation flag is set pre-drop"
+    );
+
+    // Act.
+    let stats = shard
+        .drop_tenant_holders_and_runattempts("tenant-a")
+        .await
+        .expect("drop tenant state");
+    assert_eq!(stats.run_attempts_dropped, 1);
+
+    // Because the job was cancelled, the leased attempt must be finalized as
+    // Cancelled — NOT Failed (which is what the WORKER_CRASHED path produces).
+    let status = shard
+        .get_job_status("tenant-a", &job_id)
+        .await
+        .expect("status")
+        .expect("job exists");
+    assert_eq!(
+        status.kind,
+        JobStatusKind::Cancelled,
+        "cancelled running job must finalize as Cancelled, not {:?}",
+        status.kind
+    );
+    assert_eq!(
+        count_lease_keys(shard.db()).await,
+        0,
+        "no lease may be left behind"
+    );
+    assert_eq!(shard.concurrency_holder_count("tenant-a", "qA"), 0);
+}
+
 /// Dropping a tenant with no holders/run attempts is a no-op that returns zeros.
 #[silo::test]
 async fn drop_tenant_with_no_state_is_a_noop() {


### PR DESCRIPTION
## Problem

The console's **"Drop holders & run attempts"** admin action (`drop_tenant_holders_and_runattempts`) raw-deleted lease and task records **without transitioning job status**:

- Deleting a lease left the job stuck in `Running` with **no lease**.
- Deleting a queued task left the job stuck in `Scheduled` with **no task**.

The lease reaper is **lease-driven** — it only scans the LEASE keyspace and reaps leases whose `expiry_ms` has passed. A `Running` job with no lease is invisible to it, so these jobs are **orphaned forever**. They also can't be recovered with existing tooling: `job delete` rejects non-terminal jobs, `job cancel` on a `Running` job only writes a marker the (now-absent) worker must ack, and `job restart`/`expedite` reject `Running`.

This was hit on `silo-staging` tenant `env-10000400587`: after the button was used, 13 shadow-env jobs were left stuck in `Running` for days, with the reaper running healthily (scans climbing) but never touching them (`leases_reaped` flat, `silo_task_leases_active` ≤ 0, no pending tasks).

## Fix

Finalize each in-flight attempt through the **same code paths the system already uses live**, instead of raw-deleting:

- **Running (leased) attempts** → `report_attempt_outcome` — the exact call the lease reaper makes. Reports `Cancelled` if the job was cancelled, otherwise `WORKER_CRASHED` (fails the job or schedules a retry per its policy). Atomically deletes the lease, transitions `JOB_STATUS` off `Running`, releases the attempt's concurrency holders, and updates the status/time index + counters.
- **Queued (Scheduled) attempts** → `cancel_job` — deletes the pending task, transitions `Scheduled` → `Cancelled`, evicts the broker buffer, releases chain-accumulated holders.
- **Orphaned holder rows** (no corresponding live attempt) → still bulk-deleted + in-memory released, as before.

Design notes:
- Stays **non-transactional at the tenant level** (the full-shard lease/task scans would create an SSI read set that never commits on a busy shard). Only the per-attempt finalizations are atomic — exactly like a normal worker outcome report or user cancel, so they commit regardless of concurrent activity.
- **Idempotent / best-effort** preserved: `atomic_release` is a set removal and holder deletes no-op if already gone, so a finalization that races a concurrent reaper just logs and continues.
- **Retry-safe**: holders are snapshotted *before* finalizing, so holders granted by retries scheduled during the sweep (new task ids) aren't clobbered by the holder cleanup.

## Tests

`tests/job_store_shard_drop_tenant_holders_tests.rs`:
- Existing coverage still passes (holder/stat assertions unchanged).
- New regression test `drop_tenant_finalizes_running_job_instead_of_orphaning`: leases a job (→ `Running`), drops the tenant, and asserts the job ends up **terminal** (not `Running`) with **zero leases left behind**.

Cancel (19) and lease-task (7) suites also green.

## Follow-up (not in this PR)

This fixes the button going forward, but does **not** recover jobs already orphaned (their leases are already gone, so there's nothing for a corrected drop to finalize). A separate orphan-reconcile primitive — scan non-terminal jobs lacking a lease/task → force `Failed` — is still needed to clean up `env-10000400587` and as a permanent backstop.