### PR TITLE
Pass tenant to job cancel form so cancellation uses direct lookup

### DIFF
--- a/src/webui.rs
+++ b/src/webui.rs
@@ -139,6 +139,7 @@ struct JobTemplate {
     tenancy_enabled: bool,
     job_id: String,
     shard: String,
+    tenant: String,
     status: String,
     is_terminal: bool,
     priority: u8,
@@ -605,6 +606,7 @@ async fn index_handler(State(state): State<AppState>) -> impl IntoResponse {
 /// Job data fetched from the cluster query engine
 struct JobQueryResult {
     shard_id: String,
+    tenant: String,
     priority: u8,
     enqueue_time_ms: i64,
     payload: String,
@@ -628,7 +630,7 @@ async fn job_handler(
         where_clauses.push(format!("tenant = '{}'", tenant.replace('\'', "''")));
     }
     let sql = format!(
-        "SELECT shard_id, priority, enqueue_time_ms, payload, status_kind, status_changed_at_ms, metadata, limits FROM jobs WHERE {} LIMIT 1",
+        "SELECT shard_id, tenant, priority, enqueue_time_ms, payload, status_kind, status_changed_at_ms, metadata, limits FROM jobs WHERE {} LIMIT 1",
         where_clauses.join(" AND ")
     );
 
@@ -643,6 +645,15 @@ async fn job_handler(
 
                     let shard_id = batch
                         .column_by_name("shard_id")
+                        .and_then(|c| {
+                            c.as_any()
+                                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                        })
+                        .map(|a| a.value(0).to_string())
+                        .unwrap_or_default();
+
+                    let tenant = batch
+                        .column_by_name("tenant")
                         .and_then(|c| {
                             c.as_any()
                                 .downcast_ref::<datafusion::arrow::array::StringArray>()
@@ -766,6 +777,7 @@ async fn job_handler(
 
                     result = Some(JobQueryResult {
                         shard_id,
+                        tenant,
                         priority,
                         enqueue_time_ms,
                         payload,
@@ -820,6 +832,7 @@ async fn job_handler(
         tenancy_enabled: state.config.tenancy.enabled,
         job_id: params.id,
         shard: job.shard_id.to_string(),
+        tenant: urlencoding::encode(&job.tenant).into_owned(),
         status: job.status_kind,
         is_terminal,
         priority: job.priority,

--- a/templates/job.html
+++ b/templates/job.html
@@ -12,7 +12,7 @@
         </div>
         <div class="flex items-center gap-2">
             {% if !is_terminal %}
-            <form hx-post="/job/cancel?shard={{ shard }}&id={{ job_id }}" hx-swap="outerHTML" hx-target="#job-status" class="inline">
+            <form hx-post="/job/cancel?shard={{ shard }}&tenant={{ tenant }}&id={{ job_id }}" hx-swap="outerHTML" hx-target="#job-status" class="inline">
                 <button type="submit" class="px-3 py-1 text-sm bg-red-900/50 border border-red-700 text-red-400  hover:bg-red-900 transition-colors">
                     Cancel Job
                 </button>

--- a/tests/webui_tests.rs
+++ b/tests/webui_tests.rs
@@ -160,6 +160,12 @@ async fn test_job_view_renders() {
     assert!(body.contains("P25"), "expected priority in body");
     assert!(body.contains("key1"), "expected metadata key in body");
     assert!(body.contains("value1"), "expected metadata value in body");
+    // The cancel form must carry the tenant so cancellation uses the direct,
+    // tenant-keyed lookup rather than the tenant-less fallback scan.
+    assert!(
+        body.contains("/job/cancel?shard=") && body.contains("tenant=-"),
+        "expected cancel form to include the tenant param"
+    );
 }
 
 #[silo::test]


### PR DESCRIPTION
## Problem

Clicking **Cancel Job** in the web UI job view rendered `Job not found`.

Every link that opens the job page carries the tenant in the URL (`templates/queue.html`, `templates/tenant.html`), so `job_handler` resolves the job via the direct, tenant-keyed `ExactId { tenant: Some }` lookup — reliable. But the cancel form (`templates/job.html`) posted only `shard` + `id`:

```
hx-post="/job/cancel?shard={{ shard }}&id={{ job_id }}"
```

`JobTemplate` had no `tenant` field to thread through, so `cancel_job_handler` fell into its tenant-less branch and ran the `ExactId { tenant: None }` fallback scan instead of the direct lookup the page used. That difference is the only thing separating the working page render from the failing cancel.

## Fix

- Resolve `tenant` from the jobs query in `job_handler` (added to the SELECT and `JobQueryResult`).
- Add a `tenant` field to `JobTemplate`, populated with the URL-encoded tenant (matching the repo's `urlencoding::encode` convention).
- Include `&tenant={{ tenant }}` in the cancel form so cancellation takes the early direct-cancel branch and uses the same reliable lookup as the page.

## Tests

- Added an assertion to `test_job_view_renders` verifying the rendered cancel form now carries the tenant param.
- Existing cancel tests (which post without a tenant) still pass — the fallback path is left intact.
- `cargo fmt`, `cargo check`, `cargo clippy --all-targets` clean; all 43 `webui_tests` pass.
