### PR TITLE
Add ReconcileTenant RPC to recover orphaned jobs

### DIFF
--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -238,7 +238,8 @@ message ReconcileTenantRequest {
 
 // Response reporting what was reconciled.
 message ReconcileTenantResponse {
-  uint64 orphaned_running_failed = 1; // Running jobs with no lease force-failed.
+  uint64 orphaned_running_failed = 1;     // Running jobs with no lease force-failed.
+  uint64 orphaned_scheduled_redriven = 2; // Scheduled jobs with no task/request re-injected into the limit chain.
 }
 
 // Restart a cancelled or failed job, allowing it to be processed again.

--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -227,6 +227,20 @@ message DropTenantHoldersResponse {
   uint64 run_attempts_dropped = 2; // Number of in-flight run attempts deleted.
 }
 
+// Finalize a tenant's orphaned `Running` jobs (Running status with no lease
+// record) by force-transitioning them to terminal `Failed`. Admin/operator
+// action that recovers jobs the lease reaper can't see, and a backstop against
+// future orphan sources.
+message ReconcileTenantRequest {
+  string shard = 1;           // Shard ID (UUID) to operate on.
+  optional string tenant = 2; // Tenant ID if multi-tenancy is enabled.
+}
+
+// Response reporting what was reconciled.
+message ReconcileTenantResponse {
+  uint64 orphaned_running_failed = 1; // Running jobs with no lease force-failed.
+}
+
 // Restart a cancelled or failed job, allowing it to be processed again.
 // The job will get a fresh set of retries according to its retry policy.
 message RestartJobRequest { string shard = 1; string id = 2; optional string tenant = 3; }
@@ -686,7 +700,11 @@ service Silo {
   // Forcibly drop all concurrency holders and in-flight run attempts for a
   // tenant on this shard. Admin action to clear stuck concurrency state.
   rpc DropTenantHolders(DropTenantHoldersRequest) returns (DropTenantHoldersResponse);
-  
+
+  // Finalize a tenant's orphaned `Running` jobs (Running with no lease) by
+  // force-failing them. Recovers jobs the lease reaper can't see.
+  rpc ReconcileTenant(ReconcileTenantRequest) returns (ReconcileTenantResponse);
+
   // Restart a cancelled or failed job for another attempt.
   // Returns FAILED_PRECONDITION if job is not in a restartable state.
   // Returns NOT_FOUND if the job doesn't exist.

--- a/src/job_store_shard/drop_tenant_holders.rs
+++ b/src/job_store_shard/drop_tenant_holders.rs
@@ -9,13 +9,15 @@ use std::collections::HashSet;
 use slatedb::WriteBatch;
 use slatedb::config::WriteOptions;
 use tracing::warn;
+use uuid::Uuid;
 
 use crate::codec::{decode_lease, decode_task};
 use crate::job::{JobStatus, JobStatusKind};
 use crate::job_store_shard::helpers::{DbWriteBatcher, now_epoch_ms};
-use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
+use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
-    concurrency_holders_tenant_prefix, end_bound, leases_prefix, parse_concurrency_holder_key,
+    concurrency_holders_tenant_prefix, concurrency_request_tenant_prefix, end_bound, leases_prefix,
+    parse_concurrency_holder_key, parse_concurrency_request_key, task_key_lookup_prefix,
     tasks_prefix,
 };
 use crate::task::Task;
@@ -35,11 +37,14 @@ pub struct DropTenantStats {
     pub run_attempts_dropped: usize,
 }
 
-/// Counts of what `reconcile_orphaned_running_jobs` finalized.
+/// Counts of what `reconcile_orphaned_jobs` finalized.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ReconcileTenantStats {
     /// `Running` jobs that had no lease and were force-failed.
     pub orphaned_running_failed: usize,
+    /// `Scheduled` jobs that had no task and no concurrency request, and were
+    /// re-injected into the limit chain so they dispatch again.
+    pub orphaned_scheduled_redriven: usize,
 }
 
 impl JobStoreShard {
@@ -191,51 +196,61 @@ impl JobStoreShard {
         })
     }
 
-    /// Finalize a tenant's orphaned `Running` jobs — jobs stuck in `Running`
-    /// status with **no lease record** — by force-transitioning them to
-    /// terminal `Failed`.
+    /// Recover a tenant's orphaned jobs — jobs that no longer have anything in
+    /// the pipeline to advance them — on this shard.
     ///
-    /// ## Why this exists
+    /// Two orphan classes are handled, both produced by the old "Drop holders &
+    /// run attempts" admin action, which raw-deleted leases and queued
+    /// `RunAttempt` tasks without touching job status (see
+    /// [`drop_tenant_holders_and_runattempts`]):
     ///
-    /// The lease reaper is lease-driven: it finalizes a `Running` job by acting
-    /// on its (expired) lease. A `Running` job whose lease was raw-deleted
-    /// without a status transition — e.g. by the old "Drop holders & run
-    /// attempts" admin action before PR #365 — is therefore invisible to the
-    /// reaper and never cleaned up. No other tool recovers it either: `delete`
-    /// rejects non-terminal jobs, `cancel` on `Running` only writes a marker an
-    /// absent worker must ack, and `restart`/`expedite` reject `Running`. This
-    /// reconcile is the recovery path, and a permanent backstop against any
-    /// future orphan source.
+    /// 1. **`Running` with no lease → force-`Failed`.** The lease reaper is
+    ///    lease-driven, so a `Running` job whose lease was deleted is invisible
+    ///    to it and never cleaned up. No other tool recovers it either: `delete`
+    ///    rejects non-terminal jobs, `cancel` on `Running` only writes a marker
+    ///    an absent worker must ack, and `restart`/`expedite` reject `Running`.
+    ///    Its attempt is lost (the worker is gone), so we finalize it terminal.
+    /// 2. **`Scheduled` with no task and no concurrency request → redrive.** A
+    ///    `Scheduled` job always gets a pipeline entry at enqueue — a queued
+    ///    task, or (at capacity) a deferred concurrency request. If *both* are
+    ///    gone nothing will ever dispatch it. It never started, so rather than
+    ///    fail it we re-inject it into the limit chain exactly as a fresh
+    ///    enqueue would (via [`enqueue_limit_task_at_index`]), re-applying its
+    ///    concurrency/rate limits — at capacity it re-parks as a request, never
+    ///    bypassing the tenant's concurrency cap.
+    ///
+    /// This is the recovery path for already-orphaned jobs and a permanent
+    /// backstop against any future orphan source.
     ///
     /// ## Semantics
     ///
-    /// - **Orphan = `Running` with no lease.** We scan the whole LEASE keyspace
-    ///   and collect *every* lease for the tenant regardless of expiry: if a
-    ///   lease exists at all, the reaper owns that job and we must not race it.
-    ///   Only `Running` jobs with no lease are finalized.
-    /// - **No synthetic ATTEMPT row.** We have no lease/attempt context, so we
-    ///   write no new attempt. The job becomes `Failed` terminal;
-    ///   `expire_terminal_job_records` re-puts the existing (stale `Running`)
-    ///   attempt row with the terminal TTL so all records age out together.
-    /// - **Idempotent / partial-progress-safe.** Each job is finalized in its
-    ///   own durable batch and re-reads status first, so re-running skips
-    ///   already-`Failed` jobs and a crash mid-run loses no correctness.
+    /// - **Lease/request sets collected up front.** We scan the whole LEASE
+    ///   keyspace (any lease, regardless of expiry — if one exists the reaper
+    ///   owns the job and we must not race it) and the tenant's concurrency
+    ///   REQUEST keyspace once each, so a `Running` job with any lease and a
+    ///   `Scheduled` job with any pending request are left untouched.
+    /// - **No synthetic ATTEMPT row** on the `Failed` path: we have no
+    ///   lease/attempt context, so `expire_terminal_job_records` just re-puts
+    ///   the existing (stale `Running`) attempt with the terminal TTL.
+    /// - **Redrive preserves the attempt and schedule.** The new chain head
+    ///   keeps the job's `current_attempt` and `next_attempt_starts_after_ms`,
+    ///   so a future-scheduled orphan re-lands at its original time and the
+    ///   broker picks it up then. We do **not** re-apply the background-action
+    ///   queue counter: the job has been continuously `Scheduled` (the drop
+    ///   deleted only the task, never decremented the status gauge), so
+    ///   re-applying would double-count.
+    /// - **Idempotent / partial-progress-safe.** Each job is handled in its own
+    ///   durable batch and re-reads status first; a pre-write point-check skips
+    ///   any `Scheduled` job that already has a task (so a re-run never writes a
+    ///   duplicate `RunAttempt`).
     /// - **Best-effort, like the reaper.** A per-job failure is logged, its
-    ///   in-memory queue-counter side effect rolled back, and the scan
-    ///   continues.
-    ///
-    /// ## Non-goal
-    ///
-    /// Orphaned `Scheduled` jobs are intentionally out of scope: a `Scheduled`
-    /// job legitimately has either a queued task or a pending concurrency
-    /// request, so classifying it as orphaned is ambiguous. A future extension
-    /// could handle that with a more careful definition.
+    ///   in-memory side effects rolled back, and the scan continues.
     #[tracing::instrument(skip_all, fields(shard = %self.name, tenant))]
-    pub async fn reconcile_orphaned_running_jobs(
+    pub async fn reconcile_orphaned_jobs(
         &self,
         tenant: &str,
     ) -> Result<ReconcileTenantStats, JobStoreShardError> {
-        // ---- 1. Build the leased-job set (any lease, regardless of expiry) ----
+        // ---- Build the leased-job set (any lease, regardless of expiry) ----
         let mut leased_job_ids: HashSet<String> = HashSet::new();
         {
             let start = leases_prefix();
@@ -255,12 +270,46 @@ impl JobStoreShard {
             }
         }
 
-        // ---- 2. List the tenant's Running jobs ----
+        // ---- Build the pending-concurrency-request set for the tenant ----
+        // A Scheduled job with a request is legitimately waiting on a slot and
+        // must never be redriven. Requests are keyed (tenant, queue, ...), so a
+        // single tenant-prefix scan captures all of them.
+        let mut requested_job_ids: HashSet<String> = HashSet::new();
+        {
+            let start = concurrency_request_tenant_prefix(tenant);
+            let end = end_bound(&start);
+            let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
+            while let Some(kv) = iter.next().await? {
+                if let Some(parsed) = parse_concurrency_request_key(&kv.key) {
+                    requested_job_ids.insert(parsed.job_id);
+                }
+            }
+        }
+
+        let orphaned_running_failed = self
+            .reconcile_running_orphans(tenant, &leased_job_ids)
+            .await?;
+        let orphaned_scheduled_redriven = self
+            .reconcile_scheduled_orphans(tenant, &requested_job_ids)
+            .await?;
+
+        Ok(ReconcileTenantStats {
+            orphaned_running_failed,
+            orphaned_scheduled_redriven,
+        })
+    }
+
+    /// Force-`Failed` every `Running` job of `tenant` whose id is not in
+    /// `leased_job_ids`. See [`reconcile_orphaned_jobs`].
+    async fn reconcile_running_orphans(
+        &self,
+        tenant: &str,
+        leased_job_ids: &HashSet<String>,
+    ) -> Result<usize, JobStoreShardError> {
         let running_job_ids = self
             .scan_jobs_by_status(tenant, JobStatusKind::Running, None)
             .await?;
 
-        // ---- 3. Finalize each orphan in its own durable, atomic batch ----
         let mut orphaned_running_failed = 0usize;
         for job_id in running_job_ids {
             if leased_job_ids.contains(&job_id) {
@@ -330,8 +379,138 @@ impl JobStoreShard {
             }
         }
 
-        Ok(ReconcileTenantStats {
-            orphaned_running_failed,
-        })
+        Ok(orphaned_running_failed)
+    }
+
+    /// Redrive every `Scheduled` job of `tenant` that has neither a queued task
+    /// nor a pending concurrency request (id not in `requested_job_ids`). See
+    /// [`reconcile_orphaned_jobs`].
+    async fn reconcile_scheduled_orphans(
+        &self,
+        tenant: &str,
+        requested_job_ids: &HashSet<String>,
+    ) -> Result<usize, JobStoreShardError> {
+        let scheduled_job_ids = self
+            .scan_jobs_by_status(tenant, JobStatusKind::Scheduled, None)
+            .await?;
+
+        let mut orphaned_scheduled_redriven = 0usize;
+        for job_id in scheduled_job_ids {
+            // A pending concurrency request means the job is legitimately
+            // waiting on a slot — not an orphan.
+            if requested_job_ids.contains(&job_id) {
+                continue;
+            }
+
+            let now_ms = now_epoch_ms();
+
+            // Re-read status: skip unless still Scheduled, and capture the
+            // attempt number + scheduled start the redriven task must preserve.
+            let (attempt, start_ms) = match self.get_job_status(tenant, &job_id).await? {
+                Some(status) if status.kind == JobStatusKind::Scheduled => {
+                    match (status.current_attempt, status.next_attempt_starts_after_ms) {
+                        (Some(attempt), Some(start_ms)) => (attempt, start_ms),
+                        // A Scheduled status always carries both fields; if not,
+                        // skip rather than guess.
+                        _ => continue,
+                    }
+                }
+                _ => continue,
+            };
+
+            // Recover the job's task_group / priority / limits to rebuild the
+            // chain head identically to a fresh enqueue.
+            let Some(info_raw) = self
+                .db
+                .get(&crate::keys::job_info_key(tenant, &job_id))
+                .await?
+            else {
+                continue;
+            };
+            let view = crate::job::JobView::new(info_raw)?;
+            let task_group = view.task_group().to_string();
+            let priority = view.priority();
+            let limits = view.limits();
+
+            // Point-check: skip if a task already exists for this identity, so a
+            // re-run can never write a duplicate RunAttempt (double-execution).
+            if self
+                .job_has_queued_task(&task_group, start_ms, priority, &job_id, attempt)
+                .await?
+            {
+                continue;
+            }
+
+            let mut batch = WriteBatch::new();
+            let task_id = Uuid::new_v4().to_string();
+
+            // Re-inject into the limit chain from index 0 with no held queues,
+            // mirroring a fresh enqueue (and the retry path in lease.rs). At
+            // capacity this writes a deferred request instead of a RunAttempt.
+            let res = self
+                .enqueue_limit_task_at_index(
+                    &mut DbWriteBatcher::new(&self.db, &mut batch),
+                    LimitTaskParams {
+                        tenant,
+                        task_id: &task_id,
+                        job_id: &job_id,
+                        attempt_number: attempt,
+                        relative_attempt_number: 1,
+                        limit_index: 0,
+                        limits: &limits,
+                        priority,
+                        scheduled_at_ms: start_ms,
+                        task_key_epoch_ms: now_ms,
+                        now_ms,
+                        held_queues: Vec::new(),
+                        task_group: &task_group,
+                        skip_try_reserve: false,
+                    },
+                )
+                .await?;
+
+            // Commit durably; mirror enqueue's grant lifecycle: confirm + wake
+            // the broker on success, roll back the in-memory grants on failure.
+            match self
+                .db
+                .write_with_options(
+                    batch,
+                    &WriteOptions {
+                        await_durable: true,
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
+                Ok(_) => {
+                    self.finish_enqueue(&job_id, &task_group, start_ms, &res.grants)
+                        .await?;
+                    orphaned_scheduled_redriven += 1;
+                }
+                Err(e) => {
+                    self.rollback_grants(tenant, &res.grants);
+                    warn!(error = %e, %job_id, "failed to redrive orphaned Scheduled job; continuing");
+                }
+            }
+        }
+
+        Ok(orphaned_scheduled_redriven)
+    }
+
+    /// True if a task for `(task_group, start_ms, priority, job_id, attempt)`
+    /// exists in the TASK keyspace. Used to avoid redriving a Scheduled job that
+    /// already has a queued task.
+    async fn job_has_queued_task(
+        &self,
+        task_group: &str,
+        start_ms: i64,
+        priority: u8,
+        job_id: &str,
+        attempt: u32,
+    ) -> Result<bool, JobStoreShardError> {
+        let prefix = task_key_lookup_prefix(task_group, start_ms, priority, job_id, attempt);
+        let end = end_bound(&prefix);
+        let mut iter = self.db.scan::<Vec<u8>, _>(prefix..end).await?;
+        Ok(iter.next().await?.is_some())
     }
 }

--- a/src/job_store_shard/drop_tenant_holders.rs
+++ b/src/job_store_shard/drop_tenant_holders.rs
@@ -4,10 +4,15 @@
 //! forcibly clears a tenant's stuck concurrency state on a single shard so the
 //! tenant returns to a consistent, runnable state.
 
+use std::collections::HashSet;
+
 use slatedb::WriteBatch;
+use slatedb::config::WriteOptions;
 use tracing::warn;
 
 use crate::codec::{decode_lease, decode_task};
+use crate::job::{JobStatus, JobStatusKind};
+use crate::job_store_shard::helpers::{DbWriteBatcher, now_epoch_ms};
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
     concurrency_holders_tenant_prefix, end_bound, leases_prefix, parse_concurrency_holder_key,
@@ -28,6 +33,13 @@ pub struct DropTenantStats {
     /// Number of in-flight `RunAttempt`s deleted — both queued task-queue
     /// entries and running (leased) attempts.
     pub run_attempts_dropped: usize,
+}
+
+/// Counts of what `reconcile_orphaned_running_jobs` finalized.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReconcileTenantStats {
+    /// `Running` jobs that had no lease and were force-failed.
+    pub orphaned_running_failed: usize,
 }
 
 impl JobStoreShard {
@@ -176,6 +188,150 @@ impl JobStoreShard {
         Ok(DropTenantStats {
             holders_dropped: holder_keys.len(),
             run_attempts_dropped: deleted_task_keys.len() + deleted_lease_keys.len(),
+        })
+    }
+
+    /// Finalize a tenant's orphaned `Running` jobs — jobs stuck in `Running`
+    /// status with **no lease record** — by force-transitioning them to
+    /// terminal `Failed`.
+    ///
+    /// ## Why this exists
+    ///
+    /// The lease reaper is lease-driven: it finalizes a `Running` job by acting
+    /// on its (expired) lease. A `Running` job whose lease was raw-deleted
+    /// without a status transition — e.g. by the old "Drop holders & run
+    /// attempts" admin action before PR #365 — is therefore invisible to the
+    /// reaper and never cleaned up. No other tool recovers it either: `delete`
+    /// rejects non-terminal jobs, `cancel` on `Running` only writes a marker an
+    /// absent worker must ack, and `restart`/`expedite` reject `Running`. This
+    /// reconcile is the recovery path, and a permanent backstop against any
+    /// future orphan source.
+    ///
+    /// ## Semantics
+    ///
+    /// - **Orphan = `Running` with no lease.** We scan the whole LEASE keyspace
+    ///   and collect *every* lease for the tenant regardless of expiry: if a
+    ///   lease exists at all, the reaper owns that job and we must not race it.
+    ///   Only `Running` jobs with no lease are finalized.
+    /// - **No synthetic ATTEMPT row.** We have no lease/attempt context, so we
+    ///   write no new attempt. The job becomes `Failed` terminal;
+    ///   `expire_terminal_job_records` re-puts the existing (stale `Running`)
+    ///   attempt row with the terminal TTL so all records age out together.
+    /// - **Idempotent / partial-progress-safe.** Each job is finalized in its
+    ///   own durable batch and re-reads status first, so re-running skips
+    ///   already-`Failed` jobs and a crash mid-run loses no correctness.
+    /// - **Best-effort, like the reaper.** A per-job failure is logged, its
+    ///   in-memory queue-counter side effect rolled back, and the scan
+    ///   continues.
+    ///
+    /// ## Non-goal
+    ///
+    /// Orphaned `Scheduled` jobs are intentionally out of scope: a `Scheduled`
+    /// job legitimately has either a queued task or a pending concurrency
+    /// request, so classifying it as orphaned is ambiguous. A future extension
+    /// could handle that with a more careful definition.
+    #[tracing::instrument(skip_all, fields(shard = %self.name, tenant))]
+    pub async fn reconcile_orphaned_running_jobs(
+        &self,
+        tenant: &str,
+    ) -> Result<ReconcileTenantStats, JobStoreShardError> {
+        // ---- 1. Build the leased-job set (any lease, regardless of expiry) ----
+        let mut leased_job_ids: HashSet<String> = HashSet::new();
+        {
+            let start = leases_prefix();
+            let end = end_bound(&start);
+            let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
+            while let Some(kv) = iter.next().await? {
+                let decoded = match decode_lease(kv.value.clone()) {
+                    Ok(decoded) => decoded,
+                    Err(e) => {
+                        warn!(error = %e, "skipping undecodable lease during reconcile");
+                        continue;
+                    }
+                };
+                if decoded.tenant() == tenant {
+                    leased_job_ids.insert(decoded.job_id().to_string());
+                }
+            }
+        }
+
+        // ---- 2. List the tenant's Running jobs ----
+        let running_job_ids = self
+            .scan_jobs_by_status(tenant, JobStatusKind::Running, None)
+            .await?;
+
+        // ---- 3. Finalize each orphan in its own durable, atomic batch ----
+        let mut orphaned_running_failed = 0usize;
+        for job_id in running_job_ids {
+            if leased_job_ids.contains(&job_id) {
+                continue;
+            }
+
+            let now_ms = now_epoch_ms();
+
+            // Re-read status: skip unless still Running (guards against a
+            // concurrent transition and makes re-runs idempotent).
+            match self.get_job_status(tenant, &job_id).await? {
+                Some(status) if status.kind == JobStatusKind::Running => {}
+                _ => continue,
+            }
+
+            let expire_ts = self.terminal_expire_ts(JobStatusKind::Failed, now_ms);
+            let mut batch = WriteBatch::new();
+
+            // JOB_STATUS + IDX_STATUS_TIME + Running->Failed counter swap +
+            // background-action queue counters.
+            let transition = self
+                .set_job_status_with_index_opts(
+                    &mut DbWriteBatcher::new(&self.db, &mut batch),
+                    tenant,
+                    &job_id,
+                    JobStatus::failed(now_ms),
+                    expire_ts,
+                    None,
+                )
+                .await?;
+
+            // Terminal completion counter.
+            self.increment_completed_jobs_counter(&mut DbWriteBatcher::new(&self.db, &mut batch))?;
+
+            // TTL the job's records (JOB_INFO / IDX_METADATA / ATTEMPT /
+            // JOB_CANCELLED), including the stale Running attempt row.
+            if let Some(ts) = expire_ts {
+                self.expire_terminal_job_records(
+                    &mut DbWriteBatcher::new(&self.db, &mut batch),
+                    tenant,
+                    &job_id,
+                    ts,
+                )
+                .await?;
+            }
+
+            // Commit durably; on failure roll back the in-memory queue-counter
+            // side effect and continue (best-effort, like the reaper).
+            match self
+                .db
+                .write_with_options(
+                    batch,
+                    &WriteOptions {
+                        await_durable: true,
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
+                Ok(_) => orphaned_running_failed += 1,
+                Err(e) => {
+                    if let Some(transition) = &transition {
+                        self.rollback_background_action_metric_gauge_transition(transition);
+                    }
+                    warn!(error = %e, %job_id, "failed to finalize orphaned Running job; continuing");
+                }
+            }
+        }
+
+        Ok(ReconcileTenantStats {
+            orphaned_running_failed,
         })
     }
 }

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -17,7 +17,7 @@ mod restart;
 mod scan;
 
 pub use cleanup::{CleanupProgress, CleanupResult};
-pub use drop_tenant_holders::DropTenantStats;
+pub use drop_tenant_holders::{DropTenantStats, ReconcileTenantStats};
 
 pub use counters::{
     JobStatusTruth, ReconcileSummary, ShardCounters, TenantStatusCounterScanRange,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1101,6 +1101,23 @@ impl Silo for SiloService {
         }))
     }
 
+    async fn reconcile_tenant(
+        &self,
+        req: Request<ReconcileTenantRequest>,
+    ) -> Result<Response<ReconcileTenantResponse>, Status> {
+        let r = req.into_inner();
+        let (shard, tenant) = self
+            .resolve_shard_and_tenant(&r.shard, r.tenant.as_deref())
+            .await?;
+        let stats = shard
+            .reconcile_orphaned_running_jobs(&tenant)
+            .await
+            .map_err(map_err)?;
+        Ok(Response::new(ReconcileTenantResponse {
+            orphaned_running_failed: stats.orphaned_running_failed as u64,
+        }))
+    }
+
     async fn restart_job(
         &self,
         req: Request<RestartJobRequest>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1110,11 +1110,12 @@ impl Silo for SiloService {
             .resolve_shard_and_tenant(&r.shard, r.tenant.as_deref())
             .await?;
         let stats = shard
-            .reconcile_orphaned_running_jobs(&tenant)
+            .reconcile_orphaned_jobs(&tenant)
             .await
             .map_err(map_err)?;
         Ok(Response::new(ReconcileTenantResponse {
             orphaned_running_failed: stats.orphaned_running_failed as u64,
+            orphaned_scheduled_redriven: stats.orphaned_scheduled_redriven as u64,
         }))
     }
 

--- a/tests/job_store_shard_drop_tenant_holders_tests.rs
+++ b/tests/job_store_shard_drop_tenant_holders_tests.rs
@@ -107,7 +107,7 @@ async fn drop_tenant_with_no_state_is_a_noop() {
 }
 
 /// A `Running` job whose lease was raw-deleted (the old admin-action bug) is an
-/// orphan: invisible to the lease reaper. `reconcile_orphaned_running_jobs`
+/// orphan: invisible to the lease reaper. `reconcile_orphaned_jobs`
 /// force-transitions it to terminal `Failed`.
 #[silo::test]
 async fn reconcile_fails_orphaned_running_job() {
@@ -146,7 +146,7 @@ async fn reconcile_fails_orphaned_running_job() {
 
     // Reconcile finalizes the orphan.
     let stats = shard
-        .reconcile_orphaned_running_jobs("tenant-a")
+        .reconcile_orphaned_jobs("tenant-a")
         .await
         .expect("reconcile");
     assert_eq!(stats.orphaned_running_failed, 1);
@@ -183,7 +183,7 @@ async fn reconcile_leaves_live_leased_running_job_untouched() {
     assert!(count_lease_keys(shard.db()).await >= 1, "lease present");
 
     let stats = shard
-        .reconcile_orphaned_running_jobs("tenant-a")
+        .reconcile_orphaned_jobs("tenant-a")
         .await
         .expect("reconcile");
     assert_eq!(stats.orphaned_running_failed, 0, "live lease untouched");
@@ -200,15 +200,220 @@ async fn reconcile_leaves_live_leased_running_job_untouched() {
     );
 }
 
-/// Reconciling a tenant with no orphaned Running jobs is a no-op returning zero.
+/// Reconciling a tenant with no orphaned jobs is a no-op returning zeros.
 #[silo::test]
 async fn reconcile_with_no_orphans_is_noop() {
     let (_tmp, shard) = open_temp_shard().await;
 
     let stats = shard
-        .reconcile_orphaned_running_jobs("ghost")
+        .reconcile_orphaned_jobs("ghost")
         .await
         .expect("reconcile");
 
     assert_eq!(stats.orphaned_running_failed, 0);
+    assert_eq!(stats.orphaned_scheduled_redriven, 0);
+}
+
+/// Enqueue a job with no limits → status `Scheduled` + a single `RunAttempt`
+/// task in the TASK queue. Returns the job id.
+async fn enqueue_no_limits(
+    shard: &silo::job_store_shard::JobStoreShard,
+    tenant: &str,
+    now: i64,
+) -> String {
+    let payload = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
+    shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            now,
+            None,
+            payload,
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue")
+}
+
+/// A `Scheduled` job whose queued `RunAttempt` task was raw-deleted (the old
+/// admin-action bug) — with no concurrency request either — is an orphan that
+/// nothing will dispatch. `reconcile_orphaned_jobs` redrives it back into the
+/// limit chain so it runs again.
+#[silo::test]
+async fn reconcile_redrives_task_less_scheduled_orphan() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    let job_id = enqueue_no_limits(&shard, "tenant-a", now).await;
+    assert_eq!(count_task_keys(shard.db()).await, 1, "one task enqueued");
+
+    // Simulate the old bug: raw-delete the queued task, leaving JOB_STATUS =
+    // Scheduled with nothing in the pipeline.
+    let (task_key, _) = first_task_kv(shard.db()).await.expect("task exists");
+    shard.db().delete(&task_key).await.expect("delete task");
+    assert_eq!(count_task_keys(shard.db()).await, 0, "task removed");
+    assert_eq!(
+        shard
+            .get_job_status("tenant-a", &job_id)
+            .await
+            .expect("status")
+            .expect("job exists")
+            .kind,
+        JobStatusKind::Scheduled,
+        "job is orphaned Scheduled"
+    );
+
+    // Reconcile redrives the orphan.
+    let stats = shard
+        .reconcile_orphaned_jobs("tenant-a")
+        .await
+        .expect("reconcile");
+    assert_eq!(stats.orphaned_scheduled_redriven, 1);
+    assert_eq!(stats.orphaned_running_failed, 0);
+
+    // A fresh RunAttempt task exists and the job dequeues + runs again.
+    assert_eq!(count_task_keys(shard.db()).await, 1, "task re-created");
+    let leased = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(leased.len(), 1, "redriven job dequeues");
+    assert_eq!(leased[0].job().id(), job_id);
+    assert_eq!(
+        shard
+            .get_job_status("tenant-a", &job_id)
+            .await
+            .expect("status")
+            .expect("job exists")
+            .kind,
+        JobStatusKind::Running,
+    );
+}
+
+/// A `Scheduled` job that still has its queued task is healthy — reconcile must
+/// not touch it or write a duplicate task.
+#[silo::test]
+async fn reconcile_leaves_scheduled_with_task_untouched() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    let job_id = enqueue_no_limits(&shard, "tenant-a", now).await;
+    assert_eq!(count_task_keys(shard.db()).await, 1);
+
+    let stats = shard
+        .reconcile_orphaned_jobs("tenant-a")
+        .await
+        .expect("reconcile");
+    assert_eq!(
+        stats.orphaned_scheduled_redriven, 0,
+        "healthy job untouched"
+    );
+
+    // No duplicate task, status unchanged.
+    assert_eq!(count_task_keys(shard.db()).await, 1, "no duplicate task");
+    assert_eq!(
+        shard
+            .get_job_status("tenant-a", &job_id)
+            .await
+            .expect("status")
+            .expect("job exists")
+            .kind,
+        JobStatusKind::Scheduled,
+    );
+}
+
+/// A `Scheduled` job parked on a full concurrency queue has a pending request
+/// (not a task) and is legitimately waiting — reconcile must never redrive it.
+#[silo::test]
+async fn reconcile_leaves_scheduled_waiting_on_concurrency_untouched() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // First job grabs the only slot (holder + RunAttempt task). Second job is
+    // parked as a concurrency request (Scheduled, no task).
+    enqueue_with_holder(&shard, "tenant-a", "qA", now).await;
+    enqueue_with_holder(&shard, "tenant-a", "qA", now).await;
+    assert_eq!(
+        count_task_keys(shard.db()).await,
+        1,
+        "only first has a task"
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        1,
+        "second parked as a request"
+    );
+
+    let stats = shard
+        .reconcile_orphaned_jobs("tenant-a")
+        .await
+        .expect("reconcile");
+    assert_eq!(
+        stats.orphaned_scheduled_redriven, 0,
+        "neither the task-holding nor the request-waiting job is an orphan"
+    );
+
+    // Nothing duplicated.
+    assert_eq!(count_task_keys(shard.db()).await, 1);
+    assert_eq!(count_concurrency_requests(shard.db()).await, 1);
+}
+
+/// Running and Scheduled orphans for the same tenant are both recovered in one
+/// reconcile pass.
+#[silo::test]
+async fn reconcile_handles_running_and_scheduled_orphans_together() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Running orphan: enqueue → dequeue (Running + lease) → delete the lease.
+    let running_id = enqueue_no_limits(&shard, "tenant-a", now).await;
+    let leased = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(leased.len(), 1);
+    assert_eq!(leased[0].job().id(), running_id);
+    let task_id = leased[0].attempt().task_id().to_string();
+    shard
+        .db()
+        .delete(&silo::keys::leased_task_key(&task_id))
+        .await
+        .expect("delete lease");
+
+    // Scheduled orphan: enqueue (now in TASK queue) → delete its task.
+    let scheduled_id = enqueue_no_limits(&shard, "tenant-a", now).await;
+    let (task_key, _) = first_task_kv(shard.db()).await.expect("scheduled task");
+    shard.db().delete(&task_key).await.expect("delete task");
+
+    let stats = shard
+        .reconcile_orphaned_jobs("tenant-a")
+        .await
+        .expect("reconcile");
+    assert_eq!(stats.orphaned_running_failed, 1);
+    assert_eq!(stats.orphaned_scheduled_redriven, 1);
+
+    assert_eq!(
+        shard
+            .get_job_status("tenant-a", &running_id)
+            .await
+            .expect("status")
+            .expect("job")
+            .kind,
+        JobStatusKind::Failed,
+    );
+    assert_eq!(
+        shard
+            .get_job_status("tenant-a", &scheduled_id)
+            .await
+            .expect("status")
+            .expect("job")
+            .kind,
+        JobStatusKind::Scheduled,
+        "redriven job stays Scheduled until a worker leases its new task"
+    );
 }

--- a/tests/job_store_shard_drop_tenant_holders_tests.rs
+++ b/tests/job_store_shard_drop_tenant_holders_tests.rs
@@ -1,6 +1,6 @@
 mod test_helpers;
 
-use silo::job::{ConcurrencyLimit, Limit};
+use silo::job::{ConcurrencyLimit, JobStatusKind, Limit};
 use test_helpers::*;
 
 /// Enqueue a job for `tenant` with a concurrency limit on `queue` (max 1). The
@@ -104,4 +104,111 @@ async fn drop_tenant_with_no_state_is_a_noop() {
 
     assert_eq!(stats.holders_dropped, 0);
     assert_eq!(stats.run_attempts_dropped, 0);
+}
+
+/// A `Running` job whose lease was raw-deleted (the old admin-action bug) is an
+/// orphan: invisible to the lease reaper. `reconcile_orphaned_running_jobs`
+/// force-transitions it to terminal `Failed`.
+#[silo::test]
+async fn reconcile_fails_orphaned_running_job() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    let job_id = enqueue_with_holder(&shard, "tenant-a", "qA", now).await;
+
+    // Dequeue → the job is Running with a lease.
+    let leased = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(leased.len(), 1, "exactly one task leased");
+    let task_id = leased[0].attempt().task_id().to_string();
+
+    // Simulate the old bug: raw-delete the lease without a status transition,
+    // leaving JOB_STATUS = Running with no lease.
+    shard
+        .db()
+        .delete(&silo::keys::leased_task_key(&task_id))
+        .await
+        .expect("delete lease");
+    assert_eq!(count_lease_keys(shard.db()).await, 0, "lease removed");
+    assert_eq!(
+        shard
+            .get_job_status("tenant-a", &job_id)
+            .await
+            .expect("status")
+            .expect("job exists")
+            .kind,
+        JobStatusKind::Running,
+        "job is orphaned Running"
+    );
+
+    // Reconcile finalizes the orphan.
+    let stats = shard
+        .reconcile_orphaned_running_jobs("tenant-a")
+        .await
+        .expect("reconcile");
+    assert_eq!(stats.orphaned_running_failed, 1);
+
+    assert_eq!(
+        shard
+            .get_job_status("tenant-a", &job_id)
+            .await
+            .expect("status")
+            .expect("job exists")
+            .kind,
+        JobStatusKind::Failed,
+        "orphan transitioned to terminal Failed"
+    );
+    assert_eq!(count_lease_keys(shard.db()).await, 0);
+}
+
+/// A `Running` job with its lease intact may have a worker actively running it,
+/// so reconcile must never touch it.
+#[silo::test]
+async fn reconcile_leaves_live_leased_running_job_untouched() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    let job_id = enqueue_with_holder(&shard, "tenant-a", "qA", now).await;
+
+    // Dequeue → Running WITH lease intact (no bug simulated).
+    let leased = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(leased.len(), 1);
+    assert!(count_lease_keys(shard.db()).await >= 1, "lease present");
+
+    let stats = shard
+        .reconcile_orphaned_running_jobs("tenant-a")
+        .await
+        .expect("reconcile");
+    assert_eq!(stats.orphaned_running_failed, 0, "live lease untouched");
+
+    assert_eq!(
+        shard
+            .get_job_status("tenant-a", &job_id)
+            .await
+            .expect("status")
+            .expect("job exists")
+            .kind,
+        JobStatusKind::Running,
+        "still Running — a worker may be running it",
+    );
+}
+
+/// Reconciling a tenant with no orphaned Running jobs is a no-op returning zero.
+#[silo::test]
+async fn reconcile_with_no_orphans_is_noop() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    let stats = shard
+        .reconcile_orphaned_running_jobs("ghost")
+        .await
+        .expect("reconcile");
+
+    assert_eq!(stats.orphaned_running_failed, 0);
 }

--- a/tests/routing_client_tests.rs
+++ b/tests/routing_client_tests.rs
@@ -104,6 +104,13 @@ impl Silo for CountingClusterInfoService {
         Self::unimplemented("drop_tenant_holders")
     }
 
+    async fn reconcile_tenant(
+        &self,
+        _request: Request<ReconcileTenantRequest>,
+    ) -> Result<Response<ReconcileTenantResponse>, Status> {
+        Self::unimplemented("reconcile_tenant")
+    }
+
     async fn restart_job(
         &self,
         _request: Request<RestartJobRequest>,

--- a/typescript_client/src/pb/silo.client.ts
+++ b/typescript_client/src/pb/silo.client.ts
@@ -47,6 +47,8 @@ import type { ExpediteJobResponse } from "./silo";
 import type { ExpediteJobRequest } from "./silo";
 import type { RestartJobResponse } from "./silo";
 import type { RestartJobRequest } from "./silo";
+import type { ReconcileTenantResponse } from "./silo";
+import type { ReconcileTenantRequest } from "./silo";
 import type { DropTenantHoldersResponse } from "./silo";
 import type { DropTenantHoldersRequest } from "./silo";
 import type { CancelJobResponse } from "./silo";
@@ -127,6 +129,13 @@ export interface ISiloClient {
      * @generated from protobuf rpc: DropTenantHolders
      */
     dropTenantHolders(input: DropTenantHoldersRequest, options?: RpcOptions): UnaryCall<DropTenantHoldersRequest, DropTenantHoldersResponse>;
+    /**
+     * Finalize a tenant's orphaned `Running` jobs (Running with no lease) by
+     * force-failing them. Recovers jobs the lease reaper can't see.
+     *
+     * @generated from protobuf rpc: ReconcileTenant
+     */
+    reconcileTenant(input: ReconcileTenantRequest, options?: RpcOptions): UnaryCall<ReconcileTenantRequest, ReconcileTenantResponse>;
     /**
      * Restart a cancelled or failed job for another attempt.
      * Returns FAILED_PRECONDITION if job is not in a restartable state.
@@ -389,6 +398,16 @@ export class SiloClient implements ISiloClient, ServiceInfo {
         return stackIntercept<DropTenantHoldersRequest, DropTenantHoldersResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * Finalize a tenant's orphaned `Running` jobs (Running with no lease) by
+     * force-failing them. Recovers jobs the lease reaper can't see.
+     *
+     * @generated from protobuf rpc: ReconcileTenant
+     */
+    reconcileTenant(input: ReconcileTenantRequest, options?: RpcOptions): UnaryCall<ReconcileTenantRequest, ReconcileTenantResponse> {
+        const method = this.methods[8], opt = this._transport.mergeOptions(options);
+        return stackIntercept<ReconcileTenantRequest, ReconcileTenantResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
      * Restart a cancelled or failed job for another attempt.
      * Returns FAILED_PRECONDITION if job is not in a restartable state.
      * Returns NOT_FOUND if the job doesn't exist.
@@ -396,7 +415,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: RestartJob
      */
     restartJob(input: RestartJobRequest, options?: RpcOptions): UnaryCall<RestartJobRequest, RestartJobResponse> {
-        const method = this.methods[8], opt = this._transport.mergeOptions(options);
+        const method = this.methods[9], opt = this._transport.mergeOptions(options);
         return stackIntercept<RestartJobRequest, RestartJobResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -409,7 +428,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ExpediteJob
      */
     expediteJob(input: ExpediteJobRequest, options?: RpcOptions): UnaryCall<ExpediteJobRequest, ExpediteJobResponse> {
-        const method = this.methods[9], opt = this._transport.mergeOptions(options);
+        const method = this.methods[10], opt = this._transport.mergeOptions(options);
         return stackIntercept<ExpediteJobRequest, ExpediteJobResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -421,7 +440,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: LeaseTask
      */
     leaseTask(input: LeaseTaskRequest, options?: RpcOptions): UnaryCall<LeaseTaskRequest, LeaseTaskResponse> {
-        const method = this.methods[10], opt = this._transport.mergeOptions(options);
+        const method = this.methods[11], opt = this._transport.mergeOptions(options);
         return stackIntercept<LeaseTaskRequest, LeaseTaskResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -432,7 +451,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: LeaseTasks
      */
     leaseTasks(input: LeaseTasksRequest, options?: RpcOptions): UnaryCall<LeaseTasksRequest, LeaseTasksResponse> {
-        const method = this.methods[11], opt = this._transport.mergeOptions(options);
+        const method = this.methods[12], opt = this._transport.mergeOptions(options);
         return stackIntercept<LeaseTasksRequest, LeaseTasksResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -442,7 +461,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ReportOutcome
      */
     reportOutcome(input: ReportOutcomeRequest, options?: RpcOptions): UnaryCall<ReportOutcomeRequest, ReportOutcomeResponse> {
-        const method = this.methods[12], opt = this._transport.mergeOptions(options);
+        const method = this.methods[13], opt = this._transport.mergeOptions(options);
         return stackIntercept<ReportOutcomeRequest, ReportOutcomeResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -452,7 +471,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ReportRefreshOutcome
      */
     reportRefreshOutcome(input: ReportRefreshOutcomeRequest, options?: RpcOptions): UnaryCall<ReportRefreshOutcomeRequest, ReportRefreshOutcomeResponse> {
-        const method = this.methods[13], opt = this._transport.mergeOptions(options);
+        const method = this.methods[14], opt = this._transport.mergeOptions(options);
         return stackIntercept<ReportRefreshOutcomeRequest, ReportRefreshOutcomeResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -463,7 +482,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: Heartbeat
      */
     heartbeat(input: HeartbeatRequest, options?: RpcOptions): UnaryCall<HeartbeatRequest, HeartbeatResponse> {
-        const method = this.methods[14], opt = this._transport.mergeOptions(options);
+        const method = this.methods[15], opt = this._transport.mergeOptions(options);
         return stackIntercept<HeartbeatRequest, HeartbeatResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -473,7 +492,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: Query
      */
     query(input: QueryRequest, options?: RpcOptions): UnaryCall<QueryRequest, QueryResponse> {
-        const method = this.methods[15], opt = this._transport.mergeOptions(options);
+        const method = this.methods[16], opt = this._transport.mergeOptions(options);
         return stackIntercept<QueryRequest, QueryResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -484,7 +503,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: QueryArrow
      */
     queryArrow(input: QueryArrowRequest, options?: RpcOptions): ServerStreamingCall<QueryArrowRequest, ArrowIpcMessage> {
-        const method = this.methods[16], opt = this._transport.mergeOptions(options);
+        const method = this.methods[17], opt = this._transport.mergeOptions(options);
         return stackIntercept<QueryArrowRequest, ArrowIpcMessage>("serverStreaming", this._transport, method, opt, input);
     }
     /**
@@ -495,7 +514,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: CpuProfile
      */
     cpuProfile(input: CpuProfileRequest, options?: RpcOptions): UnaryCall<CpuProfileRequest, CpuProfileResponse> {
-        const method = this.methods[17], opt = this._transport.mergeOptions(options);
+        const method = this.methods[18], opt = this._transport.mergeOptions(options);
         return stackIntercept<CpuProfileRequest, CpuProfileResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -506,7 +525,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: HeapProfile
      */
     heapProfile(input: HeapProfileRequest, options?: RpcOptions): UnaryCall<HeapProfileRequest, HeapProfileResponse> {
-        const method = this.methods[18], opt = this._transport.mergeOptions(options);
+        const method = this.methods[19], opt = this._transport.mergeOptions(options);
         return stackIntercept<HeapProfileRequest, HeapProfileResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -519,7 +538,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: RequestSplit
      */
     requestSplit(input: RequestSplitRequest, options?: RpcOptions): UnaryCall<RequestSplitRequest, RequestSplitResponse> {
-        const method = this.methods[19], opt = this._transport.mergeOptions(options);
+        const method = this.methods[20], opt = this._transport.mergeOptions(options);
         return stackIntercept<RequestSplitRequest, RequestSplitResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -530,7 +549,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: GetSplitStatus
      */
     getSplitStatus(input: GetSplitStatusRequest, options?: RpcOptions): UnaryCall<GetSplitStatusRequest, GetSplitStatusResponse> {
-        const method = this.methods[20], opt = this._transport.mergeOptions(options);
+        const method = this.methods[21], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetSplitStatusRequest, GetSplitStatusResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -542,7 +561,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ConfigureShard
      */
     configureShard(input: ConfigureShardRequest, options?: RpcOptions): UnaryCall<ConfigureShardRequest, ConfigureShardResponse> {
-        const method = this.methods[21], opt = this._transport.mergeOptions(options);
+        const method = this.methods[22], opt = this._transport.mergeOptions(options);
         return stackIntercept<ConfigureShardRequest, ConfigureShardResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -554,7 +573,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ImportJobs
      */
     importJobs(input: ImportJobsRequest, options?: RpcOptions): UnaryCall<ImportJobsRequest, ImportJobsResponse> {
-        const method = this.methods[22], opt = this._transport.mergeOptions(options);
+        const method = this.methods[23], opt = this._transport.mergeOptions(options);
         return stackIntercept<ImportJobsRequest, ImportJobsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -565,7 +584,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ResetShards
      */
     resetShards(input: ResetShardsRequest, options?: RpcOptions): UnaryCall<ResetShardsRequest, ResetShardsResponse> {
-        const method = this.methods[23], opt = this._transport.mergeOptions(options);
+        const method = this.methods[24], opt = this._transport.mergeOptions(options);
         return stackIntercept<ResetShardsRequest, ResetShardsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -576,7 +595,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: ForceReleaseShard
      */
     forceReleaseShard(input: ForceReleaseShardRequest, options?: RpcOptions): UnaryCall<ForceReleaseShardRequest, ForceReleaseShardResponse> {
-        const method = this.methods[24], opt = this._transport.mergeOptions(options);
+        const method = this.methods[25], opt = this._transport.mergeOptions(options);
         return stackIntercept<ForceReleaseShardRequest, ForceReleaseShardResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -587,7 +606,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: CompactShard
      */
     compactShard(input: CompactShardRequest, options?: RpcOptions): UnaryCall<CompactShardRequest, CompactShardResponse> {
-        const method = this.methods[25], opt = this._transport.mergeOptions(options);
+        const method = this.methods[26], opt = this._transport.mergeOptions(options);
         return stackIntercept<CompactShardRequest, CompactShardResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -597,7 +616,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: FlushShard
      */
     flushShard(input: FlushShardRequest, options?: RpcOptions): UnaryCall<FlushShardRequest, FlushShardResponse> {
-        const method = this.methods[26], opt = this._transport.mergeOptions(options);
+        const method = this.methods[27], opt = this._transport.mergeOptions(options);
         return stackIntercept<FlushShardRequest, FlushShardResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -608,7 +627,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: GetShardStorageInfo
      */
     getShardStorageInfo(input: GetShardStorageInfoRequest, options?: RpcOptions): UnaryCall<GetShardStorageInfoRequest, GetShardStorageInfoResponse> {
-        const method = this.methods[27], opt = this._transport.mergeOptions(options);
+        const method = this.methods[28], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetShardStorageInfoRequest, GetShardStorageInfoResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -618,7 +637,7 @@ export class SiloClient implements ISiloClient, ServiceInfo {
      * @generated from protobuf rpc: DumpTasks
      */
     dumpTasks(input: DumpTasksRequest, options?: RpcOptions): UnaryCall<DumpTasksRequest, DumpTasksResponse> {
-        const method = this.methods[28], opt = this._transport.mergeOptions(options);
+        const method = this.methods[29], opt = this._transport.mergeOptions(options);
         return stackIntercept<DumpTasksRequest, DumpTasksResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -589,6 +589,10 @@ export interface ReconcileTenantResponse {
      * @generated from protobuf field: uint64 orphaned_running_failed = 1
      */
     orphanedRunningFailed: bigint; // Running jobs with no lease force-failed.
+    /**
+     * @generated from protobuf field: uint64 orphaned_scheduled_redriven = 2
+     */
+    orphanedScheduledRedriven: bigint; // Scheduled jobs with no task/request re-injected into the limit chain.
 }
 /**
  * Restart a cancelled or failed job, allowing it to be processed again.
@@ -3560,12 +3564,14 @@ export const ReconcileTenantRequest = new ReconcileTenantRequest$Type();
 class ReconcileTenantResponse$Type extends MessageType<ReconcileTenantResponse> {
     constructor() {
         super("silo.v1.ReconcileTenantResponse", [
-            { no: 1, name: "orphaned_running_failed", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
+            { no: 1, name: "orphaned_running_failed", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "orphaned_scheduled_redriven", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
     create(value?: PartialMessage<ReconcileTenantResponse>): ReconcileTenantResponse {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.orphanedRunningFailed = 0n;
+        message.orphanedScheduledRedriven = 0n;
         if (value !== undefined)
             reflectionMergePartial<ReconcileTenantResponse>(this, message, value);
         return message;
@@ -3577,6 +3583,9 @@ class ReconcileTenantResponse$Type extends MessageType<ReconcileTenantResponse> 
             switch (fieldNo) {
                 case /* uint64 orphaned_running_failed */ 1:
                     message.orphanedRunningFailed = reader.uint64().toBigInt();
+                    break;
+                case /* uint64 orphaned_scheduled_redriven */ 2:
+                    message.orphanedScheduledRedriven = reader.uint64().toBigInt();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -3593,6 +3602,9 @@ class ReconcileTenantResponse$Type extends MessageType<ReconcileTenantResponse> 
         /* uint64 orphaned_running_failed = 1; */
         if (message.orphanedRunningFailed !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.orphanedRunningFailed);
+        /* uint64 orphaned_scheduled_redriven = 2; */
+        if (message.orphanedScheduledRedriven !== 0n)
+            writer.tag(2, WireType.Varint).uint64(message.orphanedScheduledRedriven);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -562,6 +562,35 @@ export interface DropTenantHoldersResponse {
     runAttemptsDropped: bigint; // Number of in-flight run attempts deleted.
 }
 /**
+ * Finalize a tenant's orphaned `Running` jobs (Running status with no lease
+ * record) by force-transitioning them to terminal `Failed`. Admin/operator
+ * action that recovers jobs the lease reaper can't see, and a backstop against
+ * future orphan sources.
+ *
+ * @generated from protobuf message silo.v1.ReconcileTenantRequest
+ */
+export interface ReconcileTenantRequest {
+    /**
+     * @generated from protobuf field: string shard = 1
+     */
+    shard: string; // Shard ID (UUID) to operate on.
+    /**
+     * @generated from protobuf field: optional string tenant = 2
+     */
+    tenant?: string; // Tenant ID if multi-tenancy is enabled.
+}
+/**
+ * Response reporting what was reconciled.
+ *
+ * @generated from protobuf message silo.v1.ReconcileTenantResponse
+ */
+export interface ReconcileTenantResponse {
+    /**
+     * @generated from protobuf field: uint64 orphaned_running_failed = 1
+     */
+    orphanedRunningFailed: bigint; // Running jobs with no lease force-failed.
+}
+/**
  * Restart a cancelled or failed job, allowing it to be processed again.
  * The job will get a fresh set of retries according to its retry policy.
  *
@@ -3473,6 +3502,107 @@ class DropTenantHoldersResponse$Type extends MessageType<DropTenantHoldersRespon
  * @generated MessageType for protobuf message silo.v1.DropTenantHoldersResponse
  */
 export const DropTenantHoldersResponse = new DropTenantHoldersResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ReconcileTenantRequest$Type extends MessageType<ReconcileTenantRequest> {
+    constructor() {
+        super("silo.v1.ReconcileTenantRequest", [
+            { no: 1, name: "shard", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "tenant", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ReconcileTenantRequest>): ReconcileTenantRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.shard = "";
+        if (value !== undefined)
+            reflectionMergePartial<ReconcileTenantRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ReconcileTenantRequest): ReconcileTenantRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string shard */ 1:
+                    message.shard = reader.string();
+                    break;
+                case /* optional string tenant */ 2:
+                    message.tenant = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ReconcileTenantRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string shard = 1; */
+        if (message.shard !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.shard);
+        /* optional string tenant = 2; */
+        if (message.tenant !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.tenant);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.ReconcileTenantRequest
+ */
+export const ReconcileTenantRequest = new ReconcileTenantRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ReconcileTenantResponse$Type extends MessageType<ReconcileTenantResponse> {
+    constructor() {
+        super("silo.v1.ReconcileTenantResponse", [
+            { no: 1, name: "orphaned_running_failed", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ReconcileTenantResponse>): ReconcileTenantResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.orphanedRunningFailed = 0n;
+        if (value !== undefined)
+            reflectionMergePartial<ReconcileTenantResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ReconcileTenantResponse): ReconcileTenantResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* uint64 orphaned_running_failed */ 1:
+                    message.orphanedRunningFailed = reader.uint64().toBigInt();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ReconcileTenantResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* uint64 orphaned_running_failed = 1; */
+        if (message.orphanedRunningFailed !== 0n)
+            writer.tag(1, WireType.Varint).uint64(message.orphanedRunningFailed);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message silo.v1.ReconcileTenantResponse
+ */
+export const ReconcileTenantResponse = new ReconcileTenantResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class RestartJobRequest$Type extends MessageType<RestartJobRequest> {
     constructor() {
@@ -7327,6 +7457,7 @@ export const Silo = new ServiceType("silo.v1.Silo", [
     { name: "DeleteJob", options: {}, I: DeleteJobRequest, O: DeleteJobResponse },
     { name: "CancelJob", options: {}, I: CancelJobRequest, O: CancelJobResponse },
     { name: "DropTenantHolders", options: {}, I: DropTenantHoldersRequest, O: DropTenantHoldersResponse },
+    { name: "ReconcileTenant", options: {}, I: ReconcileTenantRequest, O: ReconcileTenantResponse },
     { name: "RestartJob", options: {}, I: RestartJobRequest, O: RestartJobResponse },
     { name: "ExpediteJob", options: {}, I: ExpediteJobRequest, O: ExpediteJobResponse },
     { name: "LeaseTask", options: {}, I: LeaseTaskRequest, O: LeaseTaskResponse },


### PR DESCRIPTION
## Summary

Adds a `ReconcileTenant` gRPC RPC that recovers jobs left in a stuck state by the **bugged "Drop holders & run attempts" admin action**. That action raw-deleted leases and concurrency holders without transitioning job status, producing two classes of permanently-stuck orphans that nothing in the normal pipeline will ever clean up:

1. **`Running` with no lease record** — invisible to the lease reaper (which is lease-driven), so they hang in `Running` forever.
2. **`Scheduled` with no queued task and no pending concurrency request** — nothing will ever dispatch them.

> Context: I needed this to fix a tenant that the bugged "drop holders & run attempts" button left stuck. This RPC doubles as a permanent backstop against future orphan sources.

## What it does

- **Orphaned `Running` jobs** → force-transitioned to terminal `Failed` via the same counter/index-correct path as the normal terminal transition.
- **Orphaned `Scheduled` jobs** → redriven (not failed, since they never started): re-injected into the limit chain via `enqueue_limit_task_at_index` from index 0, re-applying the job's concurrency/rate limits so an at-capacity job re-parks as a request instead of bypassing the cap. Preserves the current attempt number and scheduled start time. A pre-write point-check skips any `Scheduled` job that already has a task, so re-runs never duplicate a `RunAttempt`. Does not touch the background-action queue counter (the job stayed `Scheduled` throughout; the drop never decremented the gauge).

The shard method `reconcile_orphaned_jobs` is tenant-scoped and modeled on `DropTenantHolders`. Response reports `orphaned_running_failed` and `orphaned_scheduled_redriven` counts.

## Changes

- `proto/silo.proto` — new `ReconcileTenant` RPC + request/response messages
- `src/job_store_shard/drop_tenant_holders.rs` — `reconcile_orphaned_jobs` implementation
- `src/server.rs` — RPC handler
- `typescript_client/` — regenerated proto files
- `tests/` — coverage for both orphan classes

## Test plan

- [ ] `tests/job_store_shard_drop_tenant_holders_tests.rs` covers both the Running-force-fail and Scheduled-redrive paths
- [ ] Verify against the affected tenant
