### PR TITLE
Make silo resilient to holder orphans (ghost holders)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,10 @@ name = "job_shard_throughput"
 harness = false
 
 [[bench]]
+name = "noisy_neighbor_throughput"
+harness = false
+
+[[bench]]
 name = "query_performance"
 harness = false
 required-features = ["server"]

--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -618,6 +618,7 @@ pub async fn clone_golden_shard(
             terminal_job_expire_s: None,
             grant_scanner_batch_size: silo::settings::DEFAULT_GRANT_SCANNER_BATCH_SIZE,
             grant_scanner_buffer_size: silo::settings::DEFAULT_GRANT_SCANNER_BUFFER_SIZE,
+            grant_scanner_concurrency: silo::settings::DEFAULT_GRANT_SCANNER_CONCURRENCY,
         },
         ShardRange::full(),
     )

--- a/benches/noisy_neighbor_throughput.rs
+++ b/benches/noisy_neighbor_throughput.rs
@@ -1,0 +1,306 @@
+//! Noisy-neighbor grant-scanner fairness benchmark.
+//!
+//! Two tenants live on the SAME shard (same `JobStoreShard`, same grant scanner
+//! and task broker registry):
+//!
+//!   * Tenant A ("the noisy neighbor") enqueues a large number of jobs spread
+//!     across many concurrency queues. Every queue has a tight static
+//!     `Concurrency(max=1)` limit plus a wide `FloatingConcurrency(max=360)`
+//!     limit, so each queue keeps a deep backlog of pending concurrency
+//!     *requesters* that the grant scanner must repeatedly walk as holders are
+//!     released and re-granted.
+//!
+//!   * Tenant B ("the victim") enqueues far fewer jobs, with the same shape of
+//!     limits.
+//!
+//! We measure tenant B's end-to-end completion throughput (jobs/sec) both in
+//! isolation and while tenant A is hammering the shared grant scanner. If the
+//! scanner is fair — bounded per-invocation scan budget and per-queue parallel
+//! fan-out — tenant B's throughput should barely move when A is present. If the
+//! scanner processes queues serially and walks unbounded backlogs, tenant A
+//! starves B and the "noisy" throughput collapses.
+//!
+//! The runtime is intentionally multi-threaded (`worker_threads >= 2`) so the
+//! background grant-scanner task can run on a different worker than the drain
+//! loops, matching production.
+
+use silo::gubernator::NullGubernatorClient;
+use silo::job::{ConcurrencyLimit, FloatingConcurrencyLimit, Limit};
+use silo::job_attempt::AttemptOutcome;
+use silo::job_store_shard::JobStoreShard;
+use silo::settings::{Backend, DatabaseConfig};
+use silo::shard_range::ShardRange;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+// ---- Workload knobs (override via env for quick tuning) ----
+
+/// Number of distinct concurrency queues tenant A spreads its jobs over.
+const A_QUEUES: usize = 24;
+/// Jobs per tenant-A queue. Deep so each queue carries a long requester backlog.
+const A_DEPTH: usize = 160;
+/// Number of distinct concurrency queues tenant B spreads its jobs over.
+const B_QUEUES: usize = 8;
+/// Jobs per tenant-B queue. Far fewer than tenant A overall.
+const B_DEPTH: usize = 60;
+
+/// Worker (consumer) count per tenant.
+const A_WORKERS: usize = 8;
+const B_WORKERS: usize = 8;
+/// Dequeue batch size per claim.
+const BATCH: usize = 8;
+
+/// Static (tight) concurrency limit — only one holder per queue at a time.
+const TIGHT_MAX: u32 = 1;
+/// Floating (wide) concurrency limit — effectively never binding; it exists to
+/// double the number of requester rows the scanner must walk per job.
+const FLOAT_MAX: u32 = 360;
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+async fn open_temp_shard(flush_interval_ms: u64) -> (tempfile::TempDir, Arc<JobStoreShard>) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = DatabaseConfig {
+        name: "noisy-neighbor-shard".to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(slatedb::config::Settings {
+            flush_interval: Some(Duration::from_millis(flush_interval_ms)),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let shard = JobStoreShard::open(&cfg, NullGubernatorClient::new(), None, ShardRange::full())
+        .await
+        .expect("open shard");
+    (tmp, shard)
+}
+
+/// Two limits per job: a tight static concurrency queue (max 1) and a wide
+/// floating concurrency queue (max 360). Both are tenant-scoped via the key.
+fn job_limits(tight_key: &str, float_key: &str) -> Vec<Limit> {
+    vec![
+        Limit::Concurrency(ConcurrencyLimit {
+            key: tight_key.to_string(),
+            max_concurrency: TIGHT_MAX,
+        }),
+        Limit::FloatingConcurrency(FloatingConcurrencyLimit {
+            key: float_key.to_string(),
+            default_max_concurrency: FLOAT_MAX,
+            // Long refresh interval: we don't want worker-driven refreshes to
+            // perturb the measurement.
+            refresh_interval_ms: 600_000,
+            metadata: vec![],
+        }),
+    ]
+}
+
+/// Enqueue `num_queues * depth` jobs for `tenant` under task group `group`,
+/// fanning the enqueues out across producers for fast setup. Returns the total
+/// number of jobs enqueued.
+async fn enqueue_tenant(
+    shard: &Arc<JobStoreShard>,
+    tenant: &'static str,
+    group: &'static str,
+    num_queues: usize,
+    depth: usize,
+    now: i64,
+) -> usize {
+    let mut handles = Vec::new();
+    for q in 0..num_queues {
+        let shard = Arc::clone(shard);
+        let handle = tokio::spawn(async move {
+            let tight = format!("{tenant}-tight-{q}");
+            let float = format!("{tenant}-float-{q}");
+            for i in 0..depth {
+                let payload = rmp_serde::to_vec(&serde_json::json!({"q": q, "i": i}))
+                    .expect("serialize payload");
+                shard
+                    .enqueue(
+                        tenant,
+                        None,
+                        50,
+                        now,
+                        None,
+                        payload,
+                        job_limits(&tight, &float),
+                        None,
+                        group,
+                    )
+                    .await
+                    .expect("enqueue");
+            }
+        });
+        handles.push(handle);
+    }
+    for h in handles {
+        h.await.expect("enqueue producer");
+    }
+    num_queues * depth
+}
+
+/// Spawn `num_workers` drain workers for a task group. Each worker dequeues,
+/// reports success (releasing the concurrency holder so the next requester can
+/// be granted), and bumps `counter`. Workers run until `stop` is set.
+fn spawn_drain_workers(
+    shard: &Arc<JobStoreShard>,
+    group: &'static str,
+    num_workers: usize,
+    batch: usize,
+    counter: Arc<AtomicUsize>,
+    stop: Arc<AtomicBool>,
+) -> Vec<tokio::task::JoinHandle<()>> {
+    (0..num_workers)
+        .map(|w| {
+            let shard = Arc::clone(shard);
+            let counter = Arc::clone(&counter);
+            let stop = Arc::clone(&stop);
+            tokio::spawn(async move {
+                let worker_id = format!("{group}-w{w}");
+                while !stop.load(Ordering::Relaxed) {
+                    let result = shard.dequeue(&worker_id, group, batch).await.expect("dequeue");
+                    if result.tasks.is_empty() {
+                        tokio::time::sleep(Duration::from_millis(2)).await;
+                        continue;
+                    }
+                    for t in &result.tasks {
+                        let tid = t.attempt().task_id().to_string();
+                        shard
+                            .report_attempt_outcome(&tid, AttemptOutcome::Success { result: Vec::new() })
+                            .await
+                            .expect("report");
+                        counter.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            })
+        })
+        .collect()
+}
+
+/// Drive tenant B's workers until all `b_total` jobs complete, returning the
+/// elapsed wall-clock time. Assumes any noisy-neighbor load is already running.
+async fn measure_drain(
+    shard: &Arc<JobStoreShard>,
+    group: &'static str,
+    num_workers: usize,
+    batch: usize,
+    b_total: usize,
+) -> Duration {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let start = Instant::now();
+    let handles = spawn_drain_workers(shard, group, num_workers, batch, Arc::clone(&counter), Arc::clone(&stop));
+
+    while counter.load(Ordering::Relaxed) < b_total {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    let elapsed = start.elapsed();
+
+    stop.store(true, Ordering::Relaxed);
+    for h in handles {
+        let _ = h.await;
+    }
+    elapsed
+}
+
+/// Tenant B draining a shard all to itself — the baseline.
+async fn scenario_isolated(flush_ms: u64, b_queues: usize, b_depth: usize) -> f64 {
+    let (_tmp, shard) = open_temp_shard(flush_ms).await;
+    let now = now_ms();
+    let b_total = enqueue_tenant(&shard, "tenant-b", "group-b", b_queues, b_depth, now).await;
+
+    let elapsed = measure_drain(&shard, "group-b", B_WORKERS, BATCH, b_total).await;
+    shard.close().await.expect("close");
+    b_total as f64 / elapsed.as_secs_f64()
+}
+
+/// Tenant B draining while tenant A hammers the shared grant scanner.
+async fn scenario_noisy(
+    flush_ms: u64,
+    a_queues: usize,
+    a_depth: usize,
+    b_queues: usize,
+    b_depth: usize,
+) -> f64 {
+    let (_tmp, shard) = open_temp_shard(flush_ms).await;
+    let now = now_ms();
+
+    let a_total = enqueue_tenant(&shard, "tenant-a", "group-a", a_queues, a_depth, now).await;
+    let b_total = enqueue_tenant(&shard, "tenant-b", "group-b", b_queues, b_depth, now).await;
+    println!("  (tenant A backlog: {a_total} jobs across {a_queues} queues; tenant B: {b_total} jobs)");
+
+    // Start tenant A's churn and let it ramp before timing B, so the scanner is
+    // already under sustained load when B begins draining.
+    let a_counter = Arc::new(AtomicUsize::new(0));
+    let a_stop = Arc::new(AtomicBool::new(false));
+    let a_handles = spawn_drain_workers(
+        &shard,
+        "group-a",
+        A_WORKERS,
+        BATCH,
+        Arc::clone(&a_counter),
+        Arc::clone(&a_stop),
+    );
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let elapsed = measure_drain(&shard, "group-b", B_WORKERS, BATCH, b_total).await;
+
+    // Stop the noisy neighbor.
+    a_stop.store(true, Ordering::Relaxed);
+    for h in a_handles {
+        let _ = h.await;
+    }
+    let a_done = a_counter.load(Ordering::Relaxed);
+    println!("  (tenant A completed {a_done} jobs while B drained)");
+
+    shard.close().await.expect("close");
+    b_total as f64 / elapsed.as_secs_f64()
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() {
+    let flush_ms: u64 = env_usize("NN_FLUSH_MS", 1) as u64;
+    let a_queues = env_usize("NN_A_QUEUES", A_QUEUES);
+    let a_depth = env_usize("NN_A_DEPTH", A_DEPTH);
+    let b_queues = env_usize("NN_B_QUEUES", B_QUEUES);
+    let b_depth = env_usize("NN_B_DEPTH", B_DEPTH);
+
+    println!("\n=================================================");
+    println!("Noisy-Neighbor Grant-Scanner Throughput Benchmark");
+    println!("=================================================\n");
+    println!(
+        "runtime: multi_thread (4 workers) | tight max={TIGHT_MAX}, floating max={FLOAT_MAX}\n"
+    );
+
+    println!("--- Scenario 1: tenant B alone (baseline) ---");
+    let isolated = scenario_isolated(flush_ms, b_queues, b_depth).await;
+    println!("  tenant B throughput: {isolated:.0} jobs/sec\n");
+
+    println!("--- Scenario 2: tenant B + noisy tenant A on same shard ---");
+    let noisy = scenario_noisy(flush_ms, a_queues, a_depth, b_queues, b_depth).await;
+    println!("  tenant B throughput: {noisy:.0} jobs/sec\n");
+
+    let retained = if isolated > 0.0 {
+        100.0 * noisy / isolated
+    } else {
+        0.0
+    };
+    println!("=================================================");
+    println!("tenant B retains {retained:.1}% of baseline throughput under noisy neighbor");
+    println!("(higher = scanner is fair; A is not hogging it)");
+    println!("=================================================\n");
+}

--- a/benches/noisy_neighbor_throughput.rs
+++ b/benches/noisy_neighbor_throughput.rs
@@ -30,8 +30,8 @@ use silo::job_attempt::AttemptOutcome;
 use silo::job_store_shard::JobStoreShard;
 use silo::settings::{Backend, DatabaseConfig};
 use silo::shard_range::ShardRange;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 // ---- Workload knobs (override via env for quick tuning) ----
@@ -172,7 +172,10 @@ fn spawn_drain_workers(
             tokio::spawn(async move {
                 let worker_id = format!("{group}-w{w}");
                 while !stop.load(Ordering::Relaxed) {
-                    let result = shard.dequeue(&worker_id, group, batch).await.expect("dequeue");
+                    let result = shard
+                        .dequeue(&worker_id, group, batch)
+                        .await
+                        .expect("dequeue");
                     if result.tasks.is_empty() {
                         tokio::time::sleep(Duration::from_millis(2)).await;
                         continue;
@@ -180,7 +183,10 @@ fn spawn_drain_workers(
                     for t in &result.tasks {
                         let tid = t.attempt().task_id().to_string();
                         shard
-                            .report_attempt_outcome(&tid, AttemptOutcome::Success { result: Vec::new() })
+                            .report_attempt_outcome(
+                                &tid,
+                                AttemptOutcome::Success { result: Vec::new() },
+                            )
                             .await
                             .expect("report");
                         counter.fetch_add(1, Ordering::Relaxed);
@@ -203,7 +209,14 @@ async fn measure_drain(
     let counter = Arc::new(AtomicUsize::new(0));
     let stop = Arc::new(AtomicBool::new(false));
     let start = Instant::now();
-    let handles = spawn_drain_workers(shard, group, num_workers, batch, Arc::clone(&counter), Arc::clone(&stop));
+    let handles = spawn_drain_workers(
+        shard,
+        group,
+        num_workers,
+        batch,
+        Arc::clone(&counter),
+        Arc::clone(&stop),
+    );
 
     while counter.load(Ordering::Relaxed) < b_total {
         tokio::time::sleep(Duration::from_millis(5)).await;
@@ -241,7 +254,9 @@ async fn scenario_noisy(
 
     let a_total = enqueue_tenant(&shard, "tenant-a", "group-a", a_queues, a_depth, now).await;
     let b_total = enqueue_tenant(&shard, "tenant-b", "group-b", b_queues, b_depth, now).await;
-    println!("  (tenant A backlog: {a_total} jobs across {a_queues} queues; tenant B: {b_total} jobs)");
+    println!(
+        "  (tenant A backlog: {a_total} jobs across {a_queues} queues; tenant B: {b_total} jobs)"
+    );
 
     // Start tenant A's churn and let it ramp before timing B, so the scanner is
     // already under sustained load when B begins draining.

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -856,6 +856,14 @@ pub struct ConcurrencyManager {
     /// Configurable via `grant_scanner_buffer_size` (default 64); stored
     /// already clamped to `>= 1`.
     grant_scanner_buffer_size: usize,
+    /// Max number of per-queue `process_grants` passes run concurrently when
+    /// draining `pending_grants`. Each entry in `work` is a unique
+    /// `(tenant, queue)`, so no two in-flight passes share a gating queue; this
+    /// bounds the `.buffered(...)` fan-out over those passes (order-preserving,
+    /// for DST determinism) so peak memory stays `N × per-pass`. Configurable
+    /// via `grant_scanner_concurrency` (default 8); stored already clamped to
+    /// `>= 1` (`.buffered(0)` is invalid).
+    grant_scanner_concurrency: usize,
     /// Consecutive-pass observation counts for drift-detected ghost
     /// candidates, keyed by (tenant, queue, task_id). Maintained only by
     /// `report_holder_drift` (a single periodic task). Rebuilt each pass from
@@ -881,6 +889,7 @@ impl ConcurrencyManager {
         hydrate_all_at_startup: bool,
         grant_scanner_batch_size: usize,
         grant_scanner_buffer_size: usize,
+        grant_scanner_concurrency: usize,
     ) -> Self {
         Self {
             shard: shard.into(),
@@ -896,6 +905,7 @@ impl ConcurrencyManager {
             // `.buffered(0)` is invalid.
             grant_scanner_batch_size: grant_scanner_batch_size.max(1),
             grant_scanner_buffer_size: grant_scanner_buffer_size.max(1),
+            grant_scanner_concurrency: grant_scanner_concurrency.max(1),
             ghost_candidates: Mutex::new(HashMap::new()),
         }
     }
@@ -1506,13 +1516,26 @@ impl ConcurrencyManager {
                         break;
                     }
 
-                    let mut granted_groups: Vec<String> = Vec::new();
-                    for (_key, (tenant, queue, count)) in work {
-                        let groups = mgr
-                            .process_grants(&db, &range, &tenant, &queue, count)
-                            .await;
-                        granted_groups.extend(groups);
-                    }
+                    // Fan out across queues with bounded concurrency. Each
+                    // (tenant, queue) is unique in `work`, so no two in-flight
+                    // passes share a gating queue; downstream chain-resumer
+                    // reservations are gated atomically by the per-key DashMap
+                    // guard. `buffered` (order-preserving) keeps collected order
+                    // deterministic against the BTreeMap iteration order for DST.
+                    let granted: Vec<Vec<String>> = futures::stream::iter(work.into_values())
+                        .map(|(tenant, queue, count)| {
+                            let mgr = Arc::clone(&mgr);
+                            let db = Arc::clone(&db);
+                            let range = range.clone();
+                            async move {
+                                mgr.process_grants(&db, &range, &tenant, &queue, count)
+                                    .await
+                            }
+                        })
+                        .buffered(mgr.grant_scanner_concurrency)
+                        .collect()
+                        .await;
+                    let granted_groups: Vec<String> = granted.into_iter().flatten().collect();
 
                     // Wake only the brokers whose task groups received grants
                     if !granted_groups.is_empty() {

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -856,7 +856,23 @@ pub struct ConcurrencyManager {
     /// Configurable via `grant_scanner_buffer_size` (default 64); stored
     /// already clamped to `>= 1`.
     grant_scanner_buffer_size: usize,
+    /// Consecutive-pass observation counts for drift-detected ghost
+    /// candidates, keyed by (tenant, queue, task_id). Maintained only by
+    /// `report_holder_drift` (a single periodic task). Rebuilt each pass from
+    /// the current ghost set, so it is bounded by the current ghost +
+    /// in-flight-reservation count and self-prunes when a candidate gains a
+    /// durable row or is released. See `GHOST_CONFIRM_PASSES`.
+    ghost_candidates: Mutex<HashMap<(String, String, String), u32>>,
 }
+
+/// A drift-detected ghost must be observed as a ghost in this many
+/// *consecutive* `report_holder_drift` passes before it is enqueued for
+/// release. A true ghost (a dropped-future leak) is permanent and survives
+/// every pass; an in-flight reservation (`try_reserve_internal` inserts into
+/// the in-memory holder set before its durable write commits) clears within
+/// one reconcile interval, so a value of 2 excludes those false positives.
+/// Bump to debounce harder.
+const GHOST_CONFIRM_PASSES: u32 = 2;
 
 impl ConcurrencyManager {
     pub fn new(
@@ -880,6 +896,7 @@ impl ConcurrencyManager {
             // `.buffered(0)` is invalid.
             grant_scanner_batch_size: grant_scanner_batch_size.max(1),
             grant_scanner_buffer_size: grant_scanner_buffer_size.max(1),
+            ghost_candidates: Mutex::new(HashMap::new()),
         }
     }
 
@@ -1313,17 +1330,27 @@ impl ConcurrencyManager {
     /// in-memory holder set to the durable holder set (one ranged scan per
     /// queue), and:
     ///
-    /// 1. **Self-heal ghosts.** Any in-memory holder with no durable row is a
-    ///    ghost (the wedge bug — an in-memory reservation that survived after
-    ///    its durable holder was deleted). Each such `task_id` is enqueued via
-    ///    `request_reconciliation`, which routes it through
-    ///    `reconcile_pending_holders`. That path re-checks the durable row for
-    ///    that specific `task_id` immediately before releasing, so a
-    ///    reservation that is committed-but-not-yet-durable (durable write in
-    ///    flight) is left untouched — that re-check IS the false-positive
-    ///    guard, no separate multi-tick counter needed. This recovers ghosts
-    ///    regardless of how they formed (e.g. a handler that releases in-memory
-    ///    state outside a `PendingHolderReleaseGuard`).
+    /// 1. **Self-heal ghosts.** An in-memory holder with no durable row is a
+    ///    ghost candidate (the wedge bug — an in-memory reservation that
+    ///    survived after its durable holder was deleted). Candidates must be
+    ///    observed in `GHOST_CONFIRM_PASSES` *consecutive* passes (tracked in
+    ///    `ghost_candidates`) before being enqueued via `request_reconciliation`
+    ///    / `reconcile_pending_holders`. This recovers ghosts regardless of how
+    ///    they formed (e.g. a handler that releases in-memory state outside a
+    ///    `PendingHolderReleaseGuard`).
+    ///
+    ///    **Two-stage false-positive guard.** The per-`task_id` durable
+    ///    re-check in `reconcile_pending_holders` guards against the snapshot
+    ///    racing a holder *delete* (the original ghost case). But it cannot
+    ///    distinguish a true ghost from an in-flight reservation:
+    ///    `process_grants` calls `try_reserve_internal` (which inserts into the
+    ///    in-memory holder set) *before* its durable holder write commits, so a
+    ///    just-reserved-not-yet-durable slot looks identical to a ghost to a
+    ///    point-in-time `db.get`. Releasing it would over-grant the queue. The
+    ///    consecutive-pass requirement closes that gap: an in-flight reservation
+    ///    commits within milliseconds — far inside one `concurrency_reconcile_interval`
+    ///    — so it never survives to a second pass, whereas a real ghost is
+    ///    permanent and survives every pass.
     /// 2. **Publish metrics** (only when metrics are enabled):
     ///    * `silo_concurrency_holder_drift` — Σ |in_mem - durable| across hydrated queues
     ///    * `silo_concurrency_reconciliation_pending` — current size of the
@@ -1334,6 +1361,16 @@ impl ConcurrencyManager {
     /// `concurrency_reconcile_interval` rather than firing on every dropped
     /// dequeue future. Self-healing runs even when metrics are disabled.
     pub async fn report_holder_drift(&self, db: &Arc<InstrumentedDb>, range: &ShardRange) {
+        // Take the previous pass's ghost-candidate counts and rebuild a fresh
+        // map from this pass. Held outside the per-queue `.await` scans below
+        // (the lock must never span an await). A candidate absent from this
+        // pass (durable row appeared, or it was released) simply drops out.
+        let prev_candidates = {
+            let mut g = self.ghost_candidates.lock().unwrap();
+            std::mem::take(&mut *g)
+        };
+        let mut next_candidates: HashMap<(String, String, String), u32> = HashMap::new();
+
         let mut drift_total: u64 = 0;
         for (tenant, queue, in_mem_holders) in self.counts.hydrated_queue_holders_with_ids() {
             if !range.contains_tenant(&tenant) {
@@ -1381,13 +1418,33 @@ impl ConcurrencyManager {
 
             drift_total += (in_mem_holders.len() as i64 - durable_ids.len() as i64).unsigned_abs();
 
-            // Ghosts: in-memory holders with no durable row. Enqueue each for
-            // reconciliation; `reconcile_pending_holders` re-checks durable
-            // presence per task_id before releasing, so this is safe even if
-            // the scan raced an in-flight durable write.
+            // Ghost candidates: in-memory holders with no durable row. Only
+            // enqueue for reconciliation once a candidate has survived
+            // `GHOST_CONFIRM_PASSES` consecutive passes — an in-flight
+            // reservation (durable write not yet committed) clears within one
+            // interval and so never reaches the threshold, while a real ghost
+            // is permanent. See this fn's doc comment for the full rationale.
             for task_id in in_mem_holders.difference(&durable_ids) {
-                self.request_reconciliation(tenant.clone(), queue.clone(), task_id.clone());
+                let key = (tenant.clone(), queue.clone(), task_id.clone());
+                let seen = prev_candidates
+                    .get(&key)
+                    .copied()
+                    .unwrap_or(0)
+                    .saturating_add(1);
+                if seen >= GHOST_CONFIRM_PASSES {
+                    self.request_reconciliation(tenant.clone(), queue.clone(), task_id.clone());
+                }
+                // Saturate at the threshold so a long-lived ghost the
+                // reconciler keeps re-queueing doesn't grow the count
+                // unboundedly; re-enqueuing each pass is harmless
+                // (`pending_reconciliations` dedups and release is idempotent).
+                next_candidates.insert(key, seen.min(GHOST_CONFIRM_PASSES));
             }
+        }
+
+        {
+            let mut g = self.ghost_candidates.lock().unwrap();
+            *g = next_candidates;
         }
 
         if let Some(metrics) = self.metrics.as_ref() {

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -864,6 +864,18 @@ pub struct ConcurrencyManager {
     /// via `grant_scanner_concurrency` (default 8); stored already clamped to
     /// `>= 1` (`.buffered(0)` is invalid).
     grant_scanner_concurrency: usize,
+    /// Max number of pending-request keys a single `process_grants` invocation
+    /// will walk across all of its passes before committing what it found and
+    /// returning — even if neither capacity nor the iterator is exhausted. This
+    /// bounds the cost one queue can impose per scanner cycle so a single queue
+    /// with a huge backlog of non-grantable keys (holder-orphan / stale-request
+    /// shape) can't pin a `.buffered` slot and starve every other tenant's queue
+    /// on the shard. The queue is re-driven on the next cycle (its requester
+    /// counter is still non-zero), making bounded forward progress from the
+    /// front each time. Derived from `grant_scanner_batch_size` (a small
+    /// multiple) in `new`; always `>= grant_scanner_batch_size` so every
+    /// invocation can run at least one full pass.
+    grant_scanner_max_scan_per_invocation: usize,
     /// Consecutive-pass observation counts for drift-detected ghost
     /// candidates, keyed by (tenant, queue, task_id). Maintained only by
     /// `report_holder_drift` (a single periodic task). Rebuilt each pass from
@@ -906,6 +918,14 @@ impl ConcurrencyManager {
             grant_scanner_batch_size: grant_scanner_batch_size.max(1),
             grant_scanner_buffer_size: grant_scanner_buffer_size.max(1),
             grant_scanner_concurrency: grant_scanner_concurrency.max(1),
+            // Cap total keys walked per invocation at a small multiple of the
+            // per-pass batch so a giant non-grantable backlog yields after a
+            // bounded walk and round-robins with other queues, while still
+            // allowing several full passes of real draining per cycle. Clamp to
+            // `>= batch_size` so at least one full pass always runs.
+            grant_scanner_max_scan_per_invocation: (grant_scanner_batch_size.max(1))
+                .saturating_mul(4)
+                .max(grant_scanner_batch_size.max(1)),
             ghost_candidates: Mutex::new(HashMap::new()),
         }
     }
@@ -1687,6 +1707,17 @@ impl ConcurrencyManager {
         let mut total_granted: usize = 0;
         let mut iter_exhausted = false;
         let mut capacity_exhausted = false;
+        // Per-invocation scan budget. Total request keys walked
+        // across all passes (valid, stale, and corrupt — the walk cost is what
+        // we bound). When it reaches `grant_scanner_max_scan_per_invocation` the
+        // call commits what it found and returns even if capacity/iterator are
+        // not exhausted, so a single queue with a huge non-grantable front
+        // cannot starve other tenants' queues sharing the `.buffered` fan-out.
+        // The queue is re-driven next cycle (its requester counter is still
+        // non-zero), making bounded forward progress from the front each time.
+        let mut scanned_this_invocation: usize = 0;
+        let mut total_stale_deleted: usize = 0;
+        let mut budget_exhausted = false;
         let chain_resumer = self.chain_resumer();
 
         // Scan→validate→grant loop: keeps pulling from the iterator until we've
@@ -1696,8 +1727,15 @@ impl ConcurrencyManager {
         // are cleaned up along the way. Bounding per-pass scan size caps peak memory
         // (the scanned Vec, buffered status results, and WriteBatch all scale with it),
         // so a large accumulated `count` is drained over multiple bounded passes
-        // rather than one unbounded one.
-        while total_granted < count as usize && !iter_exhausted && !capacity_exhausted {
+        // rather than one unbounded one. The per-invocation scan budget
+        // (`budget_exhausted`) additionally bounds total keys walked across all
+        // passes, so a queue whose front is millions of non-grantable keys yields
+        // after bounded work instead of walking the whole backlog in one call.
+        while total_granted < count as usize
+            && !iter_exhausted
+            && !capacity_exhausted
+            && !budget_exhausted
+        {
             let needed = (count as usize - total_granted).min(self.grant_scanner_batch_size);
 
             let mut batch = WriteBatch::new();
@@ -1707,6 +1745,12 @@ impl ConcurrencyManager {
             // --- Scan batch of candidates ---
             let mut scanned: Vec<ScannedRequest> = Vec::new();
             while scanned.len() < needed {
+                if scanned_this_invocation >= self.grant_scanner_max_scan_per_invocation {
+                    // Yield mid-scan: commit this pass's accumulated edits below
+                    // and let the outer guard end the invocation.
+                    budget_exhausted = true;
+                    break;
+                }
                 let kv = match iter.next().await {
                     Ok(Some(kv)) => kv,
                     Ok(None) => {
@@ -1719,6 +1763,7 @@ impl ConcurrencyManager {
                         break;
                     }
                 };
+                scanned_this_invocation += 1;
 
                 let Some(parsed_req) = parse_concurrency_request_key(&kv.key) else {
                     tracing::warn!(queue = %queue, "grant scanner: malformed request key, deleting");
@@ -2136,7 +2181,23 @@ impl ConcurrencyManager {
             }
 
             total_granted += grants.len();
+            total_stale_deleted += stale_and_corrupt_count;
             all_granted_groups.extend(grants.into_iter().map(|(_, tg)| tg));
+        }
+
+        // No silent cap: surface invocations that yielded on the scan budget so
+        // a queue needing many cycles to drain a huge non-grantable front is
+        // visible rather than looking fully drained.
+        if budget_exhausted {
+            tracing::debug!(
+                tenant = %tenant,
+                queue = %queue,
+                requested = count,
+                scanned = scanned_this_invocation,
+                stale_deleted = total_stale_deleted,
+                total_granted,
+                "grant scanner: hit per-invocation scan budget; yielding, will re-drive next cycle"
+            );
         }
 
         all_granted_groups

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -622,37 +622,16 @@ impl ConcurrencyCounts {
         self.pending_reconciliations.lock().unwrap().len()
     }
 
-    /// Snapshot every hydrated (tenant, queue) and its current in-memory
-    /// holder count. Used by the reconciler tick to compute drift against
-    /// the durable holder rows for each queue.
+    /// Snapshot every hydrated (tenant, queue) and the full set of in-memory
+    /// holder task_ids. Used by the self-healing drift pass to compute both the
+    /// exact ghost set (in-memory holders with no durable row) and the
+    /// per-queue drift count (`.len()` of the returned set).
     ///
     /// `NotHydrated` and `Hydrating` queues are intentionally skipped: we
     /// haven't loaded their durable rows yet, so comparing in-memory (empty)
-    /// against durable (unknown) is meaningless.
-    pub fn hydrated_queue_holders_snapshot(&self) -> Vec<(String, String, usize)> {
-        let mut out = Vec::new();
-        for entry in self.queues.iter() {
-            if !matches!(entry.state, HydrationState::Hydrated) {
-                continue;
-            }
-            let (tenant_arc, queue_arc) = entry.key();
-            out.push((
-                tenant_arc.to_string(),
-                queue_arc.to_string(),
-                entry.holders.len(),
-            ));
-        }
-        out
-    }
-
-    /// Snapshot every hydrated (tenant, queue) and the full set of in-memory
-    /// holder task_ids. Used by the self-healing drift pass to compute the
-    /// exact ghost set (in-memory holders with no durable row) rather than
-    /// just a count delta.
-    ///
-    /// Same hydration filter as `hydrated_queue_holders_snapshot`. The
-    /// DashMap entry guard is dropped before the caller does any `.await`
-    /// (the returned `HashSet`s are owned clones).
+    /// against durable (unknown) is meaningless. The DashMap entry guard is
+    /// dropped before the caller does any `.await` (the returned `HashSet`s
+    /// are owned clones).
     pub fn hydrated_queue_holders_with_ids(&self) -> Vec<(String, String, HashSet<String>)> {
         let mut out = Vec::new();
         for entry in self.queues.iter() {
@@ -921,11 +900,11 @@ impl ConcurrencyManager {
             // Cap total keys walked per invocation at a small multiple of the
             // per-pass batch so a giant non-grantable backlog yields after a
             // bounded walk and round-robins with other queues, while still
-            // allowing several full passes of real draining per cycle. Clamp to
-            // `>= batch_size` so at least one full pass always runs.
-            grant_scanner_max_scan_per_invocation: (grant_scanner_batch_size.max(1))
-                .saturating_mul(4)
-                .max(grant_scanner_batch_size.max(1)),
+            // allowing several full passes of real draining per cycle. `×4` is
+            // inherently `>= batch_size`, so at least one full pass always runs.
+            grant_scanner_max_scan_per_invocation: grant_scanner_batch_size
+                .max(1)
+                .saturating_mul(4),
             ghost_candidates: Mutex::new(HashMap::new()),
         }
     }

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -50,7 +50,7 @@ use slatedb::config::WriteOptions;
 
 use crate::instrumented_db::InstrumentedDb;
 
-use crate::job_store_shard::counters::encode_counter;
+use crate::job_store_shard::counters::{decode_counter, encode_counter};
 use crate::job_store_shard::helpers::WriteBatcher;
 
 use crate::codec::{
@@ -63,9 +63,9 @@ use crate::job_store_shard::helpers::decode_job_status_owned;
 use crate::keys::{
     concurrency_counts_key, concurrency_holder_key, concurrency_holders_prefix,
     concurrency_holders_queue_prefix, concurrency_request_key, concurrency_request_prefix,
-    concurrency_requester_counter_key, concurrency_requests_prefix, end_bound,
-    floating_limit_state_key, job_info_key, job_status_key, parse_concurrency_holder_key,
-    parse_concurrency_request_key, task_key,
+    concurrency_requester_counter_key, end_bound, floating_limit_state_key, job_info_key,
+    job_status_key, parse_concurrency_holder_key, parse_concurrency_request_key,
+    parse_concurrency_requester_counter_key, task_key,
 };
 use crate::metrics::Metrics;
 use crate::shard_range::ShardRange;
@@ -640,6 +640,30 @@ impl ConcurrencyCounts {
                 tenant_arc.to_string(),
                 queue_arc.to_string(),
                 entry.holders.len(),
+            ));
+        }
+        out
+    }
+
+    /// Snapshot every hydrated (tenant, queue) and the full set of in-memory
+    /// holder task_ids. Used by the self-healing drift pass to compute the
+    /// exact ghost set (in-memory holders with no durable row) rather than
+    /// just a count delta.
+    ///
+    /// Same hydration filter as `hydrated_queue_holders_snapshot`. The
+    /// DashMap entry guard is dropped before the caller does any `.await`
+    /// (the returned `HashSet`s are owned clones).
+    pub fn hydrated_queue_holders_with_ids(&self) -> Vec<(String, String, HashSet<String>)> {
+        let mut out = Vec::new();
+        for entry in self.queues.iter() {
+            if !matches!(entry.state, HydrationState::Hydrated) {
+                continue;
+            }
+            let (tenant_arc, queue_arc) = entry.key();
+            out.push((
+                tenant_arc.to_string(),
+                queue_arc.to_string(),
+                entry.holders.clone(),
             ));
         }
         out
@@ -1286,25 +1310,32 @@ impl ConcurrencyManager {
     }
 
     /// Walk every hydrated (tenant, queue) in this shard, compare the
-    /// in-memory holder count to the durable holder count (one ranged scan
-    /// per queue), and publish:
+    /// in-memory holder set to the durable holder set (one ranged scan per
+    /// queue), and:
     ///
-    /// * `silo_concurrency_holder_drift` — Σ |in_mem - durable| across hydrated queues
-    /// * `silo_concurrency_reconciliation_pending` — current size of the
-    ///   per-task_id reconciliation queue (stuck-reconciler signal)
+    /// 1. **Self-heal ghosts.** Any in-memory holder with no durable row is a
+    ///    ghost (the wedge bug — an in-memory reservation that survived after
+    ///    its durable holder was deleted). Each such `task_id` is enqueued via
+    ///    `request_reconciliation`, which routes it through
+    ///    `reconcile_pending_holders`. That path re-checks the durable row for
+    ///    that specific `task_id` immediately before releasing, so a
+    ///    reservation that is committed-but-not-yet-durable (durable write in
+    ///    flight) is left untouched — that re-check IS the false-positive
+    ///    guard, no separate multi-tick counter needed. This recovers ghosts
+    ///    regardless of how they formed (e.g. a handler that releases in-memory
+    ///    state outside a `PendingHolderReleaseGuard`).
+    /// 2. **Publish metrics** (only when metrics are enabled):
+    ///    * `silo_concurrency_holder_drift` — Σ |in_mem - durable| across hydrated queues
+    ///    * `silo_concurrency_reconciliation_pending` — current size of the
+    ///      per-task_id reconciliation queue (stuck-reconciler signal)
     ///
     /// Called from the periodic reconciler's tick (NOT from the reactive
     /// sub-tick wake) — keeps the cost amortized at the deployment-configured
     /// `concurrency_reconcile_interval` rather than firing on every dropped
-    /// dequeue future. Noop if metrics are disabled.
+    /// dequeue future. Self-healing runs even when metrics are disabled.
     pub async fn report_holder_drift(&self, db: &Arc<InstrumentedDb>, range: &ShardRange) {
-        let Some(metrics) = self.metrics.as_ref() else {
-            // Always publish the pending gauge if metrics are present; if not, skip everything.
-            return;
-        };
-
         let mut drift_total: u64 = 0;
-        for (tenant, queue, in_mem_count) in self.counts.hydrated_queue_holders_snapshot() {
+        for (tenant, queue, in_mem_holders) in self.counts.hydrated_queue_holders_with_ids() {
             if !range.contains_tenant(&tenant) {
                 continue;
             }
@@ -1327,10 +1358,14 @@ impl ConcurrencyManager {
                     continue;
                 }
             };
-            let mut durable_count: usize = 0;
+            let mut durable_ids: HashSet<String> = HashSet::new();
             loop {
                 match iter.next().await {
-                    Ok(Some(_)) => durable_count += 1,
+                    Ok(Some(kv)) => {
+                        if let Some(parsed) = parse_concurrency_holder_key(&kv.key) {
+                            durable_ids.insert(parsed.task_id);
+                        }
+                    }
                     Ok(None) => break,
                     Err(e) => {
                         tracing::debug!(
@@ -1343,14 +1378,25 @@ impl ConcurrencyManager {
                     }
                 }
             }
-            drift_total += (in_mem_count as i64 - durable_count as i64).unsigned_abs();
+
+            drift_total += (in_mem_holders.len() as i64 - durable_ids.len() as i64).unsigned_abs();
+
+            // Ghosts: in-memory holders with no durable row. Enqueue each for
+            // reconciliation; `reconcile_pending_holders` re-checks durable
+            // presence per task_id before releasing, so this is safe even if
+            // the scan raced an in-flight durable write.
+            for task_id in in_mem_holders.difference(&durable_ids) {
+                self.request_reconciliation(tenant.clone(), queue.clone(), task_id.clone());
+            }
         }
 
-        let pending = self.counts.pending_reconciliations_len() as u64;
-        metrics.set_concurrency_reconciler_signals(&self.shard, drift_total, pending);
+        if let Some(metrics) = self.metrics.as_ref() {
+            let pending = self.counts.pending_reconciliations_len() as u64;
+            metrics.set_concurrency_reconciler_signals(&self.shard, drift_total, pending);
+        }
     }
 
-    fn request_grant_count(&self, tenant: &str, queue: &str, count: u32) {
+    pub(crate) fn request_grant_count(&self, tenant: &str, queue: &str, count: u32) {
         let key = concurrency_counts_key(tenant, queue);
         {
             let mut pending = self.pending_grants.lock().unwrap();
@@ -1426,12 +1472,24 @@ impl ConcurrencyManager {
         self.grant_notify.notify_one();
     }
 
-    /// Scan all pending concurrency requests and trigger grants for each queue.
+    /// Scan the per-queue requester counters and trigger grants for each queue
+    /// that has pending concurrency requests.
     ///
     /// This is used at grant-scanner startup and by the shard's periodic
     /// reconciliation task to self-heal from missed notifications.
+    ///
+    /// Rather than scanning the entire `CONCURRENCY_REQUEST` keyspace (tens of
+    /// millions of keys on a busy shard) we iterate the
+    /// `COUNTER_CONCURRENCY_REQUESTERS` counters, which are maintained
+    /// co-committed with request creation (`append_request_edits`) and
+    /// decremented on grant/cancel — a bounded set of ~one row per active
+    /// (tenant, queue). The counter is a safe over-estimate: `process_grants`
+    /// re-validates the real pending requests, so a stale-positive counter just
+    /// wakes the scanner for a queue that grants nothing. It will not
+    /// under-report newly created work because the increment lands in the same
+    /// write batch as the request row.
     pub async fn reconcile_pending_requests(&self, db: &InstrumentedDb, range: &ShardRange) {
-        let start = concurrency_requests_prefix();
+        let start = vec![crate::keys::prefix::COUNTER_CONCURRENCY_REQUESTERS];
         let end = end_bound(&start);
         let mut iter = match db
             .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options_uncached())
@@ -1441,14 +1499,12 @@ impl ConcurrencyManager {
             Err(e) => {
                 tracing::warn!(
                     error = %e,
-                    "grant scanner: failed to scan requests during reconciliation"
+                    "grant scanner: failed to scan requester counters during reconciliation"
                 );
                 return;
             }
         };
 
-        // Count pending requests per (tenant, queue)
-        let mut queue_counts: BTreeMap<Vec<u8>, (String, String, u32)> = BTreeMap::new();
         loop {
             let kv = match iter.next().await {
                 Ok(Some(kv)) => kv,
@@ -1462,7 +1518,7 @@ impl ConcurrencyManager {
                 }
             };
 
-            let Some(parsed) = parse_concurrency_request_key(&kv.key) else {
+            let Some(parsed) = parse_concurrency_requester_counter_key(&kv.key) else {
                 continue;
             };
 
@@ -1471,16 +1527,10 @@ impl ConcurrencyManager {
                 continue;
             }
 
-            let key = concurrency_counts_key(&parsed.tenant, &parsed.queue);
-            let entry = queue_counts
-                .entry(key)
-                .or_insert_with(|| (parsed.tenant.clone(), parsed.queue.clone(), 0));
-            entry.2 += 1;
-        }
-
-        // Trigger grants for each queue with pending requests
-        for (_key, (tenant, queue, count)) in queue_counts {
-            self.request_grant_count(&tenant, &queue, count);
+            let count = decode_counter(&kv.value);
+            if count > 0 {
+                self.request_grant_count(&parsed.tenant, &parsed.queue, count as u32);
+            }
         }
     }
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -203,6 +203,7 @@ impl ShardFactory {
                         hydrate_all_at_startup: template.hydrate_all_at_startup,
                         grant_scanner_batch_size: template.grant_scanner_batch_size,
                         grant_scanner_buffer_size: template.grant_scanner_buffer_size,
+                        grant_scanner_concurrency: template.grant_scanner_concurrency,
                         completed_job_expire_s: template.completed_job_expire_s,
                         terminal_job_expire_s: template.terminal_job_expire_s,
                     },

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -11,6 +11,7 @@ use crate::job::{JobStatus, JobStatusKind, JobView, Limit};
 use crate::job_attempt::{AttemptStatus, JobAttempt, JobAttemptView};
 use crate::job_store_shard::counters::BackgroundActionMetricTransition;
 use crate::job_store_shard::helpers::{DbWriteBatcher, decode_job_status_owned, now_epoch_ms};
+use crate::job_store_shard::holder_release_guard::PendingHolderReleaseGuard;
 use crate::job_store_shard::{DequeueResult, JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
     attempt_key, concurrency_holder_key, job_info_key, job_status_key, leased_task_key,
@@ -199,84 +200,6 @@ impl Drop for PendingGrantGuard<'_> {
         tracing::warn!(
             count = pending.len(),
             "dequeue future dropped/panicked with pending concurrency grants; queueing reconciliation"
-        );
-        for (tenant, queue, task_id) in pending {
-            self.concurrency
-                .request_reconciliation(tenant, queue, task_id);
-        }
-    }
-}
-
-/// RAII guard over durable concurrency holders that the iteration's batch
-/// has staged for deletion, paired with an in-memory `atomic_release` +
-/// `request_grant` that the dequeue body runs post-commit.
-///
-/// **Why this exists.** When `handle_run_attempt` finds a task whose
-/// `job_info` is missing (migration/cleanup race), it adds the durable
-/// holder-row delete to the batch and queues a matching in-memory release.
-/// `write_with_options(... await_durable: true)` applies the batch to the
-/// WAL on first poll, so by the time the await yields, the durable row may
-/// already be gone — but the post-commit `atomic_release` loop only runs if
-/// the await resolves cleanly. Cancellation mid-await leaves durable=0,
-/// in_memory=1: a ghost holder that wedges the queue (the prod 300/300 bug).
-///
-/// **What it does.** Same shape as [`PendingGrantGuard`]. On normal exit the
-/// dequeue body calls `take_all()` to run the in-memory release loop itself.
-/// If the future is dropped or panics, Drop enqueues each tuple for the
-/// reconciler, which point-looks-up the durable holder row to decide
-/// whether to release the in-memory entry (the WAL apply landed) or leave
-/// it alone (the WAL apply did not). Per-task_id, idempotent, correct in
-/// both branches of the ambiguity.
-struct PendingHolderReleaseGuard<'a> {
-    concurrency: &'a ConcurrencyManager,
-    pending: Option<Vec<(String, String, String)>>,
-}
-
-impl<'a> PendingHolderReleaseGuard<'a> {
-    fn new(concurrency: &'a ConcurrencyManager) -> Self {
-        Self {
-            concurrency,
-            pending: Some(Vec::new()),
-        }
-    }
-
-    fn extend<I: IntoIterator<Item = (String, String, String)>>(&mut self, iter: I) {
-        if let Some(v) = self.pending.as_mut() {
-            v.extend(iter);
-        }
-    }
-
-    /// Drain and return the current pending releases while leaving the guard
-    /// armed (with an empty buffer) for the next iteration. Used on the
-    /// commit-success path so the dequeue body runs the existing
-    /// `atomic_release` + `request_grant` loop itself.
-    fn take_all(&mut self) -> Vec<(String, String, String)> {
-        self.pending
-            .as_mut()
-            .map(std::mem::take)
-            .unwrap_or_default()
-    }
-
-    /// Neutralize the guard. Used at terminal exit paths (commit-failure /
-    /// dequeue Ok return). On commit-failure the caller discards the
-    /// returned vec: the batch didn't land so the durable holder is still
-    /// there and the in-memory state is already correct.
-    fn disarm(&mut self) -> Vec<(String, String, String)> {
-        self.pending.take().unwrap_or_default()
-    }
-}
-
-impl Drop for PendingHolderReleaseGuard<'_> {
-    fn drop(&mut self) {
-        let Some(pending) = self.pending.take() else {
-            return;
-        };
-        if pending.is_empty() {
-            return;
-        }
-        tracing::warn!(
-            count = pending.len(),
-            "dequeue future dropped/panicked with pending holder releases; queueing reconciliation"
         );
         for (tenant, queue, task_id) in pending {
             self.concurrency

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -191,6 +191,7 @@ impl JobStoreShard {
             )));
         };
         let decoded_state = decode_floating_limit_state(raw)?;
+        let old_max_concurrency = decoded_state.current_max_concurrency();
 
         let new_state = FloatingLimitState {
             current_max_concurrency: new_max_concurrency,
@@ -215,6 +216,17 @@ impl JobStoreShard {
             new_max_concurrency,
             crate::concurrency::ConcurrencyLimitType::Floating,
         );
+
+        // Nudge the grant scanner by the capacity delta so requests waiting on
+        // a raised floating cap (including the 0->N bootstrap) are granted
+        // immediately rather than waiting for the periodic reconcile scan.
+        // `process_grants` re-validates real capacity, so passing the delta is a
+        // safe upper bound on how many pending requests to consider.
+        let delta = new_max_concurrency.saturating_sub(old_max_concurrency);
+        if delta > 0 {
+            self.concurrency
+                .request_grant_count(tenant, queue_key, delta);
+        }
 
         tracing::debug!(
             queue_key = %queue_key,

--- a/src/job_store_shard/holder_release_guard.rs
+++ b/src/job_store_shard/holder_release_guard.rs
@@ -1,0 +1,84 @@
+//! Cancellation-safety guard for post-commit in-memory concurrency holder
+//! releases.
+
+use crate::concurrency::ConcurrencyManager;
+
+/// RAII guard over durable concurrency holders that a write batch has staged
+/// for deletion, paired with an in-memory `atomic_release` + `request_grant`
+/// that the caller runs post-commit.
+///
+/// **Why this exists.** A handler that finishes/releases a task deletes the
+/// durable holder row in its batch and queues a matching in-memory release.
+/// `write_with_options(... await_durable: true)` applies the batch to the WAL
+/// on first poll, so by the time the await yields, the durable row may already
+/// be gone — but the post-commit `atomic_release` loop only runs if the await
+/// resolves cleanly. Cancellation mid-await (the request future is dropped)
+/// leaves durable=0, in_memory=1: a ghost holder that wedges the queue (the
+/// prod 300/300 bug).
+///
+/// **What it does.** On normal exit the caller calls `take_all()` (commit
+/// success) or `disarm()` (commit failure) to neutralize the guard and run the
+/// in-memory release loop itself. If the future is dropped or panics, `Drop`
+/// enqueues each tuple for the reconciler, which point-looks-up the durable
+/// holder row to decide whether to release the in-memory entry (the WAL apply
+/// landed) or leave it alone (the WAL apply did not). Per-task_id, idempotent,
+/// correct in both branches of the ambiguity.
+///
+/// Used by `dequeue.rs` and `lease.rs::report_attempt_outcome`.
+pub(crate) struct PendingHolderReleaseGuard<'a> {
+    concurrency: &'a ConcurrencyManager,
+    pending: Option<Vec<(String, String, String)>>,
+}
+
+impl<'a> PendingHolderReleaseGuard<'a> {
+    pub(crate) fn new(concurrency: &'a ConcurrencyManager) -> Self {
+        Self {
+            concurrency,
+            pending: Some(Vec::new()),
+        }
+    }
+
+    pub(crate) fn extend<I: IntoIterator<Item = (String, String, String)>>(&mut self, iter: I) {
+        if let Some(v) = self.pending.as_mut() {
+            v.extend(iter);
+        }
+    }
+
+    /// Drain and return the current pending releases while leaving the guard
+    /// armed (with an empty buffer) for the next iteration. Used on the
+    /// commit-success path so the caller runs the existing
+    /// `atomic_release` + `request_grant` loop itself.
+    pub(crate) fn take_all(&mut self) -> Vec<(String, String, String)> {
+        self.pending
+            .as_mut()
+            .map(std::mem::take)
+            .unwrap_or_default()
+    }
+
+    /// Neutralize the guard. Used at terminal exit paths (commit-failure /
+    /// Ok return). On commit-failure the caller discards the returned vec: the
+    /// batch didn't land so the durable holder is still there and the in-memory
+    /// state is already correct.
+    pub(crate) fn disarm(&mut self) -> Vec<(String, String, String)> {
+        self.pending.take().unwrap_or_default()
+    }
+}
+
+impl Drop for PendingHolderReleaseGuard<'_> {
+    fn drop(&mut self) {
+        let Some(pending) = self.pending.take() else {
+            return;
+        };
+        if pending.is_empty() {
+            return;
+        }
+        tracing::warn!(
+            count = pending.len(),
+            "future dropped/panicked with pending holder releases; queueing reconciliation"
+        );
+        for (tenant, queue, task_id) in pending {
+            self.concurrency
+                .request_reconciliation(tenant, queue, task_id);
+        }
+    }
+}

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -13,6 +13,7 @@ use crate::job::{FloatingLimitState, JobStatus, JobView};
 use crate::job_attempt::{AttemptOutcome, AttemptStatus, JobAttempt};
 use crate::job_store_shard::counters::BackgroundActionMetricTransition;
 use crate::job_store_shard::helpers::{DbWriteBatcher, WriteBatcher, now_epoch_ms};
+use crate::job_store_shard::holder_release_guard::PendingHolderReleaseGuard;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
     attempt_key, attempt_prefix, concurrency_holder_key, concurrency_holders_tenant_prefix,
@@ -410,6 +411,19 @@ impl JobStoreShard {
             batch.delete(concurrency_holder_key(&tenant, queue, task_id));
         }
 
+        // Cancellation safety: arm a guard with the in-memory releases that the
+        // post-commit loop will perform. If the request future is dropped
+        // around the `await_durable` commit below, the durable holder delete
+        // may land while the in-memory `atomic_release` never runs — a ghost
+        // holder. The guard's Drop enqueues each (tenant, queue, task_id) for
+        // the reconciler, which re-checks the durable row before releasing.
+        let mut release_guard = PendingHolderReleaseGuard::new(&self.concurrency);
+        release_guard.extend(
+            held_queues_local
+                .iter()
+                .map(|queue| (tenant.clone(), queue.clone(), task_id.to_string())),
+        );
+
         // Two-phase DST events: emit before write for correct causal ordering,
         // confirm after write succeeds, cancel if write fails.
         let write_op = dst_events::next_write_op();
@@ -446,6 +460,10 @@ impl JobStoreShard {
             .await
         {
             dst_events::cancel_write(write_op);
+            // Commit failed: the batch didn't land, so the durable holders are
+            // still present and the in-memory state is already correct. Disarm
+            // and discard — no reconciliation needed.
+            release_guard.disarm();
             // Rollback any grants made during retry scheduling
             for (queue, grant_task_id) in &retry_grants {
                 self.concurrency
@@ -458,20 +476,22 @@ impl JobStoreShard {
         }
         dst_events::confirm_write(write_op);
 
-        // Post-commit: release in-memory concurrency counts and signal grant scanner.
-        for queue in &held_queues_local {
+        // Post-commit: release in-memory concurrency counts and signal grant
+        // scanner. Drain the guard (leaving it armed-but-empty so its Drop is a
+        // no-op) and run the release loop ourselves now that the commit landed.
+        for (release_tenant, queue, release_task_id) in release_guard.take_all() {
             let span = info_span!(
                 "concurrency.release",
                 queue = %queue,
-                finished_task_id = %task_id
+                finished_task_id = %release_task_id
             );
             let _g = span.enter();
             debug!("released ticket for finished task");
 
             self.concurrency
                 .counts()
-                .atomic_release(&tenant, queue, task_id);
-            self.concurrency.request_grant(&tenant, queue);
+                .atomic_release(&release_tenant, &queue, &release_task_id);
+            self.concurrency.request_grant(&release_tenant, &queue);
         }
         // If we scheduled a follow-up that is ready now, wake the scanner
         if let Some(nt) = followup_next_time

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -8,6 +8,7 @@ mod enqueue;
 mod expedite;
 mod floating;
 pub(crate) mod helpers;
+pub(crate) mod holder_release_guard;
 pub mod import;
 mod lease;
 mod lease_task;
@@ -1160,6 +1161,16 @@ impl JobStoreShard {
         self.concurrency
             .reconcile_pending_holders(&self.db, &range)
             .await
+    }
+
+    /// Test-only: run one self-healing drift pass. Walks hydrated queues,
+    /// compares the in-memory holder set to durable rows, and enqueues any
+    /// ghosts (in-memory holders with no durable row) for reconciliation.
+    /// Callers typically follow with `reconcile_pending_holders_for_test` to
+    /// drive the actual release.
+    pub async fn report_holder_drift_for_test(&self) {
+        let range = self.get_range();
+        self.concurrency.report_holder_drift(&self.db, &range).await
     }
     /// Get the SlateDB metrics registry for this shard.
     /// Use this to collect storage-level statistics for observability.

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -110,6 +110,9 @@ pub struct OpenShardOptions {
     /// Max in-flight status lookups the grant scanner buffers per pass.
     /// Populated from `grant_scanner_buffer_size` in the database config.
     pub grant_scanner_buffer_size: usize,
+    /// Max per-queue `process_grants` passes the grant scanner runs concurrently.
+    /// Populated from `grant_scanner_concurrency` in the database config.
+    pub grant_scanner_concurrency: usize,
     /// When set, jobs that reach Succeeded have their associated KV records
     /// re-put with a SlateDB row TTL of this many seconds. `None` disables
     /// the feature for successful jobs.
@@ -398,6 +401,7 @@ impl JobStoreShard {
                 hydrate_all_at_startup: cfg.hydrate_all_at_startup,
                 grant_scanner_batch_size: cfg.grant_scanner_batch_size,
                 grant_scanner_buffer_size: cfg.grant_scanner_buffer_size,
+                grant_scanner_concurrency: cfg.grant_scanner_concurrency,
                 completed_job_expire_s: cfg.completed_job_expire_s,
                 terminal_job_expire_s: cfg.terminal_job_expire_s,
             },
@@ -440,6 +444,7 @@ impl JobStoreShard {
             hydrate_all_at_startup,
             grant_scanner_batch_size,
             grant_scanner_buffer_size,
+            grant_scanner_concurrency,
             completed_job_expire_s,
             terminal_job_expire_s,
         } = options;
@@ -509,6 +514,7 @@ impl JobStoreShard {
             hydrate_all_at_startup,
             grant_scanner_batch_size,
             grant_scanner_buffer_size,
+            grant_scanner_concurrency,
         ));
 
         // Eagerly hydrate the in-memory holders cache from durable storage so

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -202,6 +202,14 @@ fn default_grant_scanner_buffer_size() -> usize {
     DEFAULT_GRANT_SCANNER_BUFFER_SIZE
 }
 
+/// Default for `grant_scanner_concurrency`: max per-queue `process_grants`
+/// passes the scanner runs concurrently when draining pending grants.
+pub const DEFAULT_GRANT_SCANNER_CONCURRENCY: usize = 8;
+
+fn default_grant_scanner_concurrency() -> usize {
+    DEFAULT_GRANT_SCANNER_CONCURRENCY
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseTemplate {
     pub backend: Backend,
@@ -254,6 +262,13 @@ pub struct DatabaseTemplate {
     /// 64. Values below 1 are treated as 1.
     #[serde(default = "default_grant_scanner_buffer_size")]
     pub grant_scanner_buffer_size: usize,
+    /// Max per-queue `process_grants` passes the grant scanner runs concurrently
+    /// when draining pending grants. Each pending entry is a unique
+    /// (tenant, queue), so passes never share a gating queue; this bounds the
+    /// fan-out so peak memory stays proportional to this value. Defaults to 8.
+    /// Values below 1 are treated as 1.
+    #[serde(default = "default_grant_scanner_concurrency")]
+    pub grant_scanner_concurrency: usize,
     /// When set, jobs that finished successfully (Succeeded) have all of their
     /// associated KV records re-put with a SlateDB row TTL expiring this many
     /// seconds in the future. `None` (the default) disables the behaviour for
@@ -316,6 +331,7 @@ impl Default for DatabaseTemplate {
             hydrate_all_at_startup: default_hydrate_all_at_startup(),
             grant_scanner_batch_size: default_grant_scanner_batch_size(),
             grant_scanner_buffer_size: default_grant_scanner_buffer_size(),
+            grant_scanner_concurrency: default_grant_scanner_concurrency(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             periodic_full_compaction_s: None,
@@ -586,6 +602,10 @@ pub struct DatabaseConfig {
     /// `DatabaseTemplate::grant_scanner_buffer_size` for details. Defaults to 64.
     #[serde(default = "default_grant_scanner_buffer_size")]
     pub grant_scanner_buffer_size: usize,
+    /// Max per-queue `process_grants` passes the grant scanner runs concurrently.
+    /// See `DatabaseTemplate::grant_scanner_concurrency` for details. Defaults to 8.
+    #[serde(default = "default_grant_scanner_concurrency")]
+    pub grant_scanner_concurrency: usize,
     /// TTL (seconds) applied to Succeeded jobs' associated records. See
     /// `DatabaseTemplate::completed_job_expire_s` for details.
     #[serde(default)]
@@ -620,6 +640,7 @@ impl Default for DatabaseConfig {
             hydrate_all_at_startup: default_hydrate_all_at_startup(),
             grant_scanner_batch_size: default_grant_scanner_batch_size(),
             grant_scanner_buffer_size: default_grant_scanner_buffer_size(),
+            grant_scanner_concurrency: default_grant_scanner_concurrency(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             slatedb: None,

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -3,7 +3,9 @@ mod test_helpers;
 use silo::codec::{decode_lease, decode_task, encode_concurrency_action, encode_lease};
 use silo::job::{ConcurrencyLimit, Limit};
 use silo::job_attempt::{AttemptOutcome, AttemptStatus};
-use silo::keys::{concurrency_holder_key, concurrency_request_key};
+use silo::keys::{
+    concurrency_holder_key, concurrency_request_key, concurrency_requester_counter_key,
+};
 use silo::retry::RetryPolicy;
 use silo::task::{ConcurrencyAction, LeaseRecord, Task};
 use slatedb::WriteBatch;
@@ -210,8 +212,12 @@ async fn periodic_reconcile_grants_pending_request_without_signal() {
     );
 
     // Manually inject a pending request directly in DB without calling request_grant.
-    // This simulates a crash/bug window where durable request exists but in-memory
-    // scanner notification was missed.
+    // This simulates a crash/bug window where the durable request exists but the
+    // in-memory grant-scanner notification (`request_grant`/`grant_notify`) was
+    // missed. The durable requester counter is co-committed with the request row
+    // in the same batch here, mirroring production (`append_request_edits`): the
+    // counter is the durable source of truth the periodic reconciler scans, while
+    // the missed signal is purely in-memory.
     let action = ConcurrencyAction::EnqueueTask {
         start_time_ms: now,
         priority: 10,
@@ -228,6 +234,12 @@ async fn periodic_reconcile_grants_pending_request_without_signal() {
     let request_value = encode_concurrency_action(&action);
     let mut batch = WriteBatch::new();
     batch.put(&request_key, &request_value);
+    // Co-commit the requester counter, as production does atomically with the
+    // request. The counter-based `reconcile_pending_requests` scans these.
+    batch.merge(
+        &concurrency_requester_counter_key(tenant, &queue),
+        1i64.to_le_bytes(),
+    );
     shard
         .db()
         .write(batch)

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -586,6 +586,10 @@ path = "/tmp/silo-%shard%"
         cfg.database.grant_scanner_buffer_size, 64,
         "missing grant_scanner_buffer_size should use default"
     );
+    assert_eq!(
+        cfg.database.grant_scanner_concurrency, 8,
+        "missing grant_scanner_concurrency should use default"
+    );
 }
 
 #[silo::test]
@@ -596,10 +600,12 @@ backend = "fs"
 path = "/tmp/silo-%shard%"
 grant_scanner_batch_size = 8
 grant_scanner_buffer_size = 4
+grant_scanner_concurrency = 2
 "#;
     let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
     assert_eq!(cfg.database.grant_scanner_batch_size, 8);
     assert_eq!(cfg.database.grant_scanner_buffer_size, 4);
+    assert_eq!(cfg.database.grant_scanner_concurrency, 2);
 }
 
 #[silo::test]
@@ -662,6 +668,10 @@ path = "/tmp/silo-%shard%"
         from_default.grant_scanner_buffer_size,
         from_toml.database.grant_scanner_buffer_size
     );
+    assert_eq!(
+        from_default.grant_scanner_concurrency,
+        from_toml.database.grant_scanner_concurrency
+    );
     assert!(from_default.wal.is_none() && from_toml.database.wal.is_none());
     assert!(from_default.slatedb.is_none() && from_toml.database.slatedb.is_none());
     assert!(from_default.memory_cache.is_none() && from_toml.database.memory_cache.is_none());
@@ -697,6 +707,10 @@ path = "/tmp/silo-shard"
     assert_eq!(
         from_default.grant_scanner_buffer_size,
         from_toml.grant_scanner_buffer_size
+    );
+    assert_eq!(
+        from_default.grant_scanner_concurrency,
+        from_toml.grant_scanner_concurrency
     );
     assert!(from_default.wal.is_none() && from_toml.wal.is_none());
     assert!(from_default.slatedb.is_none() && from_toml.slatedb.is_none());

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -1897,8 +1897,8 @@ async fn reconcile_pending_holders_kicks_grant_per_release() {
 /// (in-memory holders with no durable row) and route them through the
 /// reconciler for release — even when the ghost never passed through a
 /// `PendingHolderReleaseGuard`. A holder that IS durable-backed must be left
-/// untouched (the per-task_id durable re-check in `reconcile_pending_holders`
-/// is the false-positive guard).
+/// untouched. A ghost is only enqueued after surviving `GHOST_CONFIRM_PASSES`
+/// (=2) consecutive drift passes, so the test runs the drift pass twice.
 #[tokio::test]
 async fn report_holder_drift_self_heals_ghost() {
     let (_tmp, shard) = open_temp_shard().await;
@@ -1935,7 +1935,9 @@ async fn report_holder_drift_self_heals_ghost() {
     // for reconciliation — only `report_holder_drift` can discover it.
     shard.concurrency_insert_holder(tenant, queue, "ghost");
 
-    // Drift pass discovers the ghost (in_mem − durable) and enqueues it.
+    // First drift pass only arms the candidate (count 1 < GHOST_CONFIRM_PASSES);
+    // the second confirms it (count 2) and enqueues it for reconciliation.
+    shard.report_holder_drift_for_test().await;
     shard.report_holder_drift_for_test().await;
     // Reconciler re-checks durable per task_id and releases the true ghost.
     shard.reconcile_pending_holders_for_test().await;
@@ -1947,6 +1949,76 @@ async fn report_holder_drift_self_heals_ghost() {
     assert!(
         shard.concurrency_contains_holder(tenant, queue, "keep"),
         "durable-backed holder must NOT be released — it is in both sets"
+    );
+}
+
+/// Fix 1 (Option B — consecutive-pass debounce): an in-memory holder with no
+/// durable row that is actually an *in-flight reservation* (durable write not
+/// yet committed) must NOT be released. `try_reserve_internal` inserts into the
+/// in-memory holder set before the durable holder write commits, so for a
+/// window such a slot is indistinguishable from a ghost by a point-in-time
+/// durable lookup. Requiring `GHOST_CONFIRM_PASSES` (=2) consecutive drift
+/// observations excludes it: the durable row lands between passes, so the
+/// candidate is never enqueued and the slot is preserved (no over-grant).
+#[tokio::test]
+async fn report_holder_drift_skips_unconfirmed_inflight_reservation() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "inflight-q";
+
+    // Seed a durable holder + hydrate so the queue is in the Hydrated state
+    // that `report_holder_drift` snapshots.
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(
+            &concurrency_holder_key(tenant, queue, "keep"),
+            &encode_holder(&HolderRecord { granted_at_ms: 0 }),
+        );
+        shard.db().write(batch).await.expect("durable write");
+        shard.db().flush().await.expect("flush");
+    }
+    shard.request_concurrency_reconciliation(
+        tenant.to_string(),
+        queue.to_string(),
+        "keep".to_string(),
+    );
+    shard.reconcile_pending_holders_for_test().await;
+
+    // Simulate an in-flight reservation: in-memory holder present, durable
+    // write not yet committed.
+    shard.concurrency_insert_holder(tenant, queue, "inflight");
+
+    // Pass 1 only arms the candidate (count 1 < threshold) — nothing enqueued.
+    shard.report_holder_drift_for_test().await;
+    shard.reconcile_pending_holders_for_test().await;
+    assert!(
+        shard.concurrency_contains_holder(tenant, queue, "inflight"),
+        "a single-pass candidate must NOT be released (debounce)"
+    );
+
+    // The in-flight durable write lands before the next drift pass.
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(
+            &concurrency_holder_key(tenant, queue, "inflight"),
+            &encode_holder(&HolderRecord { granted_at_ms: 0 }),
+        );
+        shard.db().write(batch).await.expect("durable write");
+        shard.db().flush().await.expect("flush");
+    }
+
+    // Pass 2 now sees a durable row, so "inflight" is no longer a ghost
+    // candidate — it is dropped, never enqueued.
+    shard.report_holder_drift_for_test().await;
+    shard.reconcile_pending_holders_for_test().await;
+
+    assert!(
+        shard.concurrency_contains_holder(tenant, queue, "inflight"),
+        "an in-flight reservation that committed before the 2nd pass must NOT be released"
+    );
+    assert!(
+        shard.concurrency_contains_holder(tenant, queue, "keep"),
+        "durable-backed holder must remain untouched"
     );
 }
 

--- a/tests/holder_leak_tests.rs
+++ b/tests/holder_leak_tests.rs
@@ -1892,3 +1892,128 @@ async fn reconcile_pending_holders_kicks_grant_per_release() {
          the immediate grant pass at 1 in production-scale wedges (300 ghosts → 1 grant)"
     );
 }
+
+/// Fix 1 (self-healing drift): `report_holder_drift` must discover ghosts
+/// (in-memory holders with no durable row) and route them through the
+/// reconciler for release — even when the ghost never passed through a
+/// `PendingHolderReleaseGuard`. A holder that IS durable-backed must be left
+/// untouched (the per-task_id durable re-check in `reconcile_pending_holders`
+/// is the false-positive guard).
+#[tokio::test]
+async fn report_holder_drift_self_heals_ghost() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "drift-q";
+
+    // Seed a durable holder so the queue hydrates with one legitimate, durable-
+    // backed holder ("keep").
+    {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(
+            &concurrency_holder_key(tenant, queue, "keep"),
+            &encode_holder(&HolderRecord { granted_at_ms: 0 }),
+        );
+        shard.db().write(batch).await.expect("durable write");
+        shard.db().flush().await.expect("flush");
+    }
+
+    // Force the queue into the Hydrated state (so `report_holder_drift`'s
+    // hydrated-only snapshot sees it) by running a reconcile pass; this calls
+    // `ensure_hydrated`, which scans "keep" into the in-memory holder set.
+    shard.request_concurrency_reconciliation(
+        tenant.to_string(),
+        queue.to_string(),
+        "keep".to_string(),
+    );
+    shard.reconcile_pending_holders_for_test().await;
+    assert!(
+        shard.concurrency_contains_holder(tenant, queue, "keep"),
+        "durable-backed holder must be present in-memory after hydration"
+    );
+
+    // Inject a ghost: in-memory holder with no durable row. It is NOT enqueued
+    // for reconciliation — only `report_holder_drift` can discover it.
+    shard.concurrency_insert_holder(tenant, queue, "ghost");
+
+    // Drift pass discovers the ghost (in_mem − durable) and enqueues it.
+    shard.report_holder_drift_for_test().await;
+    // Reconciler re-checks durable per task_id and releases the true ghost.
+    shard.reconcile_pending_holders_for_test().await;
+
+    assert!(
+        !shard.concurrency_contains_holder(tenant, queue, "ghost"),
+        "ghost (durable=N, in_mem=Y) must be self-healed by the drift pass"
+    );
+    assert!(
+        shard.concurrency_contains_holder(tenant, queue, "keep"),
+        "durable-backed holder must NOT be released — it is in both sets"
+    );
+}
+
+/// Fix 0 (counter-based request reconciliation): `reconcile_pending_requests`
+/// must find queues with pending work by reading the per-queue requester
+/// counters rather than scanning the entire CONCURRENCY_REQUEST keyspace.
+/// Given a requester counter of N for a queue, the reconcile pass kicks N
+/// grants.
+#[tokio::test]
+async fn reconcile_pending_requests_uses_requester_counters() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "-";
+    let queue = "fix0-q";
+
+    // Suspend the grant scanner so accumulated `pending_grants` are observable
+    // rather than drained by the background loop.
+    shard.stop_grant_scanner();
+
+    // First job takes the single slot (becomes a holder, not a requester).
+    shard
+        .enqueue(
+            tenant,
+            Some("job-1".to_string()),
+            10,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![conc_limit(queue, 1)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue1");
+    let deq = shard.dequeue("w", "default", 1).await.expect("deq1").tasks;
+    assert_eq!(deq.len(), 1, "first job dequeued into the only slot");
+
+    // Second job becomes a requester (queue full) → requester counter = 1.
+    shard
+        .enqueue(
+            tenant,
+            Some("job-2".to_string()),
+            10,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![conc_limit(queue, 1)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue2");
+
+    let counter = shard
+        .get_concurrency_requester_count(tenant, queue)
+        .await
+        .expect("get counter");
+    assert_eq!(counter, 1, "second job registered as a requester");
+
+    // Baseline absorbs whatever the enqueue path itself kicked, isolating the
+    // delta attributable to the counter-driven reconcile pass.
+    let baseline = shard.pending_grant_count_for_test(tenant, queue);
+    shard.reconcile_pending_concurrency_requests_once().await;
+    let after = shard.pending_grant_count_for_test(tenant, queue);
+
+    assert_eq!(
+        after - baseline,
+        1,
+        "reconcile_pending_requests read the requester counter (=1) and kicked exactly one grant"
+    );
+}

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2251,6 +2251,304 @@ async fn grant_scanner_drains_backlog_larger_than_max_per_pass() {
     assert_eq!(count_concurrency_holders(shard.db()).await, N);
 }
 
+/// Tenant-fairness + reliability: a full queue with a huge backlog of stale
+/// requests still cleans them up (orphan reliability), but only a *bounded*
+/// amount per invocation (the per-invocation scan budget), so it can't pin a
+/// scanner slot walking the whole backlog and starve other tenants. Holders are
+/// untouched and nothing is granted (queue is full). Repeated invocations drain
+/// the stale backlog. Pre-fix one invocation walked the entire backlog in a
+/// single call.
+#[silo::test]
+async fn grant_scanner_full_queue_cleans_stale_bounded() {
+    const LIMIT: usize = 5;
+    const BACKLOG: usize = 3000;
+
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "full-clean-q";
+    let tenant = "full-clean-tenant";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: LIMIT as u32,
+    });
+
+    shard.stop_grant_scanner();
+
+    // Fill all LIMIT slots with holders.
+    for i in 0..LIMIT {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("holder-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+    let mut held = 0;
+    while held < LIMIT {
+        let tasks = shard.dequeue("w", "tg", LIMIT).await.unwrap().tasks;
+        held += tasks.len();
+    }
+
+    // Inject a large backlog of stale requests (nonexistent jobs).
+    for i in 0..BACKLOG {
+        let stale_action = ConcurrencyAction::EnqueueTask {
+            start_time_ms: 0,
+            priority: 50,
+            job_id: format!("ghost-{}", i),
+            attempt_number: 1,
+            relative_attempt_number: 1,
+            task_group: "tg".to_string(),
+            limit_index: 0,
+            held_queues: Vec::new(),
+            task_id: format!("ghost-{}:1:stale", i),
+            limits: Vec::new(),
+        };
+        let key = silo::keys::concurrency_request_key(
+            tenant,
+            queue,
+            0,
+            50,
+            &format!("ghost-{}", i),
+            1,
+            &format!("{:08}", i),
+        );
+        let val = encode_concurrency_action(&stale_action);
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(&key, &val);
+        shard.db().write(batch).await.unwrap();
+    }
+    assert_eq!(count_concurrency_requests(shard.db()).await, BACKLOG);
+
+    // Queue is full (LIMIT held). One invocation cleans only a bounded slice.
+    let granted = shard
+        .process_concurrency_grants(tenant, queue, BACKLOG as u32)
+        .await;
+    assert_eq!(granted.len(), 0, "a full queue grants nothing");
+    let after_first = count_concurrency_requests(shard.db()).await;
+    assert!(
+        after_first > 0,
+        "one invocation must NOT walk/delete the whole backlog (scan budget bounds it)"
+    );
+    assert!(
+        after_first < BACKLOG,
+        "stale on a full queue must still be cleaned (orphan reliability)"
+    );
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        LIMIT,
+        "holders are untouched while cleaning stale"
+    );
+
+    // Repeated invocations eventually drain the stale backlog.
+    let mut prev = after_first;
+    for _ in 0..50 {
+        if count_concurrency_requests(shard.db()).await == 0 {
+            break;
+        }
+        let g = shard
+            .process_concurrency_grants(tenant, queue, BACKLOG as u32)
+            .await;
+        assert_eq!(g.len(), 0);
+        let remaining = count_concurrency_requests(shard.db()).await;
+        assert!(
+            remaining < prev,
+            "each invocation deletes at least some stale"
+        );
+        prev = remaining;
+    }
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "repeated invocations drain the full queue's stale backlog"
+    );
+    assert_eq!(count_concurrency_holders(shard.db()).await, LIMIT);
+}
+
+/// Tenant-fairness: an invocation grants at most `max_concurrency - holders`,
+/// regardless of how large the requested `count` is — reservations are never
+/// released mid-call, so aiming higher is pointless. Frees a subset of holders
+/// to create exactly N free slots and asserts exactly N grants out of a much
+/// larger valid backlog.
+#[silo::test]
+async fn grant_scanner_caps_grants_at_free_capacity() {
+    const LIMIT: usize = 5;
+    const WAITERS: usize = 10;
+    const RELEASE: usize = 3; // free slots after release
+
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "grantable-cap-q";
+    let tenant = "grantable-cap-tenant";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: LIMIT as u32,
+    });
+
+    shard.stop_grant_scanner();
+
+    // Fill all LIMIT slots.
+    for i in 0..LIMIT {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("holder-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+    let mut holder_tasks = Vec::new();
+    while holder_tasks.len() < LIMIT {
+        let tasks = shard.dequeue("w", "tg", LIMIT).await.unwrap().tasks;
+        for t in tasks {
+            holder_tasks.push(t.attempt().task_id().to_string());
+        }
+    }
+
+    // Enqueue WAITERS valid waiters — queue is full, so each becomes a request.
+    for i in 0..WAITERS {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("waiter-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+    assert_eq!(count_concurrency_requests(shard.db()).await, WAITERS);
+
+    // Free RELEASE slots → RELEASE grantable slots remain.
+    for task_id in holder_tasks.iter().take(RELEASE) {
+        shard
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .unwrap();
+    }
+
+    // Ask for far more than is grantable; must grant exactly the free slots.
+    let granted = shard
+        .process_concurrency_grants(tenant, queue, WAITERS as u32)
+        .await;
+    assert_eq!(
+        granted.len(),
+        RELEASE,
+        "grants are capped at free capacity ({}), not the requested count",
+        RELEASE
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        WAITERS - RELEASE,
+        "only the granted requests are consumed"
+    );
+    assert_eq!(count_concurrency_holders(shard.db()).await, LIMIT);
+}
+
+/// Tenant-fairness: when a queue has capacity but a huge front of non-grantable
+/// keys, a single invocation makes only *bounded* progress (the per-invocation
+/// scan budget), then yields so other queues in the same scanner cycle aren't
+/// starved. Repeated invocations drain it fully (forward progress each cycle).
+/// Pre-fix one invocation walked and deleted the entire backlog.
+#[silo::test]
+async fn grant_scanner_bounds_scan_per_invocation_with_capacity() {
+    const BACKLOG: usize = 3000; // comfortably exceeds the per-invocation budget
+
+    let (_tmp, shard) = open_temp_shard().await;
+    let queue = "budget-q";
+    let tenant = "budget-tenant";
+
+    shard.stop_grant_scanner();
+
+    // No holders, no cached limit: capacity is available, so the pre-scan gate
+    // cannot short-circuit and the scan must run — bounded by the budget.
+    for i in 0..BACKLOG {
+        let stale_action = ConcurrencyAction::EnqueueTask {
+            start_time_ms: 0,
+            priority: 50,
+            job_id: format!("ghost-{}", i),
+            attempt_number: 1,
+            relative_attempt_number: 1,
+            task_group: "tg".to_string(),
+            limit_index: 0,
+            held_queues: Vec::new(),
+            task_id: format!("ghost-{}:1:stale", i),
+            limits: Vec::new(),
+        };
+        let key = silo::keys::concurrency_request_key(
+            tenant,
+            queue,
+            0,
+            50,
+            &format!("ghost-{}", i),
+            1,
+            &format!("{:08}", i),
+        );
+        let val = encode_concurrency_action(&stale_action);
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(&key, &val);
+        shard.db().write(batch).await.unwrap();
+    }
+    assert_eq!(count_concurrency_requests(shard.db()).await, BACKLOG);
+
+    // First invocation: bounded progress, not a full drain.
+    let granted = shard
+        .process_concurrency_grants(tenant, queue, BACKLOG as u32)
+        .await;
+    assert_eq!(granted.len(), 0, "no valid requests behind the stale front");
+    let after_first = count_concurrency_requests(shard.db()).await;
+    assert!(
+        after_first > 0,
+        "one invocation must NOT drain the whole backlog (budget bounds the walk)"
+    );
+    assert!(
+        after_first < BACKLOG,
+        "one invocation must still make forward progress from the front"
+    );
+
+    // Repeated invocations make forward progress and eventually drain to zero.
+    let mut prev = after_first;
+    for _ in 0..50 {
+        if count_concurrency_requests(shard.db()).await == 0 {
+            break;
+        }
+        let g = shard
+            .process_concurrency_grants(tenant, queue, BACKLOG as u32)
+            .await;
+        assert_eq!(g.len(), 0);
+        let remaining = count_concurrency_requests(shard.db()).await;
+        assert!(
+            remaining < prev,
+            "each invocation must delete at least some"
+        );
+        prev = remaining;
+    }
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "repeated invocations drain the backlog fully"
+    );
+}
+
 /// Reproduces a Gadget production report: jobs enqueued with TWO concurrency limits
 /// (a floating "platform" limit + a user-named fixed concurrency limit, e.g.
 /// `exampleshopname.myshopify.com`) advance through the first (platform) limit

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -155,6 +155,7 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             hydrate_all_at_startup: false,
             grant_scanner_batch_size: silo::settings::DEFAULT_GRANT_SCANNER_BATCH_SIZE,
             grant_scanner_buffer_size: silo::settings::DEFAULT_GRANT_SCANNER_BUFFER_SIZE,
+            grant_scanner_concurrency: silo::settings::DEFAULT_GRANT_SCANNER_CONCURRENCY,
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
         },


### PR DESCRIPTION
This PR is large but has a few good fixes: holder leak fixes, and it changes the grant scanner to scan the counters concurrently, instead of a single serial scan of the concurrency_requests key that one tenant could monopolize.


## Context

A **ghost holder** is an in-memory concurrency reservation with no matching durable `CONCURRENCY_HOLDER` row. Each ghost permanently consumes a slot, so a floating-cap queue can wedge (e.g. 300/300) and starve. Ghosts arise when the durable holder-delete commits but the in-memory `atomic_release` never runs — classically because a gRPC request future is cancelled at the `.await` of the durable write.

Fixes 0–3 make the system resilient to ghosts from four angles. Fix 4 is a companion concurrency change to the grant scanner: now that we scan the bounded requester counters instead of the full request keyspace, we can fan out and bound that scan to make it fair across tenants under load.

## Fix 0 — stop scanning the full request keyspace
`reconcile_pending_requests` now scans the bounded per-queue requester counters (`COUNTER_CONCURRENCY_REQUESTERS`) instead of the entire `CONCURRENCY_REQUEST` keyspace (tens of millions of keys on a busy shard). Counters are co-committed with request creation and decremented on grant/cancel, so they're a safe over-estimate — `process_grants` re-validates real pending requests. Turns a multi-minute I/O storm into a sub-second pass and relieves noisy-neighbor pressure on other tenants on the shard.

## Fix 1 — self-healing drift reconciler
`report_holder_drift` now compares the durable and in-memory holder *sets* per hydrated queue and routes any ghost (in-mem holder with no durable row) through `request_reconciliation`. The existing per-`task_id` durable re-check in `reconcile_pending_holders` is the false-positive guard, so a committed-but-not-yet-durable reservation is left alone. Recovers ghosts regardless of how they formed; runs even when metrics are disabled.

## Fix 2 — close the ghost source
`report_attempt_outcome` wraps its post-commit in-memory release in a `PendingHolderReleaseGuard` (extracted from `dequeue.rs` to a shared `holder_release_guard` module) so a cancelled request future can't sever the durable holder delete from the in-mem release. Audited the other holder-mutating paths: `cancel.rs` and `drop_tenant_holders` are already safe (synchronous release, no intervening `.await`).

## Fix 3 — nudge on capacity increase
`report_refresh_success` nudges the grant scanner by the `new_max − old_max` capacity delta after raising a floating cap, covering the 0→N bootstrap without relying on the periodic scan.

## Fix 4 — grant-scanner tenant fairness
Now that the scan is bounded (Fix 0), two changes cap the work any one queue can impose on the shared grant scanner so a single hot or backlogged tenant can't starve everyone else on the shard:

- **Parallelize per queue.** The scanner fans out `process_grants` across queues with bounded concurrency (`grant_scanner_concurrency`, default 8) via an order-preserving `buffered(...)` stream. Each pending entry is a unique `(tenant, queue)`, so no two in-flight passes share a gating queue and peak memory stays `N × per-pass`. Using `buffered` (not `buffer_unordered`) keeps collection order deterministic against the `BTreeMap` iteration order for DST.
- **Bound per-invocation work.** A single `process_grants` invocation now walks at most `grant_scanner_max_scan_per_invocation` request keys (a small multiple of the per-pass batch) before committing what it found and yielding — even if capacity and the iterator aren't exhausted. A queue with a huge backlog of non-grantable keys (the holder-orphan / stale-request shape) can no longer pin a scanner slot walking the whole backlog: it yields and round-robins, making bounded forward progress from the front each cycle (its requester counter is still non-zero, so it's re-driven next cycle). Stale/corrupt keys encountered along the way are still cleaned up.

Net effect: the grant scanner goes from a serial, full-keyspace sweep one noisy tenant could monopolize to a fair, bounded, parallel drain across tenants.

## Tests
- `report_holder_drift_self_heals_ghost` — ghost is discovered and released; durable-backed holder is left untouched.
- `reconcile_pending_requests_uses_requester_counters` — a requester counter of N kicks N grants.
- `grant_scanner_full_queue_cleans_stale_bounded` (Fix 4) — a full queue with a 3000-key stale backlog cleans only a bounded slice per invocation (holders untouched, nothing granted); repeated invocations drain it fully.
- `grant_scanner_bounds_scan_per_invocation_with_capacity` (Fix 4) — a queue with capacity but a huge non-grantable front makes only bounded progress per invocation, then yields; repeated invocations drain to zero.
- `grant_scanner_caps_grants_at_free_capacity` (Fix 4) — an invocation grants at most `max_concurrency − holders`, regardless of how large the requested count is.
- Existing suites green: holder_leak (16), floating_concurrency (22), requester_counter (6), job_store_shard_concurrency (41).


## Benchmark — noisy-neighbor fairness

`benches/noisy_neighbor_throughput.rs` puts **two tenants on the same shard** (shared grant scanner + task broker). Tenant A (the noisy neighbor) floods 24 concurrency queues × 160 jobs — each job carrying a tight `Concurrency(max=1)` + wide `FloatingConcurrency(max=360)` limit, so every queue holds a deep backlog of pending requesters the scanner must keep re-walking. Tenant B (the victim) runs a smaller workload (8 queues × 60 jobs) with the same limit shape. We measure **tenant B's completion throughput** both alone and while A hammers the scanner, on a 4-worker multi-thread runtime.

| | Tenant B baseline | Tenant B w/ noisy neighbor | Retained |
|---|---|---|---|
| **main** (no fix) | ~456 jobs/sec | **~68 jobs/sec** | ~15% |
| **this branch** (fix) | ~700 jobs/sec | **~537 jobs/sec** | ~74% |

On `main`, tenant A starves tenant B down to ~15% of its baseline — the serial scanner walks A's deep backlogs unbounded before it ever services B. With Fix 4 (per-queue parallel fan-out + bounded per-invocation scan), B holds ~74% of baseline. **Tenant B's noisy-neighbor throughput improves ~7–8× (68 → ~537 jobs/sec)**, confirming a single large tenant can no longer hog the grant scanner. Results were stable across repeated runs.

Run it with: `cargo bench --bench noisy_neighbor_throughput`.
