### PR TITLE
webui: tenant page queries only the tenant's owning shard

### DIFF
--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -40,15 +40,17 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use crate::coordination::{Coordinator, ShardOwnerMap, SplitCleanupStatus};
 use crate::factory::ShardFactory;
 use crate::job_store_shard::DropTenantStats;
-#[cfg(feature = "server")]
-use crate::pb::QueryRequest;
 use crate::pb::silo_client::SiloClient;
 use crate::pb::{
     CancelJobRequest, ColumnInfo, CompactShardRequest, DropTenantHoldersRequest, GetJobRequest,
     GetJobResponse, GetNodeInfoRequest, GetShardStorageInfoRequest, GetShardStorageInfoResponse,
     JobStatus, RequestSplitRequest, RequestSplitResponse, SerializedBytes, serialized_bytes,
 };
+#[cfg(feature = "server")]
+use crate::pb::{QueryArrowRequest, QueryRequest};
 use crate::shard_range::ShardId;
+#[cfg(feature = "server")]
+use datafusion::arrow::array::RecordBatch;
 
 /// Configuration for gRPC client connections.
 ///
@@ -586,6 +588,74 @@ impl ClusterClient {
             row_count: resp.row_count,
             shard_id: *shard_id,
         })
+    }
+
+    /// Query a single shard and return Arrow RecordBatches (local or remote).
+    ///
+    /// Unlike [`query_shard`](Self::query_shard) (which normalizes to msgpack
+    /// [`QueryResult`]), this keeps results as Arrow so callers that already parse
+    /// `RecordBatch`es have a single decode path. Best-effort: invalidate-on-error,
+    /// no shard-moved redirect retry (the cluster_query path has richer retry if we
+    /// ever want to factor a shared helper).
+    #[cfg(feature = "server")]
+    pub async fn query_shard_batches(
+        &self,
+        shard_id: &ShardId,
+        sql: &str,
+    ) -> Result<Vec<RecordBatch>, ClusterClientError> {
+        if let Some(shard) = self.factory.get(shard_id) {
+            debug!(shard_id = %shard_id, "querying local shard (arrow)");
+            let df = shard
+                .query_engine()
+                .sql(sql)
+                .await
+                .map_err(|e| ClusterClientError::QueryFailed(format!("SQL error: {}", e)))?;
+            return df.collect().await.map_err(|e| {
+                ClusterClientError::QueryFailed(format!("Query execution failed: {}", e))
+            });
+        }
+
+        let addr = self.get_shard_addr(shard_id).await?;
+        debug!(shard_id = %shard_id, addr = %addr, "querying remote shard (arrow)");
+        self.query_remote_shard_batches(shard_id, &addr, sql).await
+    }
+
+    /// Remote single-shard query via the streaming QueryArrow RPC, decoded to RecordBatches.
+    #[cfg(feature = "server")]
+    async fn query_remote_shard_batches(
+        &self,
+        shard_id: &ShardId,
+        addr: &str,
+        sql: &str,
+    ) -> Result<Vec<RecordBatch>, ClusterClientError> {
+        let mut client = self.get_client(addr).await?;
+
+        let request = QueryArrowRequest {
+            shard: shard_id.to_string(),
+            sql: sql.to_string(),
+            tenant: None,
+            parameters: vec![],
+        };
+
+        let response = client.query_arrow(request).await.map_err(|e| {
+            self.invalidate_connection(addr);
+            ClusterClientError::QueryFailed(format!("gRPC error: {}", e))
+        })?;
+
+        let mut stream = response.into_inner();
+        let mut batches = Vec::new();
+        while let Some(msg) = stream
+            .message()
+            .await
+            .map_err(|e| ClusterClientError::QueryFailed(format!("stream error: {}", e)))?
+        {
+            batches.extend(
+                crate::arrow_ipc::ipc_to_batches_only(&msg.ipc_data)
+                    .map_err(|e| ClusterClientError::QueryFailed(format!("ipc decode: {}", e)))?,
+            );
+        }
+
+        Ok(batches)
     }
 
     /// Query all shards in the cluster and combine results

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -1371,12 +1371,28 @@ async fn tenant_handler(
     let mut top_queues: Vec<TenantQueueRow> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
 
+    // A tenant's data lives on exactly one shard (XXH64 hash → range lookup), so resolve
+    // its owning shard once and query only that shard rather than fanning out to the whole
+    // cluster. Tradeoff: orphaned tenant data on a shard the tenant no longer hashes to is
+    // not surfaced here (use the cluster pages / drop_tenant_holders for orphan cleanup).
+    let shard_id = match state.coordinator.get_shard_owner_map().await {
+        Ok(map) => map.shard_for_tenant(&params.name),
+        Err(e) => {
+            errors.push(format!("Failed to resolve tenant shard: {}", e));
+            None
+        }
+    };
+
     let count_sql = format!(
         "SELECT status_kind, cnt FROM tenant_counts WHERE tenant = '{}'",
         tenant_escaped
     );
-    match state.query_engine.sql(&count_sql).await {
-        Ok(df) => match df.collect().await {
+    if let Some(shard_id) = shard_id {
+        match state
+            .cluster_client
+            .query_shard_batches(&shard_id, &count_sql)
+            .await
+        {
             Ok(batches) => {
                 for batch in batches {
                     let status_col = batch.column_by_name("status_kind").and_then(|c| {
@@ -1408,13 +1424,9 @@ async fn tenant_handler(
                 }
             }
             Err(e) => {
-                warn!(error = %e, tenant = %params.name, "failed to collect tenant count results");
+                warn!(error = %e, tenant = %params.name, "failed to query tenant counts");
                 errors.push(format!("Tenant counts query failed: {}", e));
             }
-        },
-        Err(e) => {
-            warn!(error = %e, tenant = %params.name, "failed to query tenant counts");
-            errors.push(format!("Tenant counts query failed: {}", e));
         }
     }
 
@@ -1422,8 +1434,12 @@ async fn tenant_handler(
         "SELECT queue_name, SUM(holders) as holders, SUM(requesters) as requesters FROM queue_counts WHERE tenant = '{}' GROUP BY queue_name",
         tenant_escaped
     );
-    match state.query_engine.sql(&queue_sql).await {
-        Ok(df) => match df.collect().await {
+    if let Some(shard_id) = shard_id {
+        match state
+            .cluster_client
+            .query_shard_batches(&shard_id, &queue_sql)
+            .await
+        {
             Ok(batches) => {
                 for batch in batches {
                     let name_col = batch.column_by_name("queue_name").and_then(|c| {
@@ -1464,13 +1480,9 @@ async fn tenant_handler(
                 top_queues.sort_by(|a, b| b.total.cmp(&a.total).then_with(|| a.name.cmp(&b.name)));
             }
             Err(e) => {
-                warn!(error = %e, tenant = %params.name, "failed to collect queue counts results");
+                warn!(error = %e, tenant = %params.name, "failed to query queue counts");
                 errors.push(format!("Queue counts query failed: {}", e));
             }
-        },
-        Err(e) => {
-            warn!(error = %e, tenant = %params.name, "failed to query queue counts");
-            errors.push(format!("Queue counts query failed: {}", e));
         }
     }
 
@@ -1482,8 +1494,12 @@ async fn tenant_handler(
         "SELECT shard_id, id FROM jobs WHERE tenant = '{}' AND status_kind = 'Waiting' LIMIT 100",
         tenant_escaped
     );
-    match state.query_engine.sql(&waiting_sql).await {
-        Ok(df) => match df.collect().await {
+    if let Some(shard_id) = shard_id {
+        match state
+            .cluster_client
+            .query_shard_batches(&shard_id, &waiting_sql)
+            .await
+        {
             Ok(batches) => {
                 for batch in batches {
                     let shard_col = batch.column_by_name("shard_id").and_then(|c| {
@@ -1509,13 +1525,9 @@ async fn tenant_handler(
                 }
             }
             Err(e) => {
-                warn!(error = %e, tenant = %params.name, "failed to collect waiting jobs");
+                warn!(error = %e, tenant = %params.name, "failed to query waiting jobs");
                 errors.push(format!("Waiting jobs query failed: {}", e));
             }
-        },
-        Err(e) => {
-            warn!(error = %e, tenant = %params.name, "failed to query waiting jobs");
-            errors.push(format!("Waiting jobs query failed: {}", e));
         }
     }
 

--- a/tests/webui_tests.rs
+++ b/tests/webui_tests.rs
@@ -1328,8 +1328,14 @@ async fn test_tenant_detail_shows_queues_and_waiting_jobs() {
 
     let (_tmp, state, shard_map) = setup_multi_shard_state_with_tenancy(2, true).await;
 
-    let shard0_id = shard_map.shards()[0].id;
-    let shard0 = state.factory.get(&shard0_id).expect("shard 0");
+    // A tenant's data lives on the single shard it hashes to, and the tenant page now queries
+    // only that shard. Enqueue onto the owning shard rather than a fixed one so the data is
+    // found (writing to the wrong shard would make it "orphaned" and invisible to the page).
+    let owning_shard_id = shard_map
+        .shard_for_tenant("tenant-detail")
+        .expect("tenant-detail routes to a shard")
+        .id;
+    let shard0 = state.factory.get(&owning_shard_id).expect("owning shard");
     // Present-time enqueues so the chain populates queue_counts:
     // job 1 grants the only slot (holder), job 2 defers (requester).
     // Pre-fix this test used future start times — those grabbed holders


### PR DESCRIPTION
## Summary

The tenant overview page (`/tenant?name=...`, `tenant_handler`) ran its three SQL queries through `ClusterQueryEngine`, which **fans out to every shard** in the cluster and filters by `tenant` after the fact. Cost scaled with shard count even though a tenant's data lives on exactly one shard (XXH64 hash → range lookup).

`tenant_handler` now resolves the tenant's owning shard **once** via the shard owner map and routes all three queries (`tenant_counts`, `queue_counts`, waiting `jobs`) through a new Arrow `ClusterClient::query_shard_batches` helper. The helper normalizes local and remote shards to `Vec<RecordBatch>`, so the existing per-batch parsing loops are unchanged — only the data *source* changes. The single-shard `SUM(holders) ... GROUP BY queue_name` is now a no-op aggregation over one shard's rows, i.e. the complete result for a tenant that lives there.

## Intentional tradeoff

The all-shards fan-out also surfaced *orphaned* tenant data sitting on a shard the tenant no longer hashes to (relevant to this stack's holder-orphan work). The single-shard lookup will **not** see such stray data on the tenant overview page. This is the requested behavior; the `drop_tenant_holders` admin path and the cluster-wide pages remain available for orphan cleanup.

The new helper is best-effort (invalidate-on-error, no shard-moved redirect retry); the `cluster_query` path has richer retry if we ever want to factor a shared helper.

## Changes

- **`src/cluster_client.rs`** — add `query_shard_batches` + `query_remote_shard_batches` (Arrow path), import `RecordBatch` / `QueryArrowRequest`.
- **`src/webui.rs`** — `tenant_handler` resolves the shard once, routes the 3 queries through the helper. On `None` (no owning shard) the page renders zeros plus a soft error instead of fanning out; `query_engine` stays on `AppState` (still used elsewhere).
- **`tests/webui_tests.rs`** — `test_tenant_detail_shows_queues_and_waiting_jobs` now enqueues onto the tenant's owning shard rather than a fixed `shards()[0]`. The old fan-out masked the mismatch; under single-shard lookup, data on the wrong shard is "orphaned" and invisible.

## Verification

- `cargo build --features server` — clean.
- `cargo clippy --features server` — no warnings/errors.
- `cargo test --features server --test webui_tests -- tenant` — 9 passed, 0 failed (covers remote/local shard tenants and the unavailable-shard case).

> Stacked on #369 (`kirin/holder-orphan-reliability`).