### PR TITLE
Add debug timings to shard open and k8s reconciler

### DIFF
--- a/src/coordination/k8s.rs
+++ b/src/coordination/k8s.rs
@@ -1846,9 +1846,16 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                     };
 
                     if !cancelled {
+                        let release_started = std::time::Instant::now();
                         // Close the shard before releasing the lease
+                        let factory_close_started = std::time::Instant::now();
                         match factory.close(&self.ctx.shard_id).await {
                             Ok(()) => {
+                                debug!(
+                                    shard_id = %self.ctx.shard_id,
+                                    elapsed_ms = factory_close_started.elapsed().as_millis() as u64,
+                                    "k8s release: factory.close"
+                                );
                                 dst_events::emit(DstEvent::ShardClosed {
                                     node_id: self.node_id.clone(),
                                     shard_id: self.ctx.shard_id.to_string(),
@@ -1862,6 +1869,7 @@ impl<B: K8sBackend> K8sShardGuard<B> {
 
                                 if has_token {
                                     let release_timeout = Duration::from_secs(5);
+                                    let release_cas_started = std::time::Instant::now();
                                     match tokio::time::timeout(
                                         release_timeout,
                                         self.release_lease_cas(&lease_name),
@@ -1871,6 +1879,7 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                                         Ok(Ok(_)) => {
                                             debug!(
                                                 shard_id = %self.ctx.shard_id,
+                                                elapsed_ms = release_cas_started.elapsed().as_millis() as u64,
                                                 "k8s shard: released with CAS"
                                             );
                                         }
@@ -1895,7 +1904,11 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                                     node_id: self.node_id.clone(),
                                     shard_id: self.ctx.shard_id.to_string(),
                                 });
-                                debug!(shard_id = %self.ctx.shard_id, "k8s shard: released");
+                                debug!(
+                                    shard_id = %self.ctx.shard_id,
+                                    total_ms = release_started.elapsed().as_millis() as u64,
+                                    "k8s shard: released"
+                                );
                             }
                             Err(e) => {
                                 // Close failed - revert to Held so reconciliation retries
@@ -1913,11 +1926,18 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                 ShardPhase::ShuttingDown => {
                     // Debug: log entry into shutdown processing
                     tracing::trace!(shard_id = %self.ctx.shard_id, "guard entering ShuttingDown processing");
+                    let shutdown_started = std::time::Instant::now();
 
                     // Close the shard before releasing the lease
                     tracing::trace!(shard_id = %self.ctx.shard_id, "guard calling factory.close");
+                    let factory_close_started = std::time::Instant::now();
                     let close_succeeded = match factory.close(&self.ctx.shard_id).await {
                         Ok(()) => {
+                            debug!(
+                                shard_id = %self.ctx.shard_id,
+                                elapsed_ms = factory_close_started.elapsed().as_millis() as u64,
+                                "k8s shutdown: factory.close"
+                            );
                             dst_events::emit(DstEvent::ShardClosed {
                                 node_id: self.node_id.clone(),
                                 shard_id: self.ctx.shard_id.to_string(),
@@ -1949,6 +1969,7 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                         if has_token {
                             tracing::trace!(shard_id = %self.ctx.shard_id, "guard releasing lease");
                             let release_timeout = Duration::from_secs(5);
+                            let release_cas_started = std::time::Instant::now();
                             match tokio::time::timeout(
                                 release_timeout,
                                 self.release_lease_cas(&lease_name),
@@ -1956,7 +1977,11 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                             .await
                             {
                                 Ok(_) => {
-                                    tracing::trace!(shard_id = %self.ctx.shard_id, "guard lease released");
+                                    debug!(
+                                        shard_id = %self.ctx.shard_id,
+                                        elapsed_ms = release_cas_started.elapsed().as_millis() as u64,
+                                        "k8s shutdown: lease released"
+                                    );
                                 }
                                 Err(_) => {
                                     warn!(shard_id = %self.ctx.shard_id, "timed out releasing shard lease during shutdown");
@@ -1980,7 +2005,12 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                         let mut st = self.ctx.state.lock().await;
                         st.phase = ShardPhase::ShutDown;
                     }
-                    tracing::trace!(shard_id = %self.ctx.shard_id, "guard shutdown complete");
+                    debug!(
+                        shard_id = %self.ctx.shard_id,
+                        close_succeeded,
+                        total_ms = shutdown_started.elapsed().as_millis() as u64,
+                        "k8s shard: shutdown complete"
+                    );
                     break;
                 }
                 ShardPhase::Idle | ShardPhase::Held => {

--- a/src/coordination/k8s.rs
+++ b/src/coordination/k8s.rs
@@ -787,10 +787,12 @@ impl<B: K8sBackend> K8sCoordinator<B> {
     }
 
     async fn reconcile_shards(&self) -> Result<(), CoordinationError> {
+        let started = std::time::Instant::now();
         let members = {
             let cache = self.members_cache.lock().await;
             cache.clone()
         };
+        let member_count = members.len();
 
         let guard_shard_ids: HashSet<ShardId> = {
             let guards = self.shard_guards.lock().await;
@@ -806,6 +808,9 @@ impl<B: K8sBackend> K8sCoordinator<B> {
             None => return Ok(()),
         };
 
+        let to_cancel = actions.to_cancel.len();
+        let to_acquire = actions.to_acquire.len();
+
         for sid in actions.to_cancel {
             self.ensure_shard_guard(sid)
                 .await
@@ -820,6 +825,14 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                 .set_desired(true)
                 .await;
         }
+
+        debug!(
+            members = member_count,
+            to_acquire,
+            to_cancel,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "k8s reconcile pass"
+        );
 
         Ok(())
     }
@@ -1633,6 +1646,7 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                 ShardPhase::ShutDown => break,
                 ShardPhase::Acquiring => {
                     debug!(shard_id = %self.ctx.shard_id, "k8s shard: starting acquisition");
+                    let acquire_started = std::time::Instant::now();
                     let mut attempt: u32 = 0;
                     let initial_jitter_ms =
                         (self.ctx.shard_id.as_uuid().as_u64_pair().0.wrapping_mul(13)) % 80;
@@ -1654,6 +1668,7 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                         // the guard indefinitely. If the API call hangs (e.g., due to
                         // K8s API server overload), we retry after a short wait.
                         let acquire_timeout = Duration::from_secs(5);
+                        let lease_cas_started = std::time::Instant::now();
                         let acquire_result = tokio::time::timeout(
                             acquire_timeout,
                             self.try_acquire_lease_cas(&lease_name),
@@ -1670,6 +1685,12 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                         };
                         match acquire_result {
                             Ok((rv, uid)) => {
+                                debug!(
+                                    shard_id = %self.ctx.shard_id,
+                                    attempt,
+                                    elapsed_ms = lease_cas_started.elapsed().as_millis() as u64,
+                                    "k8s acquire: lease CAS"
+                                );
                                 // Look up the shard's range from the shard map
                                 let range = {
                                     let map = shard_map.lock().await;
@@ -1684,8 +1705,16 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                                 };
                                 // Open the shard BEFORE marking as Held - if open fails,
                                 // we should release the lease and not claim ownership.
+                                let factory_open_started = std::time::Instant::now();
                                 let shard = match factory.open(&self.ctx.shard_id, &range).await {
-                                    Ok(shard) => shard,
+                                    Ok(shard) => {
+                                        debug!(
+                                            shard_id = %self.ctx.shard_id,
+                                            elapsed_ms = factory_open_started.elapsed().as_millis() as u64,
+                                            "k8s acquire: factory.open"
+                                        );
+                                        shard
+                                    }
                                     Err(e) => {
                                         // Failed to open - release the lease and retry
                                         tracing::error!(shard_id = %self.ctx.shard_id, error = %e, "failed to open shard, releasing lease");
@@ -1759,7 +1788,7 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                                     node_id: self.node_id.clone(),
                                     shard_id: self.ctx.shard_id.to_string(),
                                 });
-                                info!(shard_id = %self.ctx.shard_id, rv = %rv, attempts = attempt, "k8s shard: acquired and opened");
+                                info!(shard_id = %self.ctx.shard_id, rv = %rv, attempts = attempt, total_ms = acquire_started.elapsed().as_millis() as u64, "k8s shard: acquired and opened");
 
                                 // Permanent lease - no renewal loop needed.
                                 // The lease persists until explicitly released.

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -338,14 +338,23 @@ impl ShardFactory {
     ///
     /// A timeout is applied because SlateDB's internal retrying_object_store retries indefinitely on transient errors, which would cause close to hang forever if the object store is unreachable.
     pub async fn close(&self, shard_id: &ShardId) -> Result<(), JobStoreShardError> {
+        // Wall-clock timer for the whole close call, including the timeout-guarded
+        // wait, so slow closes can be attributed without a profiler.
+        let call_started = std::time::Instant::now();
+
         tracing::trace!(shard_id = %shard_id, "factory.close: removing from instances");
         if let Some((id, entry)) = self.instances.remove(shard_id) {
             if let Some(shard) = entry.get() {
                 tracing::trace!(shard_id = %shard_id, "factory.close: calling shard.close()");
+                let close_started = std::time::Instant::now();
                 let close_result = tokio::time::timeout(self.close_timeout, shard.close()).await;
                 match close_result {
                     Ok(Ok(())) => {
-                        tracing::info!(shard_id = %shard_id, "closed shard");
+                        tracing::info!(
+                            shard_id = %shard_id,
+                            close_ms = close_started.elapsed().as_millis() as u64,
+                            "closed shard"
+                        );
                     }
                     Ok(Err(e)) => {
                         // If the DB is already closed (e.g. a previous timed-out close
@@ -382,6 +391,13 @@ impl ShardFactory {
         } else {
             tracing::trace!(shard_id = %shard_id, "factory.close: shard not found in instances");
         }
+
+        tracing::debug!(
+            shard_id = %shard_id,
+            total_ms = call_started.elapsed().as_millis() as u64,
+            "factory: close returned"
+        );
+
         Ok(())
     }
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -131,6 +131,11 @@ impl ShardFactory {
     ) -> Result<Arc<JobStoreShard>, JobStoreShardError> {
         let shard_id = *shard_id;
 
+        // Wall-clock timer for this open call. Compared against the per-init
+        // timer below to expose time spent waiting on a concurrent opener
+        // (OnceCell contention) vs. time spent actually opening.
+        let call_started = std::time::Instant::now();
+
         // Get or create the entry for this shard. The entry contains a OnceCell
         // that ensures only one caller actually opens the database.
         let entry = self
@@ -147,8 +152,11 @@ impl ShardFactory {
         let rate_limiter = Arc::clone(&self.rate_limiter);
         let metrics = self.metrics.clone();
 
-        entry
+        let result = entry
             .get_or_try_init(|| async {
+                // Timer for the actual open work (only the caller that wins the
+                // OnceCell runs this closure).
+                let init_started = std::time::Instant::now();
                 // For Backend::Fs, we need to open at the storage root level so that
                 // cloned databases can correctly resolve their relative parent SST paths.
                 // Extract the root from the template and use shard name as the db path.
@@ -202,10 +210,23 @@ impl ShardFactory {
                 )
                 .await?;
 
-                tracing::info!(shard_id = %shard_id, range = %range, "opened shard");
+                tracing::info!(
+                    shard_id = %shard_id,
+                    range = %range,
+                    init_ms = init_started.elapsed().as_millis() as u64,
+                    "opened shard"
+                );
                 Ok(shard_arc)
             })
-            .await
+            .await;
+
+        tracing::debug!(
+            shard_id = %shard_id,
+            total_ms = call_started.elapsed().as_millis() as u64,
+            "factory: open returned"
+        );
+
+        result
     }
 
     /// Validate that the template path has the shard placeholder at a directory boundary.

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -443,6 +443,10 @@ impl JobStoreShard {
             terminal_job_expire_s,
         } = options;
 
+        // Wall-clock timer for the whole open, used to emit per-phase debug
+        // timings so slow shard opens can be attributed without a profiler.
+        let open_started = std::time::Instant::now();
+
         let slatedb_metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
         let mut db_builder = slatedb::DbBuilder::new(db_path, store.clone())
             .with_merge_operator(counters::counter_merge_operator())
@@ -490,7 +494,13 @@ impl JobStoreShard {
         }
 
         let shard_span = info_span!("shard", shard = %name);
+        let db_build_started = std::time::Instant::now();
         let db = db_builder.build().instrument(shard_span.clone()).await?;
+        tracing::debug!(
+            shard = %name,
+            elapsed_ms = db_build_started.elapsed().as_millis() as u64,
+            "shard open: slatedb build"
+        );
         let db = InstrumentedDb::new(Arc::new(db), shard_span);
         let concurrency = Arc::new(ConcurrencyManager::new(
             name.clone(),
@@ -509,9 +519,16 @@ impl JobStoreShard {
         // Controlled by `hydrate_all_at_startup`. When false, the
         // singleflighted JIT `ensure_hydrated` path covers each queue on
         // first access.
+        let hydrate_started = std::time::Instant::now();
         if hydrate_all_at_startup {
             concurrency.counts().hydrate_all(&db, &range).await?;
         }
+        tracing::debug!(
+            shard = %name,
+            hydrated = hydrate_all_at_startup,
+            elapsed_ms = hydrate_started.elapsed().as_millis() as u64,
+            "shard open: hydrate"
+        );
 
         let brokers = TaskBrokerRegistry::new(
             Arc::clone(&db),
@@ -549,9 +566,15 @@ impl JobStoreShard {
             .concurrency
             .set_chain_resumer(limit_chain::ShardChainResumer::install(&shard));
 
+        let counters_started = std::time::Instant::now();
         shard
             .rebuild_background_action_queue_counters(&range)
             .await?;
+        tracing::debug!(
+            shard = %shard.name,
+            elapsed_ms = counters_started.elapsed().as_millis() as u64,
+            "shard open: rebuild bg action counters"
+        );
 
         // Start the grant scanner after both ConcurrencyManager and TaskBrokerRegistry are ready,
         // and after the chain resumer is installed. It takes the instrumented db so its writes
@@ -589,7 +612,19 @@ impl JobStoreShard {
         }
 
         // Set the shard creation timestamp if this is the first time opening
+        let created_at_started = std::time::Instant::now();
         shard.set_created_at_ms_if_unset().await?;
+        tracing::debug!(
+            shard = %shard.name,
+            elapsed_ms = created_at_started.elapsed().as_millis() as u64,
+            "shard open: set created_at"
+        );
+
+        tracing::debug!(
+            shard = %shard.name,
+            total_ms = open_started.elapsed().as_millis() as u64,
+            "shard open: complete"
+        );
 
         Ok(shard)
     }

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -650,6 +650,10 @@ impl JobStoreShard {
     /// This ensures all data is durably stored in object storage before closing,
     /// allowing the shard to be safely reopened elsewhere (e.g., on a different node).
     pub async fn close(&self) -> Result<(), JobStoreShardError> {
+        // Wall-clock timer for the whole close, used to emit per-phase debug
+        // timings so slow shard closes can be attributed without a profiler.
+        let close_started = std::time::Instant::now();
+
         self.cancellation.cancel();
         self.brokers.stop();
         self.concurrency.stop_grant_scanner();
@@ -666,6 +670,7 @@ impl JobStoreShard {
 
             // Flush memtable to SST to ensure all data is in object storage
             // This converts all in-memory data (and WAL data) to SSTs
+            let flush_started = std::time::Instant::now();
             self.db
                 .flush_with_options(slatedb::config::FlushOptions {
                     flush_type: slatedb::config::FlushType::MemTable,
@@ -675,14 +680,20 @@ impl JobStoreShard {
 
             tracing::debug!(
                 shard = %self.name,
-                "memtable flushed to SST, closing database"
+                elapsed_ms = flush_started.elapsed().as_millis() as u64,
+                "shard close: flush memtable"
             );
         }
 
         // Close the database
         tracing::trace!(shard = %self.name, "shard.close: calling db.close()");
+        let db_close_started = std::time::Instant::now();
         self.db.close().await.map_err(JobStoreShardError::from)?;
-        tracing::trace!(shard = %self.name, "shard.close: db.close() completed");
+        tracing::debug!(
+            shard = %self.name,
+            elapsed_ms = db_close_started.elapsed().as_millis() as u64,
+            "shard close: db close"
+        );
 
         // After closing, clean up the local WAL directory if configured
         if let Some(ref wal_config) = self.wal_close_config
@@ -694,6 +705,7 @@ impl JobStoreShard {
                 "removing local WAL directory after successful close"
             );
 
+            let wal_remove_started = std::time::Instant::now();
             if let Err(e) = tokio::fs::remove_dir_all(&wal_config.path).await {
                 // Log but don't fail if WAL directory removal fails
                 // The data is already durably in object storage
@@ -709,10 +721,17 @@ impl JobStoreShard {
                 tracing::debug!(
                     shard = %self.name,
                     wal_path = %wal_config.path,
-                    "local WAL directory removed successfully"
+                    elapsed_ms = wal_remove_started.elapsed().as_millis() as u64,
+                    "shard close: remove local WAL directory"
                 );
             }
         }
+
+        tracing::debug!(
+            shard = %self.name,
+            total_ms = close_started.elapsed().as_millis() as u64,
+            "shard close: complete"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Context

Shard opens have been slow and we have no per-step attribution for where the time goes. This adds **debug-level** wall-clock timings across the shard-open path and the k8s reconciler so the latency can be localized from logs alone (no profiler needed). All new logging is `tracing::debug!` with structured `*_ms` fields — off by default, enable with `RUST_LOG=silo=debug`.

Stacked on top of #371 (`kirin/tenant-page-single-shard`).

## Changes

**`src/job_store_shard/mod.rs`** — `open_with_resolved_store`, per-phase debug events:
- `shard open: slatedb build` (manifest/SST/WAL replay — prime suspect)
- `shard open: hydrate` (includes `hydrated` flag for the skip case)
- `shard open: rebuild bg action counters`
- `shard open: set created_at`
- `shard open: complete` (`total_ms`)

**`src/factory.rs`** — `open`, exposes OnceCell contention:
- `init_ms` added to the existing `"opened shard"` info line (actual open work)
- `factory: open returned` debug with `total_ms` (full call incl. waiting on a concurrent opener). `total_ms − init_ms` ≈ contention wait.

**`src/coordination/k8s.rs`**:
- `reconcile_shards`: `k8s reconcile pass` debug with `members`, `to_acquire`, `to_cancel`, `elapsed_ms`
- `K8sShardGuard::run` acquiring arm: `k8s acquire: lease CAS` and `k8s acquire: factory.open` timings, plus `total_ms` on the `"k8s shard: acquired and opened"` info line

## Verification

- `direnv exec . cargo fmt` + `cargo build` clean (no warnings)
- `job_store_shard` lib tests pass (21/21); test profile compiles the k8s coordination tests with the changes

## Diagnosing

Compare the `*_ms` fields — `slatedb build` and `hydrate` are the expected suspects. Factory `total_ms` vs `init_ms` reveals whether concurrent opens serialize on the OnceCell.