### PR TITLE
Make background-action counter rebuild non-blocking on shard open

### DIFF
--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -566,15 +566,16 @@ impl JobStoreShard {
             .concurrency
             .set_chain_resumer(limit_chain::ShardChainResumer::install(&shard));
 
-        let counters_started = std::time::Instant::now();
-        shard
-            .rebuild_background_action_queue_counters(&range)
-            .await?;
-        tracing::debug!(
-            shard = %shard.name,
-            elapsed_ms = counters_started.elapsed().as_millis() as u64,
-            "shard open: rebuild bg action counters"
-        );
+        // Rebuild the background-action queue counter gauges in the background
+        // rather than on the open critical path. The rebuild scans the entire
+        // JOB_STATUS prefix (one row per job on the shard) and does a point read
+        // of JOB_INFO per scheduled/running job, so it is O(jobs) and can take a
+        // very long time on large shards (tens of millions of jobs). Its only
+        // consumer is the Prometheus background-action queue gauge
+        // (`snapshot_background_action_queue_counters`), so blocking the shard
+        // from serving on it is unnecessary — the gauge simply reports an empty
+        // shard until the spawned rebuild completes.
+        shard.spawn_background_action_queue_counter_rebuild(range.clone());
 
         // Start the grant scanner after both ConcurrencyManager and TaskBrokerRegistry are ready,
         // and after the chain resumer is installed. It takes the instrumented db so its writes
@@ -813,6 +814,50 @@ impl JobStoreShard {
     /// tuple would sit idle until the next unrelated Drop or the 5 s
     /// periodic tick. The sleep also bounds the retry rate so a sustained
     /// failure (slatedb temporarily unavailable, etc.) doesn't tight-loop.
+    /// Spawn a one-shot background task that rebuilds the background-action
+    /// queue counter gauges from durable storage.
+    ///
+    /// This is kept off the open critical path because the rebuild scans the
+    /// whole JOB_STATUS prefix and point-reads JOB_INFO per scheduled/running
+    /// job — O(jobs), which is prohibitively slow on large shards. The gauge it
+    /// populates is metrics-only, so the shard can serve immediately while the
+    /// rebuild runs. A failure is logged and dropped; the periodic counter
+    /// reconciler (when enabled) and live transition deltas keep the gauge
+    /// converging afterwards.
+    fn spawn_background_action_queue_counter_rebuild(self: &Arc<Self>, range: ShardRange) {
+        let shard = Arc::clone(self);
+        let cancellation = self.cancellation.clone();
+        let shard_name = self.name.clone();
+
+        tokio::spawn(async move {
+            let started = std::time::Instant::now();
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => {
+                    tracing::debug!(
+                        shard = %shard_name,
+                        "skipping background action queue counter rebuild (shard closing)"
+                    );
+                }
+                result = shard.rebuild_background_action_queue_counters(&range) => {
+                    match result {
+                        Ok(()) => tracing::debug!(
+                            shard = %shard_name,
+                            elapsed_ms = started.elapsed().as_millis() as u64,
+                            "shard open: rebuild bg action counters (background)"
+                        ),
+                        Err(e) => tracing::warn!(
+                            shard = %shard_name,
+                            error = %e,
+                            elapsed_ms = started.elapsed().as_millis() as u64,
+                            "background action queue counter rebuild failed; gauge will converge via reconcile and live deltas"
+                        ),
+                    }
+                }
+            }
+        });
+    }
+
     fn spawn_holder_reconcile_task(self: &Arc<Self>, range: ShardRange) {
         /// Delay between reactive-reconciler retries when a pass re-queued
         /// at least one tuple. 100 ms = ~10 retries/sec ceiling under


### PR DESCRIPTION
## Problem

`factory.open` is slow on shards with many jobs, even with `hydrate_all_at_startup = false`.

With that flag off, the eager `hydrate_all` call is correctly skipped — but `open_with_resolved_store` still **awaits `rebuild_background_action_queue_counters` unconditionally** on the open critical path. That function:

1. Scans the **entire `JOB_STATUS` prefix** — one row per job on the shard.
2. Decodes each status value.
3. For every `Scheduled`/`Running` job (all scheduled jobs qualify — `background_action_status_bucket(Scheduled)` is `Some`), does an **additional point `get` of `JOB_INFO`** plus a `JobView` decode to read `queue` / `platformConcurrencyQueue` / `task_group`.

So it is **O(total jobs)**: on a shard with ~60M scheduled jobs that's ~60M sequential scan rows **plus ~60M random point reads** against an object-store-backed LSM, decoded one at a time, all before `open` returns. `hydrate_all_at_startup = false` does nothing to avoid it.

The only consumer of the result (`background_action_queue_counts`) is the Prometheus background-action queue gauge (`snapshot_background_action_queue_counters` → `collect_background_action_metrics_for_shard`). It is **not** on the correctness/serving path — so the shard should not block on it.

## Change

Spawn the rebuild as a one-shot background task (`spawn_background_action_queue_counter_rebuild`) instead of awaiting it in `open_with_resolved_store`, matching the existing spawned-reconciler pattern (grant scanner, holder/concurrency reconcilers). The task:

- is cancellable via the shard `cancellation` token so a closing shard doesn't keep scanning,
- logs success/failure timings at the same points as before,
- leaves the gauge reporting an empty shard until the rebuild completes, after which live transition deltas (and the periodic counter reconciler, when enabled) keep it converging.

`open` no longer waits on an O(jobs) scan, so shards become serviceable immediately regardless of job count.

## Follow-ups (not in this PR)

- Eliminate the per-job `JOB_INFO` point read by co-locating `task_group` / `queue` / `platformConcurrencyQueue` into the `JOB_STATUS` value, turning the rebuild into a single sequential scan with no point gets.
- Consider gating/JIT-rebuilding the gauge per queue on first access, consistent with the `ensure_hydrated` design.

## Testing

- `cargo build --lib` passes.
- `cargo fmt` applied.

> Note: stacked on #372 (`kirin/shard-open-timings`); base it there.