### PR TITLE
Make 'Drop holders' an emergency holder-only release

### DIFF
--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -214,8 +214,9 @@ message CancelJobRequest {
 // Response confirming cancellation was requested.
 message CancelJobResponse {}
 
-// Forcibly drop all concurrency holders and in-flight run attempts for a tenant
-// on a single shard. Admin/operator action used to clear stuck concurrency state.
+// Forcibly drop all concurrency holders for a tenant on a single shard, freeing
+// held slots so stuck jobs can be re-granted. Emergency admin/operator action;
+// in-flight run attempts are left running (and may briefly double-run).
 message DropTenantHoldersRequest {
   string shard = 1;           // Shard ID (UUID) to operate on.
   optional string tenant = 2; // Tenant ID if multi-tenancy is enabled.
@@ -223,8 +224,9 @@ message DropTenantHoldersRequest {
 
 // Response reporting what was dropped.
 message DropTenantHoldersResponse {
-  uint64 holders_dropped = 1;      // Number of concurrency holders deleted.
-  uint64 run_attempts_dropped = 2; // Number of in-flight run attempts deleted.
+  reserved 2;
+  reserved "run_attempts_dropped";
+  uint64 holders_dropped = 1; // Number of concurrency holders deleted.
 }
 
 // Restart a cancelled or failed job, allowing it to be processed again.

--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -909,8 +909,9 @@ impl ClusterClient {
         Ok(())
     }
 
-    /// Drop all concurrency holders and in-flight run attempts for a tenant on a
-    /// shard (local or remote).
+    /// Forcibly drop all concurrency holders for a tenant on a shard (local or
+    /// remote), freeing held slots so stuck jobs can be re-granted. In-flight run
+    /// attempts are left running.
     pub async fn drop_tenant_holders(
         &self,
         shard_id: &ShardId,
@@ -920,7 +921,7 @@ impl ClusterClient {
         if let Some(shard) = self.factory.get(shard_id) {
             debug!(shard_id = %shard_id, tenant, "dropping tenant state on local shard");
             return shard
-                .drop_tenant_holders_and_runattempts(tenant)
+                .drop_tenant_holders(tenant)
                 .await
                 .map_err(|e| ClusterClientError::QueryFailed(e.to_string()));
         }
@@ -940,7 +941,6 @@ impl ClusterClient {
                 let resp = resp.into_inner();
                 Ok(DropTenantStats {
                     holders_dropped: resp.holders_dropped as usize,
-                    run_attempts_dropped: resp.run_attempts_dropped as usize,
                 })
             }
             Err(e) => {

--- a/src/job_store_shard/drop_tenant_holders.rs
+++ b/src/job_store_shard/drop_tenant_holders.rs
@@ -1,100 +1,65 @@
-//! Tenant-wide forced cleanup of concurrency holders and in-flight run attempts.
+//! Tenant-wide forced release of concurrency holders.
 //!
-//! This backs the console's "Drop holders & run attempts" admin action: it
-//! forcibly clears a tenant's stuck concurrency state on a single shard so the
-//! tenant returns to a consistent, runnable state.
+//! This backs the console's "Drop holders" emergency admin action: when a
+//! tenant's concurrency holders are *leaked* (held by attempts that will never
+//! release them), no slots are free and the tenant's jobs stall. Force-deleting
+//! the holders frees the slots so the grant scanner re-grants and jobs start
+//! flowing again.
 
 use slatedb::WriteBatch;
-use tracing::warn;
 
-use crate::codec::{decode_lease, decode_task};
-use crate::job_attempt::AttemptOutcome;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
-use crate::keys::{
-    concurrency_holders_tenant_prefix, end_bound, leases_prefix, parse_concurrency_holder_key,
-    tasks_prefix,
-};
-use crate::task::Task;
+use crate::keys::{concurrency_holders_tenant_prefix, end_bound, parse_concurrency_holder_key};
 
 /// Max deletes flushed per write batch. Bounds batch size/memory on a tenant
 /// with a very large amount of stuck state; the operation is idempotent so
 /// chunking across multiple batches is safe.
 const DROP_BATCH_SIZE: usize = 1000;
 
-/// Counts of what `drop_tenant_holders_and_runattempts` removed.
+/// Counts of what `drop_tenant_holders` removed.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct DropTenantStats {
     /// Number of concurrency holder records deleted.
     pub holders_dropped: usize,
-    /// Number of in-flight `RunAttempt`s finalized — both queued task-queue
-    /// entries (cancelled) and running (leased) attempts (failed as if the
-    /// worker crashed).
-    pub run_attempts_dropped: usize,
 }
 
 impl JobStoreShard {
-    /// Forcibly clear **all** concurrency holders and finalize every in-flight
-    /// `RunAttempt` (queued or running) for `tenant` on this shard, returning
-    /// every affected job to a consistent terminal/runnable state.
+    /// Forcibly delete **all** concurrency holders for `tenant` on this shard and
+    /// release their in-memory counts, freeing the held slots so the grant
+    /// scanner can re-grant pending requests.
     ///
-    /// This is intentionally **non-transactional at the tenant level**,
-    /// mirroring the bulk-scan pattern in [`cleanup`](super::cleanup): it scans
-    /// the (non-tenant-keyed) task/lease keyspaces read-only, then finalizes
-    /// each collected attempt via a **per-attempt** call to the same code paths
-    /// the system already uses live. It does *not* wrap the whole operation in
-    /// one serializable transaction, because the run-attempt / lease scans
-    /// aren't tenant-scoped and would pull the whole shard's task/lease activity
-    /// into an SSI read set — on a live, busy shard that conflicts on every
-    /// other tenant's work and never commits. Each per-attempt finalization is
-    /// itself atomic and tenant/job-scoped (exactly like a normal worker
-    /// outcome report or user-initiated cancel), so it commits regardless of
-    /// concurrent activity and can fix a stuck tenant on a live env with no
-    /// downtime.
+    /// This is an **emergency** action for recovering a tenant whose holders have
+    /// leaked. It deliberately touches **only** the concurrency holder rows: it
+    /// does NOT cancel or fail in-flight run attempts and does NOT touch leases,
+    /// pending tasks, or `JOB_STATUS`. In-flight attempts keep running to
+    /// completion exactly as normal — there is no orphaning risk, because no
+    /// lease or task is deleted out from under a job.
     ///
-    /// Finalization (NOT raw deletion — raw-deleting a lease while leaving
-    /// `JOB_STATUS = Running` orphans the job, because the lease reaper only
-    /// acts on leases and would never see it again):
-    /// - **Running (leased) attempts** are finalized through
-    ///   [`report_attempt_outcome`](Self::report_attempt_outcome) — the same
-    ///   call the lease reaper makes — as `Cancelled` if the job was cancelled,
-    ///   otherwise as a `WORKER_CRASHED` error (which fails the job or schedules
-    ///   a retry per its policy). This atomically deletes the lease, transitions
-    ///   `JOB_STATUS` off `Running`, releases the attempt's concurrency holders,
-    ///   and updates the status/time index and counters.
-    /// - **Queued (granted, not yet leased) attempts** are finalized through
-    ///   [`cancel_job`](Self::cancel_job), which deletes the pending task,
-    ///   transitions the `Scheduled` job to `Cancelled`, evicts the broker
-    ///   buffer, and releases any chain-accumulated holders. (A cancelled or
-    ///   failed job is restartable, so dropped work is recoverable.)
+    /// Tradeoff: freeing a held slot while its attempt is still running lets the
+    /// scanner grant another attempt for the same queue, so a job may briefly
+    /// **over-admit / double-run**. That is the accepted cost of an emergency
+    /// unblock — double-running is safe and far preferable to a wedged tenant.
     ///
     /// Semantics:
-    /// - **Point-in-time / best-effort.** Holders or attempts created for the
-    ///   tenant *after* the scans (including retries scheduled by the
-    ///   finalizations above) are not caught; re-run if needed (the operation is
-    ///   idempotent — finalizing an already-finalized attempt is a no-op, and
-    ///   re-deleting a missing holder is a no-op).
-    /// - **Partial progress is safe.** Each finalization and holder delete is
-    ///   independent; a failure on one attempt is logged and the sweep
-    ///   continues with the rest.
-    /// - **Clean release.** After finalizing attempts, any *remaining*
-    ///   orphaned holder rows (rows with no corresponding live attempt) are
-    ///   deleted and their in-memory counts released, and the grant scanner is
-    ///   woken so pending requests can be re-granted.
-    /// - Historical `ATTEMPT` records and concurrency *requests* are
-    ///   deliberately left untouched.
+    /// - **Point-in-time / best-effort.** Holders created for the tenant *after*
+    ///   the scan are not caught; re-run if needed.
+    /// - **Idempotent / re-runnable.** Re-deleting a missing holder row is a
+    ///   no-op, and `atomic_release` is a set removal, so releasing an
+    ///   already-released holder is harmless.
+    /// - Historical `ATTEMPT` records and concurrency *requests* are left
+    ///   untouched.
     #[tracing::instrument(skip_all, fields(shard = %self.name, tenant))]
-    pub async fn drop_tenant_holders_and_runattempts(
+    pub async fn drop_tenant_holders(
         &self,
         tenant: &str,
     ) -> Result<DropTenantStats, JobStoreShardError> {
-        // ---- Collect work via read-only scans (a point-in-time snapshot; no
-        // SSI read set, so the scans never conflict with concurrent activity) ----
-
         // Holders are tenant-prefixed, so a single prefix scan captures every
-        // holder for the tenant. Track (task_id, queue) for the post-finalize
-        // in-memory release of any rows not already released by an attempt
-        // finalization below. Holder counts have no persisted counter
-        // (in-memory only), so deleting the rows is all that's needed durably.
+        // holder for the tenant. Track (task_id, queue) for the in-memory release
+        // below; holder counts have no persisted counter (in-memory only), so
+        // deleting the rows is all that's needed durably.
+        //
+        // The scan is read-only (a point-in-time snapshot; no SSI read set), so
+        // it never conflicts with concurrent activity on a live, busy shard.
         let mut holders_to_release: Vec<(String, String)> = Vec::new();
         let mut holder_keys: Vec<Vec<u8>> = Vec::new();
         {
@@ -110,121 +75,7 @@ impl JobStoreShard {
             }
         }
 
-        // Queued (granted, not yet leased) RunAttempts live in the TASK queue,
-        // keyed by task_group (not tenant) — full-shard scan + filter by the
-        // tenant carried inside the RunAttempt. Collect the job ids so we can
-        // cancel each (which deletes the task and transitions the job).
-        let mut queued_job_ids: Vec<String> = Vec::new();
-        {
-            let start = tasks_prefix();
-            let end = end_bound(&start);
-            let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
-            while let Some(kv) = iter.next().await? {
-                let task = match decode_task(&kv.value) {
-                    Ok(task) => task,
-                    Err(e) => {
-                        warn!(error = %e, "skipping undecodable task during tenant drop");
-                        continue;
-                    }
-                };
-                if let Task::RunAttempt {
-                    tenant: t, job_id, ..
-                } = task
-                    && t == tenant
-                {
-                    queued_job_ids.push(job_id);
-                }
-            }
-        }
-
-        // Running (leased) RunAttempts: the TASK entry was removed at lease time
-        // and a LeaseRecord (which embeds the Task) was written under the LEASE
-        // prefix, keyed by task_id — full-shard scan + filter on the embedded
-        // task. Collect (task_id, job_id) so we can finalize each via the lease
-        // reaper's path. The two RunAttempt sets are disjoint (a leased task is
-        // no longer in TASK).
-        let mut leased_attempts: Vec<(String, String)> = Vec::new();
-        {
-            let start = leases_prefix();
-            let end = end_bound(&start);
-            let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
-            while let Some(kv) = iter.next().await? {
-                let task = match decode_lease(kv.value.clone()).and_then(|l| l.to_task()) {
-                    Ok(task) => task,
-                    Err(e) => {
-                        warn!(error = %e, "skipping undecodable lease during tenant drop");
-                        continue;
-                    }
-                };
-                if let Task::RunAttempt {
-                    id: task_id,
-                    tenant: t,
-                    job_id,
-                    ..
-                } = task
-                    && t == tenant
-                {
-                    leased_attempts.push((task_id, job_id));
-                }
-            }
-        }
-
-        let mut run_attempts_dropped = 0usize;
-
-        // ---- Finalize running (leased) attempts via the reaper's path ----
-        // Mirrors `reap_expired_leases`: a cancelled job reports Cancelled,
-        // otherwise WORKER_CRASHED (fail or retry per policy). This deletes the
-        // lease and transitions JOB_STATUS off Running atomically, so the job is
-        // never left orphaned in Running with no lease.
-        for (task_id, job_id) in &leased_attempts {
-            let was_cancelled = self.is_job_cancelled(tenant, job_id).await.unwrap_or(false);
-            let outcome = if was_cancelled {
-                AttemptOutcome::Cancelled
-            } else {
-                AttemptOutcome::Error {
-                    error_code: "WORKER_CRASHED".to_string(),
-                    error: b"run attempt force-dropped via drop_tenant_holders admin action"
-                        .to_vec(),
-                }
-            };
-            match self.report_attempt_outcome(task_id, outcome).await {
-                Ok(()) => run_attempts_dropped += 1,
-                Err(e) => {
-                    // Best-effort: a concurrent reaper/worker may have already
-                    // finalized this lease. Log and continue.
-                    warn!(
-                        task_id = %task_id,
-                        job_id = %job_id,
-                        error = %e,
-                        "failed to finalize leased run attempt during tenant drop"
-                    );
-                }
-            }
-        }
-
-        // ---- Finalize queued (Scheduled) attempts via cancel_job ----
-        // Deletes the pending task and transitions the job to Cancelled, so the
-        // job is never left orphaned in Scheduled with no task to run it.
-        for job_id in &queued_job_ids {
-            match self.cancel_job(tenant, job_id).await {
-                Ok(()) => run_attempts_dropped += 1,
-                Err(e) => {
-                    warn!(
-                        job_id = %job_id,
-                        error = %e,
-                        "failed to cancel queued run attempt during tenant drop"
-                    );
-                }
-            }
-        }
-
-        // ---- Delete any remaining orphaned holder rows ----
-        // Attempt finalizations above already released the holders for the
-        // attempts they handled; what remains are holder rows with no
-        // corresponding live attempt (genuine leaks). Deleting the snapshot is
-        // idempotent — already-released rows are no-ops — and only touches rows
-        // observed before finalization, so holders granted by retries scheduled
-        // above (new task ids) are left intact.
+        // ---- Delete the holder rows durably (chunked, idempotent) ----
         let mut batch = WriteBatch::new();
         let mut batch_count = 0usize;
         for key in &holder_keys {
@@ -242,8 +93,8 @@ impl JobStoreShard {
 
         // Release holders from in-memory counts and wake the grant scanner per
         // freed queue so pending requests get re-granted. `atomic_release` is a
-        // set removal (idempotent), so re-releasing a holder already released by
-        // a finalization above is harmless.
+        // set removal (idempotent), so re-releasing an already-released holder is
+        // harmless.
         for (task_id, queue) in &holders_to_release {
             self.concurrency
                 .counts()
@@ -253,7 +104,6 @@ impl JobStoreShard {
 
         Ok(DropTenantStats {
             holders_dropped: holder_keys.len(),
-            run_attempts_dropped,
         })
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1091,13 +1091,9 @@ impl Silo for SiloService {
         let (shard, tenant) = self
             .resolve_shard_and_tenant(&r.shard, r.tenant.as_deref())
             .await?;
-        let stats = shard
-            .drop_tenant_holders_and_runattempts(&tenant)
-            .await
-            .map_err(map_err)?;
+        let stats = shard.drop_tenant_holders(&tenant).await.map_err(map_err)?;
         Ok(Response::new(DropTenantHoldersResponse {
             holders_dropped: stats.holders_dropped as u64,
-            run_attempts_dropped: stats.run_attempts_dropped as u64,
         }))
     }
 

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -941,7 +941,8 @@ async fn cancel_job_handler(
     }
 }
 
-/// Forcibly drop all concurrency holders and in-flight run attempts for a tenant.
+/// Forcibly drop all concurrency holders for a tenant, freeing held slots so
+/// stuck jobs can be re-granted. In-flight run attempts are left running.
 ///
 /// Resolves the tenant's shard from the cluster query engine and operates on a
 /// single shard (per the admin action's scope). If the tenant spans multiple
@@ -1004,8 +1005,8 @@ async fn drop_tenant_holders_handler(
     {
         Ok(stats) => {
             let mut body = format!(
-                "Dropped {} holders and {} run attempts on shard {}.",
-                stats.holders_dropped, stats.run_attempts_dropped, shard_id
+                "Dropped {} holders on shard {}.",
+                stats.holders_dropped, shard_id
             );
             if shard_ids.len() > 1 {
                 body.push_str(&format!(

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -944,10 +944,12 @@ async fn cancel_job_handler(
 /// Forcibly drop all concurrency holders for a tenant, freeing held slots so
 /// stuck jobs can be re-granted. In-flight run attempts are left running.
 ///
-/// Resolves the tenant's shard from the cluster query engine and operates on a
-/// single shard (per the admin action's scope). If the tenant spans multiple
-/// shards, only the first is touched and the response notes the others were
-/// skipped.
+/// Resolves the tenant's owning shard via the shard owner map (XXH64 hash →
+/// range lookup) and operates on that single shard. This is an O(log n) metadata
+/// lookup — it deliberately does NOT scan the `jobs` table, which can time out
+/// for a tenant with a huge backlog (exactly the case this emergency button is
+/// for). Tradeoff: orphaned holders on a shard the tenant no longer hashes to
+/// (after a range change) are not surfaced here.
 async fn drop_tenant_holders_handler(
     State(state): State<AppState>,
     Query(params): Query<TenantParams>,
@@ -959,43 +961,13 @@ async fn drop_tenant_holders_handler(
         ))
     }
 
-    let tenant_escaped = sql_string_literal(&params.name);
-    let sql = format!(
-        "SELECT DISTINCT shard_id FROM jobs WHERE tenant = '{}'",
-        tenant_escaped
-    );
-
-    // Resolve which shard(s) the tenant lives on.
-    let mut shard_ids: Vec<crate::shard_range::ShardId> = Vec::new();
-    match state.query_engine.sql(&sql).await {
-        Ok(df) => match df.collect().await {
-            Ok(batches) => {
-                for batch in batches {
-                    let Some(col) = batch.column_by_name("shard_id").and_then(|c| {
-                        c.as_any()
-                            .downcast_ref::<datafusion::arrow::array::StringArray>()
-                    }) else {
-                        continue;
-                    };
-                    for i in 0..batch.num_rows() {
-                        if col.is_null(i) {
-                            continue;
-                        }
-                        if let Ok(s) = crate::shard_range::ShardId::parse(col.value(i))
-                            && !shard_ids.contains(&s)
-                        {
-                            shard_ids.push(s);
-                        }
-                    }
-                }
-            }
-            Err(e) => return error_box(&format!("Failed to resolve tenant shard: {}", e)),
-        },
+    // Resolve the tenant's owning shard from the owner map (no table scan).
+    let shard_id = match state.coordinator.get_shard_owner_map().await {
+        Ok(map) => map.shard_for_tenant(&params.name),
         Err(e) => return error_box(&format!("Failed to resolve tenant shard: {}", e)),
-    }
-
-    let Some(shard_id) = shard_ids.first().copied() else {
-        return error_box("No data found for this tenant — nothing to drop.");
+    };
+    let Some(shard_id) = shard_id else {
+        return error_box("No owning shard found for this tenant — nothing to drop.");
     };
 
     match state
@@ -1004,17 +976,10 @@ async fn drop_tenant_holders_handler(
         .await
     {
         Ok(stats) => {
-            let mut body = format!(
+            let body = format!(
                 "Dropped {} holders on shard {}.",
                 stats.holders_dropped, shard_id
             );
-            if shard_ids.len() > 1 {
-                body.push_str(&format!(
-                    "\nNote: tenant spans {} shards; {} additional shard(s) were not touched.",
-                    shard_ids.len(),
-                    shard_ids.len() - 1
-                ));
-            }
             Html(format!(
                 r#"<div class="bg-emerald-900/30 border border-emerald-700 p-4"><div class="text-emerald-400 text-sm font-medium">Done</div><pre class="text-emerald-300 text-xs mt-2 whitespace-pre-wrap">{}</pre></div>"#,
                 body

--- a/templates/tenant.html
+++ b/templates/tenant.html
@@ -7,11 +7,11 @@
     <div class="flex items-center justify-between">
         <h1 class="text-xl font-bold text-zinc-100">Tenant: <span class="text-emerald-400">{{ tenant_name }}</span></h1>
         <form hx-post="/tenant/drop-state?name={{ tenant_name_url }}"
-              hx-confirm="Drop ALL holders and run attempts for tenant {{ tenant_name }}? This cannot be undone."
+              hx-confirm="Force-drop ALL concurrency holders for tenant {{ tenant_name }} so stuck jobs can run again? In-flight jobs are NOT cancelled and may briefly double-run."
               hx-target="#drop-state-result" hx-swap="innerHTML" class="inline">
             <button type="submit"
                     class="px-3 py-1 text-sm bg-red-900/50 border border-red-700 text-red-400 hover:bg-red-900 transition-colors">
-                Drop holders &amp; run attempts
+                Drop holders
             </button>
         </form>
     </div>

--- a/tests/job_store_shard_drop_tenant_holders_tests.rs
+++ b/tests/job_store_shard_drop_tenant_holders_tests.rs
@@ -31,11 +31,11 @@ async fn enqueue_with_holder(
         .expect("enqueue")
 }
 
-/// Drops both a queued and a running (leased) run attempt plus their holders for
-/// one tenant, performs a clean in-memory release, and leaves another tenant's
-/// state untouched.
+/// Drops every concurrency holder for one tenant (both a queued and a running
+/// holder), performs a clean in-memory release, and leaves another tenant's
+/// holders untouched. The run attempts themselves are NOT dropped.
 #[silo::test]
-async fn drop_tenant_clears_holders_runattempts_and_leases() {
+async fn drop_tenant_clears_holders_and_preserves_runattempts() {
     let (_tmp, shard) = open_temp_shard().await;
     let now = now_ms();
 
@@ -55,7 +55,8 @@ async fn drop_tenant_clears_holders_runattempts_and_leases() {
         .tasks;
     assert_eq!(leased.len(), 1, "exactly one task leased");
 
-    // Pre-conditions: tenant-a has 2 holders; tenant-b has 1.
+    // Pre-conditions: tenant-a has 2 holders; tenant-b has 1. One task is leased,
+    // so one queued TASK entry and one lease exist for tenant-a.
     assert_eq!(
         count_concurrency_holders_for_tenant(shard.db(), "tenant-a").await,
         2
@@ -64,25 +65,39 @@ async fn drop_tenant_clears_holders_runattempts_and_leases() {
         count_concurrency_holders_for_tenant(shard.db(), "tenant-b").await,
         1
     );
-    assert!(count_lease_keys(shard.db()).await >= 1, "a lease exists");
+    let leases_before = count_lease_keys(shard.db()).await;
+    let tasks_before = count_task_keys(shard.db()).await;
+    assert!(leases_before >= 1, "a lease exists");
 
     // Act.
     let stats = shard
-        .drop_tenant_holders_and_runattempts("tenant-a")
+        .drop_tenant_holders("tenant-a")
         .await
-        .expect("drop tenant state");
+        .expect("drop tenant holders");
 
-    // Both holders and both run attempts (one queued, one leased) were dropped.
+    // Both of tenant-a's holders were dropped.
     assert_eq!(stats.holders_dropped, 2);
-    assert_eq!(stats.run_attempts_dropped, 2);
 
-    // tenant-a is fully cleared, in durable storage and in-memory counts.
+    // tenant-a's holders are fully cleared, in durable storage and in-memory.
     assert_eq!(
         count_concurrency_holders_for_tenant(shard.db(), "tenant-a").await,
         0
     );
     assert_eq!(shard.concurrency_holder_count("tenant-a", "qA"), 0);
     assert_eq!(shard.concurrency_holder_count("tenant-a", "qB"), 0);
+
+    // The run attempts themselves survive: leases and queued TASK entries are
+    // untouched (only holders were freed).
+    assert_eq!(
+        count_lease_keys(shard.db()).await,
+        leases_before,
+        "leases must survive a holder drop"
+    );
+    assert_eq!(
+        count_task_keys(shard.db()).await,
+        tasks_before,
+        "queued tasks must survive a holder drop"
+    );
 
     // tenant-b is untouched.
     assert_eq!(
@@ -92,12 +107,11 @@ async fn drop_tenant_clears_holders_runattempts_and_leases() {
     assert_eq!(shard.concurrency_holder_count("tenant-b", "qC"), 1);
 }
 
-/// Regression: dropping a tenant's *running* (leased) attempt must finalize the
-/// job to a terminal status — it must never be left orphaned in `Running` with
-/// no lease. The lease reaper is lease-driven, so a Running job with no lease
-/// would never be cleaned up (this is exactly the bug raw lease-deletion caused).
+/// Dropping a tenant's holders must leave a *running* (leased) job exactly where
+/// it is: still `Running`, with its lease intact. The attempt keeps running to
+/// completion; only the held slot is freed.
 #[silo::test]
-async fn drop_tenant_finalizes_running_job_instead_of_orphaning() {
+async fn drop_tenant_leaves_running_job_running() {
     use silo::job::JobStatusKind;
 
     let (_tmp, shard) = open_temp_shard().await;
@@ -126,42 +140,36 @@ async fn drop_tenant_finalizes_running_job_instead_of_orphaning() {
 
     // Act.
     let stats = shard
-        .drop_tenant_holders_and_runattempts("tenant-a")
+        .drop_tenant_holders("tenant-a")
         .await
-        .expect("drop tenant state");
-    assert_eq!(stats.run_attempts_dropped, 1);
+        .expect("drop tenant holders");
+    assert_eq!(stats.holders_dropped, 1);
 
-    // The job must be finalized to a terminal status — NOT left in Running —
-    // and its lease must be gone, so nothing is orphaned beyond the reaper's reach.
+    // The job stays Running with its lease intact — the attempt is not finalized.
     let status = shard
         .get_job_status("tenant-a", &job_id)
         .await
         .expect("status")
         .expect("job exists");
-    assert!(
-        status.is_terminal(),
-        "job must be terminal after drop, got {:?}",
-        status.kind
-    );
-    assert_ne!(
+    assert_eq!(
         status.kind,
         JobStatusKind::Running,
-        "job must not be orphaned in Running"
+        "running job must stay Running after a holder drop, got {:?}",
+        status.kind
     );
-    assert_eq!(
-        count_lease_keys(shard.db()).await,
-        0,
-        "no lease may be left behind"
+    assert!(
+        count_lease_keys(shard.db()).await >= 1,
+        "the lease must survive"
     );
+    // The held slot is freed.
     assert_eq!(shard.concurrency_holder_count("tenant-a", "qA"), 0);
 }
 
-/// Regression: dropping a tenant's *queued* (Scheduled, not yet leased) attempt
-/// must finalize the job to `Cancelled` — it must never be left orphaned in
-/// `Scheduled` with no task to run it. (Raw task-deletion left it stuck in
-/// `Scheduled` with nothing in the queue, invisible to every recovery path.)
+/// Dropping a tenant's holders must leave a *queued* (Scheduled, not yet leased)
+/// job exactly where it is: still `Scheduled`, with its queued task intact. Only
+/// the held slot is freed.
 #[silo::test]
-async fn drop_tenant_cancels_queued_job_instead_of_orphaning() {
+async fn drop_tenant_leaves_queued_job_scheduled() {
     use silo::job::JobStatusKind;
 
     let (_tmp, shard) = open_temp_shard().await;
@@ -179,16 +187,17 @@ async fn drop_tenant_cancels_queued_job_instead_of_orphaning() {
         JobStatusKind::Scheduled,
         "job is Scheduled pre-drop"
     );
+    let tasks_before = count_task_keys(shard.db()).await;
+    assert!(tasks_before >= 1, "a queued task exists");
 
     // Act.
     let stats = shard
-        .drop_tenant_holders_and_runattempts("tenant-a")
+        .drop_tenant_holders("tenant-a")
         .await
-        .expect("drop tenant state");
-    assert_eq!(stats.run_attempts_dropped, 1);
+        .expect("drop tenant holders");
+    assert_eq!(stats.holders_dropped, 1);
 
-    // The queued job must be transitioned to Cancelled — not left orphaned in
-    // Scheduled — and its holder released.
+    // The queued job stays Scheduled with its task intact — not cancelled.
     let status = shard
         .get_job_status("tenant-a", &job_id)
         .await
@@ -196,97 +205,28 @@ async fn drop_tenant_cancels_queued_job_instead_of_orphaning() {
         .expect("job exists");
     assert_eq!(
         status.kind,
-        JobStatusKind::Cancelled,
-        "queued job must be Cancelled after drop, got {:?}",
-        status.kind
-    );
-    assert_eq!(shard.concurrency_holder_count("tenant-a", "qA"), 0);
-}
-
-/// Dropping a *running* attempt whose job was already cancelled must finalize it
-/// as `Cancelled` (the `was_cancelled` branch), not as a `WORKER_CRASHED`
-/// failure. This mirrors what the lease reaper does for a cancelled job and
-/// preserves the user's intent through the forced drop.
-#[silo::test]
-async fn drop_tenant_finalizes_cancelled_running_job_as_cancelled() {
-    use silo::job::JobStatusKind;
-
-    let (_tmp, shard) = open_temp_shard().await;
-    let now = now_ms();
-
-    let job_id = enqueue_with_holder(&shard, "tenant-a", "qA", now).await;
-
-    // Lease it so the job is Running, backed by a durable lease.
-    let leased = shard
-        .dequeue("w", "default", 1)
-        .await
-        .expect("dequeue")
-        .tasks;
-    assert_eq!(leased.len(), 1, "exactly one task leased");
-
-    // Cancel the running job: this only records the cancellation flag (the
-    // worker would normally ack it on heartbeat), leaving the job in Running
-    // with a live lease — exactly the state the drop must finalize correctly.
-    shard
-        .cancel_job("tenant-a", &job_id)
-        .await
-        .expect("cancel running job");
-    let status = shard
-        .get_job_status("tenant-a", &job_id)
-        .await
-        .expect("status")
-        .expect("job exists");
-    assert_eq!(
-        status.kind,
-        JobStatusKind::Running,
-        "cancel of a Running job only sets the flag; status stays Running"
-    );
-    assert!(
-        shard
-            .is_job_cancelled("tenant-a", &job_id)
-            .await
-            .expect("cancellation lookup"),
-        "cancellation flag is set pre-drop"
-    );
-
-    // Act.
-    let stats = shard
-        .drop_tenant_holders_and_runattempts("tenant-a")
-        .await
-        .expect("drop tenant state");
-    assert_eq!(stats.run_attempts_dropped, 1);
-
-    // Because the job was cancelled, the leased attempt must be finalized as
-    // Cancelled — NOT Failed (which is what the WORKER_CRASHED path produces).
-    let status = shard
-        .get_job_status("tenant-a", &job_id)
-        .await
-        .expect("status")
-        .expect("job exists");
-    assert_eq!(
-        status.kind,
-        JobStatusKind::Cancelled,
-        "cancelled running job must finalize as Cancelled, not {:?}",
+        JobStatusKind::Scheduled,
+        "queued job must stay Scheduled after a holder drop, got {:?}",
         status.kind
     );
     assert_eq!(
-        count_lease_keys(shard.db()).await,
-        0,
-        "no lease may be left behind"
+        count_task_keys(shard.db()).await,
+        tasks_before,
+        "the queued task must survive"
     );
+    // The held slot is freed.
     assert_eq!(shard.concurrency_holder_count("tenant-a", "qA"), 0);
 }
 
-/// Dropping a tenant with no holders/run attempts is a no-op that returns zeros.
+/// Dropping a tenant with no holders is a no-op that returns zero.
 #[silo::test]
 async fn drop_tenant_with_no_state_is_a_noop() {
     let (_tmp, shard) = open_temp_shard().await;
 
     let stats = shard
-        .drop_tenant_holders_and_runattempts("ghost")
+        .drop_tenant_holders("ghost")
         .await
-        .expect("drop tenant state");
+        .expect("drop tenant holders");
 
     assert_eq!(stats.holders_dropped, 0);
-    assert_eq!(stats.run_attempts_dropped, 0);
 }

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -531,8 +531,9 @@ export interface CancelJobRequest {
 export interface CancelJobResponse {
 }
 /**
- * Forcibly drop all concurrency holders and in-flight run attempts for a tenant
- * on a single shard. Admin/operator action used to clear stuck concurrency state.
+ * Forcibly drop all concurrency holders for a tenant on a single shard, freeing
+ * held slots so stuck jobs can be re-granted. Emergency admin/operator action;
+ * in-flight run attempts are left running (and may briefly double-run).
  *
  * @generated from protobuf message silo.v1.DropTenantHoldersRequest
  */
@@ -556,10 +557,6 @@ export interface DropTenantHoldersResponse {
      * @generated from protobuf field: uint64 holders_dropped = 1
      */
     holdersDropped: bigint; // Number of concurrency holders deleted.
-    /**
-     * @generated from protobuf field: uint64 run_attempts_dropped = 2
-     */
-    runAttemptsDropped: bigint; // Number of in-flight run attempts deleted.
 }
 /**
  * Restart a cancelled or failed job, allowing it to be processed again.
@@ -3422,14 +3419,12 @@ export const DropTenantHoldersRequest = new DropTenantHoldersRequest$Type();
 class DropTenantHoldersResponse$Type extends MessageType<DropTenantHoldersResponse> {
     constructor() {
         super("silo.v1.DropTenantHoldersResponse", [
-            { no: 1, name: "holders_dropped", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
-            { no: 2, name: "run_attempts_dropped", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
+            { no: 1, name: "holders_dropped", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
     create(value?: PartialMessage<DropTenantHoldersResponse>): DropTenantHoldersResponse {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.holdersDropped = 0n;
-        message.runAttemptsDropped = 0n;
         if (value !== undefined)
             reflectionMergePartial<DropTenantHoldersResponse>(this, message, value);
         return message;
@@ -3441,9 +3436,6 @@ class DropTenantHoldersResponse$Type extends MessageType<DropTenantHoldersRespon
             switch (fieldNo) {
                 case /* uint64 holders_dropped */ 1:
                     message.holdersDropped = reader.uint64().toBigInt();
-                    break;
-                case /* uint64 run_attempts_dropped */ 2:
-                    message.runAttemptsDropped = reader.uint64().toBigInt();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -3460,9 +3452,6 @@ class DropTenantHoldersResponse$Type extends MessageType<DropTenantHoldersRespon
         /* uint64 holders_dropped = 1; */
         if (message.holdersDropped !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.holdersDropped);
-        /* uint64 run_attempts_dropped = 2; */
-        if (message.runAttemptsDropped !== 0n)
-            writer.tag(2, WireType.Varint).uint64(message.runAttemptsDropped);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);


### PR DESCRIPTION
## What

Turns the tenant-page **"Drop holders & run attempts"** admin button (the `DropTenantHolders` RPC) into a true emergency unblock that **only frees concurrency holders**.

Previously the action also finalized in-flight run attempts — leased attempts as `WORKER_CRASHED`, queued attempts as `Cancelled`. That destroys live work, which is the wrong behavior when you just need a tenant whose holders have leaked to start processing again.

## Behavior now

`JobStoreShard::drop_tenant_holders` (renamed from `drop_tenant_holders_and_runattempts`) does only: scan the tenant's holder prefix → delete the rows → `atomic_release` the in-memory counts → `request_grant` to wake the grant scanner.

Leases, queued tasks, and `JOB_STATUS` are left **untouched**, so:
- In-flight attempts keep running to completion (no orphaning — the old "raw lease delete orphans the job" concern no longer applies).
- The only side effect is freed slots, which may briefly **over-admit / double-run**. That's the accepted emergency tradeoff: double-running is safe and far preferable to a wedged tenant.

## Changes

- **Core:** `src/job_store_shard/drop_tenant_holders.rs` — rename + reduce to holder-only; `DropTenantStats` now just `holders_dropped`; docstring rewritten.
- **Proto:** `proto/silo.proto` — remove `run_attempts_dropped` from `DropTenantHoldersResponse`, `reserved 2;` (post-launch). Regenerated the TS client (`typescript_client/src/pb/silo.ts`).
- **Plumbing:** `src/server.rs`, `src/cluster_client.rs` updated for the new name/stats.
- **UI:** `src/webui.rs` result banner → "Dropped N holders…"; `templates/tenant.html` button → "Drop holders" with a confirm note that jobs are not cancelled and may briefly double-run.
- **Tests:** rewritten to prove holders are freed while run attempts, leases, and job statuses survive.

## Verification

- `cargo build`, `cargo test --test job_store_shard_drop_tenant_holders_tests` (4/4), `cargo fmt --check`, `tsc --noEmit` — all green.

## Notes

Stacked on `kirin/nonblocking-bg-action-counter-rebuild` (PR #373).