### PR TITLE
Fix silent data loss when splitting shards on object-store backends

### DIFF
--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -517,6 +517,25 @@ impl ShardSplitter {
                             parent_shard_id
                         )))
                     })?;
+
+                    // Capture the parent's whole-shard job count from the still-open
+                    // handle, before closing it. The post-clone verification below
+                    // confirms each child holds this full set (a fresh clone is a
+                    // byte-for-byte copy; cleanup trims each child to its range only
+                    // after commit), catching the empty-child data-loss signature.
+                    let parent_total_jobs = parent_shard
+                        .get_counters()
+                        .await
+                        .map_err(|e| {
+                            SplitExecutionError::PreCommit(CoordinationError::BackendError(
+                                format!(
+                                    "failed to read parent shard {} counters before cloning: {}",
+                                    parent_shard_id, e
+                                ),
+                            ))
+                        })?
+                        .total_jobs;
+
                     parent_shard.close().await.map_err(|e| {
                         SplitExecutionError::PreCommit(CoordinationError::BackendError(format!(
                             "failed to close parent shard before cloning: {}",
@@ -559,7 +578,36 @@ impl ShardSplitter {
                         parent_shard_id = %parent_shard_id,
                         left_child = %split.left_child_id,
                         right_child = %split.right_child_id,
-                        "cloning complete, updating shard map"
+                        "cloning complete, verifying children before commit"
+                    );
+
+                    // Defense-in-depth: before the commit point, open each child
+                    // and confirm it holds the parent's full job set. A child that
+                    // opens empty/short (the object-store resolution bug's data-loss
+                    // signature) fails here, aborting the split as
+                    // PreCommitParentClosed so the shard map stays untouched and the
+                    // parent is recovered/reopenable -- never silent data loss.
+                    self.ctx
+                        .factory
+                        .verify_cloned_children_match_parent(
+                            parent_total_jobs,
+                            &[split.left_child_id, split.right_child_id],
+                        )
+                        .await
+                        .map_err(|e| {
+                            SplitExecutionError::PreCommitParentClosed(
+                                CoordinationError::BackendError(format!(
+                                    "post-clone child verification failed for split of {}: {}",
+                                    parent_shard_id, e
+                                )),
+                            )
+                        })?;
+
+                    info!(
+                        parent_shard_id = %parent_shard_id,
+                        left_child = %split.left_child_id,
+                        right_child = %split.right_child_id,
+                        "children verified, updating shard map"
                     );
 
                     // Pre-add BOTH children to owned set BEFORE updating the shard map.

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -820,9 +820,12 @@ impl ShardFactory {
         )
         .await?;
 
-        let total_jobs = shard.get_counters().await?.total_jobs;
+        // Always close the raw handle, even if the counter read fails, so the
+        // shard's SlateDB instance and its spawned background tasks (grant
+        // scanner, reconcilers) are released -- JobStoreShard has no Drop.
+        let counters = shard.get_counters().await;
         shard.close().await?;
-        Ok(total_jobs)
+        Ok(counters?.total_jobs)
     }
 
     /// Get the database template used by this factory.

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -87,7 +87,10 @@ impl ShardFactory {
         Self {
             instances: DashMap::new(),
             template: DatabaseTemplate {
-                path: "/noop".to_string(),
+                // A valid template path needs the %shard% placeholder at a path
+                // boundary. The root is unique per factory so the shared Memory
+                // store (the default backend) does not bleed across noop factories.
+                path: format!("noop-{}/%shard%", ShardId::new()),
                 apply_wal_on_close: false,
                 ..Default::default()
             },
@@ -744,6 +747,84 @@ impl ShardFactory {
         Ok(())
     }
 
+    /// Verify that each freshly cloned child holds the parent's full job set.
+    ///
+    /// A fresh SlateDB clone is a byte-for-byte copy of the parent, so
+    /// immediately after `clone_closed_shard` -- before post-commit cleanup
+    /// trims each child to its range -- every child's whole-shard `total_jobs`
+    /// must equal the parent's pre-close count. An empty or mis-placed child
+    /// (the object-store split data-loss signature) reads `0` and trips this
+    /// check, letting the split abort before the shard-map commit point.
+    ///
+    /// This is a manifest-landed tripwire keyed on the empty-child signature,
+    /// not a full row-integrity audit: a clone that landed the counter key but
+    /// corrupted rows would still pass.
+    pub async fn verify_cloned_children_match_parent(
+        &self,
+        parent_total_jobs: i64,
+        child_ids: &[ShardId],
+    ) -> Result<(), ShardFactoryError> {
+        for child_id in child_ids {
+            let child_total_jobs = self.read_cloned_shard_total_jobs(child_id).await?;
+            if child_total_jobs != parent_total_jobs {
+                return Err(ShardFactoryError::ChildVerification(format!(
+                    "cloned child {child_id} holds {child_total_jobs} jobs but parent held \
+                     {parent_total_jobs}; aborting split before commit to avoid data loss"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Open a freshly cloned child's database with the raw `open_with_resolved_store`
+    /// primitive, read its whole-shard `total_jobs`, and close it.
+    ///
+    /// Uses the raw open -- NOT `open` -- so the child is never registered in the
+    /// `instances` map: `open` caches the instance in the per-shard OnceCell, and
+    /// the post-commit `open(child)` would then return this stale pre-commit
+    /// handle instead of opening the committed child. Hydration is disabled and
+    /// `get_counters` reads a single merged counter key, so the check is O(1)
+    /// even on a multi-million-job shard.
+    async fn read_cloned_shard_total_jobs(
+        &self,
+        shard_id: &ShardId,
+    ) -> Result<i64, ShardFactoryError> {
+        let name = shard_id.to_string();
+        let (resolved, db_path) =
+            Self::resolve_at_root(&self.template.backend, &self.template.path, &name)?;
+        let wal_store = self.resolve_wal_store(&name)?;
+
+        let shard = JobStoreShard::open_with_resolved_store(
+            name.clone(),
+            &db_path,
+            OpenShardOptions {
+                store: resolved.store,
+                wal_store,
+                wal_close_config: None,
+                slatedb_settings: self.template.slatedb.clone(),
+                memory_cache: self.template.memory_cache.clone(),
+                rate_limiter: Arc::clone(&self.rate_limiter),
+                metrics: self.metrics.clone(),
+                concurrency_reconcile_interval: Duration::from_millis(
+                    self.template.concurrency_reconcile_interval_ms.max(1),
+                ),
+                counter_reconciliation_seconds: None,
+                hydrate_all_at_startup: false,
+                grant_scanner_batch_size: self.template.grant_scanner_batch_size,
+                grant_scanner_buffer_size: self.template.grant_scanner_buffer_size,
+                grant_scanner_concurrency: self.template.grant_scanner_concurrency,
+                completed_job_expire_s: self.template.completed_job_expire_s,
+                terminal_job_expire_s: self.template.terminal_job_expire_s,
+            },
+            ShardRange::full(),
+        )
+        .await?;
+
+        let total_jobs = shard.get_counters().await?.total_jobs;
+        shard.close().await?;
+        Ok(total_jobs)
+    }
+
     /// Get the database template used by this factory.
     pub fn template(&self) -> &DatabaseTemplate {
         &self.template
@@ -766,6 +847,9 @@ impl std::fmt::Display for CloseAllError {
 pub enum ShardFactoryError {
     #[error("clone error: {0}")]
     CloneError(String),
+
+    #[error("child verification error: {0}")]
+    ChildVerification(String),
 
     #[error("storage error: {0}")]
     Storage(#[from] crate::storage::StorageError),

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -293,13 +293,21 @@ impl ShardFactory {
             let resolved = resolve_object_store(backend, root_path)?;
             Ok((resolved, shard_name.to_string()))
         } else {
-            // Object store backends (Memory, S3, GCS, URL): resolve full path
-            let full_path = template_path
-                .replace("%shard%", shard_name)
-                .replace("{shard}", shard_name);
-            let resolved = resolve_object_store(backend, &full_path)?;
-            let db_path = resolved.canonical_path.clone();
-            Ok((resolved, db_path))
+            // Object store backends (Memory, S3, GCS, URL): resolve at the shared
+            // storage root (the prefix before the %shard% placeholder), symmetric
+            // with the local-FS branch. db_path is the bare shard name — a single
+            // relative segment under the shared root.
+            //
+            // This makes the parent store a correct shared ancestor of both
+            // children in clone_closed_shard, so a child's clone destination
+            // (<root>/<shard>) equals the path `open` later reads. Resolving the
+            // full per-shard path instead would root each shard at its own prefix
+            // (and double-nest as <root>/<shard>/<shard> for URL-style backends),
+            // leaving the clone unreachable from the child's open path.
+            let pos = Self::validate_template_path(template_path)?;
+            let root = template_path[..pos].trim_end_matches('/');
+            let resolved = resolve_object_store(backend, root)?;
+            Ok((resolved, shard_name.to_string()))
         }
     }
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -297,18 +297,27 @@ impl ShardFactory {
             Ok((resolved, shard_name.to_string()))
         } else {
             // Object store backends (Memory, S3, GCS, URL): resolve at the shared
-            // storage root (the prefix before the %shard% placeholder), symmetric
-            // with the local-FS branch. db_path is the bare shard name — a single
-            // relative segment under the shared root.
+            // storage root so a child's clone destination equals the path `open`
+            // reads for that child. When the template carries a %shard% (or
+            // {shard}) placeholder, the root is the prefix before it; otherwise the
+            // whole path is the root. db_path is always the bare shard name — a
+            // single relative segment under the shared root — so the (store,
+            // db_path) pair is identical between clone and open.
             //
             // This makes the parent store a correct shared ancestor of both
-            // children in clone_closed_shard, so a child's clone destination
-            // (<root>/<shard>) equals the path `open` later reads. Resolving the
-            // full per-shard path instead would root each shard at its own prefix
-            // (and double-nest as <root>/<shard>/<shard> for URL-style backends),
-            // leaving the clone unreachable from the child's open path.
-            let pos = Self::validate_template_path(template_path)?;
-            let root = template_path[..pos].trim_end_matches('/');
+            // children in clone_closed_shard. Resolving the full per-shard path
+            // instead would root each shard at its own prefix (and double-nest as
+            // <root>/<shard>/<shard> for URL-style backends), leaving the clone
+            // unreachable from the child's open path. Unlike the local-FS branch,
+            // this does not require the placeholder at a path boundary — object
+            // stores are key/value and impose no directory semantics.
+            let placeholder_pos = template_path
+                .find("%shard%")
+                .or_else(|| template_path.find("{shard}"));
+            let root = match placeholder_pos {
+                Some(pos) => template_path[..pos].trim_end_matches('/'),
+                None => template_path,
+            };
             let resolved = resolve_object_store(backend, root)?;
             Ok((resolved, shard_name.to_string()))
         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,6 +1,8 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use slatedb::object_store::ObjectStore;
+use slatedb::object_store::memory::InMemory;
 use slatedb::{Db, Error as SlateError};
 use std::fs;
 use std::path::Path;
@@ -8,6 +10,17 @@ use thiserror::Error;
 use url::Url;
 
 use crate::settings::Backend;
+
+/// Process-wide registry of in-memory stores keyed by root path.
+///
+/// `Backend::Memory` shards under the same root must share one `InMemory` so
+/// that multi-shard operations (clone/split, close-then-reopen) see each other's
+/// data, matching how a real object store behaves. Distinct roots stay isolated,
+/// so unrelated factories — each rooted at a unique path — do not bleed state.
+fn memory_store_registry() -> &'static Mutex<HashMap<String, Arc<InMemory>>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, Arc<InMemory>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 #[derive(Debug, Error)]
 pub enum StorageError {
@@ -54,11 +67,23 @@ pub fn resolve_object_store(backend: &Backend, path: &str) -> Result<ResolvedSto
                 root_path: canonical_str,
             })
         }
-        Backend::Memory => Ok(ResolvedStore {
-            store: Arc::new(slatedb::object_store::memory::InMemory::new()),
-            canonical_path: path.to_string(),
-            root_path: path.to_string(),
-        }),
+        Backend::Memory => {
+            let store = {
+                let mut registry = memory_store_registry()
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                Arc::clone(
+                    registry
+                        .entry(path.to_string())
+                        .or_insert_with(|| Arc::new(InMemory::new())),
+                )
+            };
+            Ok(ResolvedStore {
+                store,
+                canonical_path: path.to_string(),
+                root_path: path.to_string(),
+            })
+        }
         Backend::S3 | Backend::Gcs | Backend::Url => {
             // Interpret path as a URL understood by SlateDB's resolver, e.g. s3://bucket/prefix or gs://bucket/prefix
             let store = Db::resolve_object_store(path)?;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -17,6 +17,10 @@ use crate::settings::Backend;
 /// that multi-shard operations (clone/split, close-then-reopen) see each other's
 /// data, matching how a real object store behaves. Distinct roots stay isolated,
 /// so unrelated factories — each rooted at a unique path — do not bleed state.
+///
+/// Entries are never evicted: each distinct root holds its `InMemory` for the
+/// life of the process. This is acceptable because Memory is a dev/test-only
+/// backend; production deployments use S3/GCS and never reach this registry.
 fn memory_store_registry() -> &'static Mutex<HashMap<String, Arc<InMemory>>> {
     static REGISTRY: OnceLock<Mutex<HashMap<String, Arc<InMemory>>>> = OnceLock::new();
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -5,7 +5,7 @@ use silo::coordination::SplitPhase;
 use silo::coordination::{Coordinator, EtcdCoordinator, ShardSplitter};
 use silo::factory::ShardFactory;
 use silo::gubernator::MockGubernatorClient;
-use silo::settings::{Backend, DatabaseTemplate};
+use silo::settings::{Backend, DatabaseTemplate, WalConfig};
 use silo::shard_range::ShardId;
 use tokio::sync::Mutex;
 
@@ -32,6 +32,27 @@ fn make_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
             // Use Fs backend for split tests because SlateDB cloning requires a real object store
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
+            ..Default::default()
+        },
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
+/// Memory-backed factory for object-store split coverage: parent and children
+/// resolve under one shared store root, with a separate Memory WAL store per
+/// shard. The unique root (the test's unique prefix) keeps the process-global
+/// in-memory store from bleeding across test runs.
+fn make_memory_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
+    let root = format!("silo-split-mem-{}-{}", prefix, node_id);
+    Arc::new(ShardFactory::new(
+        DatabaseTemplate {
+            backend: Backend::Memory,
+            path: format!("{root}/data/%shard%"),
+            wal: Some(WalConfig {
+                backend: Backend::Memory,
+                path: format!("{root}/wal/%shard%"),
+            }),
             ..Default::default()
         },
         MockGubernatorClient::new_arc(),
@@ -531,6 +552,125 @@ async fn execute_split_completes_full_cycle() {
         assert!(
             routed.id == split.left_child_id || routed.id == split.right_child_id,
             "tenant should route to one of the children"
+        );
+    }
+
+    c1.shutdown().await.unwrap();
+    let _ = h1.abort();
+}
+
+/// Drive a full split on the shared-root Memory backend (an object store, with a
+/// separate WAL store) and assert every enqueued job survives in the child that
+/// now owns its tenant's range. This is the object-store analogue of the
+/// local-FS full-cycle split -- the state-machine-level regression guard for the
+/// resolution data-loss bug, and proof the WAL + object-store split path opens
+/// children without "wal store reconfiguration unsupported".
+#[silo::test(flavor = "multi_thread", worker_threads = 4)]
+async fn execute_split_preserves_jobs_on_object_store() {
+    let _guard = acquire_test_mutex().await;
+
+    let prefix = unique_prefix();
+    let num_shards: u32 = 1;
+    let cfg = silo::settings::AppConfig::load(None).expect("load default config");
+    let factory = make_memory_test_factory(&prefix, "n1");
+
+    let (c1, h1) = EtcdCoordinator::start(
+        &cfg.coordination.etcd_endpoints,
+        &prefix,
+        "n1",
+        "http://127.0.0.1:7450",
+        num_shards,
+        10,
+        Arc::clone(&factory),
+        Vec::new(),
+    )
+    .await
+    .expect("start coordinator");
+
+    assert!(c1.wait_converged(Duration::from_secs(10)).await);
+
+    let shard_id = c1.owned_shards().await[0];
+
+    // Enqueue known jobs across several tenants into the parent before splitting.
+    let parent_range = {
+        let shard_map = c1.get_shard_map().await.expect("get shard map");
+        shard_map.get_shard(&shard_id).unwrap().range.clone()
+    };
+    let parent = factory
+        .open(&shard_id, &parent_range)
+        .await
+        .expect("open parent shard");
+    let tenants = ["a", "b", "f", "m", "q", "t", "x", "z"];
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    for tenant in tenants {
+        parent
+            .enqueue(
+                tenant,
+                Some(format!("job-{tenant}")),
+                5,
+                now,
+                None,
+                rmp_serde::to_vec(&serde_json::json!({ "t": tenant })).unwrap(),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue to parent");
+    }
+    assert_eq!(
+        parent.get_counters().await.expect("counters").total_jobs,
+        tenants.len() as i64,
+    );
+
+    // Request and execute a balanced split.
+    let splitter = ShardSplitter::new(Arc::new(c1.clone()));
+    let split_point = {
+        let shard_map = c1.get_shard_map().await.expect("get shard map");
+        silo::shard_range::format_hash_boundary(
+            shard_map
+                .get_shard(&shard_id)
+                .unwrap()
+                .range
+                .midpoint()
+                .unwrap(),
+        )
+    };
+    let split = splitter
+        .request_split(shard_id, split_point)
+        .await
+        .expect("request split should succeed");
+    splitter
+        .execute_split(shard_id, || c1.get_shard_owner_map())
+        .await
+        .expect("execute split should succeed and preserve data");
+
+    // Every enqueued job must survive the split in the child that owns its
+    // tenant's range. Children open as full copies of the parent; post-commit
+    // cleanup only trims out-of-range rows, never the in-range job looked up
+    // here -- so this assertion is deterministic regardless of cleanup timing.
+    let shard_map = c1.get_shard_map().await.expect("get shard map after split");
+    for tenant in tenants {
+        let owner = shard_map
+            .shard_for_tenant(tenant)
+            .expect("tenant routes to a child");
+        assert!(
+            owner.id == split.left_child_id || owner.id == split.right_child_id,
+            "tenant {tenant} should route to one of the children",
+        );
+        let child = factory
+            .get(&owner.id)
+            .expect("child shard open after split");
+        assert!(
+            child
+                .get_job(tenant, &format!("job-{tenant}"))
+                .await
+                .expect("get_job")
+                .is_some(),
+            "job for tenant {tenant} must survive the split in its owning child",
         );
     }
 

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -22,6 +22,24 @@ fn make_fs_factory(tmp: &tempfile::TempDir) -> Arc<ShardFactory> {
     ))
 }
 
+/// Helper to create a Memory-backed factory rooted at a unique shared root.
+///
+/// All shards opened through this factory share one in-memory store, so
+/// multi-shard clone/open round-trips exercise the same shared-root path
+/// semantics as a real object store (GCS/S3).
+fn make_memory_factory() -> Arc<ShardFactory> {
+    let template = DatabaseTemplate {
+        backend: Backend::Memory,
+        path: format!("{}/%shard%", ShardId::new()),
+        ..Default::default()
+    };
+    Arc::new(ShardFactory::new(
+        template,
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
 /// Helper to create a filesystem-backed factory with separate WAL dir
 fn make_fs_factory_with_wal(
     data_tmp: &tempfile::TempDir,
@@ -336,6 +354,155 @@ async fn clone_closed_shard_with_split_wal() {
     assert_eq!(
         right_counters.total_jobs, 1,
         "right child should have the parent's job"
+    );
+}
+
+/// Regression guard for the object-store split data-loss bug.
+///
+/// On an object-store backend, parent and children must resolve under one
+/// shared storage root so a clone lands exactly where `open` later reads. When
+/// each shard instead gets its own store (or a double-nested path), the children
+/// open empty and the shard's data is silently lost. This drives the clone
+/// round-trip on the shared-root Memory backend and asserts each child holds the
+/// parent's full job set.
+#[silo::test]
+async fn clone_closed_shard_object_store_preserves_jobs() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("cloned-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"cloned": true})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+
+    let parent_counters = parent.get_counters().await.expect("get parent counters");
+    assert_eq!(parent_counters.total_jobs, 1);
+
+    // Close parent (clone_closed_shard expects it to be closed)
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard");
+
+    // A fresh clone is a full byte-for-byte copy of the parent, so each child
+    // holds the parent's whole job set immediately after the split (cleanup
+    // trims each child to its range later).
+    let left_child = factory
+        .open(&left_child_id, &ShardRange::full())
+        .await
+        .expect("open left child");
+    assert_eq!(
+        left_child
+            .get_counters()
+            .await
+            .expect("get left child counters")
+            .total_jobs,
+        1,
+        "left child should have the parent's job"
+    );
+    assert!(
+        left_child
+            .get_job("test-tenant", "cloned-job")
+            .await
+            .expect("get job from left child")
+            .is_some(),
+        "left child should contain the parent's job"
+    );
+
+    let right_child = factory
+        .open(&right_child_id, &ShardRange::full())
+        .await
+        .expect("open right child");
+    assert_eq!(
+        right_child
+            .get_counters()
+            .await
+            .expect("get right child counters")
+            .total_jobs,
+        1,
+        "right child should have the parent's job"
+    );
+}
+
+/// `delete_shard_data` on an object-store backend must scope deletion to exactly
+/// one shard's prefix. Two shards share a single store root under the new
+/// resolution, so deleting one (via `reset`) must not touch a sibling whose
+/// prefix differs only by shard name.
+#[silo::test]
+async fn delete_object_store_shard_data_leaves_sibling_intact() {
+    let factory = make_memory_factory();
+    let shard_a = ShardId::new();
+    let shard_b = ShardId::new();
+
+    let a = factory
+        .open(&shard_a, &ShardRange::full())
+        .await
+        .expect("open shard a");
+    let b = factory
+        .open(&shard_b, &ShardRange::full())
+        .await
+        .expect("open shard b");
+
+    for (shard, job_id) in [(&a, "job-a"), (&b, "job-b")] {
+        shard
+            .enqueue(
+                "test-tenant",
+                Some(job_id.to_string()),
+                5,
+                test_helpers::now_ms(),
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue job");
+    }
+
+    // reset closes shard A, deletes its data via delete_shard_data, then reopens.
+    let a_reset = factory
+        .reset(&shard_a, &ShardRange::full())
+        .await
+        .expect("reset shard a");
+    assert_eq!(
+        a_reset.get_counters().await.expect("a counters").total_jobs,
+        0,
+        "reset shard A should be empty after its data is deleted"
+    );
+
+    // Sibling B shares the store root but its prefix differs by shard name, so
+    // deleting A must not have removed B's data.
+    assert_eq!(
+        b.get_counters().await.expect("b counters").total_jobs,
+        1,
+        "sibling shard B should keep its job after shard A's data is deleted"
+    );
+    assert!(
+        b.get_job("test-tenant", "job-b")
+            .await
+            .expect("get job from b")
+            .is_some(),
+        "sibling shard B should still contain its job"
     );
 }
 

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -506,6 +506,205 @@ async fn delete_object_store_shard_data_leaves_sibling_intact() {
     );
 }
 
+// --- post-split child verification tests ---
+
+/// A child that opens empty/short of the parent's job count is the object-store
+/// split data-loss signature. The pre-commit verification must detect it: a
+/// child whose whole-shard `total_jobs` differs from the parent's pre-close
+/// count fails verification so the split can abort before the shard-map commit.
+#[silo::test]
+async fn verify_cloned_children_detects_short_child() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("only-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    let parent_total = parent
+        .get_counters()
+        .await
+        .expect("parent counters")
+        .total_jobs;
+    assert_eq!(parent_total, 1);
+    parent.close().await.expect("close parent");
+
+    // A never-cloned child opens as an empty database -- total_jobs 0 -- exactly
+    // the empty-child symptom of the resolution bug. It must not match a parent
+    // that held one job.
+    let empty_child = ShardId::new();
+    let result = factory
+        .verify_cloned_children_match_parent(parent_total, &[empty_child])
+        .await;
+    assert!(
+        result.is_err(),
+        "an empty child must fail verification against a non-empty parent"
+    );
+}
+
+/// A successful clone -- each child a full copy of the parent -- must pass
+/// verification (no false positives), and the raw verification opens must not
+/// register the children in the factory's instance map. If they did, the
+/// post-commit `open(child)` would return the stale pre-commit handle.
+#[silo::test]
+async fn verify_cloned_children_accepts_full_clone_without_caching() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("only-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    let parent_total = parent
+        .get_counters()
+        .await
+        .expect("parent counters")
+        .total_jobs;
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard");
+
+    factory
+        .verify_cloned_children_match_parent(parent_total, &[left_child_id, right_child_id])
+        .await
+        .expect("full clones should pass verification");
+
+    // The raw verification open must leave no factory instance behind.
+    assert!(
+        !factory.owns_shard(&left_child_id),
+        "verification must not cache the left child in the instances map"
+    );
+    assert!(
+        !factory.owns_shard(&right_child_id),
+        "verification must not cache the right child in the instances map"
+    );
+    assert!(factory.get(&left_child_id).is_none());
+    assert!(factory.get(&right_child_id).is_none());
+
+    // The post-clone `open` returns a child that actually holds the parent's data
+    // (not a stale pre-commit handle).
+    let left_child = factory
+        .open(&left_child_id, &ShardRange::full())
+        .await
+        .expect("open left child after verification");
+    assert_eq!(
+        left_child
+            .get_counters()
+            .await
+            .expect("left counters")
+            .total_jobs,
+        parent_total,
+    );
+}
+
+/// When verification fails, the split aborts before touching the parent: the
+/// parent's data is untouched and the parent reopens with its full job set.
+/// (In the split state machine this maps to `PreCommitParentClosed`, which
+/// abandons the split and recovers the parent.)
+#[silo::test]
+async fn parent_reopens_intact_after_verification_mismatch() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("survivor-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard");
+
+    // Inject a mismatch by claiming the parent held more jobs than it did.
+    let result = factory
+        .verify_cloned_children_match_parent(99, &[left_child_id, right_child_id])
+        .await;
+    assert!(
+        result.is_err(),
+        "inflated parent count must fail verification"
+    );
+
+    // Recover the parent the way the split state machine does on a pre-commit
+    // abort: evict the stale closed factory entry, then reopen. The parent's
+    // data is untouched by the failed child verification, so it reopens intact.
+    factory
+        .close(&parent_id)
+        .await
+        .expect("evict stale parent entry");
+    let reopened = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("reopen parent after failed verification");
+    assert_eq!(
+        reopened
+            .get_counters()
+            .await
+            .expect("parent counters")
+            .total_jobs,
+        1,
+        "parent should retain its data after a failed split verification"
+    );
+    assert!(
+        reopened
+            .get_job("test-tenant", "survivor-job")
+            .await
+            .expect("get job from reopened parent")
+            .is_some(),
+        "parent should still contain its job after a failed split verification"
+    );
+}
+
 // --- template path validation tests ---
 
 #[silo::test]

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -40,6 +40,29 @@ fn make_memory_factory() -> Arc<ShardFactory> {
     ))
 }
 
+/// Helper to create a Memory-backed factory with a separate Memory WAL store.
+///
+/// The data store is rooted at a shared root (so parent and children resolve
+/// under one store); each shard gets its own WAL store keyed by the per-shard
+/// WAL path, mirroring a real object-store deployment with split WAL.
+fn make_memory_factory_with_wal() -> Arc<ShardFactory> {
+    let root = ShardId::new();
+    let template = DatabaseTemplate {
+        backend: Backend::Memory,
+        path: format!("{root}/data/%shard%"),
+        wal: Some(WalConfig {
+            backend: Backend::Memory,
+            path: format!("{root}/wal/%shard%"),
+        }),
+        ..Default::default()
+    };
+    Arc::new(ShardFactory::new(
+        template,
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
 /// Helper to create a filesystem-backed factory with separate WAL dir
 fn make_fs_factory_with_wal(
     data_tmp: &tempfile::TempDir,
@@ -281,6 +304,72 @@ async fn clone_closed_shard_creates_copies() {
     assert_eq!(
         right_counters.total_jobs, 1,
         "right child should have the parent's job"
+    );
+}
+
+/// The object-store clone round-trip must also work with a separate WAL store:
+/// cloning propagates each child's WAL store so the children open without
+/// "wal store reconfiguration unsupported", and each holds the parent's jobs.
+#[silo::test]
+async fn clone_closed_shard_object_store_with_split_wal() {
+    let factory = make_memory_factory_with_wal();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("wal-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"wal": true})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard with WAL on object store");
+
+    // Opening the children is where "wal store reconfiguration unsupported"
+    // would surface if the clone did not configure each child's WAL store.
+    let left_child = factory
+        .open(&left_child_id, &ShardRange::full())
+        .await
+        .expect("open left child with WAL");
+    assert_eq!(
+        left_child
+            .get_counters()
+            .await
+            .expect("left counters")
+            .total_jobs,
+        1,
+        "left child should hold the parent's job"
+    );
+
+    let right_child = factory
+        .open(&right_child_id, &ShardRange::full())
+        .await
+        .expect("open right child with WAL");
+    assert_eq!(
+        right_child
+            .get_counters()
+            .await
+            .expect("right counters")
+            .total_jobs,
+        1,
+        "right child should hold the parent's job"
     );
 }
 

--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -1043,7 +1043,7 @@ async fn grpc_server_reset_shards_clears_memory_backend_data() -> anyhow::Result
 
         // Use Memory backend to exercise the object store deletion path
         let template = DatabaseTemplate {
-            path: "test-memory-%shard%".to_string(),
+            path: "test-memory/%shard%".to_string(),
             ..Default::default()
         };
         let rate_limiter = MockGubernatorClient::new_arc();


### PR DESCRIPTION
Splitting a shard on an object-store backend (GCS) silently lost the entire shard's data. The clone step wrote each child's SlateDB manifest into the parent's own per-shard namespace while `open` later read from the child's namespace, so every child opened empty. The loss was deterministic regardless of split point or shard size, and reproduced in staging where a tenant dropped from roughly 8M jobs to a handful. The parent's SSTs were never deleted, so the situation was recoverable -- but every object-store split was a data-loss event.

## Root cause

Object-store backends rooted each shard at its own full prefix and set the db path to the full canonical path, double-nesting data at `<root>/<shard>/<shard>` and -- critically -- leaving the parent store not a shared ancestor of its children. SlateDB reference-clones record parent SST paths relative to one shared store root, so a clone written under the parent's prefix is unreachable from the path `open` resolves for the child. Local-FS avoided this by rooting every shard at the shared prefix before the `%shard%` placeholder; object stores did not.

## Fix

- Resolve object-store backends (Memory/S3/GCS/URL) at the shared placeholder-prefix root with `db_path = shard_name`, symmetric with the local-FS branch. The clone destination for a child now equals the path `open` reads, and the double-nesting is gone. Local-FS resolution is unchanged.
- Share the in-memory backend across shards under one root so multi-shard clone/open is reproducible in tests; each shard previously got a fresh store, so the Memory backend could not host a clone at all.
- Add a defense-in-depth check to the split state machine: before the shard-map commit point, open each cloned child and confirm its whole-shard `total_jobs` matches the parent's pre-close count. A child that opens empty or short aborts the split as a pre-commit failure that recovers the parent, so a latent clone bug surfaces as a failed, recoverable split rather than silent data loss.
- Add object-store coverage for the clone and split paths -- the gap that hid the bug -- including clone round-trips with and without a separate WAL store and a full split state-machine round-trip that asserts every job survives in the child that owns its range.

Object-store shard data is staging-only and disposable, so moving where shards resolve needs no migration.

cc @airhorns