### PR TITLE
Grant scanner: hot/cold lanes, bounded sweeps, and next-hop backpressure

### DIFF
--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -616,9 +616,10 @@ pub async fn clone_golden_shard(
             hydrate_all_at_startup: false,
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
-            grant_scanner_batch_size: silo::settings::DEFAULT_GRANT_SCANNER_BATCH_SIZE,
-            grant_scanner_buffer_size: silo::settings::DEFAULT_GRANT_SCANNER_BUFFER_SIZE,
-            grant_scanner_concurrency: silo::settings::DEFAULT_GRANT_SCANNER_CONCURRENCY,
+            grant_scanner: silo::concurrency::GrantScannerConfig::default(),
+            concurrency_reconcile_scan_slice:
+                silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,
+            holder_drift_scan_slice: silo::settings::DEFAULT_HOLDER_DRIFT_SCAN_SLICE,
         },
         ShardRange::full(),
     )

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -36,7 +36,7 @@
 //!   request from a restart or retry is still in the DB. Since Cancelled is terminal,
 //!   this also catches any stale cancelled requests.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -622,30 +622,39 @@ impl ConcurrencyCounts {
         self.pending_reconciliations.lock().unwrap().len()
     }
 
-    /// Snapshot every hydrated (tenant, queue) and the full set of in-memory
-    /// holder task_ids. Used by the self-healing drift pass to compute both the
-    /// exact ghost set (in-memory holders with no durable row) and the
-    /// per-queue drift count (`.len()` of the returned set).
-    ///
-    /// `NotHydrated` and `Hydrating` queues are intentionally skipped: we
-    /// haven't loaded their durable rows yet, so comparing in-memory (empty)
-    /// against durable (unknown) is meaningless. The DashMap entry guard is
-    /// dropped before the caller does any `.await` (the returned `HashSet`s
-    /// are owned clones).
-    pub fn hydrated_queue_holders_with_ids(&self) -> Vec<(String, String, HashSet<String>)> {
+    /// Snapshot every hydrated (tenant, queue) key, SORTED. Used by the
+    /// self-healing drift pass to build its per-pass work list. Sorted
+    /// because DashMap iteration order is nondeterministic and must never
+    /// reach DST-observable behavior (the drift pass's visit order). Unlike
+    /// the old whole-cache snapshot this does NOT clone any holder sets —
+    /// per-queue holders are fetched lazily via `holders_if_hydrated` as the
+    /// sliced pass visits each queue.
+    pub fn hydrated_queue_keys(&self) -> Vec<(String, String)> {
         let mut out = Vec::new();
         for entry in self.queues.iter() {
             if !matches!(entry.state, HydrationState::Hydrated) {
                 continue;
             }
             let (tenant_arc, queue_arc) = entry.key();
-            out.push((
-                tenant_arc.to_string(),
-                queue_arc.to_string(),
-                entry.holders.clone(),
-            ));
+            out.push((tenant_arc.to_string(), queue_arc.to_string()));
         }
+        out.sort_unstable();
         out
+    }
+
+    /// Owned clone of one queue's in-memory holder task_ids, or `None` when
+    /// the queue is absent or not (fully) hydrated — a queue that left the
+    /// `Hydrated` state between the pass snapshot and its visit is skipped,
+    /// matching the old whole-cache snapshot's filter: comparing in-memory
+    /// (empty/partial) against durable (unknown) is meaningless. The DashMap
+    /// guard is dropped before the caller does any `.await`.
+    pub fn holders_if_hydrated(&self, tenant: &str, queue: &str) -> Option<HashSet<String>> {
+        let key = queue_key(tenant, queue);
+        let entry = self.queues.get(&key)?;
+        if !matches!(entry.state, HydrationState::Hydrated) {
+            return None;
+        }
+        Some(entry.holders.clone())
     }
 
     /// Snapshot the sizes of the in-memory holders cache for metrics reporting.
@@ -779,6 +788,64 @@ pub struct CachedQueueLimit {
     pub limit_type: ConcurrencyLimitType,
 }
 
+/// Tuning knobs for the background grant scanner, carried as one struct
+/// through `OpenShardOptions` so call sites stay readable as knobs
+/// accumulate. Raw values straight from settings; `ConcurrencyManager::new`
+/// applies the clamps (`>= 1` where a zero would stall or panic, and the
+/// `[0.0, 0.9]` fraction clamp).
+#[derive(Debug, Clone)]
+pub struct GrantScannerConfig {
+    /// Max grants materialized, status-checked, and committed per
+    /// `process_grants` pass.
+    pub batch_size: usize,
+    /// Max in-flight job-status lookups buffered within a single pass.
+    pub buffer_size: usize,
+    /// Max per-queue `process_grants` passes run concurrently per drain
+    /// iteration.
+    pub concurrency: usize,
+    /// Max reconciler-sourced (cold-lane) queue entries merged into a single
+    /// drain iteration alongside all event-driven (hot-lane) entries.
+    pub cold_batch_size: usize,
+    /// Minimum requester backlog on a candidate's next concurrency hop before
+    /// the scanner defers granting the candidate while that hop is saturated.
+    /// 0 disables the skip.
+    pub next_hop_skip_min_backlog: u64,
+    /// Fraction of each queue's capacity the scanner leaves unfilled for
+    /// immediate (live) grants.
+    pub live_headroom_fraction: f64,
+}
+
+impl Default for GrantScannerConfig {
+    fn default() -> Self {
+        Self {
+            batch_size: crate::settings::DEFAULT_GRANT_SCANNER_BATCH_SIZE,
+            buffer_size: crate::settings::DEFAULT_GRANT_SCANNER_BUFFER_SIZE,
+            concurrency: crate::settings::DEFAULT_GRANT_SCANNER_CONCURRENCY,
+            cold_batch_size: crate::settings::DEFAULT_GRANT_SCANNER_COLD_BATCH_SIZE,
+            next_hop_skip_min_backlog:
+                crate::settings::DEFAULT_GRANT_SCANNER_NEXT_HOP_SKIP_MIN_BACKLOG,
+            live_headroom_fraction: crate::settings::DEFAULT_GRANT_SCANNER_LIVE_HEADROOM_FRACTION,
+        }
+    }
+}
+
+/// The grant scanner's cold pending lane: (tenant, queue) entries seeded by
+/// the periodic `reconcile_pending_requests` sweep, drained in bounded
+/// batches so a shard-wide sweep backlog can never delay servicing the hot
+/// lane's event-driven nudges. `pop_cursor` implements round-robin draining —
+/// see `take_pending_grant_batch` for why a plain `pop_first` would starve
+/// the lexicographic tail.
+#[derive(Default)]
+struct ColdLane {
+    /// Key: `concurrency_counts_key(tenant, queue)`; value: (tenant, queue,
+    /// pending count). BTreeMap for deterministic iteration order (DST).
+    entries: BTreeMap<Vec<u8>, (String, String, u32)>,
+    /// The last key handed out by `take_pending_grant_batch`; the next batch
+    /// resumes strictly after it and wraps to the front when the tail is
+    /// exhausted.
+    pop_cursor: Option<Vec<u8>>,
+}
+
 /// High-level concurrency manager with a background grant scanner.
 ///
 /// The grant scanner is a single background task that processes all pending grants.
@@ -789,10 +856,22 @@ pub struct ConcurrencyManager {
     /// on per-shard metrics emitted from the grant paths.
     shard: String,
     counts: ConcurrencyCounts,
-    /// Pending grant counts per queue. Key: concurrency_counts_key(tenant, queue).
-    /// Value: (tenant, queue, count). Lock held only briefly for increment/drain.
-    /// BTreeMap ensures deterministic iteration order for DST reproducibility.
+    /// HOT pending lane: grant counts per queue from event-driven callers
+    /// (releases from dequeue/lease/cancel/import/drop-tenant, at-capacity
+    /// ticket conversions, floating-limit raises, ghost releases). Drained in
+    /// FULL every scanner iteration so a freed slot is refilled within one
+    /// iteration rather than one shard-wide sweep. Key:
+    /// concurrency_counts_key(tenant, queue). Value: (tenant, queue, count).
+    /// Lock held only briefly for increment/drain. BTreeMap ensures
+    /// deterministic iteration order for DST reproducibility.
     pending_grants: Mutex<BTreeMap<Vec<u8>, (String, String, u32)>>,
+    /// COLD pending lane: entries seeded by the periodic
+    /// `reconcile_pending_requests` counter sweep, drained at most
+    /// `grant_scanner_cold_batch_size` per iteration behind the hot lane. On
+    /// a queue-heavy shard the sweep re-seeds hundreds of thousands of
+    /// entries; letting them share the hot lane meant a release nudge waited
+    /// an entire shard-wide cycle (~40 min observed) to be serviced.
+    pending_grants_cold: Mutex<ColdLane>,
     grant_notify: tokio::sync::Notify,
     grant_running: AtomicBool,
     /// Sub-tick wake for the periodic holder reconciler. Fired by
@@ -805,6 +884,10 @@ pub struct ConcurrencyManager {
     /// In-memory cache of resolved concurrency limits per queue.
     /// Key: concurrency_counts_key(tenant, queue). Populated during enqueue and grant_next.
     limit_cache: Mutex<HashMap<Vec<u8>, CachedQueueLimit>>,
+    /// Resume cursor for sliced `reconcile_pending_requests` sweeps: the
+    /// counter key the next sliced sweep starts scanning from. `None` starts
+    /// at the front of the counter keyspace.
+    reconcile_cursor: Mutex<Option<Vec<u8>>>,
     metrics: Option<Metrics>,
     /// Callback for resuming a job's limit chain after a deferred concurrency
     /// grant is awarded. Wired up by `JobStoreShard::open` after the shard
@@ -856,57 +939,110 @@ pub struct ConcurrencyManager {
     /// multiple) in `new`; always `>= grant_scanner_batch_size` so every
     /// invocation can run at least one full pass.
     grant_scanner_max_scan_per_invocation: usize,
-    /// Consecutive-pass observation counts for drift-detected ghost
-    /// candidates, keyed by (tenant, queue, task_id). Maintained only by
-    /// `report_holder_drift` (a single periodic task). Rebuilt each pass from
-    /// the current ghost set, so it is bounded by the current ghost +
-    /// in-flight-reservation count and self-prunes when a candidate gains a
-    /// durable row or is released. See `GHOST_CONFIRM_PASSES`.
-    ghost_candidates: Mutex<HashMap<(String, String, String), u32>>,
+    /// Max cold-lane (reconciler-sourced) queue entries merged into a single
+    /// drain iteration alongside all hot-lane (event-driven) entries. Bounds
+    /// how long a reconcile-sweep backlog can delay servicing a release
+    /// nudge. Configurable via `grant_scanner_cold_batch_size` (default 64);
+    /// stored already clamped to `>= 1`.
+    grant_scanner_cold_batch_size: usize,
+    /// Minimum requester backlog on a candidate's next concurrency hop before
+    /// `process_grants` defers granting the candidate while that hop is
+    /// saturated. 0 disables the next-hop skip. Configurable via
+    /// `grant_scanner_next_hop_skip_min_backlog` (default 1024).
+    grant_scanner_next_hop_skip_min_backlog: u64,
+    /// Fraction of each queue's capacity the scanner leaves unfilled for
+    /// immediate (live) grants. Configurable via
+    /// `grant_scanner_live_headroom_fraction` (default 0.0); stored already
+    /// clamped to `[0.0, 0.9]` with non-finite values treated as 0.0.
+    grant_scanner_live_headroom_fraction: f64,
+    /// State of the (possibly multi-tick) holder-drift pass. Maintained only
+    /// by `report_holder_drift` (a single periodic task). See `DriftPass`.
+    drift_pass: Mutex<DriftPass>,
 }
+
+/// End a `process_grants` invocation after this many CONSECUTIVE next-hop
+/// skips with no intervening non-skipped candidate (a grant candidate or
+/// stale-row cleanup both reset the run). Bounds the walk over a front
+/// dominated by candidates whose next hop is saturated-with-backlog: without
+/// it, every cold-sweep re-drive of such a queue re-walks up to the full
+/// per-invocation scan budget (batch_size × 4 — 8192 keys with the staging
+/// config) doing nothing, inflating drain-iteration time. Large enough that
+/// a mixed front with grantable candidates for a different hop inside the
+/// window is still served in one invocation.
+const MAX_CONSECUTIVE_NEXT_HOP_SKIPS: usize = 64;
 
 /// A drift-detected ghost must be observed as a ghost in this many
 /// *consecutive* `report_holder_drift` passes before it is enqueued for
 /// release. A true ghost (a dropped-future leak) is permanent and survives
 /// every pass; an in-flight reservation (`try_reserve_internal` inserts into
 /// the in-memory holder set before its durable write commits) clears within
-/// one reconcile interval, so a value of 2 excludes those false positives.
-/// Bump to debounce harder.
+/// one pass — far shorter than a full sliced pass over all hydrated queues —
+/// so a value of 2 excludes those false positives. Bump to debounce harder.
 const GHOST_CONFIRM_PASSES: u32 = 2;
+
+/// Accumulators for the holder-drift pass. A full pass visits every hydrated
+/// queue in one sorted snapshot; with per-tick slicing
+/// (`holder_drift_scan_slice`) the pass spans multiple reconcile ticks, so
+/// its state lives here between ticks. The drift gauge and the
+/// ghost-candidate promotion both advance only at FULL-pass boundaries,
+/// preserving `GHOST_CONFIRM_PASSES` = two complete passes.
+#[derive(Default)]
+struct DriftPass {
+    /// Queues still to visit this pass, in sorted order. Refilled from a
+    /// fresh sorted snapshot when empty (= a new pass begins).
+    work: VecDeque<(String, String)>,
+    /// Ghost-candidate observation counts as of the last COMPLETED pass,
+    /// keyed by (tenant, queue, task_id). Bounded by the ghost +
+    /// in-flight-reservation count; self-prunes when a candidate gains a
+    /// durable row or is released (absent from the next pass's set).
+    prev_candidates: HashMap<(String, String, String), u32>,
+    /// Ghost-candidate observation counts accumulated by the CURRENT pass.
+    next_candidates: HashMap<(String, String, String), u32>,
+    /// Σ |in_memory - durable| accumulated by the current pass; published to
+    /// the drift gauge when the pass completes.
+    drift_total: u64,
+}
 
 impl ConcurrencyManager {
     pub fn new(
         shard: impl Into<String>,
         metrics: Option<Metrics>,
         hydrate_all_at_startup: bool,
-        grant_scanner_batch_size: usize,
-        grant_scanner_buffer_size: usize,
-        grant_scanner_concurrency: usize,
+        scanner: GrantScannerConfig,
     ) -> Self {
         Self {
             shard: shard.into(),
             counts: ConcurrencyCounts::with_config(hydrate_all_at_startup),
             pending_grants: Mutex::new(BTreeMap::new()),
+            pending_grants_cold: Mutex::new(ColdLane::default()),
             grant_notify: tokio::sync::Notify::new(),
             grant_running: AtomicBool::new(false),
             reconcile_notify: Arc::new(tokio::sync::Notify::new()),
             limit_cache: Mutex::new(HashMap::new()),
+            reconcile_cursor: Mutex::new(None),
             metrics,
             chain_resumer: Mutex::new(None),
             // Clamp to >= 1: a 0 batch would stall the drain loop and
             // `.buffered(0)` / `.buffer_unordered(0)` are invalid.
-            grant_scanner_batch_size: grant_scanner_batch_size.max(1),
-            grant_scanner_buffer_size: grant_scanner_buffer_size.max(1),
-            grant_scanner_concurrency: grant_scanner_concurrency.max(1),
+            grant_scanner_batch_size: scanner.batch_size.max(1),
+            grant_scanner_buffer_size: scanner.buffer_size.max(1),
+            grant_scanner_concurrency: scanner.concurrency.max(1),
             // Cap total keys walked per invocation at a small multiple of the
             // per-pass batch so a giant non-grantable backlog yields after a
             // bounded walk and round-robins with other queues, while still
             // allowing several full passes of real draining per cycle. `×4` is
             // inherently `>= batch_size`, so at least one full pass always runs.
-            grant_scanner_max_scan_per_invocation: grant_scanner_batch_size
-                .max(1)
-                .saturating_mul(4),
-            ghost_candidates: Mutex::new(HashMap::new()),
+            grant_scanner_max_scan_per_invocation: scanner.batch_size.max(1).saturating_mul(4),
+            grant_scanner_cold_batch_size: scanner.cold_batch_size.max(1),
+            grant_scanner_next_hop_skip_min_backlog: scanner.next_hop_skip_min_backlog,
+            // Non-finite fractions (NaN/inf from a hand-edited TOML) are
+            // meaningless as a headroom share — treat them as disabled.
+            grant_scanner_live_headroom_fraction: if scanner.live_headroom_fraction.is_finite() {
+                scanner.live_headroom_fraction.clamp(0.0, 0.9)
+            } else {
+                0.0
+            },
+            drift_pass: Mutex::new(DriftPass::default()),
         }
     }
 
@@ -1050,6 +1186,95 @@ impl ConcurrencyManager {
                 Self::floating_state_capacity(db, tenant, queue).await
             }
         }
+    }
+
+    /// Capacity the SCANNER may fill for a queue: full capacity minus the
+    /// configured live-headroom share, never reduced below 1 so a backlog
+    /// always drains. Immediate paths (enqueue-time grants, chain-resume
+    /// downstream grants, dequeue ticket conversion) keep the full capacity,
+    /// so the reserved share stays available for fresh work while the
+    /// scanner digs out a deferred backlog. With the default fraction of 0.0
+    /// this is the identity. A zero capacity stays zero — the headroom knob
+    /// must never grant slots a limit of 0 forbids.
+    fn scanner_effective_capacity(&self, capacity: usize) -> usize {
+        let fraction = self.grant_scanner_live_headroom_fraction;
+        if fraction <= 0.0 || capacity == 0 {
+            return capacity;
+        }
+        capacity
+            .saturating_sub((capacity as f64 * fraction).ceil() as usize)
+            .max(1)
+    }
+
+    /// Decide whether the grant scanner should defer a candidate because its
+    /// NEXT concurrency hop is saturated with a deep requester backlog.
+    ///
+    /// The gate is the FIRST limit after `limit_index`: a RateLimit gate
+    /// never skips (the chain writes a `CheckRateLimit` task — real progress
+    /// that holds no capacity), and a terminal candidate (no further limits)
+    /// never skips (granting emits the RunAttempt). A Concurrency /
+    /// FloatingConcurrency gate skips iff its holders >= its capacity AND its
+    /// durable requester counter >= `grant_scanner_next_hop_skip_min_backlog`
+    /// (0 disables the check entirely).
+    ///
+    /// Inputs degrade safely: `holder_count` on an unhydrated next hop reads
+    /// 0 and an unreadable counter reads 0, so missing data can only make the
+    /// skip NOT fire — behavior falls back to granting as before. Decisions
+    /// (including the floating-capacity point-read and the counter
+    /// point-read) are cached in `cache` for the invocation, keyed by the
+    /// next hop's queue name: in practice every candidate in one queue shares
+    /// the same next hop (the tenant's platform queue), so the whole
+    /// invocation pays at most a couple of point reads.
+    async fn next_hop_should_skip(
+        &self,
+        db: &Arc<InstrumentedDb>,
+        tenant: &str,
+        limits: &[Limit],
+        limit_index: u32,
+        cache: &mut HashMap<String, bool>,
+    ) -> bool {
+        if self.grant_scanner_next_hop_skip_min_backlog == 0 {
+            return false;
+        }
+        let Some(next) = limits.get(limit_index as usize + 1) else {
+            return false;
+        };
+        // Split queue-name extraction from capacity resolution so the cache
+        // check happens before the floating-state point read.
+        let (next_queue, fixed_capacity, floating_default) = match next {
+            Limit::RateLimit(_) => return false,
+            Limit::Concurrency(cl) => (cl.key.as_str(), Some(cl.max_concurrency as usize), 0),
+            Limit::FloatingConcurrency(fl) => {
+                (fl.key.as_str(), None, fl.default_max_concurrency as usize)
+            }
+        };
+        if let Some(&decision) = cache.get(next_queue) {
+            return decision;
+        }
+        let capacity = match fixed_capacity {
+            Some(capacity) => capacity,
+            // The durable floating row is what the next hop's own scan path
+            // gates on; fall back to the limit's embedded default when the
+            // row is missing/unreadable, mirroring resolve_queue_capacity_from_limits.
+            None => Self::floating_state_capacity(db, tenant, next_queue)
+                .await
+                .unwrap_or(floating_default),
+        };
+        let holders = self.counts.holder_count(tenant, next_queue);
+        let decision = if holders >= capacity {
+            let depth = match db
+                .get(&concurrency_requester_counter_key(tenant, next_queue))
+                .await
+            {
+                Ok(Some(raw)) => decode_counter(&raw),
+                _ => 0,
+            };
+            depth >= self.grant_scanner_next_hop_skip_min_backlog as i64
+        } else {
+            false
+        };
+        cache.insert(next_queue.to_string(), decision);
+        decision
     }
 
     /// Handle concurrency for a new job enqueue.
@@ -1414,25 +1639,50 @@ impl ConcurrencyManager {
     /// sub-tick wake) — keeps the cost amortized at the deployment-configured
     /// `concurrency_reconcile_interval` rather than firing on every dropped
     /// dequeue future. Self-healing runs even when metrics are disabled.
-    pub async fn report_holder_drift(&self, db: &Arc<InstrumentedDb>, range: &ShardRange) {
-        // Take the previous pass's ghost-candidate counts and rebuild a fresh
-        // map from this pass. Held outside the per-queue `.await` scans below
-        // (the lock must never span an await). A candidate absent from this
-        // pass (durable row appeared, or it was released) simply drops out.
-        let prev_candidates = {
-            let mut g = self.ghost_candidates.lock().unwrap();
-            std::mem::take(&mut *g)
+    ///
+    /// `slice` bounds the queues scanned per call: a full pass over all
+    /// hydrated queues spans `ceil(hydrated / slice)` ticks, with work,
+    /// ghost-candidate counts, and the drift accumulator carried between
+    /// ticks in `drift_pass`. On a queue-heavy shard this replaces the old
+    /// behavior of issuing one durable ranged scan per hydrated queue —
+    /// hundreds of thousands of scans — EVERY tick. The trade-off is drift
+    /// gauge freshness and drift-detected ghost latency of ~one full pass;
+    /// the reactive `request_reconciliation` path (sub-tick) is unaffected
+    /// and remains the primary ghost-release path. Tests pass `usize::MAX`
+    /// so one call is one full pass.
+    pub async fn report_holder_drift(
+        &self,
+        db: &Arc<InstrumentedDb>,
+        range: &ShardRange,
+        slice: usize,
+    ) {
+        // Pop this tick's batch under the lock (never held across awaits).
+        // An empty work list means a new pass begins: take a fresh sorted
+        // snapshot of the hydrated queues.
+        let (batch, pass_completes) = {
+            let mut pass = self.drift_pass.lock().unwrap();
+            if pass.work.is_empty() {
+                pass.work = self.counts.hydrated_queue_keys().into();
+            }
+            let take = slice.min(pass.work.len());
+            let batch: Vec<(String, String)> = pass.work.drain(..take).collect();
+            (batch, pass.work.is_empty())
         };
-        let mut next_candidates: HashMap<(String, String, String), u32> = HashMap::new();
 
-        let mut drift_total: u64 = 0;
-        for (tenant, queue, in_mem_holders) in self.counts.hydrated_queue_holders_with_ids() {
-            if !range.contains_tenant(&tenant) {
+        let mut batch_drift: u64 = 0;
+        let mut batch_ghosts: Vec<(String, String, String)> = Vec::new();
+        for (tenant, queue) in &batch {
+            if !range.contains_tenant(tenant) {
                 continue;
             }
-            // Per-queue ranged scan. Cost dominated by holder count; capped
-            // by the deployment's reconcile interval.
-            let start = crate::keys::concurrency_holders_queue_prefix(&tenant, &queue);
+            // A queue that left the Hydrated state since the pass snapshot is
+            // skipped — same filter the whole-cache snapshot applied.
+            let Some(in_mem_holders) = self.counts.holders_if_hydrated(tenant, queue) else {
+                continue;
+            };
+            // Per-queue ranged scan. Cost dominated by holder count; total
+            // per tick bounded by `slice`.
+            let start = crate::keys::concurrency_holders_queue_prefix(tenant, queue);
             let end = crate::keys::end_bound(&start);
             let mut iter = match db
                 .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
@@ -1470,40 +1720,66 @@ impl ConcurrencyManager {
                 }
             }
 
-            drift_total += (in_mem_holders.len() as i64 - durable_ids.len() as i64).unsigned_abs();
+            batch_drift += (in_mem_holders.len() as i64 - durable_ids.len() as i64).unsigned_abs();
 
-            // Ghost candidates: in-memory holders with no durable row. Only
-            // enqueue for reconciliation once a candidate has survived
-            // `GHOST_CONFIRM_PASSES` consecutive passes — an in-flight
-            // reservation (durable write not yet committed) clears within one
-            // interval and so never reaches the threshold, while a real ghost
-            // is permanent. See this fn's doc comment for the full rationale.
+            // Ghost candidates: in-memory holders with no durable row.
             for task_id in in_mem_holders.difference(&durable_ids) {
-                let key = (tenant.clone(), queue.clone(), task_id.clone());
-                let seen = prev_candidates
+                batch_ghosts.push((tenant.clone(), queue.clone(), task_id.clone()));
+            }
+        }
+
+        // Fold the batch into the pass accumulators and promote confirmed
+        // ghosts. Only enqueue a candidate for reconciliation once it has
+        // survived `GHOST_CONFIRM_PASSES` consecutive FULL passes — an
+        // in-flight reservation (durable write not yet committed) clears
+        // long before the next pass revisits its queue, while a real ghost
+        // is permanent. Candidates absent from a pass (durable row appeared,
+        // or released) drop out at the pass-boundary swap. Confirmations are
+        // collected under the lock and enqueued after it drops.
+        let (to_reconcile, completed_drift) = {
+            let mut pass = self.drift_pass.lock().unwrap();
+            pass.drift_total = pass.drift_total.saturating_add(batch_drift);
+            let mut to_reconcile = Vec::new();
+            for key in batch_ghosts {
+                let seen = pass
+                    .prev_candidates
                     .get(&key)
                     .copied()
                     .unwrap_or(0)
                     .saturating_add(1);
                 if seen >= GHOST_CONFIRM_PASSES {
-                    self.request_reconciliation(tenant.clone(), queue.clone(), task_id.clone());
+                    to_reconcile.push(key.clone());
                 }
                 // Saturate at the threshold so a long-lived ghost the
                 // reconciler keeps re-queueing doesn't grow the count
                 // unboundedly; re-enqueuing each pass is harmless
                 // (`pending_reconciliations` dedups and release is idempotent).
-                next_candidates.insert(key, seen.min(GHOST_CONFIRM_PASSES));
+                pass.next_candidates
+                    .insert(key, seen.min(GHOST_CONFIRM_PASSES));
             }
-        }
-
-        {
-            let mut g = self.ghost_candidates.lock().unwrap();
-            *g = next_candidates;
+            let completed_drift = if pass_completes {
+                let drift = pass.drift_total;
+                pass.drift_total = 0;
+                pass.prev_candidates = std::mem::take(&mut pass.next_candidates);
+                Some(drift)
+            } else {
+                None
+            };
+            (to_reconcile, completed_drift)
+        };
+        for (tenant, queue, task_id) in to_reconcile {
+            self.request_reconciliation(tenant, queue, task_id);
         }
 
         if let Some(metrics) = self.metrics.as_ref() {
+            // Pending is a live queue size: publish every tick. Drift is a
+            // pass-level aggregate: publish only when a full pass completes,
+            // so the gauge never shows a partial sweep as "drift shrank".
             let pending = self.counts.pending_reconciliations_len() as u64;
-            metrics.set_concurrency_reconciler_signals(&self.shard, drift_total, pending);
+            metrics.set_concurrency_reconciliation_pending(&self.shard, pending);
+            if let Some(drift) = completed_drift {
+                metrics.set_concurrency_holder_drift(&self.shard, drift);
+            }
         }
     }
 
@@ -1514,19 +1790,111 @@ impl ConcurrencyManager {
             let entry = pending
                 .entry(key)
                 .or_insert_with(|| (tenant.to_string(), queue.to_string(), 0));
-            entry.2 += count;
+            entry.2 = entry.2.saturating_add(count);
         }
         self.grant_notify.notify_one();
     }
 
-    /// Test-only: peek the current pending-grant count for a queue. Used by
+    /// Cold-lane variant of `request_grant_count`, used only by the
+    /// `reconcile_pending_requests` counter sweep.
+    ///
+    /// SET/max semantics rather than accumulation: the sweep re-reads the
+    /// durable requester counter on every visit, so the counter value IS the
+    /// outstanding demand. Accumulating it (the old shared-lane behavior)
+    /// grew the pending count without bound while a queue went unserviced —
+    /// u32 overflow in minutes for a queue with tens of millions of
+    /// requesters.
+    pub(crate) fn request_grant_count_cold(&self, tenant: &str, queue: &str, count: u32) {
+        let key = concurrency_counts_key(tenant, queue);
+        {
+            let mut cold = self.pending_grants_cold.lock().unwrap();
+            let entry = cold
+                .entries
+                .entry(key)
+                .or_insert_with(|| (tenant.to_string(), queue.to_string(), 0));
+            entry.2 = entry.2.max(count);
+        }
+        self.grant_notify.notify_one();
+    }
+
+    /// Compute one drain iteration's work set: ALL hot-lane entries plus at
+    /// most `grant_scanner_cold_batch_size` cold-lane entries, merged with
+    /// saturating counts on key collision.
+    ///
+    /// Cold entries are popped ROUND-ROBIN from `pop_cursor` (next key
+    /// strictly after it, wrapping to the front) — NOT `pop_first`. The
+    /// reconcile sweep re-seeds the cold lane continuously while pops proceed
+    /// at the drain rate; whenever re-seeding outpaces popping, a
+    /// global-minimum pop stays confined forever to the lexicographically
+    /// smallest resident keys and the tail is never visited. The cursor
+    /// bounds every resident entry's wait to one pop-rotation, independent of
+    /// the insert pattern, and is deterministic for DST.
+    ///
+    /// Fully synchronous; never holds both lane locks at once.
+    pub fn take_pending_grant_batch(&self) -> BTreeMap<Vec<u8>, (String, String, u32)> {
+        let mut work = {
+            let mut pending = self.pending_grants.lock().unwrap();
+            std::mem::take(&mut *pending)
+        };
+
+        let cold = &mut *self.pending_grants_cold.lock().unwrap();
+        for _ in 0..self.grant_scanner_cold_batch_size {
+            let next_key = cold
+                .pop_cursor
+                .as_deref()
+                .and_then(|cursor| {
+                    cold.entries
+                        .range::<[u8], _>((
+                            std::ops::Bound::Excluded(cursor),
+                            std::ops::Bound::Unbounded,
+                        ))
+                        .next()
+                        .map(|(k, _)| k.clone())
+                })
+                // Cursor unset or tail exhausted: wrap to the front.
+                .or_else(|| cold.entries.keys().next().cloned());
+            let Some(key) = next_key else { break };
+            let Some((tenant, queue, count)) = cold.entries.remove(&key) else {
+                break;
+            };
+            match work.entry(key.clone()) {
+                std::collections::btree_map::Entry::Occupied(mut occupied) => {
+                    let entry = occupied.get_mut();
+                    entry.2 = entry.2.saturating_add(count);
+                }
+                std::collections::btree_map::Entry::Vacant(vacant) => {
+                    vacant.insert((tenant, queue, count));
+                }
+            }
+            cold.pop_cursor = Some(key);
+        }
+        work
+    }
+
+    /// Test-only: peek the current pending-grant count for a queue, summed
+    /// across the hot and cold lanes. Used by
     /// `reconcile_pending_holders_kicks_grant_per_release` to assert that
     /// the reconciler kicked the scanner once per ghost release rather than
     /// once per queue.
     pub fn pending_grant_count_for_test(&self, tenant: &str, queue: &str) -> u32 {
+        self.hot_pending_grant_count_for_test(tenant, queue)
+            .saturating_add(self.cold_pending_grant_count_for_test(tenant, queue))
+    }
+
+    /// Test-only: peek the hot-lane pending-grant count for a queue.
+    #[doc(hidden)]
+    pub fn hot_pending_grant_count_for_test(&self, tenant: &str, queue: &str) -> u32 {
         let key = concurrency_counts_key(tenant, queue);
         let pending = self.pending_grants.lock().unwrap();
         pending.get(&key).map(|(_, _, n)| *n).unwrap_or(0)
+    }
+
+    /// Test-only: peek the cold-lane pending-grant count for a queue.
+    #[doc(hidden)]
+    pub fn cold_pending_grant_count_for_test(&self, tenant: &str, queue: &str) -> u32 {
+        let key = concurrency_counts_key(tenant, queue);
+        let cold = self.pending_grants_cold.lock().unwrap();
+        cold.entries.get(&key).map(|(_, _, n)| *n).unwrap_or(0)
     }
 
     /// Start the background grant scanner task.
@@ -1541,8 +1909,9 @@ impl ConcurrencyManager {
         self.grant_running.store(true, Ordering::SeqCst);
         let mgr = Arc::clone(self);
         tokio::spawn(async move {
-            // Startup: scan for existing pending requests
-            mgr.reconcile_pending_requests(&db, &range).await;
+            // Startup: one full sweep for existing pending requests, seeding
+            // the cold lane so recovery work drains behind live nudges.
+            mgr.reconcile_pending_requests(&db, &range, None).await;
 
             loop {
                 mgr.grant_notify.notified().await;
@@ -1550,14 +1919,34 @@ impl ConcurrencyManager {
                     break;
                 }
 
-                // Inner loop: drain and process until no more pending work
+                // Inner loop: drain and process until no more pending work.
+                // Each iteration takes ALL hot-lane entries plus a bounded
+                // cold-lane batch, so a shard-wide reconcile-sweep backlog
+                // (potentially hundreds of thousands of cold entries) can
+                // delay a release-driven hot nudge by at most one iteration
+                // instead of one full cycle over the whole backlog.
                 loop {
-                    let work = {
-                        let mut pending = mgr.pending_grants.lock().unwrap();
-                        std::mem::take(&mut *pending)
-                    };
+                    // Re-check the stop flag per iteration: with a large cold
+                    // backlog the inner loop can run for a long time, and
+                    // `close()` must not leave the scanner granting against a
+                    // closing DB. The AtomicBool (not select!/abort) is the
+                    // cancellation boundary because `process_grants` is not
+                    // cancellation-safe mid-pass — in-memory reservations are
+                    // only rolled back on its explicit error paths.
+                    if !mgr.grant_running.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    let work = mgr.take_pending_grant_batch();
                     if work.is_empty() {
                         break;
+                    }
+                    // Lane sizes AFTER the take: what remains queued. Hot is
+                    // ~0 in steady state (drained fully every iteration);
+                    // cold sawtooths with the periodic reconcile sweep.
+                    if let Some(ref m) = mgr.metrics {
+                        let hot = mgr.pending_grants.lock().unwrap().len();
+                        let cold = mgr.pending_grants_cold.lock().unwrap().entries.len();
+                        m.set_concurrency_pending_grants(&mgr.shard, hot, cold);
                     }
 
                     // Fan out across queues with bounded concurrency. Each
@@ -1626,9 +2015,34 @@ impl ConcurrencyManager {
     /// wakes the scanner for a queue that grants nothing. It will not
     /// under-report newly created work because the increment lands in the same
     /// write batch as the request row.
-    pub async fn reconcile_pending_requests(&self, db: &InstrumentedDb, range: &ShardRange) {
-        let start = vec![crate::keys::prefix::COUNTER_CONCURRENCY_REQUESTERS];
-        let end = end_bound(&start);
+    ///
+    /// Discovered queues are seeded into the scanner's COLD lane so a
+    /// shard-wide sweep can never delay event-driven (hot-lane) nudges.
+    ///
+    /// `max_keys` bounds the counter keys WALKED this call — grantable or
+    /// not, including zero-valued and out-of-range rows, since the walk cost
+    /// is what a tick must bound. `None` sweeps the whole keyspace in one
+    /// call (scanner startup, diagnostics). `Some(n)` walks at most `n` keys
+    /// resuming from the persistent cursor and saves the new resume point, so
+    /// a shard with hundreds of thousands of counter rows spreads full
+    /// coverage across ticks instead of re-scanning everything every 5s.
+    /// Reaching the end of the keyspace resets the cursor to the front.
+    pub async fn reconcile_pending_requests(
+        &self,
+        db: &InstrumentedDb,
+        range: &ShardRange,
+        max_keys: Option<usize>,
+    ) {
+        let sweep_started = std::time::Instant::now();
+        let prefix_start = vec![crate::keys::prefix::COUNTER_CONCURRENCY_REQUESTERS];
+        let end = end_bound(&prefix_start);
+        // Sliced sweeps resume from the saved cursor; full sweeps always
+        // cover the whole keyspace from the front.
+        let saved_cursor = self.reconcile_cursor.lock().unwrap().clone();
+        let start = match saved_cursor {
+            Some(cursor) if max_keys.is_some() => cursor,
+            _ => prefix_start,
+        };
         let mut iter = match db
             .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options_uncached())
             .await
@@ -1643,7 +2057,14 @@ impl ConcurrencyManager {
             }
         };
 
+        let mut walked: usize = 0;
+        let mut last_key: Option<Vec<u8>> = None;
+        let mut budget_exhausted = false;
         loop {
+            if max_keys.is_some_and(|budget| walked >= budget) {
+                budget_exhausted = true;
+                break;
+            }
             let kv = match iter.next().await {
                 Ok(Some(kv)) => kv,
                 Ok(None) => break,
@@ -1655,6 +2076,8 @@ impl ConcurrencyManager {
                     break;
                 }
             };
+            walked += 1;
+            last_key = Some(kv.key.to_vec());
 
             let Some(parsed) = parse_concurrency_requester_counter_key(&kv.key) else {
                 continue;
@@ -1667,8 +2090,31 @@ impl ConcurrencyManager {
 
             let count = decode_counter(&kv.value);
             if count > 0 {
-                self.request_grant_count(&parsed.tenant, &parsed.queue, count as u32);
+                // Clamp rather than cast: a drifted counter beyond u32::MAX
+                // must not wrap into a tiny pending count.
+                let count = count.clamp(0, u32::MAX as i64) as u32;
+                self.request_grant_count_cold(&parsed.tenant, &parsed.queue, count);
             }
+        }
+
+        // Persist the resume point. Budget exhaustion mid-keyspace resumes at
+        // the successor of the last walked key — append 0x00, the immediate
+        // successor in bytewise order (never increment bytes: 0xFF would
+        // overflow). Reaching the end (or a scan error) resets to the front
+        // so the next sliced sweep starts a fresh rotation.
+        *self.reconcile_cursor.lock().unwrap() = match (budget_exhausted, last_key) {
+            (true, Some(mut key)) => {
+                key.push(0x00);
+                Some(key)
+            }
+            _ => None,
+        };
+
+        if let Some(ref m) = self.metrics {
+            m.record_concurrency_reconcile_sweep(
+                &self.shard,
+                sweep_started.elapsed().as_secs_f64(),
+            );
         }
     }
 
@@ -1689,6 +2135,21 @@ impl ConcurrencyManager {
         queue: &str,
         count: u32,
     ) -> Vec<String> {
+        let invocation_started = std::time::Instant::now();
+        // Invocation-level accounting, recorded once at every exit path
+        // (including precheck skips) so invocation rate and per-invocation
+        // walk cost are observable regardless of how the invocation ends.
+        let record_invocation = |keys_scanned: usize, stale_deleted: usize| {
+            if let Some(ref m) = self.metrics {
+                m.record_concurrency_process_grants(
+                    &self.shard,
+                    invocation_started.elapsed().as_secs_f64(),
+                    keys_scanned as u64,
+                    stale_deleted as u64,
+                );
+            }
+        };
+
         if let Err(e) = self.counts.ensure_hydrated(db, range, tenant, queue).await {
             tracing::warn!(
                 error = %e,
@@ -1696,15 +2157,21 @@ impl ConcurrencyManager {
                 queue = %queue,
                 "grant scanner: failed to hydrate queue"
             );
+            record_invocation(0, 0);
             return Vec::new();
         }
 
         // [SILO-GRANT-1] Pre: Queue has capacity. Fast pre-scan gate: when the
         // queue's capacity is known (cached limit; durable state row for
-        // floating) and every slot is occupied, the try_reserve_internal guard
-        // below cannot succeed for any candidate — the transition cannot fire,
-        // so skip building the request iterator and the per-candidate status
-        // reads entirely. `saturating_sub` is required: holders can
+        // floating) and every SCANNER-fillable slot is occupied, the
+        // try_reserve_internal guard below cannot succeed for any candidate —
+        // the transition cannot fire, so skip building the request iterator
+        // and the per-candidate status reads entirely. The gate uses the same
+        // headroom-reduced capacity the reserve loop grants against (see
+        // `scanner_effective_capacity`): gating on full capacity while
+        // reserving against the reduced one would re-scan a full batch every
+        // cycle just to fail the first reserve whenever holders sit inside
+        // the headroom band. `saturating_sub` is required: holders can
         // legitimately exceed capacity after a floating-limit shrink
         // (try_reserve_internal gates with `>=` and never evicts). Skipping
         // leaves the requester counter untouched, so the periodic reconciler
@@ -1716,8 +2183,9 @@ impl ConcurrencyManager {
         // request cleanup for a saturated queue pauses until a slot frees, and
         // a lowered fixed limit gates old requests that embed a higher one.
         if let Some(capacity) = self.known_queue_capacity(db, tenant, queue).await {
+            let effective_capacity = self.scanner_effective_capacity(capacity);
             let holders = self.counts.holder_count(tenant, queue);
-            if capacity.saturating_sub(holders) == 0 {
+            if effective_capacity.saturating_sub(holders) == 0 {
                 if let Some(ref m) = self.metrics {
                     m.record_concurrency_grant_precheck_skip(&self.shard);
                 }
@@ -1726,9 +2194,11 @@ impl ConcurrencyManager {
                     queue = %queue,
                     requested = count,
                     capacity,
+                    effective_capacity,
                     holders,
                     "grant scanner: queue at capacity, skipping request scan"
                 );
+                record_invocation(0, 0);
                 return Vec::new();
             }
         }
@@ -1745,6 +2215,7 @@ impl ConcurrencyManager {
             Ok(i) => i,
             Err(e) => {
                 tracing::warn!(error = %e, "grant scanner: failed to scan requests");
+                record_invocation(0, 0);
                 return Vec::new();
             }
         };
@@ -1779,6 +2250,13 @@ impl ConcurrencyManager {
         let mut total_granted: usize = 0;
         let mut iter_exhausted = false;
         let mut capacity_exhausted = false;
+        // Next-hop saturation skip state: decisions cached per next-hop queue
+        // for the whole invocation (most candidates in one queue share the
+        // same next hop, e.g. the tenant's platform queue), plus a
+        // consecutive-skip run counter bounding futile walks — see the skip
+        // block below.
+        let mut next_hop_skip_cache: HashMap<String, bool> = HashMap::new();
+        let mut consecutive_next_hop_skips: usize = 0;
         // Per-invocation scan budget. Total request keys walked
         // across all passes (valid, stale, and corrupt — the walk cost is what
         // we bound). When it reaches `grant_scanner_max_scan_per_invocation` the
@@ -1814,6 +2292,10 @@ impl ConcurrencyManager {
             let mut batch = WriteBatch::new();
             let mut grants: Vec<(String, String)> = Vec::new();
             let mut stale_and_corrupt_count: usize = 0;
+            // Stale count as of the last next-hop skip: cleanup progress
+            // between skips resets the consecutive-skip run (a walk that is
+            // deleting stale rows is not futile).
+            let mut stale_at_last_skip: usize = 0;
 
             // --- Scan batch of candidates ---
             let mut scanned: Vec<ScannedRequest> = Vec::new();
@@ -1983,6 +2465,59 @@ impl ConcurrencyManager {
                     max_concurrency = Some((l, lt));
                 }
 
+                // Defer candidates whose NEXT concurrency hop is saturated
+                // with a deep requester backlog: granting them cannot make
+                // the job runnable — the chain immediately parks a deferred
+                // request at that hop — so it only converts "waiting here"
+                // into a parked holder plus one more line entry (pure state
+                // inflation), while occupying this queue's slots with jobs
+                // that cannot run (the shared-queue wedge shape). The row is
+                // left in place — no grant, no delete, no counter decrement —
+                // and keeps its original start_time, so when it is eventually
+                // granted it parks at its age-correct position in the next
+                // hop's FIFO. Liveness: the requester counter stays non-zero,
+                // so the periodic reconcile sweep re-drives this queue; the
+                // depth threshold guarantees the next hop still has far more
+                // than one sweep period of backlog when that happens.
+                if self
+                    .next_hop_should_skip(
+                        db,
+                        tenant,
+                        &limits,
+                        limit_index,
+                        &mut next_hop_skip_cache,
+                    )
+                    .await
+                {
+                    // Cleanup progress since the last skip resets the run: a
+                    // walk that is deleting stale rows is not futile.
+                    if stale_and_corrupt_count > stale_at_last_skip {
+                        consecutive_next_hop_skips = 0;
+                    }
+                    stale_at_last_skip = stale_and_corrupt_count;
+                    consecutive_next_hop_skips += 1;
+                    if let Some(ref m) = self.metrics {
+                        m.record_concurrency_grant_next_hop_skip(&self.shard);
+                    }
+                    if consecutive_next_hop_skips >= MAX_CONSECUTIVE_NEXT_HOP_SKIPS {
+                        // A uniform skip-front: end the invocation instead of
+                        // walking (and, on every cold re-drive, re-walking)
+                        // up to the full scan budget of rows that cannot
+                        // grant — the repeated futile walk is what inflated
+                        // drain-iteration time and starved the cold pop rate.
+                        // Counting consecutively regardless of WHICH hop
+                        // skipped is deliberate: a front alternating between
+                        // two saturated hops is equally futile. Any
+                        // non-skipped candidate resets the run, so a mixed
+                        // front with grantable work inside the window still
+                        // finds it.
+                        budget_exhausted = true;
+                        break;
+                    }
+                    continue;
+                }
+                consecutive_next_hop_skips = 0;
+
                 scanned.push(ScannedRequest {
                     request_key: kv.key.to_vec(),
                     task_id: task_id_str,
@@ -2094,7 +2629,14 @@ impl ConcurrencyManager {
             // FloatingConcurrency/Concurrency limit grants immediately), so we
             // collect all per-pass reservations into `pass_reservations` for
             // rollback if the batch write fails.
-            let limit = max_concurrency.map(|(l, _)| l).unwrap_or(1);
+            //
+            // The scanner reserves against the headroom-reduced capacity so
+            // the configured live share of slots stays reachable by immediate
+            // grants (which use full capacity) while a backlog drains. Note
+            // the resumer's downstream immediate grants also use full
+            // capacity — headroom applies only to the queue being scanned.
+            let limit =
+                self.scanner_effective_capacity(max_concurrency.map(|(l, _)| l).unwrap_or(1));
             // `(queue, task_id)` reservations to release if the per-pass batch
             // write fails. Includes both the just-won queue and any further
             // grants the chain resumer made.
@@ -2150,6 +2692,7 @@ impl ConcurrencyManager {
                     for (q, tid) in &pass_reservations {
                         self.counts.release_reservation(tenant, q, tid);
                     }
+                    record_invocation(scanned_this_invocation, total_stale_deleted);
                     return all_granted_groups;
                 };
 
@@ -2186,6 +2729,7 @@ impl ConcurrencyManager {
                         for (q, tid) in &pass_reservations {
                             self.counts.release_reservation(tenant, q, tid);
                         }
+                        record_invocation(scanned_this_invocation, total_stale_deleted);
                         return all_granted_groups;
                     }
                 }
@@ -2233,6 +2777,7 @@ impl ConcurrencyManager {
                     prior_grants = total_granted,
                     "grant scanner: batch write failed, rolled back this pass's reservations"
                 );
+                record_invocation(scanned_this_invocation, total_stale_deleted);
                 return all_granted_groups;
             }
 
@@ -2273,6 +2818,7 @@ impl ConcurrencyManager {
             );
         }
 
+        record_invocation(scanned_this_invocation, total_stale_deleted);
         all_granted_groups
     }
 }

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -838,18 +838,19 @@ pub struct ConcurrencyManager {
     /// Max number of per-queue `process_grants` passes run concurrently when
     /// draining `pending_grants`. Each entry in `work` is a unique
     /// `(tenant, queue)`, so no two in-flight passes share a gating queue; this
-    /// bounds the `.buffered(...)` fan-out over those passes (order-preserving,
-    /// for DST determinism) so peak memory stays `N × per-pass`. Configurable
-    /// via `grant_scanner_concurrency` (default 8); stored already clamped to
-    /// `>= 1` (`.buffered(0)` is invalid).
+    /// bounds the `.buffer_unordered(...)` fan-out over those passes
+    /// (completion-order, so one slow queue can't head-of-line block the rest)
+    /// so peak memory stays `N × per-pass`. Configurable via
+    /// `grant_scanner_concurrency` (default 8); stored already clamped to
+    /// `>= 1` (`.buffer_unordered(0)` is invalid).
     grant_scanner_concurrency: usize,
     /// Max number of pending-request keys a single `process_grants` invocation
     /// will walk across all of its passes before committing what it found and
     /// returning — even if neither capacity nor the iterator is exhausted. This
     /// bounds the cost one queue can impose per scanner cycle so a single queue
     /// with a huge backlog of non-grantable keys (holder-orphan / stale-request
-    /// shape) can't pin a `.buffered` slot and starve every other tenant's queue
-    /// on the shard. The queue is re-driven on the next cycle (its requester
+    /// shape) can't pin a `.buffer_unordered` slot and starve every other
+    /// tenant's queue on the shard. The queue is re-driven on the next cycle (its requester
     /// counter is still non-zero), making bounded forward progress from the
     /// front each time. Derived from `grant_scanner_batch_size` (a small
     /// multiple) in `new`; always `>= grant_scanner_batch_size` so every
@@ -893,7 +894,7 @@ impl ConcurrencyManager {
             metrics,
             chain_resumer: Mutex::new(None),
             // Clamp to >= 1: a 0 batch would stall the drain loop and
-            // `.buffered(0)` is invalid.
+            // `.buffered(0)` / `.buffer_unordered(0)` are invalid.
             grant_scanner_batch_size: grant_scanner_batch_size.max(1),
             grant_scanner_buffer_size: grant_scanner_buffer_size.max(1),
             grant_scanner_concurrency: grant_scanner_concurrency.max(1),
@@ -1563,8 +1564,15 @@ impl ConcurrencyManager {
                     // (tenant, queue) is unique in `work`, so no two in-flight
                     // passes share a gating queue; downstream chain-resumer
                     // reservations are gated atomically by the per-key DashMap
-                    // guard. `buffered` (order-preserving) keeps collected order
-                    // deterministic against the BTreeMap iteration order for DST.
+                    // guard. `buffer_unordered` (completion-order) rather than
+                    // `buffered` (submission-order): with `buffered`, one slow
+                    // pass (a queue with a deep backlog) blocks yielding of
+                    // every already-finished pass behind it, so completed
+                    // futures pile up in the window and no new pass can start
+                    // until the slow one finishes — head-of-line blocking that
+                    // serializes other queues behind the busiest one. With
+                    // `buffer_unordered`, a slow pass occupies exactly one slot
+                    // while the remaining slots keep draining the other queues.
                     let granted: Vec<Vec<String>> = futures::stream::iter(work.into_values())
                         .map(|(tenant, queue, count)| {
                             let mgr = Arc::clone(&mgr);
@@ -1575,10 +1583,17 @@ impl ConcurrencyManager {
                                     .await
                             }
                         })
-                        .buffered(mgr.grant_scanner_concurrency)
+                        .buffer_unordered(mgr.grant_scanner_concurrency)
                         .collect()
                         .await;
-                    let granted_groups: Vec<String> = granted.into_iter().flatten().collect();
+                    // Canonicalize: `buffer_unordered` collects in completion
+                    // order, which depends on scheduling. Sorting (and deduping
+                    // groups granted via multiple queues) makes the broker wake
+                    // sequence a pure function of the granted *set*, keeping
+                    // downstream behavior independent of interleaving for DST.
+                    let mut granted_groups: Vec<String> = granted.into_iter().flatten().collect();
+                    granted_groups.sort_unstable();
+                    granted_groups.dedup();
 
                     // Wake only the brokers whose task groups received grants
                     if !granted_groups.is_empty() {
@@ -1769,7 +1784,8 @@ impl ConcurrencyManager {
         // we bound). When it reaches `grant_scanner_max_scan_per_invocation` the
         // call commits what it found and returns even if capacity/iterator are
         // not exhausted, so a single queue with a huge non-grantable front
-        // cannot starve other tenants' queues sharing the `.buffered` fan-out.
+        // cannot starve other tenants' queues sharing the `.buffer_unordered`
+        // fan-out.
         // The queue is re-driven next cycle (its requester counter is still
         // non-zero), making bounded forward progress from the front each time.
         let mut scanned_this_invocation: usize = 0;

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -963,6 +963,14 @@ impl ConcurrencyManager {
         cache.values().cloned().collect()
     }
 
+    /// Look up the cached limit for a single (tenant, queue). Returns None if
+    /// no enqueue/dequeue/refresh/grant pass has cached this queue's limit yet
+    /// (e.g., freshly restarted shard).
+    pub(crate) fn cached_queue_limit(&self, tenant: &str, queue: &str) -> Option<CachedQueueLimit> {
+        let key = concurrency_counts_key(tenant, queue);
+        self.limit_cache.lock().unwrap().get(&key).cloned()
+    }
+
     /// Resolve the gating queue's capacity from the persisted limits list.
     /// Public so dequeue and other shard paths can compute capacity without
     /// fetching JobInfo when the limits are already in hand (e.g., off a
@@ -974,6 +982,26 @@ impl ConcurrencyManager {
         limits: &[Limit],
     ) -> (usize, ConcurrencyLimitType) {
         Self::resolve_queue_capacity_from_limits(db, tenant, queue, limits).await
+    }
+
+    /// Point-read the durable floating-limit state row for (tenant, queue) and
+    /// return its current max concurrency. None when the row is missing or
+    /// unreadable — callers choose their own fallback (the scan path falls back
+    /// to the limit's default_max_concurrency; the pre-scan gate treats it as
+    /// unknown and lets the scan run).
+    async fn floating_state_capacity(
+        db: &InstrumentedDb,
+        tenant: &str,
+        queue: &str,
+    ) -> Option<usize> {
+        let state_key = floating_limit_state_key(tenant, queue);
+        match db.get(&state_key).await {
+            Ok(Some(raw)) => match decode_floating_limit_state(raw) {
+                Ok(state) => Some(state.current_max_concurrency() as usize),
+                Err(_) => None,
+            },
+            _ => None,
+        }
     }
 
     async fn resolve_queue_capacity_from_limits(
@@ -988,14 +1016,7 @@ impl ConcurrencyManager {
                     return (cl.max_concurrency as usize, ConcurrencyLimitType::Fixed);
                 }
                 Limit::FloatingConcurrency(fl) if fl.key == queue => {
-                    let state_key = floating_limit_state_key(tenant, queue);
-                    let state_capacity = match db.get(&state_key).await {
-                        Ok(Some(raw)) => match decode_floating_limit_state(raw) {
-                            Ok(state) => Some(state.current_max_concurrency() as usize),
-                            Err(_) => None,
-                        },
-                        _ => None,
-                    };
+                    let state_capacity = Self::floating_state_capacity(db, tenant, queue).await;
                     return (
                         state_capacity.unwrap_or(fl.default_max_concurrency as usize),
                         ConcurrencyLimitType::Floating,
@@ -1005,6 +1026,29 @@ impl ConcurrencyManager {
             }
         }
         (1, ConcurrencyLimitType::Fixed)
+    }
+
+    /// Resolve the queue's current capacity WITHOUT scanning requests.
+    /// Fixed limits come straight from the in-memory cache; Floating limits do
+    /// one point read of the durable state row (the cached snapshot may be
+    /// stale, and the durable row is what the scan path would gate on).
+    /// Returns None when capacity cannot be cheaply determined — cache miss,
+    /// or a Floating limit whose state row is missing/unreadable — in which
+    /// case the caller must fall back to the scan, which resolves capacity
+    /// from the request's embedded limits and re-populates the cache.
+    async fn known_queue_capacity(
+        &self,
+        db: &InstrumentedDb,
+        tenant: &str,
+        queue: &str,
+    ) -> Option<usize> {
+        let cached = self.cached_queue_limit(tenant, queue)?;
+        match cached.limit_type {
+            ConcurrencyLimitType::Fixed => Some(cached.max_concurrency as usize),
+            ConcurrencyLimitType::Floating => {
+                Self::floating_state_capacity(db, tenant, queue).await
+            }
+        }
     }
 
     /// Handle concurrency for a new job enqueue.
@@ -1638,6 +1682,40 @@ impl ConcurrencyManager {
                 "grant scanner: failed to hydrate queue"
             );
             return Vec::new();
+        }
+
+        // [SILO-GRANT-1] Pre: Queue has capacity. Fast pre-scan gate: when the
+        // queue's capacity is known (cached limit; durable state row for
+        // floating) and every slot is occupied, the try_reserve_internal guard
+        // below cannot succeed for any candidate — the transition cannot fire,
+        // so skip building the request iterator and the per-candidate status
+        // reads entirely. `saturating_sub` is required: holders can
+        // legitimately exceed capacity after a floating-limit shrink
+        // (try_reserve_internal gates with `>=` and never evicts). Skipping
+        // leaves the requester counter untouched, so the periodic reconciler
+        // re-drives this queue every tick at O(1) cost, and every release /
+        // floating-raise path nudges the scanner the moment capacity frees.
+        // Unknown capacity (cache miss after restart, unreadable floating
+        // state) falls through to the scan, which resolves the limit from the
+        // first request and re-warms the cache. Accepted trade-offs: stale
+        // request cleanup for a saturated queue pauses until a slot frees, and
+        // a lowered fixed limit gates old requests that embed a higher one.
+        if let Some(capacity) = self.known_queue_capacity(db, tenant, queue).await {
+            let holders = self.counts.holder_count(tenant, queue);
+            if capacity.saturating_sub(holders) == 0 {
+                if let Some(ref m) = self.metrics {
+                    m.record_concurrency_grant_precheck_skip(&self.shard);
+                }
+                tracing::debug!(
+                    tenant = %tenant,
+                    queue = %queue,
+                    requested = count,
+                    capacity,
+                    holders,
+                    "grant scanner: queue at capacity, skipping request scan"
+                );
+                return Vec::new();
+            }
         }
 
         let now_ms = crate::job_store_shard::now_epoch_ms();

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -960,16 +960,21 @@ pub struct ConcurrencyManager {
     drift_pass: Mutex<DriftPass>,
 }
 
-/// End a `process_grants` invocation after this many CONSECUTIVE next-hop
-/// skips with no intervening non-skipped candidate (a grant candidate or
-/// stale-row cleanup both reset the run). Bounds the walk over a front
-/// dominated by candidates whose next hop is saturated-with-backlog: without
-/// it, every cold-sweep re-drive of such a queue re-walks up to the full
-/// per-invocation scan budget (batch_size × 4 — 8192 keys with the staging
-/// config) doing nothing, inflating drain-iteration time. Large enough that
-/// a mixed front with grantable candidates for a different hop inside the
-/// window is still served in one invocation.
-const MAX_CONSECUTIVE_NEXT_HOP_SKIPS: usize = 64;
+/// Memoized per-hop durable reads for `next_hop_should_skip`, keyed by the
+/// next hop's queue name for the duration of one `process_grants` invocation.
+/// The two point reads (floating state row, requester counter) are per-hop and
+/// stable across candidates, so they are cached; but the capacity a Fixed hop
+/// is COMPARED against is the candidate's OWN embedded limit, resolved per
+/// candidate — so a stale low limit on an old parked row can no longer veto a
+/// newer row whose embedded (raised) limit shows the hop has real headroom.
+#[derive(Default)]
+struct NextHopReads {
+    /// Durable floating-state capacity (Floating hops only); filled on first read.
+    floating_capacity: Option<usize>,
+    /// Durable requester-counter depth; filled the first time a candidate
+    /// finds this hop saturated.
+    depth: Option<i64>,
+}
 
 /// A drift-detected ghost must be observed as a ghost in this many
 /// *consecutive* `report_holder_drift` passes before it is enqueued for
@@ -1209,72 +1214,94 @@ impl ConcurrencyManager {
     /// Decide whether the grant scanner should defer a candidate because its
     /// NEXT concurrency hop is saturated with a deep requester backlog.
     ///
-    /// The gate is the FIRST limit after `limit_index`: a RateLimit gate
-    /// never skips (the chain writes a `CheckRateLimit` task — real progress
-    /// that holds no capacity), and a terminal candidate (no further limits)
-    /// never skips (granting emits the RunAttempt). A Concurrency /
-    /// FloatingConcurrency gate skips iff its holders >= its capacity AND its
-    /// durable requester counter >= `grant_scanner_next_hop_skip_min_backlog`
-    /// (0 disables the check entirely).
+    /// The gate is the next CAPACITY-HOLDING hop after `limit_index`, found by
+    /// walking forward THROUGH any RateLimit entries: a rate limit holds and
+    /// releases no concurrency slot (the chain writes a `CheckRateLimit` task
+    /// and proceeds still holding this queue's slot), so the hop that actually
+    /// decides whether granting merely parks a holder is the next Concurrency /
+    /// FloatingConcurrency limit, not the rate limit. A terminal candidate (no
+    /// further concurrency hop) never skips (granting emits the RunAttempt). A
+    /// Concurrency / FloatingConcurrency gate skips iff its holders >= this
+    /// candidate's capacity AND its durable requester counter >=
+    /// `grant_scanner_next_hop_skip_min_backlog` (0 disables the check).
     ///
     /// Inputs degrade safely: `holder_count` on an unhydrated next hop reads
     /// 0 and an unreadable counter reads 0, so missing data can only make the
-    /// skip NOT fire — behavior falls back to granting as before. Decisions
-    /// (including the floating-capacity point-read and the counter
-    /// point-read) are cached in `cache` for the invocation, keyed by the
-    /// next hop's queue name: in practice every candidate in one queue shares
-    /// the same next hop (the tenant's platform queue), so the whole
-    /// invocation pays at most a couple of point reads.
+    /// skip NOT fire — behavior falls back to granting as before. The two
+    /// durable point reads (floating state, requester counter) are memoized in
+    /// `cache` per next-hop queue for the invocation, but the holders-vs-capacity
+    /// comparison is re-evaluated per candidate against that candidate's own
+    /// embedded capacity (see `NextHopReads`).
     async fn next_hop_should_skip(
         &self,
         db: &Arc<InstrumentedDb>,
         tenant: &str,
         limits: &[Limit],
         limit_index: u32,
-        cache: &mut HashMap<String, bool>,
+        cache: &mut HashMap<String, NextHopReads>,
     ) -> bool {
         if self.grant_scanner_next_hop_skip_min_backlog == 0 {
             return false;
         }
-        let Some(next) = limits.get(limit_index as usize + 1) else {
-            return false;
-        };
-        // Split queue-name extraction from capacity resolution so the cache
-        // check happens before the floating-state point read.
-        let (next_queue, fixed_capacity, floating_default) = match next {
-            Limit::RateLimit(_) => return false,
-            Limit::Concurrency(cl) => (cl.key.as_str(), Some(cl.max_concurrency as usize), 0),
-            Limit::FloatingConcurrency(fl) => {
-                (fl.key.as_str(), None, fl.default_max_concurrency as usize)
+        // Look through rate limits to the next capacity-holding hop; a terminal
+        // candidate (nothing, or only rate limits, after `limit_index`) never skips.
+        let mut probe = limit_index as usize + 1;
+        let next = loop {
+            match limits.get(probe) {
+                None => return false,
+                Some(Limit::RateLimit(_)) => probe += 1,
+                Some(other) => break other,
             }
         };
-        if let Some(&decision) = cache.get(next_queue) {
-            return decision;
+        let next_queue = match next {
+            Limit::Concurrency(cl) => cl.key.as_str(),
+            Limit::FloatingConcurrency(fl) => fl.key.as_str(),
+            // Unreachable: RateLimit is looked through above.
+            Limit::RateLimit(_) => return false,
+        };
+        let reads = cache.entry(next_queue.to_string()).or_default();
+
+        // This candidate's view of the hop capacity. Fixed: the embedded
+        // per-request limit, resolved per candidate. Floating: the durable
+        // state row (a per-hop value, memoized), falling back to the embedded
+        // default when the row is missing/unreadable — mirroring
+        // resolve_queue_capacity_from_limits.
+        let capacity = match next {
+            Limit::Concurrency(cl) => cl.max_concurrency as usize,
+            Limit::FloatingConcurrency(fl) => {
+                if reads.floating_capacity.is_none() {
+                    reads.floating_capacity = Some(
+                        Self::floating_state_capacity(db, tenant, next_queue)
+                            .await
+                            .unwrap_or(fl.default_max_concurrency as usize),
+                    );
+                }
+                reads.floating_capacity.unwrap()
+            }
+            Limit::RateLimit(_) => return false,
+        };
+        if self.counts.holder_count(tenant, next_queue) < capacity {
+            return false;
         }
-        let capacity = match fixed_capacity {
-            Some(capacity) => capacity,
-            // The durable floating row is what the next hop's own scan path
-            // gates on; fall back to the limit's embedded default when the
-            // row is missing/unreadable, mirroring resolve_queue_capacity_from_limits.
-            None => Self::floating_state_capacity(db, tenant, next_queue)
-                .await
-                .unwrap_or(floating_default),
-        };
-        let holders = self.counts.holder_count(tenant, next_queue);
-        let decision = if holders >= capacity {
-            let depth = match db
-                .get(&concurrency_requester_counter_key(tenant, next_queue))
-                .await
-            {
-                Ok(Some(raw)) => decode_counter(&raw),
-                _ => 0,
-            };
-            depth >= self.grant_scanner_next_hop_skip_min_backlog as i64
-        } else {
-            false
-        };
-        cache.insert(next_queue.to_string(), decision);
-        decision
+        // Saturated for this candidate — consult the durable requester counter
+        // (memoized per hop for the invocation).
+        if reads.depth.is_none() {
+            reads.depth = Some(
+                match db
+                    .get(&concurrency_requester_counter_key(tenant, next_queue))
+                    .await
+                {
+                    Ok(Some(raw)) => decode_counter(&raw),
+                    _ => 0,
+                },
+            );
+        }
+        // Saturating conversion: a config value above i64::MAX must not wrap to
+        // a negative threshold (which would make the skip fire on any saturated
+        // hop regardless of backlog depth).
+        let min_backlog =
+            i64::try_from(self.grant_scanner_next_hop_skip_min_backlog).unwrap_or(i64::MAX);
+        reads.depth.unwrap() >= min_backlog
     }
 
     /// Handle concurrency for a new job enqueue.
@@ -1656,6 +1683,12 @@ impl ConcurrencyManager {
         range: &ShardRange,
         slice: usize,
     ) {
+        // Clamp to >= 1: a slice of 0 would `drain(..0)` nothing each tick, so
+        // `pass.work` never empties, `pass_completes` is never true, and the
+        // drift gauge / ghost confirmation would stall forever (never
+        // self-healing a leaked holder). Honors the settings doc "values below
+        // 1 are treated as 1".
+        let slice = slice.max(1);
         // Pop this tick's batch under the lock (never held across awaits).
         // An empty work list means a new pass begins: take a fresh sorted
         // snapshot of the hydrated queues.
@@ -2033,6 +2066,12 @@ impl ConcurrencyManager {
         range: &ShardRange,
         max_keys: Option<usize>,
     ) {
+        // Clamp a sliced budget to >= 1 (a full sweep stays `None`): a `Some(0)`
+        // budget would break before walking any key every tick — seeding
+        // nothing into the cold lane and resetting the cursor forever — so
+        // deferred requests not carried by a hot nudge would never be
+        // rediscovered. Honors the settings doc "values below 1 are treated as 1".
+        let max_keys = max_keys.map(|budget| budget.max(1));
         let sweep_started = std::time::Instant::now();
         let prefix_start = vec![crate::keys::prefix::COUNTER_CONCURRENCY_REQUESTERS];
         let end = end_bound(&prefix_start);
@@ -2059,10 +2098,15 @@ impl ConcurrencyManager {
 
         let mut walked: usize = 0;
         let mut last_key: Option<Vec<u8>> = None;
-        let mut budget_exhausted = false;
+        // Set when the sweep stops before cleanly reaching the end of the
+        // keyspace — either the per-tick budget was hit or a scan error
+        // interrupted iteration. Both resume the next sweep AFTER the last good
+        // key rather than restarting the rotation at the front; only a clean
+        // `Ok(None)` end resets to the front for a fresh rotation.
+        let mut stopped_early = false;
         loop {
             if max_keys.is_some_and(|budget| walked >= budget) {
-                budget_exhausted = true;
+                stopped_early = true;
                 break;
             }
             let kv = match iter.next().await {
@@ -2073,6 +2117,13 @@ impl ConcurrencyManager {
                         error = %e,
                         "grant scanner: reconciliation scan iteration error"
                     );
+                    // Resume forward from the last good key instead of resetting
+                    // to the front: a transient object-store error clears and
+                    // the next sweep continues past it, so keys already covered
+                    // this rotation aren't re-walked. A persistent error is no
+                    // worse than the pre-slicing full sweep, which also
+                    // refaulted here every tick.
+                    stopped_early = true;
                     break;
                 }
             };
@@ -2097,12 +2148,12 @@ impl ConcurrencyManager {
             }
         }
 
-        // Persist the resume point. Budget exhaustion mid-keyspace resumes at
-        // the successor of the last walked key — append 0x00, the immediate
-        // successor in bytewise order (never increment bytes: 0xFF would
-        // overflow). Reaching the end (or a scan error) resets to the front
-        // so the next sliced sweep starts a fresh rotation.
-        *self.reconcile_cursor.lock().unwrap() = match (budget_exhausted, last_key) {
+        // Persist the resume point. Stopping early mid-keyspace (budget hit or
+        // scan error) resumes at the successor of the last walked key — append
+        // 0x00, the immediate successor in bytewise order (never increment
+        // bytes: 0xFF would overflow). Cleanly reaching the end resets to the
+        // front so the next sliced sweep starts a fresh rotation.
+        *self.reconcile_cursor.lock().unwrap() = match (stopped_early, last_key) {
             (true, Some(mut key)) => {
                 key.push(0x00);
                 Some(key)
@@ -2175,8 +2226,9 @@ impl ConcurrencyManager {
         // legitimately exceed capacity after a floating-limit shrink
         // (try_reserve_internal gates with `>=` and never evicts). Skipping
         // leaves the requester counter untouched, so the periodic reconciler
-        // re-drives this queue every tick at O(1) cost, and every release /
-        // floating-raise path nudges the scanner the moment capacity frees.
+        // re-drives this queue on its next sliced-sweep cursor rotation, and
+        // every release / floating-raise path (plus the scanner's own
+        // write-failure rollback) nudges the scanner the moment capacity frees.
         // Unknown capacity (cache miss after restart, unreadable floating
         // state) falls through to the scan, which resolves the limit from the
         // first request and re-warms the cache. Accepted trade-offs: stale
@@ -2250,13 +2302,13 @@ impl ConcurrencyManager {
         let mut total_granted: usize = 0;
         let mut iter_exhausted = false;
         let mut capacity_exhausted = false;
-        // Next-hop saturation skip state: decisions cached per next-hop queue
-        // for the whole invocation (most candidates in one queue share the
-        // same next hop, e.g. the tenant's platform queue), plus a
-        // consecutive-skip run counter bounding futile walks — see the skip
-        // block below.
-        let mut next_hop_skip_cache: HashMap<String, bool> = HashMap::new();
-        let mut consecutive_next_hop_skips: usize = 0;
+        // Next-hop saturation skip state: per-hop durable reads memoized for
+        // the whole invocation (most candidates in one queue share the same
+        // next hop, e.g. the tenant's platform queue). A skipped candidate
+        // still consumes the per-invocation scan budget below, so a front
+        // dominated by saturated-next-hop candidates yields at the budget like
+        // any other non-grantable front — no separate early-bail counter.
+        let mut next_hop_skip_cache: HashMap<String, NextHopReads> = HashMap::new();
         // Per-invocation scan budget. Total request keys walked
         // across all passes (valid, stale, and corrupt — the walk cost is what
         // we bound). When it reaches `grant_scanner_max_scan_per_invocation` the
@@ -2292,10 +2344,6 @@ impl ConcurrencyManager {
             let mut batch = WriteBatch::new();
             let mut grants: Vec<(String, String)> = Vec::new();
             let mut stale_and_corrupt_count: usize = 0;
-            // Stale count as of the last next-hop skip: cleanup progress
-            // between skips resets the consecutive-skip run (a walk that is
-            // deleting stale rows is not futile).
-            let mut stale_at_last_skip: usize = 0;
 
             // --- Scan batch of candidates ---
             let mut scanned: Vec<ScannedRequest> = Vec::new();
@@ -2475,10 +2523,22 @@ impl ConcurrencyManager {
                 // left in place — no grant, no delete, no counter decrement —
                 // and keeps its original start_time, so when it is eventually
                 // granted it parks at its age-correct position in the next
-                // hop's FIFO. Liveness: the requester counter stays non-zero,
-                // so the periodic reconcile sweep re-drives this queue; the
-                // depth threshold guarantees the next hop still has far more
-                // than one sweep period of backlog when that happens.
+                // hop's FIFO.
+                //
+                // A skipped row still consumed the per-invocation scan budget
+                // (`scanned_this_invocation` was already incremented above), so
+                // a front of >budget saturated candidates yields at the budget
+                // like any other non-grantable front and a grantable candidate
+                // anywhere within the budget window is still reached this
+                // invocation. Liveness for candidates past the window: the
+                // requester counter stays non-zero, so the periodic reconcile
+                // sweep re-drives this queue on its next cursor rotation. The
+                // min-backlog threshold is a heuristic that the hop stays
+                // saturated across that rotation — sound for a deep, slowly
+                // draining hop (the wedge shape this targets), but a small-cap
+                // hop that drains its whole line within a rotation is re-driven
+                // a rotation later than ideal (bounded staleness, no lost work;
+                // no reverse-edge nudge wakes upstream queues on desaturation).
                 if self
                     .next_hop_should_skip(
                         db,
@@ -2489,34 +2549,11 @@ impl ConcurrencyManager {
                     )
                     .await
                 {
-                    // Cleanup progress since the last skip resets the run: a
-                    // walk that is deleting stale rows is not futile.
-                    if stale_and_corrupt_count > stale_at_last_skip {
-                        consecutive_next_hop_skips = 0;
-                    }
-                    stale_at_last_skip = stale_and_corrupt_count;
-                    consecutive_next_hop_skips += 1;
                     if let Some(ref m) = self.metrics {
                         m.record_concurrency_grant_next_hop_skip(&self.shard);
                     }
-                    if consecutive_next_hop_skips >= MAX_CONSECUTIVE_NEXT_HOP_SKIPS {
-                        // A uniform skip-front: end the invocation instead of
-                        // walking (and, on every cold re-drive, re-walking)
-                        // up to the full scan budget of rows that cannot
-                        // grant — the repeated futile walk is what inflated
-                        // drain-iteration time and starved the cold pop rate.
-                        // Counting consecutively regardless of WHICH hop
-                        // skipped is deliberate: a front alternating between
-                        // two saturated hops is equally futile. Any
-                        // non-skipped candidate resets the run, so a mixed
-                        // front with grantable work inside the window still
-                        // finds it.
-                        budget_exhausted = true;
-                        break;
-                    }
                     continue;
                 }
-                consecutive_next_hop_skips = 0;
 
                 scanned.push(ScannedRequest {
                     request_key: kv.key.to_vec(),
@@ -2770,6 +2807,13 @@ impl ConcurrencyManager {
                 for (q, tid) in &pass_reservations {
                     self.counts.release_reservation(tenant, q, tid);
                 }
+                // The batch did not commit, so this queue's durable request
+                // rows and requester counter are untouched — the freed slots
+                // are grantable again immediately. Re-nudge the hot lane so the
+                // retry happens on the next drain iteration rather than waiting
+                // for the sliced reconcile sweep to rotate back to this queue
+                // (release_reservation alone does not wake the scanner).
+                self.request_grant(tenant, queue);
                 tracing::warn!(
                     error = %e,
                     pass_grants = grants.len(),

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::OnceCell;
 
+use crate::concurrency::GrantScannerConfig;
 use crate::gubernator::RateLimitClient;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError, OpenShardOptions};
 use crate::metrics::Metrics;
@@ -201,9 +202,17 @@ impl ShardFactory {
                         ),
                         counter_reconciliation_seconds: template.counter_reconciliation_seconds,
                         hydrate_all_at_startup: template.hydrate_all_at_startup,
-                        grant_scanner_batch_size: template.grant_scanner_batch_size,
-                        grant_scanner_buffer_size: template.grant_scanner_buffer_size,
-                        grant_scanner_concurrency: template.grant_scanner_concurrency,
+                        grant_scanner: GrantScannerConfig {
+                            batch_size: template.grant_scanner_batch_size,
+                            buffer_size: template.grant_scanner_buffer_size,
+                            concurrency: template.grant_scanner_concurrency,
+                            cold_batch_size: template.grant_scanner_cold_batch_size,
+                            next_hop_skip_min_backlog: template
+                                .grant_scanner_next_hop_skip_min_backlog,
+                            live_headroom_fraction: template.grant_scanner_live_headroom_fraction,
+                        },
+                        concurrency_reconcile_scan_slice: template.concurrency_reconcile_scan_slice,
+                        holder_drift_scan_slice: template.holder_drift_scan_slice,
                         completed_job_expire_s: template.completed_job_expire_s,
                         terminal_job_expire_s: template.terminal_job_expire_s,
                     },

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -46,7 +46,7 @@ use tracing::{Instrument, info_span};
 use crate::instrumented_db::InstrumentedDb;
 
 use crate::codec::CodecError;
-use crate::concurrency::ConcurrencyManager;
+use crate::concurrency::{ConcurrencyManager, GrantScannerConfig};
 use crate::gubernator::RateLimitClient;
 use crate::job::{JobStatus, JobStatusKind, JobView};
 use crate::job_attempt::JobAttemptView;
@@ -104,15 +104,17 @@ pub struct OpenShardOptions {
     /// Populated from `DatabaseConfig::hydrate_all_at_startup` /
     /// `DatabaseTemplate::hydrate_all_at_startup`; tests set it explicitly.
     pub hydrate_all_at_startup: bool,
-    /// Max grants the background grant scanner commits per `process_grants`
-    /// pass. Populated from `grant_scanner_batch_size` in the database config.
-    pub grant_scanner_batch_size: usize,
-    /// Max in-flight status lookups the grant scanner buffers per pass.
-    /// Populated from `grant_scanner_buffer_size` in the database config.
-    pub grant_scanner_buffer_size: usize,
-    /// Max per-queue `process_grants` passes the grant scanner runs concurrently.
-    /// Populated from `grant_scanner_concurrency` in the database config.
-    pub grant_scanner_concurrency: usize,
+    /// Grant scanner tuning (batch/buffer/fan-out sizes, cold-lane batch,
+    /// next-hop skip threshold, live headroom). Populated from the
+    /// `grant_scanner_*` knobs in the database config.
+    pub grant_scanner: GrantScannerConfig,
+    /// Max requester-counter keys the periodic concurrency reconcile sweep
+    /// walks per tick. Populated from `concurrency_reconcile_scan_slice` in
+    /// the database config.
+    pub concurrency_reconcile_scan_slice: usize,
+    /// Max hydrated queues the periodic holder-drift report scans per tick.
+    /// Populated from `holder_drift_scan_slice` in the database config.
+    pub holder_drift_scan_slice: usize,
     /// When set, jobs that reach Succeeded have their associated KV records
     /// re-put with a SlateDB row TTL of this many seconds. `None` disables
     /// the feature for successful jobs.
@@ -199,6 +201,10 @@ pub struct JobStoreShard {
     pub(crate) metrics: Option<Metrics>,
     /// Interval for periodic concurrency request reconciliation.
     concurrency_reconcile_interval: Duration,
+    /// Max requester-counter keys walked per periodic reconcile tick.
+    concurrency_reconcile_scan_slice: usize,
+    /// Max hydrated queues scanned per periodic holder-drift tick.
+    holder_drift_scan_slice: usize,
     /// Cancellation token for background tasks like cleanup.
     /// Signaled when the shard is closing.
     cancellation: CancellationToken,
@@ -399,9 +405,16 @@ impl JobStoreShard {
                 ),
                 counter_reconciliation_seconds: cfg.counter_reconciliation_seconds,
                 hydrate_all_at_startup: cfg.hydrate_all_at_startup,
-                grant_scanner_batch_size: cfg.grant_scanner_batch_size,
-                grant_scanner_buffer_size: cfg.grant_scanner_buffer_size,
-                grant_scanner_concurrency: cfg.grant_scanner_concurrency,
+                grant_scanner: GrantScannerConfig {
+                    batch_size: cfg.grant_scanner_batch_size,
+                    buffer_size: cfg.grant_scanner_buffer_size,
+                    concurrency: cfg.grant_scanner_concurrency,
+                    cold_batch_size: cfg.grant_scanner_cold_batch_size,
+                    next_hop_skip_min_backlog: cfg.grant_scanner_next_hop_skip_min_backlog,
+                    live_headroom_fraction: cfg.grant_scanner_live_headroom_fraction,
+                },
+                concurrency_reconcile_scan_slice: cfg.concurrency_reconcile_scan_slice,
+                holder_drift_scan_slice: cfg.holder_drift_scan_slice,
                 completed_job_expire_s: cfg.completed_job_expire_s,
                 terminal_job_expire_s: cfg.terminal_job_expire_s,
             },
@@ -442,9 +455,9 @@ impl JobStoreShard {
             concurrency_reconcile_interval,
             counter_reconciliation_seconds,
             hydrate_all_at_startup,
-            grant_scanner_batch_size,
-            grant_scanner_buffer_size,
-            grant_scanner_concurrency,
+            grant_scanner,
+            concurrency_reconcile_scan_slice,
+            holder_drift_scan_slice,
             completed_job_expire_s,
             terminal_job_expire_s,
         } = options;
@@ -512,9 +525,7 @@ impl JobStoreShard {
             name.clone(),
             metrics.clone(),
             hydrate_all_at_startup,
-            grant_scanner_batch_size,
-            grant_scanner_buffer_size,
-            grant_scanner_concurrency,
+            grant_scanner,
         ));
 
         // Eagerly hydrate the in-memory holders cache from durable storage so
@@ -555,6 +566,8 @@ impl JobStoreShard {
             wal_close_config,
             metrics,
             concurrency_reconcile_interval,
+            concurrency_reconcile_scan_slice,
+            holder_drift_scan_slice,
             cancellation: CancellationToken::new(),
             store,
             db_path: db_path.to_string(),
@@ -969,17 +982,26 @@ impl JobStoreShard {
                             .concurrency
                             .reconcile_pending_holders(&shard.db, &range)
                             .await;
+                        // Sliced sweep: walk at most `scan_slice` counter
+                        // keys per tick, resuming from a cursor, so full
+                        // keyspace coverage spreads across ticks instead of
+                        // re-scanning every counter row every 5s on
+                        // queue-heavy shards.
                         shard
                             .concurrency
-                            .reconcile_pending_requests(shard.db.as_ref(), &range)
+                            .reconcile_pending_requests(
+                                shard.db.as_ref(),
+                                &range,
+                                Some(shard.concurrency_reconcile_scan_slice),
+                            )
                             .await;
-                        // After draining, snapshot drift + pending-queue size
-                        // for prometheus. Cheap per tick (one ranged scan per
-                        // hydrated queue); the per-tick cadence keeps the
-                        // total cost bounded.
+                        // After draining, advance the sliced drift pass and
+                        // snapshot the pending-queue size for prometheus. A
+                        // full drift pass over all hydrated queues spans
+                        // multiple ticks on queue-heavy shards.
                         shard
                             .concurrency
-                            .report_holder_drift(&shard.db, &range)
+                            .report_holder_drift(&shard.db, &range, shard.holder_drift_scan_slice)
                             .await;
                     }
                     _ = cancellation.cancelled() => {
@@ -1150,10 +1172,44 @@ impl JobStoreShard {
     }
 
     /// Test-only: peek the current pending-grant count accumulated for
-    /// `(tenant, queue)`. Used by the reconciler regression test to assert
-    /// that each ghost release fired its own `request_grant`.
+    /// `(tenant, queue)`, summed across the hot and cold lanes. Used by the
+    /// reconciler regression test to assert that each ghost release fired its
+    /// own `request_grant`.
     pub fn pending_grant_count_for_test(&self, tenant: &str, queue: &str) -> u32 {
         self.concurrency.pending_grant_count_for_test(tenant, queue)
+    }
+
+    /// Test-only: peek the hot-lane pending-grant count for `(tenant, queue)`.
+    #[doc(hidden)]
+    pub fn hot_pending_grant_count_for_test(&self, tenant: &str, queue: &str) -> u32 {
+        self.concurrency
+            .hot_pending_grant_count_for_test(tenant, queue)
+    }
+
+    /// Test-only: peek the cold-lane pending-grant count for `(tenant, queue)`.
+    #[doc(hidden)]
+    pub fn cold_pending_grant_count_for_test(&self, tenant: &str, queue: &str) -> u32 {
+        self.concurrency
+            .cold_pending_grant_count_for_test(tenant, queue)
+    }
+
+    /// Test-only: seed the grant scanner's cold pending lane directly, as the
+    /// periodic reconcile sweep would.
+    #[doc(hidden)]
+    pub fn seed_cold_pending_grant_for_test(&self, tenant: &str, queue: &str, count: u32) {
+        self.concurrency
+            .request_grant_count_cold(tenant, queue, count);
+    }
+
+    /// Test-only: compute one drain-iteration work batch (all hot entries +
+    /// a bounded round-robin cold batch), as the scanner's inner loop would.
+    /// Call `stop_grant_scanner` first so the background task doesn't race.
+    #[doc(hidden)]
+    pub fn take_pending_grant_batch_for_test(&self) -> Vec<(String, String, u32)> {
+        self.concurrency
+            .take_pending_grant_batch()
+            .into_values()
+            .collect()
     }
 
     /// Test-only: drain pending reconciliations and apply them now. Returns
@@ -1169,14 +1225,27 @@ impl JobStoreShard {
             .await
     }
 
-    /// Test-only: run one self-healing drift pass. Walks hydrated queues,
-    /// compares the in-memory holder set to durable rows, and enqueues any
-    /// ghosts (in-memory holders with no durable row) for reconciliation.
-    /// Callers typically follow with `reconcile_pending_holders_for_test` to
-    /// drive the actual release.
+    /// Test-only: run one FULL self-healing drift pass (unbounded slice, so
+    /// one call visits every hydrated queue). Walks hydrated queues, compares
+    /// the in-memory holder set to durable rows, and enqueues any ghosts
+    /// (in-memory holders with no durable row) for reconciliation. Callers
+    /// typically follow with `reconcile_pending_holders_for_test` to drive
+    /// the actual release.
     pub async fn report_holder_drift_for_test(&self) {
         let range = self.get_range();
-        self.concurrency.report_holder_drift(&self.db, &range).await
+        self.concurrency
+            .report_holder_drift(&self.db, &range, usize::MAX)
+            .await
+    }
+
+    /// Test-only: advance the sliced drift pass by at most `slice` queues,
+    /// exactly as one periodic tick does.
+    #[doc(hidden)]
+    pub async fn report_holder_drift_sliced_for_test(&self, slice: usize) {
+        let range = self.get_range();
+        self.concurrency
+            .report_holder_drift(&self.db, &range, slice)
+            .await
     }
     /// Get the SlateDB metrics registry for this shard.
     /// Use this to collect storage-level statistics for observability.
@@ -1243,7 +1312,18 @@ impl JobStoreShard {
     pub async fn reconcile_pending_concurrency_requests_once(&self) {
         let range = self.get_range();
         self.concurrency
-            .reconcile_pending_requests(self.db.as_ref(), &range)
+            .reconcile_pending_requests(self.db.as_ref(), &range, None)
+            .await;
+    }
+
+    /// Test-only: run one SLICED reconcile sweep (at most `max_keys` counter
+    /// keys walked, resuming from the persistent cursor), exactly as the
+    /// periodic tick does.
+    #[doc(hidden)]
+    pub async fn reconcile_pending_concurrency_requests_sliced_for_test(&self, max_keys: usize) {
+        let range = self.get_range();
+        self.concurrency
+            .reconcile_pending_requests(self.db.as_ref(), &range, Some(max_keys))
             .await;
     }
 
@@ -1253,6 +1333,26 @@ impl JobStoreShard {
     /// with manual `process_concurrency_grants` calls.
     pub fn stop_grant_scanner(&self) {
         self.concurrency.stop_grant_scanner();
+    }
+
+    /// Test-only: (re)start the background grant scanner after a
+    /// `stop_grant_scanner`, re-running its startup reconcile sweep. Lets
+    /// tests stage durable state with the scanner stopped and then observe
+    /// the scanner discovering and draining it.
+    #[doc(hidden)]
+    pub fn start_grant_scanner_for_test(&self) {
+        self.concurrency.start_grant_scanner(
+            Arc::clone(&self.db),
+            Arc::clone(&self.brokers),
+            self.get_range(),
+        );
+    }
+
+    /// Test-only: seed the grant scanner's hot pending lane directly, as an
+    /// event-driven release nudge would.
+    #[doc(hidden)]
+    pub fn seed_hot_pending_grant_for_test(&self, tenant: &str, queue: &str, count: u32) {
+        self.concurrency.request_grant_count(tenant, queue, count);
     }
 
     /// Directly process pending concurrency grants for a single queue.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -168,6 +168,19 @@ pub struct Metrics {
     /// Steady-state expected to be 0; sustained growth means the reconciler
     /// is stuck (slatedb unavailable, etc.).
     concurrency_reconciliation_pending: GaugeVec,
+    /// Wall time of a single `process_grants` invocation (one (tenant, queue))
+    /// across all of its passes, including precheck-skipped invocations.
+    concurrency_process_grants_duration: HistogramVec,
+    /// CONCURRENCY_REQUEST keys walked by a single `process_grants` invocation
+    /// across all of its passes.
+    concurrency_process_grants_keys_scanned: HistogramVec,
+    concurrency_process_grants_total: CounterVec,
+    concurrency_process_grants_stale_total: CounterVec,
+    concurrency_reconcile_total: CounterVec,
+    concurrency_reconcile_duration: HistogramVec,
+    /// Sizes of the grant scanner's pending lanes, labeled `lane=hot|cold`.
+    concurrency_pending_grants: GaugeVec,
+    concurrency_grant_next_hop_skips: CounterVec,
 
     // SlateDB watcher metrics (driven by Db::subscribe)
     slatedb_durable_seq: GaugeVec,
@@ -569,23 +582,83 @@ impl Metrics {
             .set(stats.hydrated_queue_count as f64);
     }
 
-    /// Update per-shard reconciler signal gauges:
-    /// * `drift` = sum of |in_memory - durable| holder counts across hydrated
-    ///   queues, computed at the end of each periodic reconciler tick.
-    /// * `pending` = current size of the per-task_id reconciliation queue.
-    ///
-    /// Non-zero `drift` or sustained-non-zero `pending` indicates the
-    /// reconciler is observing inconsistency between in-memory and durable
-    /// holder state — the same signal that, if it grows, manifests as the
-    /// production queue wedge. Pair with an alert that fires if either
-    /// remains non-zero across multiple scrape intervals.
-    pub fn set_concurrency_reconciler_signals(&self, shard: &str, drift: u64, pending: u64) {
+    /// Update the per-shard holder-drift gauge: sum of |in_memory - durable|
+    /// holder counts across hydrated queues, computed at the completion of a
+    /// full drift pass. Non-zero drift indicates inconsistency between
+    /// in-memory and durable holder state — the same signal that, if it
+    /// grows, manifests as the production queue wedge. Pair with an alert
+    /// that fires if it remains non-zero across multiple scrape intervals.
+    pub fn set_concurrency_holder_drift(&self, shard: &str, drift: u64) {
         self.concurrency_holder_drift
             .with_label_values(&[shard])
             .set(drift as f64);
+    }
+
+    /// Update the per-shard reconciliation-pending gauge: current size of the
+    /// per-task_id reconciliation queue. Published every reconcile tick;
+    /// sustained non-zero means the reconciler is stuck.
+    pub fn set_concurrency_reconciliation_pending(&self, shard: &str, pending: u64) {
         self.concurrency_reconciliation_pending
             .with_label_values(&[shard])
             .set(pending as f64);
+    }
+
+    /// Record one completed `process_grants` invocation: wall time, total
+    /// request keys walked across all of its passes, and stale request rows
+    /// deleted along the way.
+    pub fn record_concurrency_process_grants(
+        &self,
+        shard: &str,
+        duration_s: f64,
+        keys_scanned: u64,
+        stale_deleted: u64,
+    ) {
+        self.concurrency_process_grants_total
+            .with_label_values(&[shard])
+            .inc();
+        self.concurrency_process_grants_duration
+            .with_label_values(&[shard])
+            .observe(duration_s);
+        self.concurrency_process_grants_keys_scanned
+            .with_label_values(&[shard])
+            .observe(keys_scanned as f64);
+        if stale_deleted > 0 {
+            self.concurrency_process_grants_stale_total
+                .with_label_values(&[shard])
+                .inc_by(stale_deleted as f64);
+        }
+    }
+
+    /// Record one completed `reconcile_pending_requests` sweep slice: the
+    /// wall time of the counter scan that re-seeds the grant scanner's cold
+    /// lane.
+    pub fn record_concurrency_reconcile_sweep(&self, shard: &str, duration_s: f64) {
+        self.concurrency_reconcile_total
+            .with_label_values(&[shard])
+            .inc();
+        self.concurrency_reconcile_duration
+            .with_label_values(&[shard])
+            .observe(duration_s);
+    }
+
+    /// Update the grant scanner pending-lane size gauges (hot = event-driven
+    /// nudges drained fully each iteration; cold = reconciler sweep entries
+    /// drained in bounded batches).
+    pub fn set_concurrency_pending_grants(&self, shard: &str, hot: usize, cold: usize) {
+        self.concurrency_pending_grants
+            .with_label_values(&[shard, "hot"])
+            .set(hot as f64);
+        self.concurrency_pending_grants
+            .with_label_values(&[shard, "cold"])
+            .set(cold as f64);
+    }
+
+    /// Record a grant-scanner candidate deferred because its next concurrency
+    /// hop was saturated with a deep requester backlog.
+    pub fn record_concurrency_grant_next_hop_skip(&self, shard: &str) {
+        self.concurrency_grant_next_hop_skips
+            .with_label_values(&[shard])
+            .inc();
     }
 
     /// Update SlateDB storage metrics from a shard's StatRegistry.
@@ -2062,6 +2135,97 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let concurrency_process_grants_duration = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_concurrency_process_grants_duration_seconds",
+                "Wall time of a single process_grants invocation (one (tenant, queue)) across all of its passes, including precheck-skipped invocations",
+            )
+            .buckets(SCAN_DURATION_BUCKETS.to_vec()),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_process_grants_keys_scanned = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_concurrency_process_grants_keys_scanned",
+                "Number of CONCURRENCY_REQUEST keys read by a single process_grants invocation across all passes",
+            )
+            .buckets(vec![1.0, 4.0, 16.0, 64.0, 256.0, 1024.0, 4096.0, 16384.0]),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_process_grants_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_concurrency_process_grants_total",
+                "Total process_grants invocations per shard (each invocation drains pending requests for a single (tenant, queue))",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_process_grants_stale_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_concurrency_process_grants_stale_total",
+                "Total request rows deleted by process_grants for being malformed, of unknown variant, or for a non-current job attempt",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_reconcile_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_concurrency_reconcile_total",
+                "Total reconcile_pending_requests sweep slices completed per shard",
+            ),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_reconcile_duration = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_concurrency_reconcile_duration_seconds",
+                "Wall time of a reconcile_pending_requests sweep slice per shard",
+            )
+            .buckets(SCAN_DURATION_BUCKETS.to_vec()),
+            &["shard"],
+        )?,
+    );
+
+    let concurrency_pending_grants = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_concurrency_pending_grants",
+                "Number of (tenant, queue) entries pending in the grant scanner's lanes: lane=hot (event-driven nudges, drained fully each iteration) vs lane=cold (reconciler sweep entries, drained in bounded batches)",
+            ),
+            &["shard", "lane"],
+        )?,
+    );
+
+    let concurrency_grant_next_hop_skips = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_concurrency_grant_next_hop_skips_total",
+                "Grant-scanner candidates deferred because their next concurrency hop was saturated with a deep requester backlog",
+            ),
+            &["shard"],
+        )?,
+    );
+
     // SlateDB watcher metrics (driven by Db::subscribe)
     let slatedb_durable_seq = register(
         &registry,
@@ -2171,6 +2335,14 @@ pub fn init() -> anyhow::Result<Metrics> {
         concurrency_holders_cache_hydrated_queues,
         concurrency_holder_drift,
         concurrency_reconciliation_pending,
+        concurrency_process_grants_duration,
+        concurrency_process_grants_keys_scanned,
+        concurrency_process_grants_total,
+        concurrency_process_grants_stale_total,
+        concurrency_reconcile_total,
+        concurrency_reconcile_duration,
+        concurrency_pending_grants,
+        concurrency_grant_next_hop_skips,
         slatedb_durable_seq,
         slatedb_manifest_revisions,
         slatedb_manifest_last_l0_seq,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -153,6 +153,7 @@ pub struct Metrics {
     // Concurrency metrics
     concurrency_tickets_granted: CounterVec,
     concurrency_tickets_converted: CounterVec,
+    concurrency_grant_precheck_skips: CounterVec,
     concurrency_holders_cache_holders: GaugeVec,
     concurrency_holders_cache_queues: GaugeVec,
     concurrency_holders_cache_hydrated_queues: GaugeVec,
@@ -541,6 +542,14 @@ impl Metrics {
         self.concurrency_tickets_converted
             .with_label_values(&[shard])
             .inc_by(n as f64);
+    }
+
+    /// Record a grant-scanner invocation that skipped the request scan
+    /// because the queue's known capacity was fully occupied.
+    pub fn record_concurrency_grant_precheck_skip(&self, shard: &str) {
+        self.concurrency_grant_precheck_skips
+            .with_label_values(&[shard])
+            .inc();
     }
 
     /// Update the in-memory concurrency holders cache size gauges for a shard.
@@ -1987,6 +1996,17 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let concurrency_grant_precheck_skips = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_concurrency_grant_precheck_skips_total",
+                "Total number of grant-scanner invocations skipped because the queue's known capacity had zero free slots",
+            ),
+            &["shard"],
+        )?,
+    );
+
     let concurrency_holders_cache_holders = register(
         &registry,
         GaugeVec::new(
@@ -2145,6 +2165,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         lease_reaper_errors_total,
         concurrency_tickets_granted,
         concurrency_tickets_converted,
+        concurrency_grant_precheck_skips,
         concurrency_holders_cache_holders,
         concurrency_holders_cache_queues,
         concurrency_holders_cache_hydrated_queues,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -210,6 +210,51 @@ fn default_grant_scanner_concurrency() -> usize {
     DEFAULT_GRANT_SCANNER_CONCURRENCY
 }
 
+/// Default for `grant_scanner_cold_batch_size`: max reconciler-sourced
+/// (cold-lane) queue entries merged into one drain iteration alongside all
+/// event-driven (hot-lane) entries.
+pub const DEFAULT_GRANT_SCANNER_COLD_BATCH_SIZE: usize = 64;
+
+fn default_grant_scanner_cold_batch_size() -> usize {
+    DEFAULT_GRANT_SCANNER_COLD_BATCH_SIZE
+}
+
+/// Default for `concurrency_reconcile_scan_slice`: max requester-counter keys
+/// the periodic reconcile sweep walks per tick before saving a cursor and
+/// yielding.
+pub const DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE: usize = 20_000;
+
+fn default_concurrency_reconcile_scan_slice() -> usize {
+    DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE
+}
+
+/// Default for `holder_drift_scan_slice`: max hydrated queues the periodic
+/// holder-drift report scans per tick before yielding; a full pass over all
+/// hydrated queues spans multiple ticks on queue-heavy shards.
+pub const DEFAULT_HOLDER_DRIFT_SCAN_SLICE: usize = 5_000;
+
+fn default_holder_drift_scan_slice() -> usize {
+    DEFAULT_HOLDER_DRIFT_SCAN_SLICE
+}
+
+/// Default for `grant_scanner_next_hop_skip_min_backlog`: minimum requester
+/// backlog on a candidate's next concurrency hop before the scanner defers
+/// granting the candidate while that hop is saturated. 0 disables the skip.
+pub const DEFAULT_GRANT_SCANNER_NEXT_HOP_SKIP_MIN_BACKLOG: u64 = 1024;
+
+fn default_grant_scanner_next_hop_skip_min_backlog() -> u64 {
+    DEFAULT_GRANT_SCANNER_NEXT_HOP_SKIP_MIN_BACKLOG
+}
+
+/// Default for `grant_scanner_live_headroom_fraction`: fraction of each
+/// queue's capacity the grant scanner leaves unfilled for immediate (live)
+/// grants. 0.0 means the scanner may fill every slot.
+pub const DEFAULT_GRANT_SCANNER_LIVE_HEADROOM_FRACTION: f64 = 0.0;
+
+fn default_grant_scanner_live_headroom_fraction() -> f64 {
+    DEFAULT_GRANT_SCANNER_LIVE_HEADROOM_FRACTION
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseTemplate {
     pub backend: Backend,
@@ -269,6 +314,38 @@ pub struct DatabaseTemplate {
     /// Values below 1 are treated as 1.
     #[serde(default = "default_grant_scanner_concurrency")]
     pub grant_scanner_concurrency: usize,
+    /// Max reconciler-sourced (cold-lane) queue entries the grant scanner
+    /// merges into a single drain iteration alongside all event-driven
+    /// (hot-lane) entries. Bounds how long a reconcile-sweep backlog can delay
+    /// servicing a release-driven nudge. Defaults to 64. Values below 1 are
+    /// treated as 1.
+    #[serde(default = "default_grant_scanner_cold_batch_size")]
+    pub grant_scanner_cold_batch_size: usize,
+    /// Max requester-counter keys the periodic concurrency reconcile sweep
+    /// walks per tick. The sweep resumes from a cursor on the next tick, so
+    /// full keyspace coverage spans multiple ticks on queue-heavy shards
+    /// instead of re-scanning everything every tick. Defaults to 20000.
+    /// Values below 1 are treated as 1.
+    #[serde(default = "default_concurrency_reconcile_scan_slice")]
+    pub concurrency_reconcile_scan_slice: usize,
+    /// Max hydrated queues the periodic holder-drift report scans per tick.
+    /// A full drift pass over all hydrated queues spans multiple ticks; the
+    /// drift gauge updates at full-pass boundaries. Defaults to 5000. Values
+    /// below 1 are treated as 1.
+    #[serde(default = "default_holder_drift_scan_slice")]
+    pub holder_drift_scan_slice: usize,
+    /// Minimum requester backlog on a candidate's next concurrency hop before
+    /// the grant scanner defers granting the candidate while that hop is
+    /// saturated (avoids parking holders behind a deeply backlogged
+    /// downstream queue). 0 disables the skip. Defaults to 1024.
+    #[serde(default = "default_grant_scanner_next_hop_skip_min_backlog")]
+    pub grant_scanner_next_hop_skip_min_backlog: u64,
+    /// Fraction of each queue's capacity the grant scanner leaves unfilled
+    /// for immediate (live) grants, so fresh enqueues keep instant admission
+    /// while the scanner digs out a deferred backlog. Clamped to [0.0, 0.9].
+    /// Defaults to 0.0 (scanner may fill every slot).
+    #[serde(default = "default_grant_scanner_live_headroom_fraction")]
+    pub grant_scanner_live_headroom_fraction: f64,
     /// When set, jobs that finished successfully (Succeeded) have all of their
     /// associated KV records re-put with a SlateDB row TTL expiring this many
     /// seconds in the future. `None` (the default) disables the behaviour for
@@ -332,6 +409,12 @@ impl Default for DatabaseTemplate {
             grant_scanner_batch_size: default_grant_scanner_batch_size(),
             grant_scanner_buffer_size: default_grant_scanner_buffer_size(),
             grant_scanner_concurrency: default_grant_scanner_concurrency(),
+            grant_scanner_cold_batch_size: default_grant_scanner_cold_batch_size(),
+            concurrency_reconcile_scan_slice: default_concurrency_reconcile_scan_slice(),
+            holder_drift_scan_slice: default_holder_drift_scan_slice(),
+            grant_scanner_next_hop_skip_min_backlog:
+                default_grant_scanner_next_hop_skip_min_backlog(),
+            grant_scanner_live_headroom_fraction: default_grant_scanner_live_headroom_fraction(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             periodic_full_compaction_s: None,
@@ -606,6 +689,29 @@ pub struct DatabaseConfig {
     /// See `DatabaseTemplate::grant_scanner_concurrency` for details. Defaults to 8.
     #[serde(default = "default_grant_scanner_concurrency")]
     pub grant_scanner_concurrency: usize,
+    /// Max cold-lane entries merged per drain iteration. See
+    /// `DatabaseTemplate::grant_scanner_cold_batch_size` for details. Defaults to 64.
+    #[serde(default = "default_grant_scanner_cold_batch_size")]
+    pub grant_scanner_cold_batch_size: usize,
+    /// Max requester-counter keys walked per reconcile tick. See
+    /// `DatabaseTemplate::concurrency_reconcile_scan_slice` for details.
+    /// Defaults to 20000.
+    #[serde(default = "default_concurrency_reconcile_scan_slice")]
+    pub concurrency_reconcile_scan_slice: usize,
+    /// Max hydrated queues scanned per holder-drift tick. See
+    /// `DatabaseTemplate::holder_drift_scan_slice` for details. Defaults to 5000.
+    #[serde(default = "default_holder_drift_scan_slice")]
+    pub holder_drift_scan_slice: usize,
+    /// Minimum next-hop backlog before the scanner defers a candidate. See
+    /// `DatabaseTemplate::grant_scanner_next_hop_skip_min_backlog` for details.
+    /// Defaults to 1024; 0 disables.
+    #[serde(default = "default_grant_scanner_next_hop_skip_min_backlog")]
+    pub grant_scanner_next_hop_skip_min_backlog: u64,
+    /// Fraction of queue capacity the scanner leaves for immediate grants. See
+    /// `DatabaseTemplate::grant_scanner_live_headroom_fraction` for details.
+    /// Defaults to 0.0.
+    #[serde(default = "default_grant_scanner_live_headroom_fraction")]
+    pub grant_scanner_live_headroom_fraction: f64,
     /// TTL (seconds) applied to Succeeded jobs' associated records. See
     /// `DatabaseTemplate::completed_job_expire_s` for details.
     #[serde(default)]
@@ -641,6 +747,12 @@ impl Default for DatabaseConfig {
             grant_scanner_batch_size: default_grant_scanner_batch_size(),
             grant_scanner_buffer_size: default_grant_scanner_buffer_size(),
             grant_scanner_concurrency: default_grant_scanner_concurrency(),
+            grant_scanner_cold_batch_size: default_grant_scanner_cold_batch_size(),
+            concurrency_reconcile_scan_slice: default_concurrency_reconcile_scan_slice(),
+            holder_drift_scan_slice: default_holder_drift_scan_slice(),
+            grant_scanner_next_hop_skip_min_backlog:
+                default_grant_scanner_next_hop_skip_min_backlog(),
+            grant_scanner_live_headroom_fraction: default_grant_scanner_live_headroom_fraction(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             slatedb: None,

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -1939,6 +1939,23 @@ fn read_concurrency_tickets_granted_for(
         .unwrap_or(0.0)
 }
 
+/// Read the current value of the `silo_concurrency_grant_precheck_skips_total`
+/// counter, summed across all label values.
+fn read_concurrency_grant_precheck_skips(metrics: &silo::metrics::Metrics) -> f64 {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|f| f.get_name() == "silo_concurrency_grant_precheck_skips_total")
+        .map(|f| {
+            f.get_metric()
+                .iter()
+                .map(|m| m.get_counter().get_value())
+                .sum()
+        })
+        .unwrap_or(0.0)
+}
+
 /// Tests that stale requests interleaved with valid ones are handled correctly:
 /// the grant scanner should skip stale ones and keep scanning to find valid ones.
 #[silo::test]
@@ -2251,19 +2268,18 @@ async fn grant_scanner_drains_backlog_larger_than_max_per_pass() {
     assert_eq!(count_concurrency_holders(shard.db()).await, N);
 }
 
-/// Tenant-fairness + reliability: a full queue with a huge backlog of stale
-/// requests still cleans them up (orphan reliability), but only a *bounded*
-/// amount per invocation (the per-invocation scan budget), so it can't pin a
-/// scanner slot walking the whole backlog and starve other tenants. Holders are
-/// untouched and nothing is granted (queue is full). Repeated invocations drain
-/// the stale backlog. Pre-fix one invocation walked the entire backlog in a
-/// single call.
+/// A saturated queue with a huge stale backlog: the pre-scan capacity gate
+/// skips the scan entirely while the queue is full (stale cleanup pauses — the
+/// accepted trade-off), then once a slot frees, cleanup resumes with only a
+/// *bounded* amount walked per invocation (the per-invocation scan budget), so
+/// it can't pin a scanner slot walking the whole backlog and starve other
+/// tenants. Repeated invocations drain the stale backlog.
 #[silo::test]
 async fn grant_scanner_full_queue_cleans_stale_bounded() {
     const LIMIT: usize = 5;
     const BACKLOG: usize = 3000;
 
-    let (_tmp, shard) = open_temp_shard().await;
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
     let now = now_ms();
     let queue = "full-clean-q";
     let tenant = "full-clean-tenant";
@@ -2291,10 +2307,12 @@ async fn grant_scanner_full_queue_cleans_stale_bounded() {
             .await
             .unwrap();
     }
-    let mut held = 0;
-    while held < LIMIT {
+    let mut holder_tasks = Vec::with_capacity(LIMIT);
+    while holder_tasks.len() < LIMIT {
         let tasks = shard.dequeue("w", "tg", LIMIT).await.unwrap().tasks;
-        held += tasks.len();
+        for t in tasks {
+            holder_tasks.push(t.attempt().task_id().to_string());
+        }
     }
 
     // Inject a large backlog of stale requests (nonexistent jobs).
@@ -2327,11 +2345,39 @@ async fn grant_scanner_full_queue_cleans_stale_bounded() {
     }
     assert_eq!(count_concurrency_requests(shard.db()).await, BACKLOG);
 
-    // Queue is full (LIMIT held). One invocation cleans only a bounded slice.
+    // Queue is full (LIMIT held): the capacity gate skips the scan without
+    // walking (or cleaning) any of the stale backlog.
+    let skips_before = read_concurrency_grant_precheck_skips(&metrics);
     let granted = shard
         .process_concurrency_grants(tenant, queue, BACKLOG as u32)
         .await;
     assert_eq!(granted.len(), 0, "a full queue grants nothing");
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics) - skips_before,
+        1.0,
+        "a saturated queue with a warm limit cache must skip via the pre-scan gate"
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        BACKLOG,
+        "the gate must not touch the backlog while saturated"
+    );
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        LIMIT,
+        "holders are untouched by the skip"
+    );
+
+    // Free one slot: stale cleanup resumes, bounded per invocation.
+    shard
+        .report_attempt_outcome(&holder_tasks[0], AttemptOutcome::Success { result: vec![] })
+        .await
+        .unwrap();
+
+    let granted = shard
+        .process_concurrency_grants(tenant, queue, BACKLOG as u32)
+        .await;
+    assert_eq!(granted.len(), 0, "stale requests grant nothing");
     let after_first = count_concurrency_requests(shard.db()).await;
     assert!(
         after_first > 0,
@@ -2339,12 +2385,7 @@ async fn grant_scanner_full_queue_cleans_stale_bounded() {
     );
     assert!(
         after_first < BACKLOG,
-        "stale on a full queue must still be cleaned (orphan reliability)"
-    );
-    assert_eq!(
-        count_concurrency_holders(shard.db()).await,
-        LIMIT,
-        "holders are untouched while cleaning stale"
+        "stale must be cleaned once capacity exists (orphan reliability)"
     );
 
     // Repeated invocations eventually drain the stale backlog.
@@ -2367,9 +2408,498 @@ async fn grant_scanner_full_queue_cleans_stale_bounded() {
     assert_eq!(
         count_concurrency_requests(shard.db()).await,
         0,
-        "repeated invocations drain the full queue's stale backlog"
+        "repeated invocations drain the stale backlog once capacity exists"
     );
-    assert_eq!(count_concurrency_holders(shard.db()).await, LIMIT);
+    assert_eq!(count_concurrency_holders(shard.db()).await, LIMIT - 1);
+}
+
+/// A saturated fixed-limit queue with a warm limit cache: the pre-scan
+/// capacity gate returns before opening the request iterator. The oracle for
+/// "no scan ran" is a stale request injected at the front of the queue — a
+/// scan would delete it (see grant_scanner_handles_all_stale_requests), so its
+/// survival plus the skip counter proves the gate fired.
+#[silo::test]
+async fn grant_scanner_precheck_skips_scan_when_fixed_queue_saturated() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let queue = "precheck-fixed-q";
+    let tenant = "precheck-fixed-tenant";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: 1,
+    });
+
+    shard.stop_grant_scanner();
+
+    // Take the only slot (the enqueue warms the limit cache).
+    shard
+        .enqueue(
+            tenant,
+            Some("holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .unwrap();
+    let tasks = shard.dequeue("w", "tg", 1).await.unwrap().tasks;
+    assert_eq!(tasks.len(), 1);
+
+    // A real waiter defers into a request…
+    shard
+        .enqueue(
+            tenant,
+            Some("waiter".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .unwrap();
+    // …plus a stale request (nonexistent job) that sorts first.
+    let stale_action = ConcurrencyAction::EnqueueTask {
+        start_time_ms: 0,
+        priority: 50,
+        job_id: "ghost".to_string(),
+        attempt_number: 1,
+        relative_attempt_number: 1,
+        task_group: "tg".to_string(),
+        limit_index: 0,
+        held_queues: Vec::new(),
+        task_id: "ghost:1:stale".to_string(),
+        limits: Vec::new(),
+    };
+    let key = silo::keys::concurrency_request_key(tenant, queue, 0, 50, "ghost", 1, "x0000");
+    let val = encode_concurrency_action(&stale_action);
+    let mut batch = slatedb::WriteBatch::new();
+    batch.put(&key, &val);
+    shard.db().write(batch).await.unwrap();
+    assert_eq!(count_concurrency_requests(shard.db()).await, 2);
+
+    let skips_before = read_concurrency_grant_precheck_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, queue, 100).await;
+    assert_eq!(granted.len(), 0, "saturated queue grants nothing");
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics) - skips_before,
+        1.0,
+        "the gate must skip the scan for a saturated fixed-limit queue"
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        2,
+        "no scan ran: the stale front row survives untouched"
+    );
+    assert_eq!(count_concurrency_holders(shard.db()).await, 1);
+
+    // The skip is stable across repeated drives while saturated.
+    let granted = shard.process_concurrency_grants(tenant, queue, 100).await;
+    assert_eq!(granted.len(), 0);
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics) - skips_before,
+        2.0,
+        "every saturated drive skips again"
+    );
+    assert_eq!(count_concurrency_requests(shard.db()).await, 2);
+}
+
+/// Releasing a holder re-opens the gate: the next drive scans, cleans the
+/// stale front (cleanup deferred while saturated resumes on the first free
+/// slot), and grants the real waiter.
+#[silo::test]
+async fn grant_scanner_precheck_resumes_grants_after_release() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let queue = "precheck-release-q";
+    let tenant = "precheck-release-tenant";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: 1,
+    });
+
+    shard.stop_grant_scanner();
+
+    shard
+        .enqueue(
+            tenant,
+            Some("holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .unwrap();
+    let tasks = shard.dequeue("w", "tg", 1).await.unwrap().tasks;
+    assert_eq!(tasks.len(), 1);
+    let holder_task = tasks[0].attempt().task_id().to_string();
+
+    shard
+        .enqueue(
+            tenant,
+            Some("waiter".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .unwrap();
+    let stale_action = ConcurrencyAction::EnqueueTask {
+        start_time_ms: 0,
+        priority: 50,
+        job_id: "ghost".to_string(),
+        attempt_number: 1,
+        relative_attempt_number: 1,
+        task_group: "tg".to_string(),
+        limit_index: 0,
+        held_queues: Vec::new(),
+        task_id: "ghost:1:stale".to_string(),
+        limits: Vec::new(),
+    };
+    let key = silo::keys::concurrency_request_key(tenant, queue, 0, 50, "ghost", 1, "x0000");
+    let val = encode_concurrency_action(&stale_action);
+    let mut batch = slatedb::WriteBatch::new();
+    batch.put(&key, &val);
+    shard.db().write(batch).await.unwrap();
+    assert_eq!(count_concurrency_requests(shard.db()).await, 2);
+
+    // Sanity: while saturated, the gate skips.
+    let skips_before = read_concurrency_grant_precheck_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, queue, 100).await;
+    assert_eq!(granted.len(), 0);
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics) - skips_before,
+        1.0
+    );
+
+    // Release the holder, then drive again: the gate sees free capacity, the
+    // scan runs, deletes the stale front row, and grants the waiter.
+    shard
+        .report_attempt_outcome(&holder_task, AttemptOutcome::Success { result: vec![] })
+        .await
+        .unwrap();
+
+    let skips_before_resume = read_concurrency_grant_precheck_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, queue, 100).await;
+    assert_eq!(
+        granted.len(),
+        1,
+        "the real waiter is granted once a slot frees"
+    );
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics) - skips_before_resume,
+        0.0,
+        "no skip when capacity exists"
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "stale front cleaned and waiter request consumed"
+    );
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        1,
+        "the waiter now holds the slot"
+    );
+}
+
+/// The gate for floating-limit queues follows the DURABLE state row, not the
+/// cached snapshot: raising the row re-opens grants, shrinking it below the
+/// holder count (legitimately over-capacity) skips via saturating math, and a
+/// missing row makes capacity unknown so the scan runs (and cleans stale).
+#[silo::test]
+async fn grant_scanner_precheck_floating_follows_durable_state() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let queue = "precheck-float-q";
+    let tenant = "precheck-float-tenant";
+    let refresh_interval_ms = 60_000_000i64;
+    let limit = Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+        key: queue.to_string(),
+        default_max_concurrency: 1,
+        refresh_interval_ms,
+        metadata: vec![],
+    });
+
+    shard.stop_grant_scanner();
+
+    // Holder takes the single default slot; two waiters defer into requests.
+    shard
+        .enqueue(
+            tenant,
+            Some("holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .unwrap();
+    let tasks = shard.dequeue("w", "tg", 1).await.unwrap().tasks;
+    assert_eq!(tasks.len(), 1);
+    for i in 0..2 {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("waiter-{}", i)),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .unwrap();
+    }
+    assert_eq!(count_concurrency_requests(shard.db()).await, 2);
+
+    let encode_state = |max: u32| {
+        silo::codec::encode_floating_limit_state(&silo::job::FloatingLimitState {
+            current_max_concurrency: max,
+            last_refreshed_at_ms: now,
+            refresh_task_scheduled: true,
+            refresh_interval_ms,
+            default_max_concurrency: 1,
+            retry_count: 0,
+            next_retry_at_ms: None,
+            metadata: vec![],
+        })
+    };
+    let state_key = silo::keys::floating_limit_state_key(tenant, queue);
+
+    // Durable state at 1 == holder count → skip.
+    let skips_before = read_concurrency_grant_precheck_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, queue, 10).await;
+    assert_eq!(granted.len(), 0);
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics) - skips_before,
+        1.0
+    );
+    assert_eq!(count_concurrency_requests(shard.db()).await, 2);
+
+    // Raise the DURABLE row to 3 without touching the in-memory cache (the
+    // cached snapshot still says 1): the gate must read the row and let the
+    // scan grant both waiters.
+    let mut batch = slatedb::WriteBatch::new();
+    batch.put(&state_key, &encode_state(3));
+    shard.db().write(batch).await.unwrap();
+
+    let granted = shard.process_concurrency_grants(tenant, queue, 10).await;
+    assert_eq!(granted.len(), 2, "raised durable state re-opens grants");
+    assert_eq!(count_concurrency_holders(shard.db()).await, 3);
+    assert_eq!(count_concurrency_requests(shard.db()).await, 0);
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics) - skips_before,
+        1.0,
+        "no skip when the durable row shows free capacity"
+    );
+
+    // Shrink the row back below the holder count (3 holders, capacity 1):
+    // saturating math must treat this as zero free, not underflow.
+    let mut batch = slatedb::WriteBatch::new();
+    batch.put(&state_key, &encode_state(1));
+    shard.db().write(batch).await.unwrap();
+    shard
+        .enqueue(
+            tenant,
+            Some("late-waiter".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .unwrap();
+    assert_eq!(count_concurrency_requests(shard.db()).await, 1);
+
+    let granted = shard.process_concurrency_grants(tenant, queue, 10).await;
+    assert_eq!(granted.len(), 0);
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics) - skips_before,
+        2.0,
+        "an over-capacity queue skips"
+    );
+    assert_eq!(count_concurrency_requests(shard.db()).await, 1);
+
+    // Delete the state row: capacity is unknown, so the gate falls through and
+    // the scan runs — proven by it cleaning an injected stale front row.
+    let stale_action = ConcurrencyAction::EnqueueTask {
+        start_time_ms: 0,
+        priority: 50,
+        job_id: "ghost".to_string(),
+        attempt_number: 1,
+        relative_attempt_number: 1,
+        task_group: "tg".to_string(),
+        limit_index: 0,
+        held_queues: Vec::new(),
+        task_id: "ghost:1:stale".to_string(),
+        limits: Vec::new(),
+    };
+    let key = silo::keys::concurrency_request_key(tenant, queue, 0, 50, "ghost", 1, "x0000");
+    let val = encode_concurrency_action(&stale_action);
+    let mut batch = slatedb::WriteBatch::new();
+    batch.put(&key, &val);
+    batch.delete(&state_key);
+    shard.db().write(batch).await.unwrap();
+    assert_eq!(count_concurrency_requests(shard.db()).await, 2);
+
+    let granted = shard.process_concurrency_grants(tenant, queue, 10).await;
+    assert_eq!(
+        granted.len(),
+        0,
+        "the scan falls back to default_max_concurrency=1 against 3 holders"
+    );
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics) - skips_before,
+        2.0,
+        "unknown capacity must not count as a skip"
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        1,
+        "the scan ran: the stale ghost row was deleted"
+    );
+}
+
+/// After a restart the limit cache is empty, so the gate cannot fire: the
+/// first drive falls through to the scan (current behavior), which resolves
+/// the limit from the head request and re-caches it — so the second drive
+/// skips. Uses a real close/reopen to exercise the production cold path
+/// (hydration rebuilds holder counts from durable rows). The pending request
+/// is injected directly (no requester counter) so the reopened shard's
+/// startup reconciliation has nothing to drive — keeps the background
+/// scanner quiescent and the metric deterministic.
+#[silo::test]
+async fn grant_scanner_precheck_cold_cache_scans_and_self_warms() {
+    use silo::gubernator::MockGubernatorClient;
+    use silo::settings::{Backend, DatabaseConfig};
+    use silo::shard_range::ShardRange;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = DatabaseConfig {
+        name: "test".to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(test_helpers::fast_flush_slatedb_settings()),
+        ..Default::default()
+    };
+    let rate_limiter = MockGubernatorClient::new_arc();
+    let queue = "precheck-cold-q";
+    let tenant = "precheck-cold-tenant";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: 1,
+    });
+
+    // Phase 1: durably saturate the queue (one holder), then close.
+    let shard1 = silo::job_store_shard::JobStoreShard::open(
+        &cfg,
+        rate_limiter.clone(),
+        None,
+        ShardRange::full(),
+    )
+    .await
+    .expect("open shard1");
+    shard1.stop_grant_scanner();
+    let now = now_ms();
+    shard1
+        .enqueue(
+            tenant,
+            Some("holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .unwrap();
+    let tasks = shard1.dequeue("w", "tg", 1).await.unwrap().tasks;
+    assert_eq!(tasks.len(), 1);
+
+    // Inject a ghost request that EMBEDS the queue's limits: the cold scan
+    // resolves capacity from it (warming the cache) before its missing job
+    // status gets it deleted as stale.
+    let stale_action = ConcurrencyAction::EnqueueTask {
+        start_time_ms: 0,
+        priority: 50,
+        job_id: "ghost".to_string(),
+        attempt_number: 1,
+        relative_attempt_number: 1,
+        task_group: "tg".to_string(),
+        limit_index: 0,
+        held_queues: Vec::new(),
+        task_id: "ghost:1:stale".to_string(),
+        limits: vec![limit.clone()],
+    };
+    let key = silo::keys::concurrency_request_key(tenant, queue, 0, 50, "ghost", 1, "x0000");
+    let val = encode_concurrency_action(&stale_action);
+    let mut batch = slatedb::WriteBatch::new();
+    batch.put(&key, &val);
+    shard1.db().write(batch).await.unwrap();
+    shard1.close().await.expect("close shard1");
+
+    // Phase 2: reopen — the in-memory limit cache is empty.
+    let metrics = silo::metrics::init().expect("init metrics");
+    let shard2 = silo::job_store_shard::JobStoreShard::open(
+        &cfg,
+        rate_limiter,
+        Some(metrics.clone()),
+        ShardRange::full(),
+    )
+    .await
+    .expect("open shard2");
+    shard2.stop_grant_scanner();
+    assert_eq!(count_concurrency_requests(shard2.db()).await, 1);
+
+    // First drive: cache miss → the gate falls through, the scan runs
+    // (hydration rebuilt holder_count = 1), caches the limit from the ghost's
+    // embedded limits, and deletes the ghost as stale.
+    let granted = shard2.process_concurrency_grants(tenant, queue, 10).await;
+    assert_eq!(granted.len(), 0);
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics),
+        0.0,
+        "a cold cache must scan, not skip"
+    );
+    assert_eq!(
+        count_concurrency_requests(shard2.db()).await,
+        0,
+        "the scan ran and cleaned the stale ghost"
+    );
+
+    // Second drive: the first scan self-warmed the cache, so the gate fires.
+    let granted = shard2.process_concurrency_grants(tenant, queue, 10).await;
+    assert_eq!(granted.len(), 0);
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics),
+        1.0,
+        "the first scan self-warms the cache; the second drive skips"
+    );
 }
 
 /// Tenant-fairness: an invocation grants at most `max_concurrency - holders`,

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -5483,3 +5483,1183 @@ async fn count_holders_for_queue(
     }
     count
 }
+
+// ---------------------------------------------------------------------------
+// Grant scanner pending-lane tests (hot/cold split)
+// ---------------------------------------------------------------------------
+
+/// One drain batch takes ALL hot-lane entries but caps the cold lane at
+/// `grant_scanner_cold_batch_size` (default 64), so a large reconcile-sweep
+/// backlog cannot delay event-driven nudges by more than one iteration.
+#[silo::test]
+async fn grant_scanner_lane_batch_takes_hot_fully_and_cold_bounded() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let tenant = "lane-tenant";
+
+    // 70 cold entries (six more than the default cold batch of 64) plus 3
+    // hot nudges.
+    for i in 0..70 {
+        shard.seed_cold_pending_grant_for_test(tenant, &format!("cold-{i:03}"), 1);
+    }
+    for i in 0..3 {
+        shard.seed_hot_pending_grant_for_test(tenant, &format!("hot-{i}"), 1);
+    }
+
+    let batch = shard.take_pending_grant_batch_for_test();
+    assert_eq!(batch.len(), 64 + 3, "all hot + one bounded cold batch");
+    let queues: HashSet<&str> = batch.iter().map(|(_, q, _)| q.as_str()).collect();
+    for i in 0..3 {
+        assert!(
+            queues.contains(format!("hot-{i}").as_str()),
+            "hot-{i} taken"
+        );
+    }
+    // Cold is drained from the front on the first batch (cursor unset), so
+    // cold-000..cold-063 are taken and cold-064..cold-069 remain.
+    assert!(queues.contains("cold-000") && queues.contains("cold-063"));
+    assert!(!queues.contains("cold-064"));
+    for i in 0..3 {
+        assert_eq!(
+            shard.hot_pending_grant_count_for_test(tenant, &format!("hot-{i}")),
+            0,
+            "hot lane fully drained"
+        );
+    }
+    assert_eq!(
+        shard.cold_pending_grant_count_for_test(tenant, "cold-063"),
+        0
+    );
+    assert_eq!(
+        shard.cold_pending_grant_count_for_test(tenant, "cold-064"),
+        1
+    );
+
+    // Second batch drains the cold remainder.
+    let batch2 = shard.take_pending_grant_batch_for_test();
+    assert_eq!(batch2.len(), 6);
+    let batch3 = shard.take_pending_grant_batch_for_test();
+    assert!(batch3.is_empty());
+}
+
+/// Finding-1 regression: the cold lane pops round-robin from a cursor, so a
+/// reconcile sweep continuously re-seeding lexicographically-small keys can
+/// never starve the tail. With a naive `pop_first`, re-inserted small keys
+/// would be re-popped every batch and large keys would never be visited.
+#[silo::test]
+async fn grant_scanner_cold_lane_round_robin_survives_reseed() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let tenant = "rr-tenant";
+    let queue = |i: usize| format!("q-{i:03}");
+
+    for i in 0..130 {
+        shard.seed_cold_pending_grant_for_test(tenant, &queue(i), 1);
+    }
+
+    // Batch 1: front of the keyspace, q-000..q-063.
+    let b1: HashSet<String> = shard
+        .take_pending_grant_batch_for_test()
+        .into_iter()
+        .map(|(_, q, _)| q)
+        .collect();
+    assert_eq!(b1.len(), 64);
+    assert!(b1.contains("q-000") && b1.contains("q-063"));
+    assert!(!b1.contains("q-064"));
+
+    // Re-seed the already-popped small keys, as the periodic sweep would.
+    for i in 0..10 {
+        shard.seed_cold_pending_grant_for_test(tenant, &queue(i), 1);
+    }
+
+    // Batch 2 continues from the cursor (q-064..q-127) — it must NOT return
+    // to the freshly re-seeded q-000..q-009.
+    let b2: HashSet<String> = shard
+        .take_pending_grant_batch_for_test()
+        .into_iter()
+        .map(|(_, q, _)| q)
+        .collect();
+    assert_eq!(b2.len(), 64);
+    assert!(b2.contains("q-064") && b2.contains("q-127"));
+    for i in 0..10 {
+        assert!(
+            !b2.contains(&queue(i)),
+            "{} must wait for the wrap",
+            queue(i)
+        );
+    }
+
+    // Batch 3 finishes the tail (q-128, q-129) then wraps to the re-seeded
+    // front — every resident key is visited within one rotation.
+    let b3: HashSet<String> = shard
+        .take_pending_grant_batch_for_test()
+        .into_iter()
+        .map(|(_, q, _)| q)
+        .collect();
+    assert_eq!(b3.len(), 12, "tail (2) + wrapped re-seeded front (10)");
+    assert!(b3.contains("q-128") && b3.contains("q-129"));
+    for i in 0..10 {
+        assert!(b3.contains(&queue(i)));
+    }
+
+    assert!(shard.take_pending_grant_batch_for_test().is_empty());
+}
+
+/// Lane merge semantics: a queue present in both lanes merges with a
+/// saturating sum; repeated cold seeds take the max (the sweep re-reads the
+/// counter, so its value IS the demand — accumulation was the u32-overflow
+/// bug), while hot seeds accumulate (each release is one new free slot).
+#[silo::test]
+async fn grant_scanner_lane_counts_merge_and_saturate() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let tenant = "merge-tenant";
+
+    // Cold takes the max of repeated seeds, not the sum.
+    shard.seed_cold_pending_grant_for_test(tenant, "q", 5);
+    shard.seed_cold_pending_grant_for_test(tenant, "q", 2);
+    assert_eq!(shard.cold_pending_grant_count_for_test(tenant, "q"), 5);
+    shard.seed_cold_pending_grant_for_test(tenant, "q", 9);
+    assert_eq!(shard.cold_pending_grant_count_for_test(tenant, "q"), 9);
+    // A drifted counter near u32::MAX must not wrap when re-seeded.
+    shard.seed_cold_pending_grant_for_test(tenant, "q", u32::MAX);
+    assert_eq!(
+        shard.cold_pending_grant_count_for_test(tenant, "q"),
+        u32::MAX
+    );
+
+    // Hot accumulates (saturating).
+    shard.seed_hot_pending_grant_for_test(tenant, "q", 3);
+    shard.seed_hot_pending_grant_for_test(tenant, "q", 4);
+    assert_eq!(shard.hot_pending_grant_count_for_test(tenant, "q"), 7);
+    assert_eq!(shard.pending_grant_count_for_test(tenant, "q"), u32::MAX);
+
+    // The merged batch carries a single entry for the queue with a
+    // saturating combined count.
+    let batch = shard.take_pending_grant_batch_for_test();
+    assert_eq!(batch.len(), 1);
+    let (t, q, n) = &batch[0];
+    assert_eq!((t.as_str(), q.as_str()), (tenant, "q"));
+    assert_eq!(*n, u32::MAX, "hot + cold saturates instead of wrapping");
+}
+
+/// End-to-end: work discovered only via the reconcile sweep (cold lane) is
+/// granted by the running scanner — the cold lane drains even with zero
+/// event-driven nudges.
+#[silo::test]
+async fn grant_scanner_cold_lane_drains_via_running_scanner() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "cold-drain-tenant";
+    let queue = "cold-drain-q";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: 1,
+    });
+
+    shard.stop_grant_scanner();
+
+    // Holder takes the slot; waiter defers into a durable request row with a
+    // non-zero requester counter.
+    shard
+        .enqueue(
+            tenant,
+            Some("holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue holder");
+    let tasks = shard.dequeue("w", "tg", 1).await.expect("dequeue").tasks;
+    assert_eq!(tasks.len(), 1);
+    let holder_task = tasks[0].attempt().task_id().to_string();
+    shard
+        .enqueue(
+            tenant,
+            Some("waiter".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue waiter");
+    assert_eq!(count_concurrency_requests(shard.db()).await, 1);
+
+    // Free the slot. The release fires a hot nudge, but the scanner is
+    // stopped — take (and discard) the batch so only durable state remains:
+    // a free slot, a pending request row, and a non-zero requester counter.
+    shard
+        .report_attempt_outcome(&holder_task, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("release holder");
+    let _ = shard.take_pending_grant_batch_for_test();
+
+    // Restarting the scanner runs the startup reconcile sweep, which
+    // rediscovers the queue from its requester counter and grants the waiter
+    // with no event-driven nudge involved.
+    shard.start_grant_scanner_for_test();
+    let holders = poll_until(|| count_concurrency_holders(shard.db()), |n| *n == 1, 5_000).await;
+    assert_eq!(holders, 1, "waiter granted via sweep-discovered work");
+    let requests = poll_until(
+        || count_concurrency_requests(shard.db()),
+        |n| *n == 0,
+        5_000,
+    )
+    .await;
+    assert_eq!(requests, 0, "waiter's request row consumed");
+}
+
+// ---------------------------------------------------------------------------
+// Sliced reconcile sweep tests (cursor + SET semantics)
+// ---------------------------------------------------------------------------
+
+/// The reconcile sweep SETs the cold-lane pending count to the requester
+/// counter value instead of accumulating it. Under the old `+=` semantics a
+/// queue that went unserviced between sweeps grew its pending count without
+/// bound — u32 overflow in minutes for a queue with tens of millions of
+/// requesters.
+#[silo::test]
+async fn reconcile_sweep_sets_pending_to_counter_instead_of_accumulating() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "sweep-set-tenant";
+    let queue = "sweep-set-q";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: 1,
+    });
+
+    shard.stop_grant_scanner();
+
+    // One holder + three deferred waiters => requester counter == 3.
+    shard
+        .enqueue(
+            tenant,
+            Some("holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue holder");
+    for i in 0..3 {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("waiter-{i}")),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .expect("enqueue waiter");
+    }
+    assert_eq!(count_concurrency_requests(shard.db()).await, 3);
+
+    shard.reconcile_pending_concurrency_requests_once().await;
+    assert_eq!(
+        shard.cold_pending_grant_count_for_test(tenant, queue),
+        3,
+        "sweep seeds the cold lane with the counter value"
+    );
+    assert_eq!(
+        shard.hot_pending_grant_count_for_test(tenant, queue),
+        0,
+        "sweep must not touch the hot lane"
+    );
+
+    // A second sweep re-reads the same counter: the pending count must stay
+    // equal to it, not double.
+    shard.reconcile_pending_concurrency_requests_once().await;
+    assert_eq!(
+        shard.cold_pending_grant_count_for_test(tenant, queue),
+        3,
+        "repeat sweeps are idempotent (SET/max, not +=)"
+    );
+}
+
+/// Sliced sweeps walk at most `max_keys` counter keys per call, resume from
+/// a persistent cursor, and wrap to the front after reaching the end of the
+/// counter keyspace.
+#[silo::test]
+async fn reconcile_sweep_cursor_progresses_and_wraps() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let tenant = "sweep-cursor-tenant";
+    let queues = ["q-a", "q-b", "q-c"];
+
+    shard.stop_grant_scanner();
+
+    // Each queue: one holder + one deferred waiter => counter == 1.
+    for queue in &queues {
+        let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: queue.to_string(),
+            max_concurrency: 1,
+        });
+        for id in ["holder", "waiter"] {
+            shard
+                .enqueue(
+                    tenant,
+                    Some(format!("{queue}-{id}")),
+                    50,
+                    now,
+                    None,
+                    vec![1],
+                    vec![limit.clone()],
+                    None,
+                    "tg",
+                )
+                .await
+                .expect("enqueue");
+        }
+    }
+
+    // Slice 1 walks the first two counter keys only.
+    shard
+        .reconcile_pending_concurrency_requests_sliced_for_test(2)
+        .await;
+    assert_eq!(shard.cold_pending_grant_count_for_test(tenant, "q-a"), 1);
+    assert_eq!(shard.cold_pending_grant_count_for_test(tenant, "q-b"), 1);
+    assert_eq!(
+        shard.cold_pending_grant_count_for_test(tenant, "q-c"),
+        0,
+        "budget exhausted before q-c"
+    );
+    let _ = shard.take_pending_grant_batch_for_test();
+
+    // Slice 2 resumes after q-b: only q-c is walked, and reaching the end of
+    // the keyspace resets the cursor.
+    shard
+        .reconcile_pending_concurrency_requests_sliced_for_test(2)
+        .await;
+    assert_eq!(
+        shard.cold_pending_grant_count_for_test(tenant, "q-a"),
+        0,
+        "already-walked keys are not re-seeded mid-rotation"
+    );
+    assert_eq!(shard.cold_pending_grant_count_for_test(tenant, "q-c"), 1);
+    let _ = shard.take_pending_grant_batch_for_test();
+
+    // Slice 3 starts a fresh rotation from the front.
+    shard
+        .reconcile_pending_concurrency_requests_sliced_for_test(2)
+        .await;
+    assert_eq!(
+        shard.cold_pending_grant_count_for_test(tenant, "q-a"),
+        1,
+        "cursor wrapped to the front"
+    );
+    assert_eq!(shard.cold_pending_grant_count_for_test(tenant, "q-b"), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Sliced holder-drift pass tests
+// ---------------------------------------------------------------------------
+
+fn read_concurrency_holder_drift(metrics: &silo::metrics::Metrics) -> f64 {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|f| f.get_name() == "silo_concurrency_holder_drift")
+        .map(|f| {
+            f.get_metric()
+                .iter()
+                .map(|m| m.get_gauge().get_value())
+                .sum()
+        })
+        .unwrap_or(0.0)
+}
+
+/// The sliced drift pass publishes the drift gauge only at FULL-pass
+/// boundaries (a partial tick must not report a shrunken sweep), and ghost
+/// confirmation still requires `GHOST_CONFIRM_PASSES` = two complete passes,
+/// spanning however many ticks each pass takes.
+#[silo::test]
+async fn holder_drift_sliced_pass_full_pass_gauge_and_ghost_confirm() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let tenant = "drift-slice-tenant";
+
+    shard.stop_grant_scanner();
+
+    // Three hydrated queues, each with one durable holder.
+    for q in ["q-a", "q-b", "q-c"] {
+        let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: q.to_string(),
+            max_concurrency: 2,
+        });
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("{q}-job")),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit],
+                None,
+                "tg",
+            )
+            .await
+            .expect("enqueue");
+    }
+    let tasks = shard.dequeue("w", "tg", 3).await.expect("dequeue").tasks;
+    assert_eq!(tasks.len(), 3);
+
+    // Ghost: an in-memory holder with no durable row, on the LAST queue of
+    // the sorted snapshot so partial ticks cannot have visited it yet.
+    shard.concurrency_insert_holder(tenant, "q-c", "ghost-task");
+    assert_eq!(shard.hot_pending_grant_count_for_test(tenant, "q-c"), 0);
+
+    // Pass 1, tick 1 (slice 2): visits q-a, q-b — incomplete, gauge untouched.
+    shard.report_holder_drift_sliced_for_test(2).await;
+    assert_eq!(
+        read_concurrency_holder_drift(&metrics),
+        0.0,
+        "partial pass must not publish"
+    );
+
+    // Pass 1, tick 2: visits q-c, completing the pass — gauge publishes the
+    // ghost's drift. The ghost has been seen in ONE full pass: not confirmed,
+    // so reconciliation releases nothing.
+    shard.report_holder_drift_sliced_for_test(2).await;
+    assert_eq!(read_concurrency_holder_drift(&metrics), 1.0);
+    shard.reconcile_pending_holders_for_test().await;
+    assert_eq!(
+        shard.hot_pending_grant_count_for_test(tenant, "q-c"),
+        0,
+        "one full pass must not confirm a ghost"
+    );
+
+    // Pass 2 (two more ticks): the ghost survives a second complete pass and
+    // is enqueued for reconciliation; the release fires a hot-lane nudge.
+    shard.report_holder_drift_sliced_for_test(2).await;
+    shard.report_holder_drift_sliced_for_test(2).await;
+    shard.reconcile_pending_holders_for_test().await;
+    assert_eq!(
+        shard.hot_pending_grant_count_for_test(tenant, "q-c"),
+        1,
+        "ghost confirmed after two full passes and released"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Next-hop saturation skip tests
+// ---------------------------------------------------------------------------
+
+fn read_concurrency_next_hop_skips(metrics: &silo::metrics::Metrics) -> f64 {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|f| f.get_name() == "silo_concurrency_grant_next_hop_skips_total")
+        .map(|f| {
+            f.get_metric()
+                .iter()
+                .map(|m| m.get_counter().get_value())
+                .sum()
+        })
+        .unwrap_or(0.0)
+}
+
+/// Write a pending request row for `queue` directly, the durable shape an
+/// at-capacity deferral produces. `limits` carries the job's full chain and
+/// `limit_index` 0 points at `queue`. Rows for skip-fronts may reference
+/// fabricated job ids — the next-hop check runs before status validation, so
+/// skipped rows never read job state.
+async fn inject_request_row(
+    shard: &silo::job_store_shard::JobStoreShard,
+    tenant: &str,
+    queue: &str,
+    job_id: &str,
+    start_time_ms: i64,
+    limits: Vec<Limit>,
+) {
+    let action = ConcurrencyAction::EnqueueTask {
+        start_time_ms,
+        priority: 50,
+        job_id: job_id.to_string(),
+        attempt_number: 1,
+        relative_attempt_number: 1,
+        task_group: "tg".to_string(),
+        limit_index: 0,
+        held_queues: Vec::new(),
+        task_id: format!("{job_id}:1:x"),
+        limits,
+    };
+    let key =
+        silo::keys::concurrency_request_key(tenant, queue, start_time_ms, 50, job_id, 1, "x0000");
+    let val = encode_concurrency_action(&action);
+    let mut batch = slatedb::WriteBatch::new();
+    batch.put(&key, &val);
+    shard.db().write(batch).await.expect("inject request row");
+}
+
+/// Seed the durable requester counter for a queue with an absolute value (a
+/// plain put is the merge operator's base value).
+async fn seed_requester_counter(
+    shard: &silo::job_store_shard::JobStoreShard,
+    tenant: &str,
+    queue: &str,
+    value: i64,
+) {
+    let mut batch = slatedb::WriteBatch::new();
+    batch.put(
+        &silo::keys::concurrency_requester_counter_key(tenant, queue),
+        &value.to_le_bytes(),
+    );
+    shard.db().write(batch).await.expect("seed counter");
+}
+
+/// The scanner defers candidates whose next concurrency hop is saturated
+/// with a deep backlog (rows intact, nothing deleted, metric incremented),
+/// and grants them normally once the hop frees a slot.
+#[silo::test]
+async fn grant_scanner_next_hop_skip_defers_and_resumes_after_release() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let tenant = "nhs-tenant";
+    let user_q = "nhs-user-q";
+    let platform_q = "nhs-platform-q";
+    let chain = vec![
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: user_q.to_string(),
+            max_concurrency: 3,
+        }),
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: platform_q.to_string(),
+            max_concurrency: 1,
+        }),
+    ];
+
+    shard.stop_grant_scanner();
+
+    // Saturate the platform hop with a platform-only job and lease it so it
+    // can be released later.
+    shard
+        .enqueue(
+            tenant,
+            Some("platform-holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![chain[1].clone()],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue platform holder");
+    let tasks = shard.dequeue("w", "tg", 1).await.expect("dequeue").tasks;
+    assert_eq!(tasks.len(), 1);
+    let platform_task = tasks[0].attempt().task_id().to_string();
+    seed_requester_counter(&shard, tenant, platform_q, 2_000).await;
+
+    // Two real waiters: future-scheduled (status Scheduled, attempt 1, no
+    // capacity consumed) with past-dated injected request rows at the user
+    // queue — the "granted user slot would park at platform" shape.
+    for i in 0..2 {
+        let job_id = format!("waiter-{i}");
+        shard
+            .enqueue(
+                tenant,
+                Some(job_id.clone()),
+                50,
+                now + 3_600_000,
+                None,
+                vec![1],
+                vec![chain[0].clone(), chain[1].clone()],
+                None,
+                "tg",
+            )
+            .await
+            .expect("enqueue waiter");
+        inject_request_row(&shard, tenant, user_q, &job_id, 1_000 + i, chain.clone()).await;
+    }
+    assert_eq!(count_concurrency_requests(shard.db()).await, 2);
+
+    // Saturated + deep next hop: both candidates defer; rows survive.
+    let skips_before = read_concurrency_next_hop_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, user_q, 100).await;
+    assert_eq!(
+        granted.len(),
+        0,
+        "no grants while the next hop is saturated"
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        2,
+        "skipped rows are neither granted nor deleted"
+    );
+    assert_eq!(
+        read_concurrency_next_hop_skips(&metrics) - skips_before,
+        2.0
+    );
+
+    // Free the platform slot: the skip no longer fires (holders < cap
+    // regardless of line depth) and both user grants proceed — the first
+    // waiter chains straight through the platform hop, the second parks
+    // there as a deferred request.
+    shard
+        .report_attempt_outcome(&platform_task, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("release platform holder");
+    let granted = shard.process_concurrency_grants(tenant, user_q, 100).await;
+    assert_eq!(granted.len(), 2, "grants resume once the hop frees a slot");
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        1,
+        "two user rows consumed, one new platform row parked"
+    );
+}
+
+/// The skip resolves a floating next hop's capacity from its durable state
+/// row (the value the hop's own scan path gates on), not the limit's
+/// embedded default.
+#[silo::test]
+async fn grant_scanner_next_hop_skip_floating_follows_durable_state() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let tenant = "nhs-float-tenant";
+    let user_q = "nhs-float-user-q";
+    let platform_q = "nhs-float-platform-q";
+    let refresh_interval_ms = 60_000_000i64;
+    let floating = Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+        key: platform_q.to_string(),
+        default_max_concurrency: 1,
+        refresh_interval_ms,
+        metadata: vec![],
+    });
+    let chain = vec![
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: user_q.to_string(),
+            max_concurrency: 3,
+        }),
+        floating.clone(),
+    ];
+
+    shard.stop_grant_scanner();
+
+    // Platform-only holder saturates the floating hop at its durable cap of 1.
+    shard
+        .enqueue(
+            tenant,
+            Some("platform-holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![floating.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue platform holder");
+    seed_requester_counter(&shard, tenant, platform_q, 2_000).await;
+
+    let write_floating_state = |max: u32| {
+        silo::codec::encode_floating_limit_state(&silo::job::FloatingLimitState {
+            current_max_concurrency: max,
+            last_refreshed_at_ms: now,
+            refresh_task_scheduled: true,
+            refresh_interval_ms,
+            default_max_concurrency: 1,
+            retry_count: 0,
+            next_retry_at_ms: None,
+            metadata: vec![],
+        })
+    };
+
+    for i in 0..2 {
+        let job_id = format!("waiter-{i}");
+        shard
+            .enqueue(
+                tenant,
+                Some(job_id.clone()),
+                50,
+                now + 3_600_000,
+                None,
+                vec![1],
+                chain.clone(),
+                None,
+                "tg",
+            )
+            .await
+            .expect("enqueue waiter");
+        inject_request_row(&shard, tenant, user_q, &job_id, 1_000 + i, chain.clone()).await;
+    }
+
+    // Durable row says cap 1 (== holders): skip fires.
+    let skips_before = read_concurrency_next_hop_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, user_q, 100).await;
+    assert_eq!(granted.len(), 0);
+    assert_eq!(
+        read_concurrency_next_hop_skips(&metrics) - skips_before,
+        2.0
+    );
+
+    // Raise the durable row: capacity now exceeds holders, so the skip stops
+    // firing even though the deep counter is unchanged.
+    let mut batch = slatedb::WriteBatch::new();
+    batch.put(
+        &silo::keys::floating_limit_state_key(tenant, platform_q),
+        &write_floating_state(10),
+    );
+    shard.db().write(batch).await.expect("raise floating cap");
+
+    let granted = shard.process_concurrency_grants(tenant, user_q, 100).await;
+    assert_eq!(granted.len(), 2, "durable raise re-enables grants");
+}
+
+/// Setting the backlog knob to 0 disables the skip entirely: grants proceed
+/// and park at the saturated hop, matching the old behavior.
+#[silo::test]
+async fn grant_scanner_next_hop_skip_disabled_by_zero_knob() {
+    let (_tmp, shard, metrics) =
+        open_temp_shard_with_grant_scanner_config(silo::concurrency::GrantScannerConfig {
+            next_hop_skip_min_backlog: 0,
+            ..Default::default()
+        })
+        .await;
+    let now = now_ms();
+    let tenant = "nhs-off-tenant";
+    let user_q = "nhs-off-user-q";
+    let platform_q = "nhs-off-platform-q";
+    let chain = vec![
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: user_q.to_string(),
+            max_concurrency: 3,
+        }),
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: platform_q.to_string(),
+            max_concurrency: 1,
+        }),
+    ];
+
+    shard.stop_grant_scanner();
+
+    shard
+        .enqueue(
+            tenant,
+            Some("platform-holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![chain[1].clone()],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue platform holder");
+    seed_requester_counter(&shard, tenant, platform_q, 2_000).await;
+
+    for i in 0..2 {
+        let job_id = format!("waiter-{i}");
+        shard
+            .enqueue(
+                tenant,
+                Some(job_id.clone()),
+                50,
+                now + 3_600_000,
+                None,
+                vec![1],
+                chain.clone(),
+                None,
+                "tg",
+            )
+            .await
+            .expect("enqueue waiter");
+        inject_request_row(&shard, tenant, user_q, &job_id, 1_000 + i, chain.clone()).await;
+    }
+
+    let skips_before = read_concurrency_next_hop_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, user_q, 100).await;
+    assert_eq!(
+        granted.len(),
+        2,
+        "knob 0 restores the old grant-and-park behavior"
+    );
+    assert_eq!(
+        read_concurrency_next_hop_skips(&metrics) - skips_before,
+        0.0
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        2,
+        "both grants parked as deferred rows at the platform hop"
+    );
+}
+
+/// Finding-2 regression: a uniform skip-front ends the invocation after
+/// `MAX_CONSECUTIVE_NEXT_HOP_SKIPS` (64) consecutive skips instead of
+/// walking the full scan budget on every re-drive.
+#[silo::test]
+async fn grant_scanner_next_hop_skip_uniform_front_bails_bounded() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let tenant = "nhs-bail-tenant";
+    let user_q = "nhs-bail-user-q";
+    let platform_q = "nhs-bail-platform-q";
+    let chain = vec![
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: user_q.to_string(),
+            max_concurrency: 3,
+        }),
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: platform_q.to_string(),
+            max_concurrency: 1,
+        }),
+    ];
+
+    shard.stop_grant_scanner();
+
+    shard
+        .enqueue(
+            tenant,
+            Some("platform-holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![chain[1].clone()],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue platform holder");
+    seed_requester_counter(&shard, tenant, platform_q, 2_000).await;
+
+    // 500 skip-front rows. Fabricated job ids are fine: skipped rows never
+    // reach status validation.
+    for i in 0..500 {
+        inject_request_row(
+            &shard,
+            tenant,
+            user_q,
+            &format!("front-{i:04}"),
+            1_000 + i,
+            chain.clone(),
+        )
+        .await;
+    }
+
+    let skips_before = read_concurrency_next_hop_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, user_q, 100).await;
+    assert_eq!(granted.len(), 0);
+    assert_eq!(
+        read_concurrency_next_hop_skips(&metrics) - skips_before,
+        64.0,
+        "invocation bails after 64 consecutive skips, not 500"
+    );
+    assert_eq!(count_concurrency_requests(shard.db()).await, 500);
+}
+
+/// A front alternating between TWO saturated hops is equally futile and must
+/// also bail: the run counter is per-invocation, not per-hop.
+#[silo::test]
+async fn grant_scanner_next_hop_skip_alternating_hops_bails() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let tenant = "nhs-alt-tenant";
+    let user_q = "nhs-alt-user-q";
+    let user_limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: user_q.to_string(),
+        max_concurrency: 3,
+    });
+
+    shard.stop_grant_scanner();
+
+    for hop in ["nhs-alt-hop-a", "nhs-alt-hop-b"] {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("{hop}-holder")),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                    key: hop.to_string(),
+                    max_concurrency: 1,
+                })],
+                None,
+                "tg",
+            )
+            .await
+            .expect("enqueue hop holder");
+        seed_requester_counter(&shard, tenant, hop, 2_000).await;
+    }
+
+    for i in 0..100i64 {
+        let hop = if i % 2 == 0 {
+            "nhs-alt-hop-a"
+        } else {
+            "nhs-alt-hop-b"
+        };
+        let chain = vec![
+            user_limit.clone(),
+            Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: hop.to_string(),
+                max_concurrency: 1,
+            }),
+        ];
+        inject_request_row(
+            &shard,
+            tenant,
+            user_q,
+            &format!("alt-{i:03}"),
+            1_000 + i,
+            chain,
+        )
+        .await;
+    }
+
+    let skips_before = read_concurrency_next_hop_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, user_q, 100).await;
+    assert_eq!(granted.len(), 0);
+    assert_eq!(
+        read_concurrency_next_hop_skips(&metrics) - skips_before,
+        64.0,
+        "alternating saturated hops still bail at the run limit"
+    );
+    assert_eq!(count_concurrency_requests(shard.db()).await, 100);
+}
+
+/// A grantable candidate within the 64-row window behind a skip-front is
+/// still found and granted in ONE invocation — the bail must not starve
+/// mixed fronts.
+#[silo::test]
+async fn grant_scanner_next_hop_skip_mixed_front_grants_within_window() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let tenant = "nhs-mixed-tenant";
+    let user_q = "nhs-mixed-user-q";
+    let platform_q = "nhs-mixed-platform-q";
+    let user_limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: user_q.to_string(),
+        max_concurrency: 3,
+    });
+    let chain = vec![
+        user_limit.clone(),
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: platform_q.to_string(),
+            max_concurrency: 1,
+        }),
+    ];
+
+    shard.stop_grant_scanner();
+
+    shard
+        .enqueue(
+            tenant,
+            Some("platform-holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![chain[1].clone()],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue platform holder");
+    seed_requester_counter(&shard, tenant, platform_q, 2_000).await;
+
+    // 40 skip rows in front (< the 64 bail window)…
+    for i in 0..40 {
+        inject_request_row(
+            &shard,
+            tenant,
+            user_q,
+            &format!("front-{i:03}"),
+            1_000 + i,
+            chain.clone(),
+        )
+        .await;
+    }
+    // …then a grantable TERMINAL candidate (user queue only — no next hop),
+    // backed by a real Scheduled job so validation passes.
+    shard
+        .enqueue(
+            tenant,
+            Some("grantable".to_string()),
+            50,
+            now + 3_600_000,
+            None,
+            vec![1],
+            vec![user_limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue grantable");
+    inject_request_row(
+        &shard,
+        tenant,
+        user_q,
+        "grantable",
+        2_000,
+        vec![user_limit.clone()],
+    )
+    .await;
+
+    let skips_before = read_concurrency_next_hop_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, user_q, 100).await;
+    assert_eq!(
+        granted.len(),
+        1,
+        "grantable candidate behind 40 skips is served in one invocation"
+    );
+    assert_eq!(
+        read_concurrency_next_hop_skips(&metrics) - skips_before,
+        40.0
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        40,
+        "only the grantable row was consumed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Live-headroom knob tests
+// ---------------------------------------------------------------------------
+
+/// With `live_headroom_fraction` = 0.2 on a cap-10 queue, the scanner fills
+/// only to 8 (and precheck-skips beyond that, no scan churn), while the
+/// immediate enqueue path still uses all 10 slots — the reserved share stays
+/// available to fresh work during a backlog dig-out.
+#[silo::test]
+async fn grant_scanner_live_headroom_reserves_slots_for_immediate_grants() {
+    let (_tmp, shard, metrics) =
+        open_temp_shard_with_grant_scanner_config(silo::concurrency::GrantScannerConfig {
+            live_headroom_fraction: 0.2,
+            ..Default::default()
+        })
+        .await;
+    let now = now_ms();
+    let tenant = "headroom-tenant";
+    let queue = "headroom-q";
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: queue.to_string(),
+        max_concurrency: 10,
+    });
+
+    shard.stop_grant_scanner();
+
+    // The immediate enqueue path fills all 10 slots — headroom does not
+    // apply to it.
+    for i in 0..10 {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("job-{i}")),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .expect("enqueue");
+    }
+    assert_eq!(count_concurrency_holders(shard.db()).await, 10);
+    let tasks = shard.dequeue("w", "tg", 10).await.expect("dequeue").tasks;
+    assert_eq!(tasks.len(), 10);
+
+    // Two deferred waiters for the scanner to drain later.
+    for i in 0..2 {
+        shard
+            .enqueue(
+                tenant,
+                Some(format!("waiter-{i}")),
+                50,
+                now,
+                None,
+                vec![1],
+                vec![limit.clone()],
+                None,
+                "tg",
+            )
+            .await
+            .expect("enqueue waiter");
+    }
+    assert_eq!(count_concurrency_requests(shard.db()).await, 2);
+
+    // Saturated beyond the effective cap of 8: the precheck skips without
+    // scanning.
+    let skips_before = read_concurrency_grant_precheck_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, queue, 100).await;
+    assert_eq!(granted.len(), 0);
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics) - skips_before,
+        1.0
+    );
+
+    // Free four slots (holders 10 -> 6): the scanner grants only back up to
+    // its effective cap of 8.
+    for task in tasks.iter().take(4) {
+        shard
+            .report_attempt_outcome(
+                &task.attempt().task_id().to_string(),
+                AttemptOutcome::Success { result: vec![] },
+            )
+            .await
+            .expect("release");
+    }
+    let granted = shard.process_concurrency_grants(tenant, queue, 100).await;
+    assert_eq!(granted.len(), 2, "scanner refills to the effective cap");
+    assert_eq!(count_concurrency_holders(shard.db()).await, 8);
+
+    // At the effective cap the precheck skips again — no scan churn inside
+    // the headroom band.
+    let skips_before = read_concurrency_grant_precheck_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, queue, 100).await;
+    assert_eq!(granted.len(), 0);
+    assert_eq!(
+        read_concurrency_grant_precheck_skips(&metrics) - skips_before,
+        1.0
+    );
+
+    // A fresh enqueue takes a slot inside the headroom band immediately.
+    shard
+        .enqueue(
+            tenant,
+            Some("fresh".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit.clone()],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue fresh");
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        9,
+        "immediate path grants inside the reserved headroom"
+    );
+}

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -5961,6 +5961,96 @@ async fn holder_drift_sliced_pass_full_pass_gauge_and_ghost_confirm() {
     );
 }
 
+/// Finding-2 regression: a `holder_drift_scan_slice` of 0 must behave as 1
+/// (the settings doc promises "values below 1 are treated as 1"), not stall
+/// the drift pass forever. With one hydrated queue and one ghost, slice-0
+/// ticks still complete passes and self-heal the ghost.
+#[silo::test]
+async fn holder_drift_zero_slice_is_clamped_and_still_completes_passes() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let tenant = "drift-zero-tenant";
+    let q = "drift-zero-q";
+
+    shard.stop_grant_scanner();
+
+    let limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: q.to_string(),
+        max_concurrency: 2,
+    });
+    shard
+        .enqueue(
+            tenant,
+            Some(format!("{q}-job")),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![limit],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue");
+    let tasks = shard.dequeue("w", "tg", 1).await.expect("dequeue").tasks;
+    assert_eq!(tasks.len(), 1);
+
+    // Ghost: in-memory holder with no durable row.
+    shard.concurrency_insert_holder(tenant, q, "ghost-task");
+
+    // Slice 0 clamps to 1; with one hydrated queue each tick completes a full
+    // pass. Pass 1 publishes drift but does not confirm the ghost.
+    shard.report_holder_drift_sliced_for_test(0).await;
+    assert_eq!(
+        read_concurrency_holder_drift(&metrics),
+        1.0,
+        "slice-0 tick still completes a pass and publishes drift (would be 0 forever unclamped)"
+    );
+    shard.reconcile_pending_holders_for_test().await;
+    assert_eq!(
+        shard.hot_pending_grant_count_for_test(tenant, q),
+        0,
+        "one full pass must not confirm a ghost"
+    );
+
+    // Pass 2 confirms and releases the ghost.
+    shard.report_holder_drift_sliced_for_test(0).await;
+    shard.reconcile_pending_holders_for_test().await;
+    assert_eq!(
+        shard.hot_pending_grant_count_for_test(tenant, q),
+        1,
+        "second full pass confirms and releases the ghost — the pass never stalls"
+    );
+}
+
+/// Finding-2 regression: a `concurrency_reconcile_scan_slice` of 0 must behave
+/// as 1, not walk zero keys forever. A single sliced sweep with budget 0 still
+/// seeds the cold lane from a non-zero requester counter.
+#[silo::test]
+async fn reconcile_zero_slice_is_clamped_and_seeds_cold_lane() {
+    let (_tmp, shard, _metrics) = open_temp_shard_with_metrics().await;
+    let tenant = "reconcile-zero-tenant";
+    let queue = "reconcile-zero-q";
+
+    shard.stop_grant_scanner();
+
+    // A durable requester counter with no matching hot nudge — only the sweep
+    // can rediscover it.
+    seed_requester_counter(&shard, tenant, queue, 3).await;
+    assert_eq!(shard.cold_pending_grant_count_for_test(tenant, queue), 0);
+
+    // Budget 0 clamps to 1: the sweep walks the counter key and seeds the cold
+    // lane. Unclamped it would break before the first key and seed nothing.
+    shard
+        .reconcile_pending_concurrency_requests_sliced_for_test(0)
+        .await;
+    assert_eq!(
+        shard.cold_pending_grant_count_for_test(tenant, queue),
+        3,
+        "slice-0 sweep clamps to 1 and still seeds the cold lane"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Next-hop saturation skip tests
 // ---------------------------------------------------------------------------
@@ -6309,16 +6399,23 @@ async fn grant_scanner_next_hop_skip_disabled_by_zero_knob() {
     );
 }
 
-/// Finding-2 regression: a uniform skip-front ends the invocation after
-/// `MAX_CONSECUTIVE_NEXT_HOP_SKIPS` (64) consecutive skips instead of
-/// walking the full scan budget on every re-drive.
+/// A uniform skip-front is bounded by the ordinary per-invocation scan budget
+/// (`grant_scanner_max_scan_per_invocation` = batch_size × 4), NOT by an early
+/// consecutive-skip bail: skipped rows consume the walk budget like any other
+/// non-grantable front, and the invocation yields at the budget. With
+/// `batch_size` = 4 the budget is 16, so a 20-row skip-front walks exactly 16.
 #[silo::test]
-async fn grant_scanner_next_hop_skip_uniform_front_bails_bounded() {
-    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+async fn grant_scanner_next_hop_skip_uniform_front_bounded_by_scan_budget() {
+    let (_tmp, shard, metrics) =
+        open_temp_shard_with_grant_scanner_config(silo::concurrency::GrantScannerConfig {
+            batch_size: 4,
+            ..Default::default()
+        })
+        .await;
     let now = now_ms();
-    let tenant = "nhs-bail-tenant";
-    let user_q = "nhs-bail-user-q";
-    let platform_q = "nhs-bail-platform-q";
+    let tenant = "nhs-budget-tenant";
+    let user_q = "nhs-budget-user-q";
+    let platform_q = "nhs-budget-platform-q";
     let chain = vec![
         Limit::Concurrency(silo::job::ConcurrencyLimit {
             key: user_q.to_string(),
@@ -6348,9 +6445,9 @@ async fn grant_scanner_next_hop_skip_uniform_front_bails_bounded() {
         .expect("enqueue platform holder");
     seed_requester_counter(&shard, tenant, platform_q, 2_000).await;
 
-    // 500 skip-front rows. Fabricated job ids are fine: skipped rows never
-    // reach status validation.
-    for i in 0..500 {
+    // 20 skip-front rows > the 16-key budget. Fabricated job ids are fine:
+    // skipped rows never reach status validation.
+    for i in 0..20 {
         inject_request_row(
             &shard,
             tenant,
@@ -6367,93 +6464,24 @@ async fn grant_scanner_next_hop_skip_uniform_front_bails_bounded() {
     assert_eq!(granted.len(), 0);
     assert_eq!(
         read_concurrency_next_hop_skips(&metrics) - skips_before,
-        64.0,
-        "invocation bails after 64 consecutive skips, not 500"
+        16.0,
+        "skips consume the 16-key scan budget, not an early 64-skip bail"
     );
-    assert_eq!(count_concurrency_requests(shard.db()).await, 500);
+    assert_eq!(count_concurrency_requests(shard.db()).await, 20);
 }
 
-/// A front alternating between TWO saturated hops is equally futile and must
-/// also bail: the run counter is per-invocation, not per-hop.
+/// Finding-1 regression: a grantable candidate BEYOND the old 64-skip window
+/// (but within the scan budget) is reached and granted in one invocation. Pre
+/// fix the bail ended the walk at 64 and this candidate starved indefinitely
+/// while the saturated hop stayed saturated, despite its own queue having free
+/// slots.
 #[silo::test]
-async fn grant_scanner_next_hop_skip_alternating_hops_bails() {
+async fn grant_scanner_next_hop_skip_grants_past_old_bail_window() {
     let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
     let now = now_ms();
-    let tenant = "nhs-alt-tenant";
-    let user_q = "nhs-alt-user-q";
-    let user_limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
-        key: user_q.to_string(),
-        max_concurrency: 3,
-    });
-
-    shard.stop_grant_scanner();
-
-    for hop in ["nhs-alt-hop-a", "nhs-alt-hop-b"] {
-        shard
-            .enqueue(
-                tenant,
-                Some(format!("{hop}-holder")),
-                50,
-                now,
-                None,
-                vec![1],
-                vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
-                    key: hop.to_string(),
-                    max_concurrency: 1,
-                })],
-                None,
-                "tg",
-            )
-            .await
-            .expect("enqueue hop holder");
-        seed_requester_counter(&shard, tenant, hop, 2_000).await;
-    }
-
-    for i in 0..100i64 {
-        let hop = if i % 2 == 0 {
-            "nhs-alt-hop-a"
-        } else {
-            "nhs-alt-hop-b"
-        };
-        let chain = vec![
-            user_limit.clone(),
-            Limit::Concurrency(silo::job::ConcurrencyLimit {
-                key: hop.to_string(),
-                max_concurrency: 1,
-            }),
-        ];
-        inject_request_row(
-            &shard,
-            tenant,
-            user_q,
-            &format!("alt-{i:03}"),
-            1_000 + i,
-            chain,
-        )
-        .await;
-    }
-
-    let skips_before = read_concurrency_next_hop_skips(&metrics);
-    let granted = shard.process_concurrency_grants(tenant, user_q, 100).await;
-    assert_eq!(granted.len(), 0);
-    assert_eq!(
-        read_concurrency_next_hop_skips(&metrics) - skips_before,
-        64.0,
-        "alternating saturated hops still bail at the run limit"
-    );
-    assert_eq!(count_concurrency_requests(shard.db()).await, 100);
-}
-
-/// A grantable candidate within the 64-row window behind a skip-front is
-/// still found and granted in ONE invocation — the bail must not starve
-/// mixed fronts.
-#[silo::test]
-async fn grant_scanner_next_hop_skip_mixed_front_grants_within_window() {
-    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
-    let now = now_ms();
-    let tenant = "nhs-mixed-tenant";
-    let user_q = "nhs-mixed-user-q";
-    let platform_q = "nhs-mixed-platform-q";
+    let tenant = "nhs-past-tenant";
+    let user_q = "nhs-past-user-q";
+    let platform_q = "nhs-past-platform-q";
     let user_limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
         key: user_q.to_string(),
         max_concurrency: 3,
@@ -6484,8 +6512,8 @@ async fn grant_scanner_next_hop_skip_mixed_front_grants_within_window() {
         .expect("enqueue platform holder");
     seed_requester_counter(&shard, tenant, platform_q, 2_000).await;
 
-    // 40 skip rows in front (< the 64 bail window)…
-    for i in 0..40 {
+    // 80 skip rows in front — well past the old 64-skip bail window.
+    for i in 0..80 {
         inject_request_row(
             &shard,
             tenant,
@@ -6497,7 +6525,8 @@ async fn grant_scanner_next_hop_skip_mixed_front_grants_within_window() {
         .await;
     }
     // …then a grantable TERMINAL candidate (user queue only — no next hop),
-    // backed by a real Scheduled job so validation passes.
+    // backed by a real Scheduled job so validation passes. It sorts after the
+    // 80 front rows (start_time 2000 > 1079), i.e. at position 81.
     shard
         .enqueue(
             tenant,
@@ -6527,16 +6556,185 @@ async fn grant_scanner_next_hop_skip_mixed_front_grants_within_window() {
     assert_eq!(
         granted.len(),
         1,
-        "grantable candidate behind 40 skips is served in one invocation"
+        "grantable candidate 80 skips deep is served in one invocation"
     );
     assert_eq!(
         read_concurrency_next_hop_skips(&metrics) - skips_before,
-        40.0
+        80.0
     );
     assert_eq!(
         count_concurrency_requests(shard.db()).await,
-        40,
-        "only the grantable row was consumed"
+        80,
+        "only the grantable row was consumed; the 80 skip rows remain"
+    );
+}
+
+/// Finding-3 regression: an old parked row embedding a STALE LOW fixed limit
+/// for the next hop must not poison the skip decision for a newer row that
+/// embeds a RAISED limit. Per-candidate capacity resolution means the newer
+/// row is evaluated against its own limit (holders < its capacity ⇒ grant),
+/// even though the older row (scanned first) correctly skips.
+#[silo::test]
+async fn grant_scanner_next_hop_skip_stale_embedded_limit_does_not_poison() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let tenant = "nhs-poison-tenant";
+    let user_q = "nhs-poison-user-q";
+    let platform_q = "nhs-poison-platform-q";
+    let user_limit = Limit::Concurrency(silo::job::ConcurrencyLimit {
+        key: user_q.to_string(),
+        max_concurrency: 3,
+    });
+    // The old row sees the platform hop as cap 1 (saturated by 1 holder); the
+    // new row embeds the raised cap 100 (1 holder ≪ 100 ⇒ real headroom).
+    let old_chain = vec![
+        user_limit.clone(),
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: platform_q.to_string(),
+            max_concurrency: 1,
+        }),
+    ];
+    let new_chain = vec![
+        user_limit.clone(),
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: platform_q.to_string(),
+            max_concurrency: 100,
+        }),
+    ];
+
+    shard.stop_grant_scanner();
+
+    // One holder occupies the platform hop; seed a deep requester backlog so
+    // the old (cap-1) row meets the skip threshold.
+    shard
+        .enqueue(
+            tenant,
+            Some("platform-holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![Limit::Concurrency(silo::job::ConcurrencyLimit {
+                key: platform_q.to_string(),
+                max_concurrency: 1,
+            })],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue platform holder");
+    seed_requester_counter(&shard, tenant, platform_q, 2_000).await;
+
+    // Old row first (start_time 1000): correctly skips (holders 1 ≥ cap 1,
+    // backlog ≥ 1024).
+    inject_request_row(&shard, tenant, user_q, "old-row", 1_000, old_chain).await;
+    // Newer row (start_time 2000) embedding the raised limit, backed by a real
+    // Scheduled job so it can be granted.
+    shard
+        .enqueue(
+            tenant,
+            Some("new-row".to_string()),
+            50,
+            now + 3_600_000,
+            None,
+            vec![1],
+            new_chain.clone(),
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue new-row job");
+    inject_request_row(&shard, tenant, user_q, "new-row", 2_000, new_chain).await;
+
+    let skips_before = read_concurrency_next_hop_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, user_q, 100).await;
+    assert_eq!(
+        granted.len(),
+        1,
+        "newer row embedding the raised limit is granted, not poisoned by the old row's cached skip"
+    );
+    assert_eq!(
+        read_concurrency_next_hop_skips(&metrics) - skips_before,
+        1.0,
+        "only the old (cap-1) row skips"
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        1,
+        "old skip row remains; new row was consumed by the grant"
+    );
+}
+
+/// Finding-7 regression: the skip looks THROUGH a RateLimit hop to the next
+/// capacity-holding hop. A `Concurrency → RateLimit → saturated Concurrency`
+/// candidate is deferred (granting it would only park a holder at the third
+/// hop while holding this queue's slot), where the pre-fix code stopped at the
+/// rate limit and granted through.
+#[silo::test]
+async fn grant_scanner_next_hop_skip_looks_through_rate_limit() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    let tenant = "nhs-rl-tenant";
+    let user_q = "nhs-rl-user-q";
+    let platform_q = "nhs-rl-platform-q";
+    let chain = vec![
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: user_q.to_string(),
+            max_concurrency: 3,
+        }),
+        Limit::RateLimit(silo::job::GubernatorRateLimit {
+            name: "api".to_string(),
+            unique_key: "nhs-rl-key".to_string(),
+            limit: 100,
+            duration_ms: 60_000,
+            hits: 1,
+            algorithm: silo::job::GubernatorAlgorithm::TokenBucket,
+            behavior: 0,
+            retry_policy: silo::job::RateLimitRetryPolicy::default(),
+        }),
+        Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: platform_q.to_string(),
+            max_concurrency: 1,
+        }),
+    ];
+
+    shard.stop_grant_scanner();
+
+    // Saturate the third hop (behind the rate limit) with a deep backlog.
+    shard
+        .enqueue(
+            tenant,
+            Some("platform-holder".to_string()),
+            50,
+            now,
+            None,
+            vec![1],
+            vec![chain[2].clone()],
+            None,
+            "tg",
+        )
+        .await
+        .expect("enqueue platform holder");
+    seed_requester_counter(&shard, tenant, platform_q, 2_000).await;
+
+    inject_request_row(&shard, tenant, user_q, "rl-row", 1_000, chain).await;
+
+    let skips_before = read_concurrency_next_hop_skips(&metrics);
+    let granted = shard.process_concurrency_grants(tenant, user_q, 100).await;
+    assert_eq!(
+        granted.len(),
+        0,
+        "candidate deferred, not granted through the rate limit"
+    );
+    assert_eq!(
+        read_concurrency_next_hop_skips(&metrics) - skips_before,
+        1.0,
+        "the skip looked through the rate limit to the saturated third hop"
+    );
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        1,
+        "the deferred row is left in place"
     );
 }
 

--- a/tests/job_store_shard_import_tests.rs
+++ b/tests/job_store_shard_import_tests.rs
@@ -3154,17 +3154,16 @@ async fn reimport_failed_to_scheduled_ignores_stale_concurrency_requests() {
         2
     );
 
-    // Trigger reconciliation: stale request for non-current attempt should be dropped.
+    // Trigger reconciliation while the queue is saturated: the capacity gate
+    // skips the scan entirely (the blocker import warmed the limit cache via
+    // the limit-chain walker), so the stale request is not cleaned yet —
+    // cleanup is deferred until a slot frees.
     shard.reconcile_pending_concurrency_requests_once().await;
-    let requests_after_reconcile = test_helpers::poll_until(
-        || async { test_helpers::count_concurrency_requests(shard.db()).await },
-        |count| *count == 1,
-        2_000,
-    )
-    .await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     assert_eq!(
-        requests_after_reconcile, 1,
-        "stale request should be ignored and removed by grant scanner"
+        test_helpers::count_concurrency_requests(shard.db()).await,
+        2,
+        "saturated queue: the gate defers stale-request cleanup"
     );
 
     // Free queue capacity, then reconcile again to grant the valid request.
@@ -3183,6 +3182,16 @@ async fn reimport_failed_to_scheduled_ignores_stale_concurrency_requests() {
     assert_eq!(r[0].status, JobStatusKind::Succeeded);
 
     shard.reconcile_pending_concurrency_requests_once().await;
+    let requests_after_free = test_helpers::poll_until(
+        || async { test_helpers::count_concurrency_requests(shard.db()).await },
+        |count| *count == 0,
+        2_000,
+    )
+    .await;
+    assert_eq!(
+        requests_after_free, 0,
+        "once capacity frees, the scan drops the stale request and grants the valid one"
+    );
     let dequeued = test_helpers::poll_until(
         || async { shard.dequeue("worker-1", "default", 1).await.unwrap() },
         |d| d.tasks.len() == 1,

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -153,9 +153,10 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             concurrency_reconcile_interval: Duration::from_millis(interval_ms.max(1)),
             counter_reconciliation_seconds: None,
             hydrate_all_at_startup: false,
-            grant_scanner_batch_size: silo::settings::DEFAULT_GRANT_SCANNER_BATCH_SIZE,
-            grant_scanner_buffer_size: silo::settings::DEFAULT_GRANT_SCANNER_BUFFER_SIZE,
-            grant_scanner_concurrency: silo::settings::DEFAULT_GRANT_SCANNER_CONCURRENCY,
+            grant_scanner: silo::concurrency::GrantScannerConfig::default(),
+            concurrency_reconcile_scan_slice:
+                silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,
+            holder_drift_scan_slice: silo::settings::DEFAULT_HOLDER_DRIFT_SCAN_SLICE,
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
         },
@@ -164,6 +165,51 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
     .await
     .expect("open shard");
     (tmp, shard)
+}
+
+/// Open a temp shard with a custom grant scanner config (and metrics), for
+/// tests exercising scanner tuning knobs like the next-hop skip threshold.
+#[allow(dead_code)]
+pub async fn open_temp_shard_with_grant_scanner_config(
+    grant_scanner: silo::concurrency::GrantScannerConfig,
+) -> (
+    tempfile::TempDir,
+    std::sync::Arc<JobStoreShard>,
+    silo::metrics::Metrics,
+) {
+    let metrics = silo::metrics::init().expect("init metrics");
+    let rate_limiter = MockGubernatorClient::new_arc();
+    let tmp = tempfile::tempdir().unwrap();
+    let resolved = resolve_object_store(&Backend::Fs, tmp.path().to_string_lossy().as_ref())
+        .expect("resolve fs object store");
+    let shard = JobStoreShard::open_with_resolved_store(
+        "test".to_string(),
+        &resolved.canonical_path,
+        OpenShardOptions {
+            store: resolved.store,
+            wal_store: None,
+            wal_close_config: None,
+            slatedb_settings: Some(fast_flush_slatedb_settings()),
+            memory_cache: None,
+            rate_limiter,
+            metrics: Some(metrics.clone()),
+            concurrency_reconcile_interval: Duration::from_millis(
+                silo::settings::DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS,
+            ),
+            counter_reconciliation_seconds: None,
+            hydrate_all_at_startup: false,
+            grant_scanner,
+            concurrency_reconcile_scan_slice:
+                silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,
+            holder_drift_scan_slice: silo::settings::DEFAULT_HOLDER_DRIFT_SCAN_SLICE,
+            completed_job_expire_s: None,
+            terminal_job_expire_s: None,
+        },
+        ShardRange::full(),
+    )
+    .await
+    .expect("open shard");
+    (tmp, shard, metrics)
 }
 
 /// Open a temp shard with a specific range (useful for testing split-aware behavior)

--- a/tests/turmoil_runner/main.rs
+++ b/tests/turmoil_runner/main.rs
@@ -85,6 +85,15 @@ fn concurrency_limits() {
 }
 
 #[test]
+fn grant_scanner_scheduling() {
+    if is_subprocess() || is_fuzz_mode() {
+        scenarios::grant_scanner_scheduling::run();
+    } else {
+        verify_determinism("grant_scanner_scheduling", get_seed());
+    }
+}
+
+#[test]
 fn concurrent_grant_race() {
     if is_subprocess() || is_fuzz_mode() {
         scenarios::concurrent_grant_race::run();

--- a/tests/turmoil_runner/scenarios/grant_scanner_scheduling.rs
+++ b/tests/turmoil_runner/scenarios/grant_scanner_scheduling.rs
@@ -1,0 +1,218 @@
+//! Grant scanner scheduling scenario: hot-lane nudges must be serviced
+//! promptly even while the periodic reconcile sweep continuously re-seeds a
+//! large cold-lane backlog of flood queues.
+//!
+//! Shape (the silo-staging starvation incident in miniature): 120 cap-1
+//! "flood" queues each hold their single slot forever (their first job's
+//! RunAttempt is routed to a task group no worker leases) with a second job
+//! deferred behind it, so every requester counter stays non-zero and every
+//! reconcile tick re-discovers all 120 queues. One "small" cap-1 queue has a
+//! holder a worker actually completes; the release fires a hot-lane nudge.
+//!
+//! Invariants verified:
+//! 1. Hot-lane latency: after the small queue's holder completes, the
+//!    deferred waiter is granted and LEASED within a bounded sim window —
+//!    it must not wait behind the flood queues' sweep-discovered entries.
+//!    (Pre-fix, the release nudge shared one FIFO drain cycle with the
+//!    entire sweep backlog and could wait a full cycle.)
+//! 2. Liveness: the waiter's grant consumes its request row (observed via
+//!    the lease itself).
+//!
+//! All client timing is fixed (no rng) so the trace is trivially
+//! deterministic; turmoil's seeded scheduler provides the interleavings.
+
+use crate::helpers::{
+    ConcurrencyLimit, EnqueueRequest, HashMap, LeaseTasksRequest, Limit, ReportOutcomeRequest,
+    SerializedBytes, TEST_SHARD_ID, connect_to_server, get_seed, limit, report_outcome_request,
+    run_scenario_impl, serialized_bytes, setup_server,
+};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+const NUM_FLOOD_QUEUES: usize = 120;
+/// Sim-time bound between completing the small queue's holder and leasing
+/// the granted waiter. Generous vs the expected sub-second hot-lane latency,
+/// tight vs any regression back to sweep-cycle latency (the flood alone
+/// keeps the sweep re-seeding 120 entries every 5s tick).
+const MAX_GRANT_TO_LEASE_SECS: u64 = 15;
+
+fn msgpack_payload() -> Option<SerializedBytes> {
+    Some(SerializedBytes {
+        encoding: Some(serialized_bytes::Encoding::Msgpack(
+            rmp_serde::to_vec(&serde_json::json!("payload")).unwrap(),
+        )),
+    })
+}
+
+fn enqueue_request(job_id: &str, queue: &str, task_group: &str) -> EnqueueRequest {
+    EnqueueRequest {
+        shard: TEST_SHARD_ID.to_string(),
+        id: job_id.to_string(),
+        priority: 50,
+        start_at_ms: 0,
+        retry_policy: None,
+        payload: msgpack_payload(),
+        limits: vec![Limit {
+            limit: Some(limit::Limit::Concurrency(ConcurrencyLimit {
+                key: queue.into(),
+                max_concurrency: 1,
+            })),
+        }],
+        tenant: None,
+        metadata: HashMap::new(),
+        task_group: task_group.to_string(),
+    }
+}
+
+pub fn run() {
+    let seed = get_seed();
+    run_scenario_impl("grant_scanner_scheduling", seed, 120, |sim| {
+        // Set by the producer once the entire flood is enqueued; the worker
+        // starts its latency measurement only after this (plus one reconcile
+        // tick), so the sweep backlog is fully in place. Shared in-process
+        // state is deterministic under turmoil's single-threaded sim.
+        let flood_done = Arc::new(AtomicBool::new(false));
+
+        sim.host("server", || async move { setup_server(9926).await });
+
+        // Producer: the small queue's holder+waiter FIRST (so the worker can
+        // lease the holder early — each simulated enqueue round-trip costs
+        // ~100ms, so the 240-job flood takes ~25 sim-seconds), then the
+        // flood: 120 cap-1 queues whose holders keep their slot forever
+        // (their RunAttempts land in the unleased "flood" group) with one
+        // deferred waiter each, keeping every requester counter non-zero.
+        let producer_flood_done = Arc::clone(&flood_done);
+        sim.client("producer", async move {
+            let mut client = connect_to_server("http://server:9926").await?;
+
+            for job_id in ["small-holder", "small-waiter"] {
+                client
+                    .enqueue(tonic::Request::new(enqueue_request(
+                        job_id, "small-q", "small",
+                    )))
+                    .await?;
+                tracing::trace!(job_id = %job_id, "small_enqueued");
+            }
+
+            for q in 0..NUM_FLOOD_QUEUES {
+                let queue = format!("flood-{q:03}");
+                for suffix in ["holder", "waiter"] {
+                    let job_id = format!("{queue}-{suffix}");
+                    client
+                        .enqueue(tonic::Request::new(enqueue_request(
+                            &job_id, &queue, "flood",
+                        )))
+                        .await?;
+                    tracing::trace!(job_id = %job_id, "flood_enqueued");
+                }
+            }
+
+            producer_flood_done.store(true, Ordering::SeqCst);
+            tracing::trace!("producer_done");
+            Ok(())
+        });
+
+        // Worker: leases only the "small" group. It waits for the flood to
+        // be fully staged (plus one reconcile tick so the sweep has
+        // re-seeded the cold lane with all 120 flood queues), THEN leases
+        // the small holder, completes it, and measures how long the freed
+        // slot takes to reach the waiter as a leasable RunAttempt. Leasing
+        // only after staging keeps the holder's lease far from expiry (the
+        // flood takes ~25 sim-seconds to enqueue). Measurement-critical
+        // calls panic on error rather than `?`: a client Err merely ends
+        // the sim as DST_RESULT:error, which does NOT fail the test outside
+        // fuzz mode — a panic does.
+        let worker_flood_done = Arc::clone(&flood_done);
+        sim.client("worker", async move {
+            while !worker_flood_done.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            tokio::time::sleep(Duration::from_secs(6)).await;
+
+            let mut client = connect_to_server("http://server:9926").await?;
+
+            let mut holder_task_id: Option<String> = None;
+            for _ in 0..40 {
+                let tasks = client
+                    .lease_tasks(tonic::Request::new(LeaseTasksRequest {
+                        shard: Some(TEST_SHARD_ID.to_string()),
+                        worker_id: "worker".to_string(),
+                        max_tasks: 4,
+                        task_group: "small".to_string(),
+                    }))
+                    .await
+                    .expect("lease small-holder")
+                    .into_inner()
+                    .tasks;
+                for task in tasks {
+                    tracing::trace!(job_id = %task.job_id, "leased");
+                    if task.job_id == "small-holder" {
+                        holder_task_id = Some(task.id.clone());
+                    }
+                }
+                if holder_task_id.is_some() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            let holder_task_id = holder_task_id.expect("small-holder never leased");
+            tracing::trace!("small_holder_leased");
+
+            // Complete the holder: the release fires a hot-lane nudge for
+            // small-q while the flood keeps the cold lane re-seeded.
+            client
+                .report_outcome(tonic::Request::new(ReportOutcomeRequest {
+                    shard: TEST_SHARD_ID.to_string(),
+                    task_id: holder_task_id,
+                    outcome: Some(report_outcome_request::Outcome::Success(SerializedBytes {
+                        encoding: Some(serialized_bytes::Encoding::Msgpack(
+                            rmp_serde::to_vec(&serde_json::json!("done")).unwrap(),
+                        )),
+                    })),
+                    tenant_id: None,
+                }))
+                .await
+                .expect("report small-holder outcome");
+            let released_at = tokio::time::Instant::now();
+            tracing::trace!("small_holder_completed");
+
+            // The waiter must be granted and leasable within the bound.
+            let mut waiter_leased = false;
+            while released_at.elapsed() < Duration::from_secs(MAX_GRANT_TO_LEASE_SECS) {
+                let tasks = client
+                    .lease_tasks(tonic::Request::new(LeaseTasksRequest {
+                        shard: Some(TEST_SHARD_ID.to_string()),
+                        worker_id: "worker".to_string(),
+                        max_tasks: 4,
+                        task_group: "small".to_string(),
+                    }))
+                    .await
+                    .expect("lease small-waiter")
+                    .into_inner()
+                    .tasks;
+                if tasks.iter().any(|t| t.job_id == "small-waiter") {
+                    waiter_leased = true;
+                    // Sim time is deterministic, so this duration is too —
+                    // safe to trace as part of the determinism oracle.
+                    tracing::trace!(
+                        elapsed_ms = released_at.elapsed().as_millis() as u64,
+                        "small_waiter_leased"
+                    );
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(250)).await;
+            }
+
+            assert!(
+                waiter_leased,
+                "INVARIANT VIOLATION: small-q's freed slot was not granted+leased \
+                 within {MAX_GRANT_TO_LEASE_SECS}s of release — the hot-lane nudge \
+                 starved behind the flood queues' sweep backlog"
+            );
+
+            tracing::trace!("worker_done");
+            Ok(())
+        });
+    });
+}

--- a/tests/turmoil_runner/scenarios/mod.rs
+++ b/tests/turmoil_runner/scenarios/mod.rs
@@ -9,6 +9,7 @@ pub mod concurrent_grant_race;
 pub mod expedite_concurrency;
 pub mod fault_injection_partition;
 pub mod floating_concurrency;
+pub mod grant_scanner_scheduling;
 pub mod grpc_end_to_end;
 pub mod high_latency;
 pub mod high_message_loss;


### PR DESCRIPTION
## Problem

Diagnosed live on silo-staging shard `33ba2821` (shadow tenants env-10000447400 and env-10000262256, which share it): the grant scanner's drain loop `mem::take`s the ENTIRE `pending_grants` map and barrier-processes it, while the 5s reconciler re-floods that map with every non-zero requester counter on the shard (~667K queues). One drain cycle took **37+ minutes** (measured restart → first visit to the tenant's platform queue), so:

- A release-driven `request_grant` nudge waited a full shard-wide cycle to be serviced. The floating platform queue ran at **2–6 holders of cap 13** with a 336K-deep deferred request line — the tenant used ~40% of its budgeted concurrency.
- User queues wedged: `shadow-env-…-klaviyo_*` sat at 5/5 holders for **3+ days**, their held jobs parked deep in the platform line.
- The scanner actively made things worse: it granted user-queue tickets whose chains immediately parked at the saturated platform hop — pure state inflation at **+300 in-memory holders/s** (392K→541K observed in 8 minutes), plus the durable write amplification.
- `reconcile_pending_requests` re-scanned all ~667K counter rows every 5s, and `report_holder_drift` issued ~667K durable ranged scans per tick (one per hydrated queue) while cloning every in-memory holder set.
- The reconciler's `entry.2 += count` accumulation overflows the u32 pending count within minutes for a queue with tens of millions of requesters (exists in prod).
- None of this was observable: no invocation/duration/lane metrics.

## Fix (three commits)

**1. Pre-scan capacity gate** (`54acdce`) — skip the request scan when the queue's known capacity is fully occupied (`silo_concurrency_grant_precheck_skips_total`). Pure fast path on the `[SILO-GRANT-1]` precondition.

**2. `buffer_unordered` drain** (`e23728a`) — completed passes yield immediately instead of serializing behind the slowest queue in the fan-out window; broker wakes are sorted+deduped for DST determinism.

**3. Hot/cold lanes + bounded sweeps + next-hop backpressure** (`01d3ba7`):

- **Hot/cold pending lanes.** Event-driven nudges (releases, ticket conversions, floating raises, ghost releases) stay in `pending_grants` and are drained IN FULL every iteration; the reconcile sweep seeds a new cold lane drained ≤`grant_scanner_cold_batch_size` per iteration. A freed slot is refilled within one iteration instead of one shard-wide cycle. Cold entries pop **round-robin via a cursor** — a `pop_first` would be pinned to the lexicographically-smallest ~50K keys under continuous re-seeding (sweep ~4K keys/s vs pops ~300/s) and the tail tenant would never get a cold pass.
- **Cursor-sliced reconcile sweep.** The periodic tick walks ≤`concurrency_reconcile_scan_slice` counter keys, resuming from a persistent cursor; startup/diagnostics still sweep fully. Counts are now SET from the counter (clamped i64→u32) instead of accumulated — fixes the overflow.
- **Sliced `report_holder_drift`.** A `DriftPass` work-queue visits ≤`holder_drift_scan_slice` queues per tick from a sorted snapshot, fetching holder sets lazily; the drift gauge and `GHOST_CONFIRM_PASSES` promotion advance only at full-pass boundaries. Trade-off: drift-detected ghost latency becomes ~one full pass; the reactive `request_reconciliation` path is unaffected and remains primary.
- **Next-hop saturation skip.** `process_grants` defers a candidate whose next concurrency hop is saturated with ≥`grant_scanner_next_hop_skip_min_backlog` requesters — granting it can't make the job runnable, it only parks a holder. Skipped rows keep their original `start_time` (age position preserved at the next hop) and their requester counter, so the cursor sweep re-drives them; a RateLimit gate never skips. After 64 consecutive skips (any hop; grants and stale cleanup reset the run) the invocation ends instead of re-walking the full scan budget on every re-drive.
- **Dormant live-headroom knob.** `grant_scanner_live_headroom_fraction` (default 0.0) reserves a share of each queue's capacity for immediate grants during backlog dig-outs; the precheck gates on the same effective capacity the reserve loop uses.
- **Observability:** `process_grants` total/duration/keys-scanned/stale, reconcile total/duration, `pending_grants{lane=hot|cold}` gauges, next-hop-skip counter; the reconciler-signals recorder is split so drift publishes at pass boundaries while `reconciliation_pending` publishes every tick.

Scanner knobs now travel as one `GrantScannerConfig` through `OpenShardOptions`.

## Settings deployed alongside (silo-staging.toml, gadget-inc/global-infrastructure `9e5b7bfb`)

```toml
grant_scanner_buffer_size = 64        # was 512: passes are capacity-bound; 512×8 = up to 4K in-flight status gets, memory risk, no gain
grant_scanner_batch_size = 256        # was 2048: grants/invocation are capacity-bound; ×4 derived walk budget stays uniform (1024 vs 8192)
grant_scanner_concurrency = 16        # was 8: I/O-overlap lever (passes are object-store-bound, not CPU) — ~halves drain-iteration latency
grant_scanner_cold_batch_size = 32    # new: hot latency ≈ (cold_batch/concurrency)×pass_time; cold throughput ≈ concurrency/pass_time, independent of this
```

New knobs left at defaults: `concurrency_reconcile_scan_slice = 20000`, `holder_drift_scan_slice = 5000`, `grant_scanner_next_hop_skip_min_backlog = 1024` (0 disables), `grant_scanner_live_headroom_fraction = 0.0` (dormant). Production will want the same `[database]` block reviewed before rollout — the old 2048/512 values were sized for the pre-lanes world ("fewer commits per drain") and now only add worst-case pass latency.

## Staging results (shard 33ba2821)

| | before | after fix | after fix + tuning |
|---|---|---|---|
| drain-cycle / nudge latency | ~37 min | ~1.1s iterations | ~0.3s iterations |
| platform holders vs cap | 2–6 of 13 (~40%) | 9 of 15 (60%) | **pinned at cap (7/7)** |
| platform deferred line | 336K, growing | draining | **143K and draining (~8/s)** |
| klaviyo user queues | frozen 3+ days | turning over | turning over |
| tenant throughput (env-…447400) | 3.5/s (webhooks only) | — | **6.8/s, floating-cap-bound** |
| shard completions | ~29/s | ~53–57/s | **~61/s** |
| hot lane depth | n/a | 0 | 0 |
| cold lane depth | n/a | growing (62K→67K) | **stable ~11K** |
| in-memory holders | 541K, +300/s | — | ~45K, stable |

The tenant is now limited by its budgeter-granted floating cap, not by the scanner — utilization of granted capacity went from ~40% to ~100%.

Caveat for reviewers checking dashboards: the node hosting this shard is **invisible in GCP metrics** — `silo_background_actions_queue_size` exports 685K series there (one per queue on the mega-queue tenant), the 160MB `/metrics` page OOM-kills the GMP collector (672 restarts since Jul 2). Validate via the pod `:9090/metrics` endpoint or `siloctl`; cardinality cap for that gauge is a separate follow-up.

## Semantics

No `[SILO-*]` tag changes (`validate-silo-sigils` green, `.als` untouched): the lanes and slices are pure scheduling; the next-hop skip is a bounded deferral of an enabled transition (liveness: the requester counter stays non-zero so the cursor sweep re-drives the queue, and the depth threshold guarantees the hop still has ≫ one sweep period of backlog); headroom only strengthens the scanner's own `[SILO-GRANT-1]` guard, immediate paths keep full capacity.

## Tests

- 14 new unit tests: lane batching + the cold-lane round-robin reseed regression; sliced-reconcile SET-not-accumulate (overflow regression) + cursor progression/wrap; drift full-pass gauge + two-full-pass ghost confirmation; next-hop skip defer/resume, floating durable-state capacity, knob-0 off-switch, uniform-front 64-skip bail, alternating-hop bail, mixed-front window; headroom fill levels.
- New DST scenario `grant_scanner_scheduling`: 120 flood queues re-seed the cold lane every reconcile tick while one small queue's release must reach its waiter — leased **76 sim-ms** after release; double-run byte-identical.
- Full sweep green: `cargo test -- --skip k8s_ --skip etcd_ --skip coordination_split_tests --skip cluster_two_nodes`, plus `coordination_split_tests` (25) and `etcd_coordination_tests` (56) green against process-compose etcd (note: `--skip coordination_split_tests` matches test *names*, not the binary — that suite silently runs and needs etcd). Clippy clean on lib+bins.
