### PR TITLE
Reapply the split fix keeping the legacy object-store key layout

### DIFF
--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -517,6 +517,25 @@ impl ShardSplitter {
                             parent_shard_id
                         )))
                     })?;
+
+                    // Capture the parent's whole-shard job count from the still-open
+                    // handle, before closing it. The post-clone verification below
+                    // confirms each child holds this full set (a fresh clone is a
+                    // byte-for-byte copy; cleanup trims each child to its range only
+                    // after commit), catching the empty-child data-loss signature.
+                    let parent_total_jobs = parent_shard
+                        .get_counters()
+                        .await
+                        .map_err(|e| {
+                            SplitExecutionError::PreCommit(CoordinationError::BackendError(
+                                format!(
+                                    "failed to read parent shard {} counters before cloning: {}",
+                                    parent_shard_id, e
+                                ),
+                            ))
+                        })?
+                        .total_jobs;
+
                     parent_shard.close().await.map_err(|e| {
                         SplitExecutionError::PreCommit(CoordinationError::BackendError(format!(
                             "failed to close parent shard before cloning: {}",
@@ -559,7 +578,36 @@ impl ShardSplitter {
                         parent_shard_id = %parent_shard_id,
                         left_child = %split.left_child_id,
                         right_child = %split.right_child_id,
-                        "cloning complete, updating shard map"
+                        "cloning complete, verifying children before commit"
+                    );
+
+                    // Defense-in-depth: before the commit point, open each child
+                    // and confirm it holds the parent's full job set. A child that
+                    // opens empty/short (the object-store resolution bug's data-loss
+                    // signature) fails here, aborting the split as
+                    // PreCommitParentClosed so the shard map stays untouched and the
+                    // parent is recovered/reopenable -- never silent data loss.
+                    self.ctx
+                        .factory
+                        .verify_cloned_children_match_parent(
+                            parent_total_jobs,
+                            &[split.left_child_id, split.right_child_id],
+                        )
+                        .await
+                        .map_err(|e| {
+                            SplitExecutionError::PreCommitParentClosed(
+                                CoordinationError::BackendError(format!(
+                                    "post-clone child verification failed for split of {}: {}",
+                                    parent_shard_id, e
+                                )),
+                            )
+                        })?;
+
+                    info!(
+                        parent_shard_id = %parent_shard_id,
+                        left_child = %split.left_child_id,
+                        right_child = %split.right_child_id,
+                        "children verified, updating shard map"
                     );
 
                     // Pre-add BOTH children to owned set BEFORE updating the shard map.

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -87,7 +87,10 @@ impl ShardFactory {
         Self {
             instances: DashMap::new(),
             template: DatabaseTemplate {
-                path: "/noop".to_string(),
+                // A valid template path needs the %shard% placeholder at a path
+                // boundary. The root is unique per factory so the shared Memory
+                // store (the default backend) does not bleed across noop factories.
+                path: format!("noop-{}/%shard%", ShardId::new()),
                 apply_wal_on_close: false,
                 ..Default::default()
             },
@@ -293,13 +296,30 @@ impl ShardFactory {
             let resolved = resolve_object_store(backend, root_path)?;
             Ok((resolved, shard_name.to_string()))
         } else {
-            // Object store backends (Memory, S3, GCS, URL): resolve full path
-            let full_path = template_path
-                .replace("%shard%", shard_name)
-                .replace("{shard}", shard_name);
-            let resolved = resolve_object_store(backend, &full_path)?;
-            let db_path = resolved.canonical_path.clone();
-            Ok((resolved, db_path))
+            // Object store backends (Memory, S3, GCS, URL): resolve at the shared
+            // storage root so a child's clone destination equals the path `open`
+            // reads for that child. When the template carries a %shard% (or
+            // {shard}) placeholder, the root is the prefix before it; otherwise the
+            // whole path is the root. db_path is always the bare shard name — a
+            // single relative segment under the shared root — so the (store,
+            // db_path) pair is identical between clone and open.
+            //
+            // This makes the parent store a correct shared ancestor of both
+            // children in clone_closed_shard. Resolving the full per-shard path
+            // instead would root each shard at its own prefix (and double-nest as
+            // <root>/<shard>/<shard> for URL-style backends), leaving the clone
+            // unreachable from the child's open path. Unlike the local-FS branch,
+            // this does not require the placeholder at a path boundary — object
+            // stores are key/value and impose no directory semantics.
+            let placeholder_pos = template_path
+                .find("%shard%")
+                .or_else(|| template_path.find("{shard}"));
+            let root = match placeholder_pos {
+                Some(pos) => template_path[..pos].trim_end_matches('/'),
+                None => template_path,
+            };
+            let resolved = resolve_object_store(backend, root)?;
+            Ok((resolved, shard_name.to_string()))
         }
     }
 
@@ -736,6 +756,87 @@ impl ShardFactory {
         Ok(())
     }
 
+    /// Verify that each freshly cloned child holds the parent's full job set.
+    ///
+    /// A fresh SlateDB clone is a byte-for-byte copy of the parent, so
+    /// immediately after `clone_closed_shard` -- before post-commit cleanup
+    /// trims each child to its range -- every child's whole-shard `total_jobs`
+    /// must equal the parent's pre-close count. An empty or mis-placed child
+    /// (the object-store split data-loss signature) reads `0` and trips this
+    /// check, letting the split abort before the shard-map commit point.
+    ///
+    /// This is a manifest-landed tripwire keyed on the empty-child signature,
+    /// not a full row-integrity audit: a clone that landed the counter key but
+    /// corrupted rows would still pass.
+    pub async fn verify_cloned_children_match_parent(
+        &self,
+        parent_total_jobs: i64,
+        child_ids: &[ShardId],
+    ) -> Result<(), ShardFactoryError> {
+        for child_id in child_ids {
+            let child_total_jobs = self.read_cloned_shard_total_jobs(child_id).await?;
+            if child_total_jobs != parent_total_jobs {
+                return Err(ShardFactoryError::ChildVerification(format!(
+                    "cloned child {child_id} holds {child_total_jobs} jobs but parent held \
+                     {parent_total_jobs}; aborting split before commit to avoid data loss"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Open a freshly cloned child's database with the raw `open_with_resolved_store`
+    /// primitive, read its whole-shard `total_jobs`, and close it.
+    ///
+    /// Uses the raw open -- NOT `open` -- so the child is never registered in the
+    /// `instances` map: `open` caches the instance in the per-shard OnceCell, and
+    /// the post-commit `open(child)` would then return this stale pre-commit
+    /// handle instead of opening the committed child. Hydration is disabled and
+    /// `get_counters` reads a single merged counter key, so the check is O(1)
+    /// even on a multi-million-job shard.
+    async fn read_cloned_shard_total_jobs(
+        &self,
+        shard_id: &ShardId,
+    ) -> Result<i64, ShardFactoryError> {
+        let name = shard_id.to_string();
+        let (resolved, db_path) =
+            Self::resolve_at_root(&self.template.backend, &self.template.path, &name)?;
+        let wal_store = self.resolve_wal_store(&name)?;
+
+        let shard = JobStoreShard::open_with_resolved_store(
+            name.clone(),
+            &db_path,
+            OpenShardOptions {
+                store: resolved.store,
+                wal_store,
+                wal_close_config: None,
+                slatedb_settings: self.template.slatedb.clone(),
+                memory_cache: self.template.memory_cache.clone(),
+                rate_limiter: Arc::clone(&self.rate_limiter),
+                metrics: self.metrics.clone(),
+                concurrency_reconcile_interval: Duration::from_millis(
+                    self.template.concurrency_reconcile_interval_ms.max(1),
+                ),
+                counter_reconciliation_seconds: None,
+                hydrate_all_at_startup: false,
+                grant_scanner_batch_size: self.template.grant_scanner_batch_size,
+                grant_scanner_buffer_size: self.template.grant_scanner_buffer_size,
+                grant_scanner_concurrency: self.template.grant_scanner_concurrency,
+                completed_job_expire_s: self.template.completed_job_expire_s,
+                terminal_job_expire_s: self.template.terminal_job_expire_s,
+            },
+            ShardRange::full(),
+        )
+        .await?;
+
+        // Always close the raw handle, even if the counter read fails, so the
+        // shard's SlateDB instance and its spawned background tasks (grant
+        // scanner, reconcilers) are released -- JobStoreShard has no Drop.
+        let counters = shard.get_counters().await;
+        shard.close().await?;
+        Ok(counters?.total_jobs)
+    }
+
     /// Get the database template used by this factory.
     pub fn template(&self) -> &DatabaseTemplate {
         &self.template
@@ -758,6 +859,9 @@ impl std::fmt::Display for CloseAllError {
 pub enum ShardFactoryError {
     #[error("clone error: {0}")]
     CloneError(String),
+
+    #[error("child verification error: {0}")]
+    ChildVerification(String),
 
     #[error("storage error: {0}")]
     Storage(#[from] crate::storage::StorageError),

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -296,31 +296,88 @@ impl ShardFactory {
             let resolved = resolve_object_store(backend, root_path)?;
             Ok((resolved, shard_name.to_string()))
         } else {
-            // Object store backends (Memory, S3, GCS, URL): resolve at the shared
+            // Object store backends (Memory, S3, GCS, URL): resolve at a shared
             // storage root so a child's clone destination equals the path `open`
-            // reads for that child. When the template carries a %shard% (or
-            // {shard}) placeholder, the root is the prefix before it; otherwise the
-            // whole path is the root. db_path is always the bare shard name — a
-            // single relative segment under the shared root — so the (store,
-            // db_path) pair is identical between clone and open.
-            //
-            // This makes the parent store a correct shared ancestor of both
-            // children in clone_closed_shard. Resolving the full per-shard path
-            // instead would root each shard at its own prefix (and double-nest as
-            // <root>/<shard>/<shard> for URL-style backends), leaving the clone
-            // unreachable from the child's open path. Unlike the local-FS branch,
-            // this does not require the placeholder at a path boundary — object
-            // stores are key/value and impose no directory semantics.
-            let placeholder_pos = template_path
-                .find("%shard%")
-                .or_else(|| template_path.find("{shard}"));
-            let root = match placeholder_pos {
-                Some(pos) => template_path[..pos].trim_end_matches('/'),
-                None => template_path,
-            };
-            let resolved = resolve_object_store(backend, root)?;
-            Ok((resolved, shard_name.to_string()))
+            // reads for that child, while keeping every object at the exact key
+            // the pre-split-fix code wrote. Production data already lives at
+            // those legacy keys — `<path>/<path>` relative to the bucket, where
+            // <path> is the template's URL path with the shard substituted — so
+            // the key layout is load-bearing: moving it strands every existing
+            // shard, which then reopens empty (the staging "data reset"
+            // incident). The store root is a shared ancestor of parent and
+            // children, which is what clone_closed_shard needs; db_path carries
+            // the remainder of the legacy key so root + db_path reproduces it
+            // byte-for-byte. Memory uses the same formula so tests exercise the
+            // production layout. Unlike the local-FS branch, this never rejects
+            // a template — object stores are key/value and impose no directory
+            // semantics.
+            let (root, db_path) =
+                Self::object_store_root_and_db_path(backend, template_path, shard_name)?;
+            let resolved = resolve_object_store(backend, &root)?;
+            Ok((resolved, db_path))
         }
+    }
+
+    /// Compute the shared store root and per-shard db_path for object-store
+    /// backends (Memory, S3, GCS, URL).
+    ///
+    /// Legacy layout contract: the pre-split-fix code resolved the fully
+    /// substituted template as each shard's own store prefix AND its db_path,
+    /// so objects landed at `<path>/<path>` relative to the bucket — template
+    /// `gs://bucket/silo/%shard%` put shard `data-0`'s objects under
+    /// `silo/data-0/silo/data-0/`. Production wrote durable data there, so the
+    /// pair returned here must satisfy: the root's bucket-relative path joined
+    /// with db_path equals that legacy `<path>/<path>` prefix.
+    ///
+    /// The root is the template truncated at the last `/` strictly before the
+    /// shard placeholder — a shared ancestor of all shards, and a path-segment
+    /// boundary, which object_store prefix composition requires. db_path is
+    /// `<tail>/<path>`, where <tail> is the substituted template remainder
+    /// after the root and <path> is the substituted template's bucket-relative
+    /// path (the raw substituted string for Memory, which has no bucket).
+    ///
+    /// Templates without a placeholder (test sentinels) have no legacy data:
+    /// the whole path is the root and db_path is the bare shard name.
+    fn object_store_root_and_db_path(
+        backend: &crate::settings::Backend,
+        template_path: &str,
+        shard_name: &str,
+    ) -> Result<(String, String), JobStoreShardError> {
+        let placeholder_pos = template_path
+            .find("%shard%")
+            .or_else(|| template_path.find("{shard}"));
+        let Some(pos) = placeholder_pos else {
+            return Ok((template_path.to_string(), shard_name.to_string()));
+        };
+
+        let full = template_path
+            .replace("%shard%", shard_name)
+            .replace("{shard}", shard_name);
+
+        let root = match template_path[..pos].rfind('/') {
+            Some(slash) => &template_path[..slash],
+            None => "",
+        };
+        let tail = full[root.len()..].trim_start_matches('/');
+
+        let legacy_path = match backend {
+            crate::settings::Backend::S3
+            | crate::settings::Backend::Gcs
+            | crate::settings::Backend::Url => {
+                let url = url::Url::parse(&full).map_err(|e| {
+                    JobStoreShardError::Codec(format!(
+                        "failed to parse object store URL '{}': {}. Expected format: \
+                         gs://bucket/path or s3://bucket/path",
+                        full, e
+                    ))
+                })?;
+                let url_path = url.path();
+                url_path.strip_prefix('/').unwrap_or(url_path).to_string()
+            }
+            _ => full.clone(),
+        };
+
+        Ok((root.to_string(), format!("{tail}/{legacy_path}")))
     }
 
     /// Resolve the WAL object store for a shard, if split WAL storage is configured.
@@ -868,4 +925,75 @@ pub enum ShardFactoryError {
 
     #[error("shard error: {0}")]
     ShardError(#[from] JobStoreShardError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShardFactory;
+    use crate::settings::Backend;
+
+    fn resolve(backend: Backend, template: &str, shard: &str) -> (String, String) {
+        ShardFactory::object_store_root_and_db_path(&backend, template, shard).unwrap()
+    }
+
+    /// The production/staging template shape. The legacy resolver wrote shard
+    /// objects at `silo/<shard>/silo/<shard>/…` relative to the bucket, and
+    /// durable data lives there: the root's bucket-relative path (`silo`)
+    /// joined with db_path must keep addressing exactly that prefix.
+    #[test]
+    fn gcs_template_reproduces_legacy_double_nested_keys() {
+        let (root, db_path) = resolve(Backend::Gcs, "gs://bucket/silo/%shard%", "data-0");
+        assert_eq!(root, "gs://bucket/silo");
+        assert_eq!(db_path, "data-0/silo/data-0");
+    }
+
+    #[test]
+    fn gcs_template_at_bucket_root() {
+        let (root, db_path) = resolve(Backend::Gcs, "gs://bucket/%shard%", "data-0");
+        assert_eq!(root, "gs://bucket");
+        assert_eq!(db_path, "data-0/data-0");
+    }
+
+    #[test]
+    fn gcs_template_with_suffix_after_placeholder() {
+        let (root, db_path) = resolve(Backend::Gcs, "gs://bucket/pre/%shard%/db", "data-0");
+        assert_eq!(root, "gs://bucket/pre");
+        assert_eq!(db_path, "data-0/db/pre/data-0/db");
+    }
+
+    #[test]
+    fn curly_placeholder_resolves_like_percent() {
+        let (root, db_path) = resolve(Backend::Gcs, "gs://bucket/silo/{shard}", "data-0");
+        assert_eq!(root, "gs://bucket/silo");
+        assert_eq!(db_path, "data-0/silo/data-0");
+    }
+
+    /// Memory shares the URL-backend formula (minus URL parsing), so tests on
+    /// the Memory backend exercise the same key layout as production.
+    #[test]
+    fn memory_template_uses_same_layout_as_url_backends() {
+        let (root, db_path) = resolve(Backend::Memory, "mem-root/silo/%shard%", "data-0");
+        assert_eq!(root, "mem-root/silo");
+        assert_eq!(db_path, "data-0/mem-root/silo/data-0");
+    }
+
+    /// A mid-segment placeholder roots one path segment up, because object
+    /// store prefixes compose per segment. The full substituted path embedded
+    /// in db_path keeps shards of different templates distinct even when they
+    /// share that root.
+    #[test]
+    fn mid_segment_placeholder_roots_at_segment_boundary() {
+        let (root, db_path) = resolve(Backend::Memory, "test-memory-%shard%", "data-0");
+        assert_eq!(root, "");
+        assert_eq!(db_path, "test-memory-data-0/test-memory-data-0");
+    }
+
+    /// Placeholder-less templates are test sentinels with no legacy data; each
+    /// shard is a bare name under the whole path.
+    #[test]
+    fn no_placeholder_uses_bare_shard_name() {
+        let (root, db_path) = resolve(Backend::Memory, "unused", "data-0");
+        assert_eq!(root, "unused");
+        assert_eq!(db_path, "data-0");
+    }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,6 +1,8 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use slatedb::object_store::ObjectStore;
+use slatedb::object_store::memory::InMemory;
 use slatedb::{Db, Error as SlateError};
 use std::fs;
 use std::path::Path;
@@ -8,6 +10,21 @@ use thiserror::Error;
 use url::Url;
 
 use crate::settings::Backend;
+
+/// Process-wide registry of in-memory stores keyed by root path.
+///
+/// `Backend::Memory` shards under the same root must share one `InMemory` so
+/// that multi-shard operations (clone/split, close-then-reopen) see each other's
+/// data, matching how a real object store behaves. Distinct roots stay isolated,
+/// so unrelated factories — each rooted at a unique path — do not bleed state.
+///
+/// Entries are never evicted: each distinct root holds its `InMemory` for the
+/// life of the process. This is acceptable because Memory is a dev/test-only
+/// backend; production deployments use S3/GCS and never reach this registry.
+fn memory_store_registry() -> &'static Mutex<HashMap<String, Arc<InMemory>>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, Arc<InMemory>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 #[derive(Debug, Error)]
 pub enum StorageError {
@@ -54,11 +71,23 @@ pub fn resolve_object_store(backend: &Backend, path: &str) -> Result<ResolvedSto
                 root_path: canonical_str,
             })
         }
-        Backend::Memory => Ok(ResolvedStore {
-            store: Arc::new(slatedb::object_store::memory::InMemory::new()),
-            canonical_path: path.to_string(),
-            root_path: path.to_string(),
-        }),
+        Backend::Memory => {
+            let store = {
+                let mut registry = memory_store_registry()
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                Arc::clone(
+                    registry
+                        .entry(path.to_string())
+                        .or_insert_with(|| Arc::new(InMemory::new())),
+                )
+            };
+            Ok(ResolvedStore {
+                store,
+                canonical_path: path.to_string(),
+                root_path: path.to_string(),
+            })
+        }
         Backend::S3 | Backend::Gcs | Backend::Url => {
             // Interpret path as a URL understood by SlateDB's resolver, e.g. s3://bucket/prefix or gs://bucket/prefix
             let store = Db::resolve_object_store(path)?;

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -5,7 +5,7 @@ use silo::coordination::SplitPhase;
 use silo::coordination::{Coordinator, EtcdCoordinator, ShardSplitter};
 use silo::factory::ShardFactory;
 use silo::gubernator::MockGubernatorClient;
-use silo::settings::{Backend, DatabaseTemplate};
+use silo::settings::{Backend, DatabaseTemplate, WalConfig};
 use silo::shard_range::ShardId;
 use tokio::sync::Mutex;
 
@@ -32,6 +32,27 @@ fn make_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
             // Use Fs backend for split tests because SlateDB cloning requires a real object store
             backend: Backend::Fs,
             path: tmpdir.join("%shard%").to_string_lossy().to_string(),
+            ..Default::default()
+        },
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
+/// Memory-backed factory for object-store split coverage: parent and children
+/// resolve under one shared store root, with a separate Memory WAL store per
+/// shard. The unique root (the test's unique prefix) keeps the process-global
+/// in-memory store from bleeding across test runs.
+fn make_memory_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
+    let root = format!("silo-split-mem-{}-{}", prefix, node_id);
+    Arc::new(ShardFactory::new(
+        DatabaseTemplate {
+            backend: Backend::Memory,
+            path: format!("{root}/data/%shard%"),
+            wal: Some(WalConfig {
+                backend: Backend::Memory,
+                path: format!("{root}/wal/%shard%"),
+            }),
             ..Default::default()
         },
         MockGubernatorClient::new_arc(),
@@ -531,6 +552,125 @@ async fn execute_split_completes_full_cycle() {
         assert!(
             routed.id == split.left_child_id || routed.id == split.right_child_id,
             "tenant should route to one of the children"
+        );
+    }
+
+    c1.shutdown().await.unwrap();
+    let _ = h1.abort();
+}
+
+/// Drive a full split on the shared-root Memory backend (an object store, with a
+/// separate WAL store) and assert every enqueued job survives in the child that
+/// now owns its tenant's range. This is the object-store analogue of the
+/// local-FS full-cycle split -- the state-machine-level regression guard for the
+/// resolution data-loss bug, and proof the WAL + object-store split path opens
+/// children without "wal store reconfiguration unsupported".
+#[silo::test(flavor = "multi_thread", worker_threads = 4)]
+async fn execute_split_preserves_jobs_on_object_store() {
+    let _guard = acquire_test_mutex().await;
+
+    let prefix = unique_prefix();
+    let num_shards: u32 = 1;
+    let cfg = silo::settings::AppConfig::load(None).expect("load default config");
+    let factory = make_memory_test_factory(&prefix, "n1");
+
+    let (c1, h1) = EtcdCoordinator::start(
+        &cfg.coordination.etcd_endpoints,
+        &prefix,
+        "n1",
+        "http://127.0.0.1:7450",
+        num_shards,
+        10,
+        Arc::clone(&factory),
+        Vec::new(),
+    )
+    .await
+    .expect("start coordinator");
+
+    assert!(c1.wait_converged(Duration::from_secs(10)).await);
+
+    let shard_id = c1.owned_shards().await[0];
+
+    // Enqueue known jobs across several tenants into the parent before splitting.
+    let parent_range = {
+        let shard_map = c1.get_shard_map().await.expect("get shard map");
+        shard_map.get_shard(&shard_id).unwrap().range.clone()
+    };
+    let parent = factory
+        .open(&shard_id, &parent_range)
+        .await
+        .expect("open parent shard");
+    let tenants = ["a", "b", "f", "m", "q", "t", "x", "z"];
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    for tenant in tenants {
+        parent
+            .enqueue(
+                tenant,
+                Some(format!("job-{tenant}")),
+                5,
+                now,
+                None,
+                rmp_serde::to_vec(&serde_json::json!({ "t": tenant })).unwrap(),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue to parent");
+    }
+    assert_eq!(
+        parent.get_counters().await.expect("counters").total_jobs,
+        tenants.len() as i64,
+    );
+
+    // Request and execute a balanced split.
+    let splitter = ShardSplitter::new(Arc::new(c1.clone()));
+    let split_point = {
+        let shard_map = c1.get_shard_map().await.expect("get shard map");
+        silo::shard_range::format_hash_boundary(
+            shard_map
+                .get_shard(&shard_id)
+                .unwrap()
+                .range
+                .midpoint()
+                .unwrap(),
+        )
+    };
+    let split = splitter
+        .request_split(shard_id, split_point)
+        .await
+        .expect("request split should succeed");
+    splitter
+        .execute_split(shard_id, || c1.get_shard_owner_map())
+        .await
+        .expect("execute split should succeed and preserve data");
+
+    // Every enqueued job must survive the split in the child that owns its
+    // tenant's range. Children open as full copies of the parent; post-commit
+    // cleanup only trims out-of-range rows, never the in-range job looked up
+    // here -- so this assertion is deterministic regardless of cleanup timing.
+    let shard_map = c1.get_shard_map().await.expect("get shard map after split");
+    for tenant in tenants {
+        let owner = shard_map
+            .shard_for_tenant(tenant)
+            .expect("tenant routes to a child");
+        assert!(
+            owner.id == split.left_child_id || owner.id == split.right_child_id,
+            "tenant {tenant} should route to one of the children",
+        );
+        let child = factory
+            .get(&owner.id)
+            .expect("child shard open after split");
+        assert!(
+            child
+                .get_job(tenant, &format!("job-{tenant}"))
+                .await
+                .expect("get_job")
+                .is_some(),
+            "job for tenant {tenant} must survive the split in its owning child",
         );
     }
 

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -22,6 +22,47 @@ fn make_fs_factory(tmp: &tempfile::TempDir) -> Arc<ShardFactory> {
     ))
 }
 
+/// Helper to create a Memory-backed factory rooted at a unique shared root.
+///
+/// All shards opened through this factory share one in-memory store, so
+/// multi-shard clone/open round-trips exercise the same shared-root path
+/// semantics as a real object store (GCS/S3).
+fn make_memory_factory() -> Arc<ShardFactory> {
+    let template = DatabaseTemplate {
+        backend: Backend::Memory,
+        path: format!("{}/%shard%", ShardId::new()),
+        ..Default::default()
+    };
+    Arc::new(ShardFactory::new(
+        template,
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
+/// Helper to create a Memory-backed factory with a separate Memory WAL store.
+///
+/// The data store is rooted at a shared root (so parent and children resolve
+/// under one store); each shard gets its own WAL store keyed by the per-shard
+/// WAL path, mirroring a real object-store deployment with split WAL.
+fn make_memory_factory_with_wal() -> Arc<ShardFactory> {
+    let root = ShardId::new();
+    let template = DatabaseTemplate {
+        backend: Backend::Memory,
+        path: format!("{root}/data/%shard%"),
+        wal: Some(WalConfig {
+            backend: Backend::Memory,
+            path: format!("{root}/wal/%shard%"),
+        }),
+        ..Default::default()
+    };
+    Arc::new(ShardFactory::new(
+        template,
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
 /// Helper to create a filesystem-backed factory with separate WAL dir
 fn make_fs_factory_with_wal(
     data_tmp: &tempfile::TempDir,
@@ -266,6 +307,72 @@ async fn clone_closed_shard_creates_copies() {
     );
 }
 
+/// The object-store clone round-trip must also work with a separate WAL store:
+/// cloning propagates each child's WAL store so the children open without
+/// "wal store reconfiguration unsupported", and each holds the parent's jobs.
+#[silo::test]
+async fn clone_closed_shard_object_store_with_split_wal() {
+    let factory = make_memory_factory_with_wal();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("wal-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"wal": true})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard with WAL on object store");
+
+    // Opening the children is where "wal store reconfiguration unsupported"
+    // would surface if the clone did not configure each child's WAL store.
+    let left_child = factory
+        .open(&left_child_id, &ShardRange::full())
+        .await
+        .expect("open left child with WAL");
+    assert_eq!(
+        left_child
+            .get_counters()
+            .await
+            .expect("left counters")
+            .total_jobs,
+        1,
+        "left child should hold the parent's job"
+    );
+
+    let right_child = factory
+        .open(&right_child_id, &ShardRange::full())
+        .await
+        .expect("open right child with WAL");
+    assert_eq!(
+        right_child
+            .get_counters()
+            .await
+            .expect("right counters")
+            .total_jobs,
+        1,
+        "right child should hold the parent's job"
+    );
+}
+
 /// When the parent shard has a separate WAL configured, cloning should propagate
 /// WAL stores to the children so they can open without hitting
 /// "wal store reconfiguration unsupported".
@@ -336,6 +443,354 @@ async fn clone_closed_shard_with_split_wal() {
     assert_eq!(
         right_counters.total_jobs, 1,
         "right child should have the parent's job"
+    );
+}
+
+/// Regression guard for the object-store split data-loss bug.
+///
+/// On an object-store backend, parent and children must resolve under one
+/// shared storage root so a clone lands exactly where `open` later reads. When
+/// each shard instead gets its own store (or a double-nested path), the children
+/// open empty and the shard's data is silently lost. This drives the clone
+/// round-trip on the shared-root Memory backend and asserts each child holds the
+/// parent's full job set.
+#[silo::test]
+async fn clone_closed_shard_object_store_preserves_jobs() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("cloned-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"cloned": true})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+
+    let parent_counters = parent.get_counters().await.expect("get parent counters");
+    assert_eq!(parent_counters.total_jobs, 1);
+
+    // Close parent (clone_closed_shard expects it to be closed)
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard");
+
+    // A fresh clone is a full byte-for-byte copy of the parent, so each child
+    // holds the parent's whole job set immediately after the split (cleanup
+    // trims each child to its range later).
+    let left_child = factory
+        .open(&left_child_id, &ShardRange::full())
+        .await
+        .expect("open left child");
+    assert_eq!(
+        left_child
+            .get_counters()
+            .await
+            .expect("get left child counters")
+            .total_jobs,
+        1,
+        "left child should have the parent's job"
+    );
+    assert!(
+        left_child
+            .get_job("test-tenant", "cloned-job")
+            .await
+            .expect("get job from left child")
+            .is_some(),
+        "left child should contain the parent's job"
+    );
+
+    let right_child = factory
+        .open(&right_child_id, &ShardRange::full())
+        .await
+        .expect("open right child");
+    assert_eq!(
+        right_child
+            .get_counters()
+            .await
+            .expect("get right child counters")
+            .total_jobs,
+        1,
+        "right child should have the parent's job"
+    );
+}
+
+/// `delete_shard_data` on an object-store backend must scope deletion to exactly
+/// one shard's prefix. Two shards share a single store root under the new
+/// resolution, so deleting one (via `reset`) must not touch a sibling whose
+/// prefix differs only by shard name.
+#[silo::test]
+async fn delete_object_store_shard_data_leaves_sibling_intact() {
+    let factory = make_memory_factory();
+    let shard_a = ShardId::new();
+    let shard_b = ShardId::new();
+
+    let a = factory
+        .open(&shard_a, &ShardRange::full())
+        .await
+        .expect("open shard a");
+    let b = factory
+        .open(&shard_b, &ShardRange::full())
+        .await
+        .expect("open shard b");
+
+    for (shard, job_id) in [(&a, "job-a"), (&b, "job-b")] {
+        shard
+            .enqueue(
+                "test-tenant",
+                Some(job_id.to_string()),
+                5,
+                test_helpers::now_ms(),
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue job");
+    }
+
+    // reset closes shard A, deletes its data via delete_shard_data, then reopens.
+    let a_reset = factory
+        .reset(&shard_a, &ShardRange::full())
+        .await
+        .expect("reset shard a");
+    assert_eq!(
+        a_reset.get_counters().await.expect("a counters").total_jobs,
+        0,
+        "reset shard A should be empty after its data is deleted"
+    );
+
+    // Sibling B shares the store root but its prefix differs by shard name, so
+    // deleting A must not have removed B's data.
+    assert_eq!(
+        b.get_counters().await.expect("b counters").total_jobs,
+        1,
+        "sibling shard B should keep its job after shard A's data is deleted"
+    );
+    assert!(
+        b.get_job("test-tenant", "job-b")
+            .await
+            .expect("get job from b")
+            .is_some(),
+        "sibling shard B should still contain its job"
+    );
+}
+
+// --- post-split child verification tests ---
+
+/// A child that opens empty/short of the parent's job count is the object-store
+/// split data-loss signature. The pre-commit verification must detect it: a
+/// child whose whole-shard `total_jobs` differs from the parent's pre-close
+/// count fails verification so the split can abort before the shard-map commit.
+#[silo::test]
+async fn verify_cloned_children_detects_short_child() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("only-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    let parent_total = parent
+        .get_counters()
+        .await
+        .expect("parent counters")
+        .total_jobs;
+    assert_eq!(parent_total, 1);
+    parent.close().await.expect("close parent");
+
+    // A never-cloned child opens as an empty database -- total_jobs 0 -- exactly
+    // the empty-child symptom of the resolution bug. It must not match a parent
+    // that held one job.
+    let empty_child = ShardId::new();
+    let result = factory
+        .verify_cloned_children_match_parent(parent_total, &[empty_child])
+        .await;
+    assert!(
+        result.is_err(),
+        "an empty child must fail verification against a non-empty parent"
+    );
+}
+
+/// A successful clone -- each child a full copy of the parent -- must pass
+/// verification (no false positives), and the raw verification opens must not
+/// register the children in the factory's instance map. If they did, the
+/// post-commit `open(child)` would return the stale pre-commit handle.
+#[silo::test]
+async fn verify_cloned_children_accepts_full_clone_without_caching() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("only-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    let parent_total = parent
+        .get_counters()
+        .await
+        .expect("parent counters")
+        .total_jobs;
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard");
+
+    factory
+        .verify_cloned_children_match_parent(parent_total, &[left_child_id, right_child_id])
+        .await
+        .expect("full clones should pass verification");
+
+    // The raw verification open must leave no factory instance behind.
+    assert!(
+        !factory.owns_shard(&left_child_id),
+        "verification must not cache the left child in the instances map"
+    );
+    assert!(
+        !factory.owns_shard(&right_child_id),
+        "verification must not cache the right child in the instances map"
+    );
+    assert!(factory.get(&left_child_id).is_none());
+    assert!(factory.get(&right_child_id).is_none());
+
+    // The post-clone `open` returns a child that actually holds the parent's data
+    // (not a stale pre-commit handle).
+    let left_child = factory
+        .open(&left_child_id, &ShardRange::full())
+        .await
+        .expect("open left child after verification");
+    assert_eq!(
+        left_child
+            .get_counters()
+            .await
+            .expect("left counters")
+            .total_jobs,
+        parent_total,
+    );
+}
+
+/// When verification fails, the split aborts before touching the parent: the
+/// parent's data is untouched and the parent reopens with its full job set.
+/// (In the split state machine this maps to `PreCommitParentClosed`, which
+/// abandons the split and recovers the parent.)
+#[silo::test]
+async fn parent_reopens_intact_after_verification_mismatch() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("survivor-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard");
+
+    // Inject a mismatch by claiming the parent held more jobs than it did.
+    let result = factory
+        .verify_cloned_children_match_parent(99, &[left_child_id, right_child_id])
+        .await;
+    assert!(
+        result.is_err(),
+        "inflated parent count must fail verification"
+    );
+
+    // Recover the parent the way the split state machine does on a pre-commit
+    // abort: evict the stale closed factory entry, then reopen. The parent's
+    // data is untouched by the failed child verification, so it reopens intact.
+    factory
+        .close(&parent_id)
+        .await
+        .expect("evict stale parent entry");
+    let reopened = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("reopen parent after failed verification");
+    assert_eq!(
+        reopened
+            .get_counters()
+            .await
+            .expect("parent counters")
+            .total_jobs,
+        1,
+        "parent should retain its data after a failed split verification"
+    );
+    assert!(
+        reopened
+            .get_job("test-tenant", "survivor-job")
+            .await
+            .expect("get job from reopened parent")
+            .is_some(),
+        "parent should still contain its job after a failed split verification"
     );
 }
 

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -905,3 +905,93 @@ async fn close_all_shards() {
     // So get() will still return the closed shard Arc
     // The key test is that close_all doesn't error
 }
+
+// --- legacy key-layout compatibility tests ---
+
+/// Regression test for the staging data-reset incident (PR #377 deploy).
+///
+/// The legacy resolver opened shard `data-0` of template
+/// `gs://bucket/silo/%shard%` with a store scoped to `silo/data-0` and
+/// db_path `silo/data-0`, landing every object at
+/// `silo/data-0/silo/data-0/…` relative to the bucket. The current resolver
+/// scopes the store to the shared root `silo` (so clone/split works) with
+/// db_path `data-0/silo/data-0`. Both must address the same objects: if they
+/// diverge, every shard written before the resolver change reopens empty.
+#[silo::test]
+async fn new_resolution_reads_data_written_by_legacy_resolution() {
+    use slatedb::object_store::ObjectStore;
+    use slatedb::object_store::memory::InMemory;
+    use slatedb::object_store::prefix::PrefixStore;
+
+    let bucket: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+
+    // Legacy writer: store scoped to the full per-shard prefix, db_path the
+    // bucket-relative per-shard path — the double-nested layout.
+    let legacy_store: Arc<dyn ObjectStore> =
+        Arc::new(PrefixStore::new(Arc::clone(&bucket), "silo/data-0"));
+    let db = slatedb::DbBuilder::new("silo/data-0", legacy_store)
+        .build()
+        .await
+        .expect("legacy open");
+    db.put(b"job:1", b"payload").await.expect("legacy put");
+    db.close().await.expect("legacy close");
+
+    // Current reader: store scoped to the shared root, db_path carrying the
+    // rest of the legacy key.
+    let new_store: Arc<dyn ObjectStore> = Arc::new(PrefixStore::new(Arc::clone(&bucket), "silo"));
+    let db = slatedb::DbBuilder::new("data-0/silo/data-0", new_store)
+        .build()
+        .await
+        .expect("current open");
+    let value = db.get(b"job:1").await.expect("current get");
+    assert_eq!(value.as_deref(), Some(b"payload".as_ref()));
+    db.close().await.expect("current close");
+}
+
+/// Objects written through the factory land under the legacy double-nested
+/// prefix: `<shard>/<substituted template>/` relative to the shared root.
+/// Memory shares the production formula, so this pins the layout that GCS/S3
+/// deployments depend on.
+#[silo::test]
+async fn factory_shard_objects_land_at_legacy_double_nested_keys() {
+    use futures::TryStreamExt;
+
+    let root = format!("{}/silo", ShardId::new());
+    let template = DatabaseTemplate {
+        backend: Backend::Memory,
+        path: format!("{root}/%shard%"),
+        ..Default::default()
+    };
+    let factory = Arc::new(ShardFactory::new(
+        template,
+        MockGubernatorClient::new_arc(),
+        None,
+    ));
+
+    let shard_id = ShardId::new();
+    factory
+        .open(&shard_id, &ShardRange::full())
+        .await
+        .expect("open shard");
+    factory.close(&shard_id).await.expect("close shard");
+
+    let resolved =
+        silo::storage::resolve_object_store(&Backend::Memory, &root).expect("resolve root store");
+    let objects: Vec<_> = resolved
+        .store
+        .list(None)
+        .try_collect()
+        .await
+        .expect("list objects");
+
+    assert!(!objects.is_empty(), "shard open should write objects");
+    let expected_prefix = format!("{shard_id}/{root}/{shard_id}/");
+    for obj in &objects {
+        assert!(
+            obj.location.as_ref().starts_with(&expected_prefix),
+            "object {} is not under the legacy double-nested prefix {}",
+            obj.location,
+            expected_prefix
+        );
+    }
+}

--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -1043,7 +1043,7 @@ async fn grpc_server_reset_shards_clears_memory_backend_data() -> anyhow::Result
 
         // Use Memory backend to exercise the object store deletion path
         let template = DatabaseTemplate {
-            path: "test-memory-%shard%".to_string(),
+            path: "test-memory/%shard%".to_string(),
             ..Default::default()
         };
         let rate_limiter = MockGubernatorClient::new_arc();


### PR DESCRIPTION
Reapplies #377 (reverted in #380) with the resolution changed so existing shards keep their data.

## Why #377 was reverted

Deploying #377 to staging reset every tenant's job data. The fix rooted object-store shards at the shared template prefix with `db_path` = bare shard name, which **moved every shard's keys**: durable data written by the legacy resolver lives at the double-nested keys `<path>/<path>` relative to the bucket (staging: `silo/<shard>/silo/<shard>/…`), but the new code opened `silo/<shard>/…`, found no manifest, and initialized a fresh empty database. The old objects were stranded, not deleted — recoverable, but a full data-visibility outage. The PR's premise that object-store shard data was "staging-only and disposable" was wrong: staging and production have been live on GCS with durable data since 2026-07-02.

## What this PR does

1. **Reverts the revert**, restoring the split fix: shared-root resolution (clone destination == open path), the pre-commit child-verification tripwire, and the object-store clone/split test coverage.
2. **Changes `resolve_at_root` to reproduce the legacy keys byte-for-byte**, so no migration is needed and existing shards reopen in place:
   - The store roots at the last path-segment boundary before the `%shard%` placeholder — still a shared ancestor of parent and children, which is all the clone fix needs.
   - `db_path` carries the rest of the legacy key: `<tail>/<path>` (e.g. `data-0/silo/data-0` under root `gs://bucket/silo`). Root + db_path = `<path>/<path>`, exactly where the legacy resolver wrote.
3. **Memory resolves with the identical formula**, so Memory-backed tests exercise the production key layout — the coverage gap that let the layout move ship unnoticed. Placeholder-less sentinel templates keep bare-shard-name paths (no legacy data exists for them).

## How the layout is pinned

- Unit tests assert the exact `(root, db_path)` pairs, including the production template shape, bucket-root templates, `{shard}` syntax, mid-segment placeholders, and suffix-after-placeholder templates.
- A slatedb-level regression test writes a database through the **legacy** resolution (per-shard `PrefixStore` + full-path `db_path`) and reads it back through the **current** resolution against the same bucket — the exact old-writer/new-reader scenario the staging deploy failed.
- A factory-level test lists the objects a shard writes and asserts every key sits under the double-nested prefix.

## Verified

- `cargo test --lib factory::tests` — 7 layout unit tests pass
- `cargo test --test factory_tests` — 19 pass (incl. legacy-compat + clone round-trips)
- `cargo test --test coordination_split_tests` — 26 pass against a local etcd, incl. `execute_split_preserves_jobs_on_object_store`
- `grpc_misc_tests` (21), `config_and_db_tests` (37) pass

## Deploy notes

- Existing staging/production shards reopen at their current keys — **no migration**.
- Staging has leftover fresh-DB objects at the flat `silo/<shard>/…` keys from the incident deploy window; they are inert under this layout but can be cleaned up manually.
- The WAL sub-path inside a per-shard WAL store follows `db_path`, so it moves from `<path>/wal` to `<tail>/<path>/wal`. WAL contents are transient (applied on clean close); this only matters for a crash immediately preceding the deploy.