### PR TITLE
Fix shard-split data loss on object-store backends

### DIFF
--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -517,6 +517,25 @@ impl ShardSplitter {
                             parent_shard_id
                         )))
                     })?;
+
+                    // Capture the parent's whole-shard job count from the still-open
+                    // handle, before closing it. The post-clone verification below
+                    // confirms each child holds this full set (a fresh clone is a
+                    // byte-for-byte copy; cleanup trims each child to its range only
+                    // after commit), catching the empty-child data-loss signature.
+                    let parent_total_jobs = parent_shard
+                        .get_counters()
+                        .await
+                        .map_err(|e| {
+                            SplitExecutionError::PreCommit(CoordinationError::BackendError(
+                                format!(
+                                    "failed to read parent shard {} counters before cloning: {}",
+                                    parent_shard_id, e
+                                ),
+                            ))
+                        })?
+                        .total_jobs;
+
                     parent_shard.close().await.map_err(|e| {
                         SplitExecutionError::PreCommit(CoordinationError::BackendError(format!(
                             "failed to close parent shard before cloning: {}",
@@ -559,7 +578,36 @@ impl ShardSplitter {
                         parent_shard_id = %parent_shard_id,
                         left_child = %split.left_child_id,
                         right_child = %split.right_child_id,
-                        "cloning complete, updating shard map"
+                        "cloning complete, verifying children before commit"
+                    );
+
+                    // Defense-in-depth: before the commit point, open each child
+                    // and confirm it holds the parent's full job set. A child that
+                    // opens empty/short (the object-store resolution bug's data-loss
+                    // signature) fails here, aborting the split as
+                    // PreCommitParentClosed so the shard map stays untouched and the
+                    // parent is recovered/reopenable -- never silent data loss.
+                    self.ctx
+                        .factory
+                        .verify_cloned_children_match_parent(
+                            parent_total_jobs,
+                            &[split.left_child_id, split.right_child_id],
+                        )
+                        .await
+                        .map_err(|e| {
+                            SplitExecutionError::PreCommitParentClosed(
+                                CoordinationError::BackendError(format!(
+                                    "post-clone child verification failed for split of {}: {}",
+                                    parent_shard_id, e
+                                )),
+                            )
+                        })?;
+
+                    info!(
+                        parent_shard_id = %parent_shard_id,
+                        left_child = %split.left_child_id,
+                        right_child = %split.right_child_id,
+                        "children verified, updating shard map"
                     );
 
                     // Pre-add BOTH children to owned set BEFORE updating the shard map.

--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -11,6 +11,12 @@ use crate::shard_range::{ShardId, ShardMap, SplitInProgress};
 
 use crate::coordination::{CoordinationError, ShardOwnerMap};
 
+/// Log markers for the split's pre-commit child verification. Operational
+/// tooling asserts on these exact strings in deployed logs -- do not reword.
+pub const MARKER_VERIFYING_CHILDREN: &str = "cloning complete, verifying children before commit";
+pub const MARKER_CHILDREN_VERIFIED: &str = "children verified, updating shard map";
+pub const MARKER_CHILD_VERIFICATION_FAILED: &str = "post-clone child verification failed";
+
 /// [SILO-COORD-INV-8] Status of post-split cleanup for a shard.
 ///
 /// After a split, child shards contain defunct data (keys outside their new range).
@@ -517,25 +523,6 @@ impl ShardSplitter {
                             parent_shard_id
                         )))
                     })?;
-
-                    // Capture the parent's whole-shard job count from the still-open
-                    // handle, before closing it. The post-clone verification below
-                    // confirms each child holds this full set (a fresh clone is a
-                    // byte-for-byte copy; cleanup trims each child to its range only
-                    // after commit), catching the empty-child data-loss signature.
-                    let parent_total_jobs = parent_shard
-                        .get_counters()
-                        .await
-                        .map_err(|e| {
-                            SplitExecutionError::PreCommit(CoordinationError::BackendError(
-                                format!(
-                                    "failed to read parent shard {} counters before cloning: {}",
-                                    parent_shard_id, e
-                                ),
-                            ))
-                        })?
-                        .total_jobs;
-
                     parent_shard.close().await.map_err(|e| {
                         SplitExecutionError::PreCommit(CoordinationError::BackendError(format!(
                             "failed to close parent shard before cloning: {}",
@@ -578,27 +565,28 @@ impl ShardSplitter {
                         parent_shard_id = %parent_shard_id,
                         left_child = %split.left_child_id,
                         right_child = %split.right_child_id,
-                        "cloning complete, verifying children before commit"
+                        "{}", MARKER_VERIFYING_CHILDREN
                     );
 
                     // Defense-in-depth: before the commit point, open each child
-                    // and confirm it holds the parent's full job set. A child that
-                    // opens empty/short (a clone that landed somewhere the child's
-                    // open cannot see) fails here, aborting the split as
-                    // PreCommitParentClosed so the shard map stays untouched and the
-                    // parent is recovered/reopenable -- never silent data loss.
+                    // and confirm it holds the closed parent's full job set. A
+                    // child that opens empty/short (a clone that landed somewhere
+                    // the child's open cannot see) fails here, aborting the split
+                    // as PreCommitParentClosed so the shard map stays untouched
+                    // and the parent is recovered/reopenable -- never silent data
+                    // loss.
                     self.ctx
                         .factory
                         .verify_cloned_children_match_parent(
-                            parent_total_jobs,
+                            &parent_shard_id,
                             &[split.left_child_id, split.right_child_id],
                         )
                         .await
                         .map_err(|e| {
                             SplitExecutionError::PreCommitParentClosed(
                                 CoordinationError::BackendError(format!(
-                                    "post-clone child verification failed for split of {}: {}",
-                                    parent_shard_id, e
+                                    "{} for split of {}: {}",
+                                    MARKER_CHILD_VERIFICATION_FAILED, parent_shard_id, e
                                 )),
                             )
                         })?;
@@ -607,7 +595,7 @@ impl ShardSplitter {
                         parent_shard_id = %parent_shard_id,
                         left_child = %split.left_child_id,
                         right_child = %split.right_child_id,
-                        "children verified, updating shard map"
+                        "{}", MARKER_CHILDREN_VERIFIED
                     );
 
                     // Pre-add BOTH children to owned set BEFORE updating the shard map.

--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -583,8 +583,8 @@ impl ShardSplitter {
 
                     // Defense-in-depth: before the commit point, open each child
                     // and confirm it holds the parent's full job set. A child that
-                    // opens empty/short (the object-store resolution bug's data-loss
-                    // signature) fails here, aborting the split as
+                    // opens empty/short (a clone that landed somewhere the child's
+                    // open cannot see) fails here, aborting the split as
                     // PreCommitParentClosed so the shard map stays untouched and the
                     // parent is recovered/reopenable -- never silent data loss.
                     self.ctx

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -61,6 +61,11 @@ pub struct ShardFactory {
     rate_limiter: Arc<dyn RateLimitClient>,
     metrics: Option<Metrics>,
     close_timeout: Duration,
+    /// Test-only clone fault: when armed, the next `clone_closed_shard` skips
+    /// cloning this child so it comes up empty. Debug builds only; inert
+    /// unless a test arms it.
+    #[cfg(debug_assertions)]
+    clone_skip_child: std::sync::Mutex<Option<ShardId>>,
 }
 
 impl ShardFactory {
@@ -75,6 +80,8 @@ impl ShardFactory {
             rate_limiter,
             metrics,
             close_timeout: DEFAULT_CLOSE_TIMEOUT,
+            #[cfg(debug_assertions)]
+            clone_skip_child: std::sync::Mutex::new(None),
         }
     }
 
@@ -98,6 +105,36 @@ impl ShardFactory {
             rate_limiter: NullGubernatorClient::new(),
             metrics: None,
             close_timeout: DEFAULT_CLOSE_TIMEOUT,
+            #[cfg(debug_assertions)]
+            clone_skip_child: std::sync::Mutex::new(None),
+        }
+    }
+
+    /// Arm the test-only clone fault: the next `clone_closed_shard` call skips
+    /// cloning `child_id`, so that child opens empty. Lets tests drive the
+    /// pre-commit verification abort path, which a correct clone cannot reach
+    /// through the public interface.
+    #[cfg(debug_assertions)]
+    pub fn inject_empty_child_clone(&self, child_id: ShardId) {
+        *self
+            .clone_skip_child
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(child_id);
+    }
+
+    /// Disarm and return the injected clone fault, if any. Always `None` in
+    /// release builds.
+    fn take_injected_empty_child(&self) -> Option<ShardId> {
+        #[cfg(debug_assertions)]
+        {
+            self.clone_skip_child
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            None
         }
     }
 
@@ -741,47 +778,57 @@ impl ShardFactory {
             "created checkpoint for shard cloning (from closed parent)"
         );
 
-        // Clone for left child
-        let mut left_admin_builder = slatedb::admin::Admin::builder(
-            left_child_db_path.as_str(),
-            Arc::clone(&parent_resolved.store),
-        );
-        if let Some(wal) = &left_child_wal_store {
-            left_admin_builder = left_admin_builder.with_wal_object_store(Arc::clone(wal));
-        }
-        let left_admin = left_admin_builder.build();
+        let injected_empty_child = self.take_injected_empty_child();
 
-        left_admin
-            .create_clone_builder(parent_db_path.as_str(), Some(checkpoint.id))
-            .build()
-            .await
-            .map_err(|e| {
-                ShardFactoryError::CloneError(format!(
-                    "failed to clone left child database: {} (parent={}, child={})",
-                    e, parent_db_path, left_child_db_path
-                ))
-            })?;
+        // Clone for left child
+        if injected_empty_child == Some(*left_child_id) {
+            tracing::warn!(child_id = %left_child_id, "test fault injection: skipping left child clone");
+        } else {
+            let mut left_admin_builder = slatedb::admin::Admin::builder(
+                left_child_db_path.as_str(),
+                Arc::clone(&parent_resolved.store),
+            );
+            if let Some(wal) = &left_child_wal_store {
+                left_admin_builder = left_admin_builder.with_wal_object_store(Arc::clone(wal));
+            }
+            let left_admin = left_admin_builder.build();
+
+            left_admin
+                .create_clone_builder(parent_db_path.as_str(), Some(checkpoint.id))
+                .build()
+                .await
+                .map_err(|e| {
+                    ShardFactoryError::CloneError(format!(
+                        "failed to clone left child database: {} (parent={}, child={})",
+                        e, parent_db_path, left_child_db_path
+                    ))
+                })?;
+        }
 
         // Clone for right child
-        let mut right_admin_builder = slatedb::admin::Admin::builder(
-            right_child_db_path.as_str(),
-            Arc::clone(&parent_resolved.store),
-        );
-        if let Some(wal) = &right_child_wal_store {
-            right_admin_builder = right_admin_builder.with_wal_object_store(Arc::clone(wal));
-        }
-        let right_admin = right_admin_builder.build();
+        if injected_empty_child == Some(*right_child_id) {
+            tracing::warn!(child_id = %right_child_id, "test fault injection: skipping right child clone");
+        } else {
+            let mut right_admin_builder = slatedb::admin::Admin::builder(
+                right_child_db_path.as_str(),
+                Arc::clone(&parent_resolved.store),
+            );
+            if let Some(wal) = &right_child_wal_store {
+                right_admin_builder = right_admin_builder.with_wal_object_store(Arc::clone(wal));
+            }
+            let right_admin = right_admin_builder.build();
 
-        right_admin
-            .create_clone_builder(parent_db_path.as_str(), Some(checkpoint.id))
-            .build()
-            .await
-            .map_err(|e| {
-                ShardFactoryError::CloneError(format!(
-                    "failed to clone right child database: {} (parent={}, child={})",
-                    e, parent_db_path, right_child_db_path
-                ))
-            })?;
+            right_admin
+                .create_clone_builder(parent_db_path.as_str(), Some(checkpoint.id))
+                .build()
+                .await
+                .map_err(|e| {
+                    ShardFactoryError::CloneError(format!(
+                        "failed to clone right child database: {} (parent={}, child={})",
+                        e, parent_db_path, right_child_db_path
+                    ))
+                })?;
+        }
 
         // Close the raw database
         db.close().await.map_err(|e| {
@@ -802,6 +849,97 @@ impl ShardFactory {
         );
 
         Ok(())
+    }
+
+    /// Verify that each freshly cloned child holds the parent's full job set.
+    ///
+    /// A fresh SlateDB clone is a byte-for-byte copy of the parent, so
+    /// immediately after `clone_closed_shard` -- before post-commit cleanup
+    /// trims each child to its range -- every child's whole-shard `total_jobs`
+    /// must equal the parent's pre-close count. An empty or mis-placed child
+    /// (the object-store split data-loss signature) reads `0` and trips this
+    /// check, letting the split abort before the shard-map commit point.
+    ///
+    /// This is a manifest-landed tripwire keyed on the empty-child signature,
+    /// not a full row-integrity audit: a clone that landed the counter key but
+    /// corrupted rows would still pass.
+    pub async fn verify_cloned_children_match_parent(
+        &self,
+        parent_total_jobs: i64,
+        child_ids: &[ShardId],
+    ) -> Result<(), ShardFactoryError> {
+        for child_id in child_ids {
+            let child_total_jobs = self.read_cloned_shard_total_jobs(child_id).await?;
+            if child_total_jobs != parent_total_jobs {
+                return Err(ShardFactoryError::ChildVerification(format!(
+                    "cloned child {child_id} holds {child_total_jobs} jobs but parent held \
+                     {parent_total_jobs}; aborting split before commit to avoid data loss"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Open a freshly cloned child's database with the raw `open_with_resolved_store`
+    /// primitive, read its whole-shard `total_jobs`, and close it.
+    ///
+    /// Uses the raw open -- NOT `open` -- so the child is never registered in the
+    /// `instances` map: `open` caches the instance in the per-shard OnceCell, and
+    /// the post-commit `open(child)` would then return this stale pre-commit
+    /// handle instead of opening the committed child. Hydration is disabled and
+    /// `get_counters` reads single merged counter keys, so the check is O(1)
+    /// even on a multi-million-job shard.
+    async fn read_cloned_shard_total_jobs(
+        &self,
+        shard_id: &ShardId,
+    ) -> Result<i64, ShardFactoryError> {
+        let name = shard_id.to_string();
+        let (resolved, db_path) =
+            Self::resolve_at_root(&self.template.backend, &self.template.path, &name)?;
+        let wal_store = self.resolve_wal_store(&name)?;
+
+        let shard = JobStoreShard::open_with_resolved_store(
+            name.clone(),
+            &db_path,
+            OpenShardOptions {
+                store: resolved.store,
+                wal_store,
+                wal_close_config: None,
+                slatedb_settings: self.template.slatedb.clone(),
+                memory_cache: self.template.memory_cache.clone(),
+                rate_limiter: Arc::clone(&self.rate_limiter),
+                metrics: self.metrics.clone(),
+                concurrency_reconcile_interval: Duration::from_millis(
+                    self.template.concurrency_reconcile_interval_ms.max(1),
+                ),
+                counter_reconciliation_seconds: None,
+                hydrate_all_at_startup: false,
+                grant_scanner: GrantScannerConfig {
+                    batch_size: self.template.grant_scanner_batch_size,
+                    buffer_size: self.template.grant_scanner_buffer_size,
+                    concurrency: self.template.grant_scanner_concurrency,
+                    cold_batch_size: self.template.grant_scanner_cold_batch_size,
+                    next_hop_skip_min_backlog: self
+                        .template
+                        .grant_scanner_next_hop_skip_min_backlog,
+                    live_headroom_fraction: self.template.grant_scanner_live_headroom_fraction,
+                },
+                concurrency_reconcile_scan_slice: self.template.concurrency_reconcile_scan_slice,
+                holder_drift_scan_slice: self.template.holder_drift_scan_slice,
+                completed_job_expire_s: self.template.completed_job_expire_s,
+                terminal_job_expire_s: self.template.terminal_job_expire_s,
+                count_from_status_counters: self.template.count_from_status_counters,
+            },
+            ShardRange::full(),
+        )
+        .await?;
+
+        // Always close the raw handle, even if the counter read fails, so the
+        // shard's SlateDB instance and its spawned background tasks (grant
+        // scanner, reconcilers) are released -- JobStoreShard has no Drop.
+        let counters = shard.get_counters().await;
+        shard.close().await?;
+        Ok(counters?.total_jobs)
     }
 
     /// Get the database template used by this factory.
@@ -826,6 +964,9 @@ impl std::fmt::Display for CloseAllError {
 pub enum ShardFactoryError {
     #[error("clone error: {0}")]
     CloneError(String),
+
+    #[error("child verification error: {0}")]
+    ChildVerification(String),
 
     #[error("storage error: {0}")]
     Storage(#[from] crate::storage::StorageError),

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::OnceCell;
+use url::Url;
 
 use crate::concurrency::GrantScannerConfig;
 use crate::gubernator::RateLimitClient;
@@ -88,7 +89,9 @@ impl ShardFactory {
         Self {
             instances: DashMap::new(),
             template: DatabaseTemplate {
-                path: "/noop".to_string(),
+                // The root is unique per factory so the shared Memory store
+                // (the default backend) does not bleed across noop factories.
+                path: format!("noop-{}/%shard%", ShardId::new()),
                 apply_wal_on_close: false,
                 ..Default::default()
             },
@@ -277,8 +280,11 @@ impl ShardFactory {
     /// Resolve the object store at the storage root level.
     ///
     /// For Backend::Fs, this extracts the root path before the placeholder and
-    /// returns the shard name as the db_path. For cloud backends, this works
-    /// the same as before since the object store is already at bucket level.
+    /// returns the shard name as the db_path. For object-store backends, the
+    /// store resolves once at the shared template root with the
+    /// layout-preserving database path from [`Self::object_store_layout`], so
+    /// parent and children of a split share one store while every shard's
+    /// absolute object keys match what deployed binaries read and write.
     ///
     /// The returned `ResolvedStore.root_path` combined with `db_path` gives the
     /// full path where shard data is stored.
@@ -303,14 +309,66 @@ impl ShardFactory {
             let resolved = resolve_object_store(backend, root_path)?;
             Ok((resolved, shard_name.to_string()))
         } else {
-            // Object store backends (Memory, S3, GCS, URL): resolve full path
-            let full_path = template_path
-                .replace("%shard%", shard_name)
-                .replace("{shard}", shard_name);
-            let resolved = resolve_object_store(backend, &full_path)?;
-            let db_path = resolved.canonical_path.clone();
+            let (root, db_path) = Self::object_store_layout(backend, template_path, shard_name)?;
+            let resolved = resolve_object_store(backend, &root)?;
             Ok((resolved, db_path))
         }
+    }
+
+    /// Compute the shared store root and layout-preserving database path for a
+    /// shard on an object-store backend (Memory, S3, GCS, URL).
+    ///
+    /// The root is the template prefix before the first `%shard%`/`{shard}`
+    /// placeholder (trailing slashes trimmed), or the whole path when no
+    /// placeholder exists. Resolving every shard's store at this one root makes
+    /// clone destinations equal open paths: a split's children land in the same
+    /// store the parent resolved, exactly where each child's own `open` reads.
+    ///
+    /// The database path is the expanded template relative to the root,
+    /// followed by the store-path component of the expanded template (the URL's
+    /// path for URL-style backends, the raw expanded path for Memory). slatedb
+    /// roots URL-resolved stores at the URL's path component, so for a
+    /// `gs://bucket/silo/%shard%` template this puts absolute keys at
+    /// `silo/<shard>/silo/<shard>/…` — byte-for-byte the keys deployed shards
+    /// already use, so no data moves. Placeholder-free templates degenerate to
+    /// database path = store-path component, preserving their keys too.
+    pub fn object_store_layout(
+        backend: &crate::settings::Backend,
+        template_path: &str,
+        shard_name: &str,
+    ) -> Result<(String, String), JobStoreShardError> {
+        let placeholder_pos = template_path
+            .find("%shard%")
+            .or_else(|| template_path.find("{shard}"));
+        let root = match placeholder_pos {
+            Some(pos) => template_path[..pos].trim_end_matches('/'),
+            None => template_path,
+        };
+        let expanded = template_path
+            .replace("%shard%", shard_name)
+            .replace("{shard}", shard_name);
+        let store_path = match backend {
+            crate::settings::Backend::S3
+            | crate::settings::Backend::Gcs
+            | crate::settings::Backend::Url => {
+                let url = Url::parse(&expanded).map_err(|e| {
+                    JobStoreShardError::Codec(format!(
+                        "failed to parse object store URL '{}': {}. Expected format: gs://bucket/path or s3://bucket/path",
+                        expanded, e
+                    ))
+                })?;
+                let url_path = url.path();
+                url_path.strip_prefix('/').unwrap_or(url_path).to_string()
+            }
+            _ => expanded.clone(),
+        };
+        let relative = expanded[root.len()..].trim_start_matches('/');
+        let db_path = if relative.is_empty() {
+            store_path
+        } else {
+            format!("{relative}/{store_path}")
+        };
+        Ok((root.to_string(), db_path))
     }
 
     /// Resolve the WAL object store for a shard, if split WAL storage is configured.

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -113,7 +113,9 @@ impl ShardFactory {
     /// Arm the test-only clone fault: the next `clone_closed_shard` call skips
     /// cloning `child_id`, so that child opens empty. Lets tests drive the
     /// pre-commit verification abort path, which a correct clone cannot reach
-    /// through the public interface.
+    /// through the public interface. `pub` because integration tests compile
+    /// as a separate crate.
+    #[doc(hidden)]
     #[cfg(debug_assertions)]
     pub fn inject_empty_child_clone(&self, child_id: ShardId) {
         *self
@@ -377,6 +379,28 @@ impl ShardFactory {
         let placeholder_pos = template_path
             .find("%shard%")
             .or_else(|| template_path.find("{shard}"));
+        // For URL-style backends, a placeholder that is not at a `/` boundary
+        // would make the shared-root arithmetic produce different absolute
+        // keys than resolving the full expanded URL, silently moving every
+        // shard's data. Fail loudly instead. Memory templates stay
+        // unrestricted: they are test sentinels with no deployed data.
+        if let Some(pos) = placeholder_pos
+            && matches!(
+                backend,
+                crate::settings::Backend::S3
+                    | crate::settings::Backend::Gcs
+                    | crate::settings::Backend::Url
+            )
+            && pos > 0
+            && template_path.chars().nth(pos - 1) != Some('/')
+        {
+            return Err(JobStoreShardError::Codec(format!(
+                "shard placeholder in object-store database template path must be preceded by '/' \
+                 so shards resolve under a shared root with unchanged keys. \
+                 Got: '{}'. Change to something like 'gs://bucket/silo/%shard%'.",
+                template_path
+            )));
+        }
         let root = match placeholder_pos {
             Some(pos) => template_path[..pos].trim_end_matches('/'),
             None => template_path,
@@ -851,45 +875,50 @@ impl ShardFactory {
         Ok(())
     }
 
-    /// Verify that each freshly cloned child holds the parent's full job set.
+    /// Verify that each freshly cloned child holds the closed parent's full
+    /// job set.
     ///
-    /// A fresh SlateDB clone is a byte-for-byte copy of the parent, so
+    /// A fresh SlateDB clone is a byte-for-byte copy of the closed parent, so
     /// immediately after `clone_closed_shard` -- before post-commit cleanup
     /// trims each child to its range -- every child's whole-shard `total_jobs`
-    /// must equal the parent's pre-close count. An empty or mis-placed child
-    /// (the object-store split data-loss signature) reads `0` and trips this
-    /// check, letting the split abort before the shard-map commit point.
+    /// must equal the parent's. Both counts are read from raw post-close
+    /// opens of the same storage, so the comparison is exact by construction
+    /// (a count taken from the live parent could drift: background cleanup
+    /// decrements counters until close completes). An empty or mis-placed
+    /// child reads `0` (or fails to open at all, aborting via the open
+    /// error), letting the split abort before the shard-map commit point.
     ///
     /// This is a manifest-landed tripwire keyed on the empty-child signature,
     /// not a full row-integrity audit: a clone that landed the counter key but
     /// corrupted rows would still pass.
     pub async fn verify_cloned_children_match_parent(
         &self,
-        parent_total_jobs: i64,
+        parent_id: &ShardId,
         child_ids: &[ShardId],
     ) -> Result<(), ShardFactoryError> {
+        let parent_total_jobs = self.read_closed_shard_total_jobs(parent_id).await?;
         for child_id in child_ids {
-            let child_total_jobs = self.read_cloned_shard_total_jobs(child_id).await?;
+            let child_total_jobs = self.read_closed_shard_total_jobs(child_id).await?;
             if child_total_jobs != parent_total_jobs {
                 return Err(ShardFactoryError::ChildVerification(format!(
-                    "cloned child {child_id} holds {child_total_jobs} jobs but parent held \
-                     {parent_total_jobs}; aborting split before commit to avoid data loss"
+                    "cloned child {child_id} holds {child_total_jobs} jobs but parent {parent_id} \
+                     held {parent_total_jobs}; aborting split before commit to avoid data loss"
                 )));
             }
         }
         Ok(())
     }
 
-    /// Open a freshly cloned child's database with the raw `open_with_resolved_store`
+    /// Open a closed shard's database with the raw `open_with_resolved_store`
     /// primitive, read its whole-shard `total_jobs`, and close it.
     ///
-    /// Uses the raw open -- NOT `open` -- so the child is never registered in the
+    /// Uses the raw open -- NOT `open` -- so the shard is never registered in the
     /// `instances` map: `open` caches the instance in the per-shard OnceCell, and
     /// the post-commit `open(child)` would then return this stale pre-commit
     /// handle instead of opening the committed child. Hydration is disabled and
     /// `get_counters` reads single merged counter keys, so the check is O(1)
     /// even on a multi-million-job shard.
-    async fn read_cloned_shard_total_jobs(
+    async fn read_closed_shard_total_jobs(
         &self,
         shard_id: &ShardId,
     ) -> Result<i64, ShardFactoryError> {
@@ -937,9 +966,13 @@ impl ShardFactory {
         // Always close the raw handle, even if the counter read fails, so the
         // shard's SlateDB instance and its spawned background tasks (grant
         // scanner, reconcilers) are released -- JobStoreShard has no Drop.
+        // Surface the counter-read error (the verification signal) before any
+        // close error.
         let counters = shard.get_counters().await;
-        shard.close().await?;
-        Ok(counters?.total_jobs)
+        let close_result = shard.close().await;
+        let total_jobs = counters?.total_jobs;
+        close_result?;
+        Ok(total_jobs)
     }
 
     /// Get the database template used by this factory.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,6 +1,8 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use slatedb::object_store::ObjectStore;
+use slatedb::object_store::memory::InMemory;
 use slatedb::{Db, Error as SlateError};
 use std::fs;
 use std::path::Path;
@@ -8,6 +10,21 @@ use thiserror::Error;
 use url::Url;
 
 use crate::settings::Backend;
+
+/// Process-wide registry of in-memory stores keyed by root path.
+///
+/// `Backend::Memory` shards under the same root must share one `InMemory` so
+/// that multi-shard operations (clone/split, close-then-reopen) see each other's
+/// data, matching how a real object store behaves. Distinct roots stay isolated,
+/// so unrelated factories — each rooted at a unique path — do not bleed state.
+///
+/// Entries are never evicted: each distinct root holds its `InMemory` for the
+/// life of the process. This is acceptable because Memory is a dev/test-only
+/// backend; production deployments use S3/GCS and never reach this registry.
+fn memory_store_registry() -> &'static Mutex<HashMap<String, Arc<InMemory>>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, Arc<InMemory>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 #[derive(Debug, Error)]
 pub enum StorageError {
@@ -54,11 +71,23 @@ pub fn resolve_object_store(backend: &Backend, path: &str) -> Result<ResolvedSto
                 root_path: canonical_str,
             })
         }
-        Backend::Memory => Ok(ResolvedStore {
-            store: Arc::new(slatedb::object_store::memory::InMemory::new()),
-            canonical_path: path.to_string(),
-            root_path: path.to_string(),
-        }),
+        Backend::Memory => {
+            let store = {
+                let mut registry = memory_store_registry()
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                Arc::clone(
+                    registry
+                        .entry(path.to_string())
+                        .or_insert_with(|| Arc::new(InMemory::new())),
+                )
+            };
+            Ok(ResolvedStore {
+                store,
+                canonical_path: path.to_string(),
+                root_path: path.to_string(),
+            })
+        }
         Backend::S3 | Backend::Gcs | Backend::Url => {
             // Interpret path as a URL understood by SlateDB's resolver, e.g. s3://bucket/prefix or gs://bucket/prefix
             let store = Db::resolve_object_store(path)?;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -44,6 +44,12 @@ pub struct ResolvedStore {
     pub root_path: String,
 }
 
+/// Resolve an object store for the given backend and path.
+///
+/// `Backend::Memory` returns the shared per-root store from the process-wide
+/// registry: callers that need isolation (independent factories, tests) must
+/// use a unique root path, while callers that need shared visibility (all
+/// shards of one template) resolve the same root.
 pub fn resolve_object_store(backend: &Backend, path: &str) -> Result<ResolvedStore, StorageError> {
     match backend {
         Backend::Fs => {

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,3 +1,4 @@
+#[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Once};
 
@@ -55,18 +56,21 @@ impl<'a> MakeWriter<'a> for DebugFileWriter {
     }
 }
 
-/// Whether the process-global log capture is armed. Checked per event by a
-/// cheap layer filter, so the capture layer costs one atomic load per event
-/// when disarmed.
+/// Whether the process-global log capture is armed. Checked per event by the
+/// capture layer's filter.
+#[cfg(debug_assertions)]
 static LOG_CAPTURE_ARMED: AtomicBool = AtomicBool::new(false);
 
 /// Buffer holding formatted log lines while capture is armed.
+#[cfg(debug_assertions)]
 static LOG_CAPTURE_BUF: Mutex<Vec<u8>> = Mutex::new(Vec::new());
 
 /// Writer that appends formatted events to the process-global capture buffer.
+#[cfg(debug_assertions)]
 #[derive(Clone)]
 struct LogCaptureWriter;
 
+#[cfg(debug_assertions)]
 impl std::io::Write for LogCaptureWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         LOG_CAPTURE_BUF
@@ -81,6 +85,7 @@ impl std::io::Write for LogCaptureWriter {
     }
 }
 
+#[cfg(debug_assertions)]
 impl<'a> MakeWriter<'a> for LogCaptureWriter {
     type Writer = LogCaptureWriter;
 
@@ -96,6 +101,10 @@ impl<'a> MakeWriter<'a> for LogCaptureWriter {
 /// subscriber, which panics when spans cross subscriber registries. Capture
 /// is process-global: arm it only while holding whatever serialization the
 /// test suite uses, or expect interleaved output from concurrent tests.
+///
+/// Debug builds only: the capture layer's dynamic filter defeats tracing's
+/// callsite caching, so release builds do not register it (or this API).
+#[cfg(debug_assertions)]
 pub fn start_log_capture() {
     LOG_CAPTURE_BUF
         .lock()
@@ -106,6 +115,7 @@ pub fn start_log_capture() {
 
 /// Disarm the log capture and return everything captured since
 /// [`start_log_capture`].
+#[cfg(debug_assertions)]
 pub fn stop_log_capture() -> String {
     LOG_CAPTURE_ARMED.store(false, Ordering::SeqCst);
     let mut buf = LOG_CAPTURE_BUF
@@ -118,6 +128,7 @@ pub fn stop_log_capture() -> String {
 
 /// Layer that formats events into the capture buffer while capture is armed.
 /// Filtered by an atomic check so it does no formatting work when disarmed.
+#[cfg(debug_assertions)]
 fn log_capture_layer<S>() -> impl tracing_subscriber::Layer<S>
 where
     S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
@@ -129,8 +140,15 @@ where
         .compact()
         .with_writer(LogCaptureWriter)
         .with_filter(tracing_subscriber::filter::filter_fn(|_| {
-            LOG_CAPTURE_ARMED.load(Ordering::Relaxed)
+            LOG_CAPTURE_ARMED.load(Ordering::SeqCst)
         }))
+}
+
+/// Release builds skip the capture layer entirely so callsite caching stays
+/// intact on hot log paths.
+#[cfg(not(debug_assertions))]
+fn log_capture_layer() -> tracing_subscriber::layer::Identity {
+    tracing_subscriber::layer::Identity::new()
 }
 
 /// Initialize tracing once based on config and environment:

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Once};
 
 use opentelemetry::KeyValue;
@@ -52,6 +53,84 @@ impl<'a> MakeWriter<'a> for DebugFileWriter {
     fn make_writer(&'a self) -> Self::Writer {
         self.clone()
     }
+}
+
+/// Whether the process-global log capture is armed. Checked per event by a
+/// cheap layer filter, so the capture layer costs one atomic load per event
+/// when disarmed.
+static LOG_CAPTURE_ARMED: AtomicBool = AtomicBool::new(false);
+
+/// Buffer holding formatted log lines while capture is armed.
+static LOG_CAPTURE_BUF: Mutex<Vec<u8>> = Mutex::new(Vec::new());
+
+/// Writer that appends formatted events to the process-global capture buffer.
+#[derive(Clone)]
+struct LogCaptureWriter;
+
+impl std::io::Write for LogCaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        LOG_CAPTURE_BUF
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for LogCaptureWriter {
+    type Writer = LogCaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        LogCaptureWriter
+    }
+}
+
+/// Begin capturing formatted log output into a process-global buffer.
+///
+/// Tests use this to assert on operational log markers (e.g. the split state
+/// machine's pre-commit verification markers) without swapping the global
+/// subscriber, which panics when spans cross subscriber registries. Capture
+/// is process-global: arm it only while holding whatever serialization the
+/// test suite uses, or expect interleaved output from concurrent tests.
+pub fn start_log_capture() {
+    LOG_CAPTURE_BUF
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
+    LOG_CAPTURE_ARMED.store(true, Ordering::SeqCst);
+}
+
+/// Disarm the log capture and return everything captured since
+/// [`start_log_capture`].
+pub fn stop_log_capture() -> String {
+    LOG_CAPTURE_ARMED.store(false, Ordering::SeqCst);
+    let mut buf = LOG_CAPTURE_BUF
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let captured = String::from_utf8_lossy(&buf).into_owned();
+    buf.clear();
+    captured
+}
+
+/// Layer that formats events into the capture buffer while capture is armed.
+/// Filtered by an atomic check so it does no formatting work when disarmed.
+fn log_capture_layer<S>() -> impl tracing_subscriber::Layer<S>
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    tracing_subscriber::fmt::layer()
+        .with_target(true)
+        .with_level(true)
+        .with_ansi(false)
+        .compact()
+        .with_writer(LogCaptureWriter)
+        .with_filter(tracing_subscriber::filter::filter_fn(|_| {
+            LOG_CAPTURE_ARMED.load(Ordering::Relaxed)
+        }))
 }
 
 /// Initialize tracing once based on config and environment:
@@ -140,6 +219,7 @@ where
 {
     let base = tracing_subscriber::registry()
         .with(fmt_layer)
+        .with(log_capture_layer())
         .with(console_layer());
 
     if let Some(path) = std::env::var_os("SILO_PERFETTO") {
@@ -197,6 +277,7 @@ where
     let base = tracing_subscriber::registry()
         .with(fmt_layer)
         .with(file_layer)
+        .with(log_capture_layer())
         .with(console_layer());
 
     // Note: Perfetto and OTEL are not supported when using debug file logging

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -5,7 +5,7 @@ use silo::settings::{
     AppConfig, Backend, DatabaseConfig, DatabaseTemplate, GubernatorSettings, LoggingConfig,
     WalConfig, WebUiConfig, expand_env_vars_for_test,
 };
-use silo::shard_range::{ShardMap, ShardRange};
+use silo::shard_range::{ShardId, ShardMap, ShardRange};
 use silo::storage::resolve_object_store;
 use std::time::Duration;
 
@@ -485,6 +485,29 @@ fn resolve_object_store_memory_returns_same_path() {
 
     // Memory backend should return the path as-is
     assert_eq!(result.canonical_path, "my-test-path");
+}
+
+/// Memory shards under one root must share a single in-memory store — like a
+/// real object store, where every shard from one template lives in one bucket.
+/// Multi-shard operations (clone/split, close-then-reopen) depend on later
+/// resolutions of the same root seeing earlier resolutions' writes. Distinct
+/// roots stay isolated so unrelated factories don't bleed state.
+#[silo::test]
+fn resolve_object_store_memory_shares_store_per_root() {
+    let root = format!("shared-root-{}", ShardId::new());
+    let first = resolve_object_store(&Backend::Memory, &root).unwrap();
+    let second = resolve_object_store(&Backend::Memory, &root).unwrap();
+    assert!(
+        std::sync::Arc::ptr_eq(&first.store, &second.store),
+        "resolving the same Memory root twice must return the same store"
+    );
+
+    let other =
+        resolve_object_store(&Backend::Memory, &format!("other-root-{}", ShardId::new())).unwrap();
+    assert!(
+        !std::sync::Arc::ptr_eq(&first.store, &other.store),
+        "distinct Memory roots must resolve to distinct stores"
+    );
 }
 
 #[silo::test]

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -55,6 +55,25 @@ fn make_memory_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
     ))
 }
 
+/// Memory-backed factory with a separate Memory WAL store per shard,
+/// mirroring a real object-store deployment with split WAL.
+fn make_memory_test_factory_with_wal(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
+    let root = format!("silo-split-mem-wal-{}-{}", prefix, node_id);
+    Arc::new(ShardFactory::new(
+        DatabaseTemplate {
+            backend: Backend::Memory,
+            path: format!("{root}/data/%shard%"),
+            wal: Some(silo::settings::WalConfig {
+                backend: Backend::Memory,
+                path: format!("{root}/wal/%shard%"),
+            }),
+            ..Default::default()
+        },
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
 /// Test that request_split creates a split record
 #[silo::test(flavor = "multi_thread", worker_threads = 4)]
 async fn request_split_creates_split_record() {
@@ -701,6 +720,135 @@ async fn split_with_empty_child_aborts_before_commit_and_recovers_parent() {
             .is_some(),
         "recovered parent must serve its job"
     );
+
+    c1.shutdown().await.unwrap();
+    let _ = h1.abort();
+}
+
+/// Drive a full split on the shared-root Memory backend (an object store,
+/// with a separate WAL store) and assert every enqueued job survives in the
+/// child that owns its tenant's range. This is the object-store analogue of
+/// the local-FS full-cycle split -- the state-machine-level guard against
+/// clone/open path divergence -- and proof the WAL + object-store split path
+/// opens children without "wal store reconfiguration unsupported". Also
+/// asserts the pre-commit verification's success marker so deployments can be
+/// probed for the check at runtime.
+#[silo::test(flavor = "multi_thread", worker_threads = 4)]
+async fn execute_split_preserves_jobs_on_object_store() {
+    let _guard = acquire_test_mutex().await;
+
+    let prefix = unique_prefix();
+    let num_shards: u32 = 1;
+    let cfg = silo::settings::AppConfig::load(None).expect("load default config");
+    let factory = make_memory_test_factory_with_wal(&prefix, "n1");
+
+    let (c1, h1) = EtcdCoordinator::start(
+        &cfg.coordination.etcd_endpoints,
+        &prefix,
+        "n1",
+        "http://127.0.0.1:7450",
+        num_shards,
+        10,
+        Arc::clone(&factory),
+        Vec::new(),
+    )
+    .await
+    .expect("start coordinator");
+
+    assert!(c1.wait_converged(Duration::from_secs(10)).await);
+
+    let shard_id = c1.owned_shards().await[0];
+
+    // Enqueue known jobs across several tenants into the parent before
+    // splitting.
+    let parent_range = {
+        let shard_map = c1.get_shard_map().await.expect("get shard map");
+        shard_map.get_shard(&shard_id).unwrap().range.clone()
+    };
+    let parent = factory
+        .open(&shard_id, &parent_range)
+        .await
+        .expect("open parent shard");
+    let tenants = ["a", "b", "f", "m", "q", "t", "x", "z"];
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    for tenant in tenants {
+        parent
+            .enqueue(
+                tenant,
+                Some(format!("job-{tenant}")),
+                5,
+                now,
+                None,
+                rmp_serde::to_vec(&serde_json::json!({ "t": tenant })).unwrap(),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue to parent");
+    }
+    assert_eq!(
+        parent.get_counters().await.expect("counters").total_jobs,
+        tenants.len() as i64,
+    );
+
+    // Request and execute a balanced split, capturing the state machine's
+    // logs to assert the verification success marker.
+    let splitter = ShardSplitter::new(Arc::new(c1.clone()));
+    let split_point = {
+        let shard_map = c1.get_shard_map().await.expect("get shard map");
+        silo::shard_range::format_hash_boundary(
+            shard_map
+                .get_shard(&shard_id)
+                .unwrap()
+                .range
+                .midpoint()
+                .unwrap(),
+        )
+    };
+    let split = splitter
+        .request_split(shard_id, split_point)
+        .await
+        .expect("request split should succeed");
+    silo::trace::start_log_capture();
+    splitter
+        .execute_split(shard_id, || c1.get_shard_owner_map())
+        .await
+        .expect("execute split should succeed and preserve data");
+    let logs = silo::trace::stop_log_capture();
+    assert!(
+        logs.contains("children verified, updating shard map"),
+        "verification success marker must be logged, got:\n{logs}"
+    );
+
+    // Every enqueued job must survive the split in the child that owns its
+    // tenant's range. Children open as full copies of the parent; post-commit
+    // cleanup only trims out-of-range rows, never the in-range job looked up
+    // here -- so this assertion is deterministic regardless of cleanup timing.
+    let shard_map = c1.get_shard_map().await.expect("get shard map after split");
+    for tenant in tenants {
+        let owner = shard_map
+            .shard_for_tenant(tenant)
+            .expect("tenant routes to a child");
+        assert!(
+            owner.id == split.left_child_id || owner.id == split.right_child_id,
+            "tenant {tenant} should route to one of the children",
+        );
+        let child = factory
+            .get(&owner.id)
+            .expect("child shard open after split");
+        assert!(
+            child
+                .get_job(tenant, &format!("job-{tenant}"))
+                .await
+                .expect("get_job")
+                .is_some(),
+            "job for tenant {tenant} must survive the split in its owning child",
+        );
+    }
 
     c1.shutdown().await.unwrap();
     let _ = h1.abort();

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -42,7 +42,8 @@ fn make_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
 /// Memory-backed factory for object-store split coverage: parent and children
 /// resolve under one shared store root. The unique root (the test's unique
 /// prefix) keeps the process-global in-memory store from bleeding across
-/// tests.
+/// tests. Debug-only like its sole caller, the fault-injected abort test.
+#[cfg(debug_assertions)]
 fn make_memory_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
     Arc::new(ShardFactory::new(
         DatabaseTemplate {
@@ -577,7 +578,9 @@ async fn execute_split_completes_full_cycle() {
 /// shard-map commit: the pre-commit verification detects the short child,
 /// the shard map keeps routing to the parent, and the parent is recovered
 /// and serves reads. Driven through the factory's test-only clone fault
-/// seam, since a correct clone cannot produce a short child.
+/// seam (debug builds only), since a correct clone cannot produce a short
+/// child.
+#[cfg(debug_assertions)]
 #[silo::test(flavor = "multi_thread", worker_threads = 4)]
 async fn split_with_empty_child_aborts_before_commit_and_recovers_parent() {
     let _guard = acquire_test_mutex().await;
@@ -664,11 +667,11 @@ async fn split_with_empty_child_aborts_before_commit_and_recovers_parent() {
     );
 
     assert!(
-        logs.contains("cloning complete, verifying children before commit"),
+        logs.contains(silo::coordination::split::MARKER_VERIFYING_CHILDREN),
         "verification-start marker must be logged, got:\n{logs}"
     );
     assert!(
-        logs.contains("post-clone child verification failed"),
+        logs.contains(silo::coordination::split::MARKER_CHILD_VERIFICATION_FAILED),
         "verification-failure marker must be logged, got:\n{logs}"
     );
 
@@ -722,7 +725,7 @@ async fn split_with_empty_child_aborts_before_commit_and_recovers_parent() {
     );
 
     c1.shutdown().await.unwrap();
-    let _ = h1.abort();
+    h1.abort();
 }
 
 /// Drive a full split on the shared-root Memory backend (an object store,
@@ -813,16 +816,21 @@ async fn execute_split_preserves_jobs_on_object_store() {
         .request_split(shard_id, split_point)
         .await
         .expect("request split should succeed");
+    #[cfg(debug_assertions)]
     silo::trace::start_log_capture();
     splitter
         .execute_split(shard_id, || c1.get_shard_owner_map())
         .await
         .expect("execute split should succeed and preserve data");
-    let logs = silo::trace::stop_log_capture();
-    assert!(
-        logs.contains("children verified, updating shard map"),
-        "verification success marker must be logged, got:\n{logs}"
-    );
+    // The capture layer (and its API) exists only in debug builds.
+    #[cfg(debug_assertions)]
+    {
+        let logs = silo::trace::stop_log_capture();
+        assert!(
+            logs.contains(silo::coordination::split::MARKER_CHILDREN_VERIFIED),
+            "verification success marker must be logged, got:\n{logs}"
+        );
+    }
 
     // Every enqueued job must survive the split in the child that owns its
     // tenant's range. Children open as full copies of the parent; post-commit
@@ -851,7 +859,7 @@ async fn execute_split_preserves_jobs_on_object_store() {
     }
 
     c1.shutdown().await.unwrap();
-    let _ = h1.abort();
+    h1.abort();
 }
 
 /// Test that is_shard_paused returns true during pausing phases

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -39,6 +39,22 @@ fn make_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
     ))
 }
 
+/// Memory-backed factory for object-store split coverage: parent and children
+/// resolve under one shared store root. The unique root (the test's unique
+/// prefix) keeps the process-global in-memory store from bleeding across
+/// tests.
+fn make_memory_test_factory(prefix: &str, node_id: &str) -> Arc<ShardFactory> {
+    Arc::new(ShardFactory::new(
+        DatabaseTemplate {
+            backend: Backend::Memory,
+            path: format!("silo-split-mem-{}-{}/%shard%", prefix, node_id),
+            ..Default::default()
+        },
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
 /// Test that request_split creates a split record
 #[silo::test(flavor = "multi_thread", worker_threads = 4)]
 async fn request_split_creates_split_record() {
@@ -533,6 +549,158 @@ async fn execute_split_completes_full_cycle() {
             "tenant should route to one of the children"
         );
     }
+
+    c1.shutdown().await.unwrap();
+    let _ = h1.abort();
+}
+
+/// A split whose clone produces an empty child must abort before the
+/// shard-map commit: the pre-commit verification detects the short child,
+/// the shard map keeps routing to the parent, and the parent is recovered
+/// and serves reads. Driven through the factory's test-only clone fault
+/// seam, since a correct clone cannot produce a short child.
+#[silo::test(flavor = "multi_thread", worker_threads = 4)]
+async fn split_with_empty_child_aborts_before_commit_and_recovers_parent() {
+    let _guard = acquire_test_mutex().await;
+
+    let prefix = unique_prefix();
+    let num_shards: u32 = 1;
+    let cfg = silo::settings::AppConfig::load(None).expect("load default config");
+    let factory = make_memory_test_factory(&prefix, "n1");
+
+    let (c1, h1) = EtcdCoordinator::start(
+        &cfg.coordination.etcd_endpoints,
+        &prefix,
+        "n1",
+        "http://127.0.0.1:7450",
+        num_shards,
+        10,
+        Arc::clone(&factory),
+        Vec::new(),
+    )
+    .await
+    .expect("start coordinator");
+
+    assert!(c1.wait_converged(Duration::from_secs(10)).await);
+
+    let shard_id = c1.owned_shards().await[0];
+
+    // Seed the parent with a job so a short child is detectable.
+    let parent_range = {
+        let shard_map = c1.get_shard_map().await.expect("get shard map");
+        shard_map.get_shard(&shard_id).unwrap().range.clone()
+    };
+    let parent = factory
+        .open(&shard_id, &parent_range)
+        .await
+        .expect("open parent shard");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("survivor-job".to_string()),
+            5,
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as i64,
+            None,
+            rmp_serde::to_vec(&serde_json::json!({"k": "v"})).unwrap(),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+
+    let splitter = ShardSplitter::new(Arc::new(c1.clone()));
+    let split_point = {
+        let shard_map = c1.get_shard_map().await.expect("get shard map");
+        silo::shard_range::format_hash_boundary(
+            shard_map
+                .get_shard(&shard_id)
+                .unwrap()
+                .range
+                .midpoint()
+                .unwrap(),
+        )
+    };
+    let split = splitter
+        .request_split(shard_id, split_point)
+        .await
+        .expect("request split should succeed");
+
+    // Make the left child's clone come up empty.
+    factory.inject_empty_child_clone(split.left_child_id);
+
+    // Capture the split state machine's logs to assert the verification
+    // markers.
+    silo::trace::start_log_capture();
+    let result = splitter
+        .execute_split(shard_id, || c1.get_shard_owner_map())
+        .await;
+    let logs = silo::trace::stop_log_capture();
+    assert!(
+        result.is_err(),
+        "split with an empty child must fail, got {result:?}"
+    );
+
+    assert!(
+        logs.contains("cloning complete, verifying children before commit"),
+        "verification-start marker must be logged, got:\n{logs}"
+    );
+    assert!(
+        logs.contains("post-clone child verification failed"),
+        "verification-failure marker must be logged, got:\n{logs}"
+    );
+
+    // The shard map was never committed: it still routes to the parent only.
+    let shard_map = c1.get_shard_map().await.expect("get shard map after abort");
+    assert_eq!(
+        shard_map.len(),
+        1,
+        "shard map must still hold only the parent"
+    );
+    assert!(
+        shard_map.get_shard(&shard_id).is_some(),
+        "parent must remain in the shard map"
+    );
+    assert!(
+        shard_map.get_shard(&split.left_child_id).is_none(),
+        "left child must not be committed to the shard map"
+    );
+    assert!(
+        shard_map.get_shard(&split.right_child_id).is_none(),
+        "right child must not be committed to the shard map"
+    );
+
+    // The split record is abandoned so the parent resumes normal operation.
+    let status = splitter
+        .get_split_status(shard_id)
+        .await
+        .expect("get split status");
+    assert!(status.is_none(), "split record should be abandoned");
+
+    // The parent is recovered and serves reads with its full data set.
+    let recovered = factory
+        .get(&shard_id)
+        .expect("parent shard reopened in factory after abort");
+    assert_eq!(
+        recovered
+            .get_counters()
+            .await
+            .expect("recovered parent counters")
+            .total_jobs,
+        1,
+        "recovered parent must hold its job"
+    );
+    assert!(
+        recovered
+            .get_job("test-tenant", "survivor-job")
+            .await
+            .expect("get job from recovered parent")
+            .is_some(),
+        "recovered parent must serve its job"
+    );
 
     c1.shutdown().await.unwrap();
     let _ = h1.abort();

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -40,6 +40,29 @@ fn make_memory_factory() -> Arc<ShardFactory> {
     ))
 }
 
+/// Helper to create a Memory-backed factory with a separate Memory WAL store.
+///
+/// The data store is rooted at a shared root (so parent and children resolve
+/// under one store); each shard gets its own WAL store keyed by the per-shard
+/// WAL path, mirroring a real object-store deployment with split WAL.
+fn make_memory_factory_with_wal() -> Arc<ShardFactory> {
+    let root = ShardId::new();
+    let template = DatabaseTemplate {
+        backend: Backend::Memory,
+        path: format!("{root}/data/%shard%"),
+        wal: Some(WalConfig {
+            backend: Backend::Memory,
+            path: format!("{root}/wal/%shard%"),
+        }),
+        ..Default::default()
+    };
+    Arc::new(ShardFactory::new(
+        template,
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
 /// Helper to create a filesystem-backed factory with separate WAL dir
 fn make_fs_factory_with_wal(
     data_tmp: &tempfile::TempDir,
@@ -354,6 +377,223 @@ async fn clone_closed_shard_with_split_wal() {
     assert_eq!(
         right_counters.total_jobs, 1,
         "right child should have the parent's job"
+    );
+}
+
+// --- object-store clone round-trip tests ---
+
+/// Regression guard for the object-store split data-loss signature.
+///
+/// On an object-store backend, parent and children must resolve under one
+/// shared storage root so a clone lands exactly where `open` later reads. When
+/// each shard instead gets its own store root, the children open empty and the
+/// shard's data is silently lost. This drives the clone round-trip on the
+/// shared-root Memory backend and asserts each child holds the parent's full
+/// job set.
+#[silo::test]
+async fn clone_closed_shard_object_store_preserves_jobs() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("cloned-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"cloned": true})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+
+    let parent_counters = parent.get_counters().await.expect("get parent counters");
+    assert_eq!(parent_counters.total_jobs, 1);
+
+    // Close parent (clone_closed_shard expects it to be closed)
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard");
+
+    // A fresh clone is a full byte-for-byte copy of the parent, so each child
+    // holds the parent's whole job set immediately after the split (cleanup
+    // trims each child to its range later).
+    let left_child = factory
+        .open(&left_child_id, &ShardRange::full())
+        .await
+        .expect("open left child");
+    assert_eq!(
+        left_child
+            .get_counters()
+            .await
+            .expect("get left child counters")
+            .total_jobs,
+        1,
+        "left child should have the parent's job"
+    );
+    assert!(
+        left_child
+            .get_job("test-tenant", "cloned-job")
+            .await
+            .expect("get job from left child")
+            .is_some(),
+        "left child should contain the parent's job"
+    );
+
+    let right_child = factory
+        .open(&right_child_id, &ShardRange::full())
+        .await
+        .expect("open right child");
+    assert_eq!(
+        right_child
+            .get_counters()
+            .await
+            .expect("get right child counters")
+            .total_jobs,
+        1,
+        "right child should have the parent's job"
+    );
+}
+
+/// The object-store clone round-trip must also work with a separate WAL store:
+/// cloning propagates each child's WAL store so the children open without
+/// "wal store reconfiguration unsupported", and each holds the parent's jobs.
+#[silo::test]
+async fn clone_closed_shard_object_store_with_split_wal() {
+    let factory = make_memory_factory_with_wal();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("wal-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"wal": true})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard with WAL on object store");
+
+    // Opening the children is where "wal store reconfiguration unsupported"
+    // would surface if the clone did not configure each child's WAL store.
+    let left_child = factory
+        .open(&left_child_id, &ShardRange::full())
+        .await
+        .expect("open left child with WAL");
+    assert_eq!(
+        left_child
+            .get_counters()
+            .await
+            .expect("left counters")
+            .total_jobs,
+        1,
+        "left child should hold the parent's job"
+    );
+
+    let right_child = factory
+        .open(&right_child_id, &ShardRange::full())
+        .await
+        .expect("open right child with WAL");
+    assert_eq!(
+        right_child
+            .get_counters()
+            .await
+            .expect("right counters")
+            .total_jobs,
+        1,
+        "right child should hold the parent's job"
+    );
+}
+
+/// `delete_shard_data` on an object-store backend must scope deletion to
+/// exactly one shard's prefix. Two shards share a single store root, so
+/// deleting one (via `reset`) must not touch a sibling whose prefix differs
+/// only by shard name.
+#[silo::test]
+async fn delete_object_store_shard_data_leaves_sibling_intact() {
+    let factory = make_memory_factory();
+    let shard_a = ShardId::new();
+    let shard_b = ShardId::new();
+
+    let a = factory
+        .open(&shard_a, &ShardRange::full())
+        .await
+        .expect("open shard a");
+    let b = factory
+        .open(&shard_b, &ShardRange::full())
+        .await
+        .expect("open shard b");
+
+    for (shard, job_id) in [(&a, "job-a"), (&b, "job-b")] {
+        shard
+            .enqueue(
+                "test-tenant",
+                Some(job_id.to_string()),
+                5,
+                test_helpers::now_ms(),
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue job");
+    }
+
+    // reset closes shard A, deletes its data via delete_shard_data, then reopens.
+    let a_reset = factory
+        .reset(&shard_a, &ShardRange::full())
+        .await
+        .expect("reset shard a");
+    assert_eq!(
+        a_reset.get_counters().await.expect("a counters").total_jobs,
+        0,
+        "reset shard A should be empty after its data is deleted"
+    );
+
+    // Sibling B shares the store root but its prefix differs by shard name, so
+    // deleting A must not have removed B's data.
+    assert_eq!(
+        b.get_counters().await.expect("b counters").total_jobs,
+        1,
+        "sibling shard B should keep its job after shard A's data is deleted"
+    );
+    assert!(
+        b.get_job("test-tenant", "job-b")
+            .await
+            .expect("get job from b")
+            .is_some(),
+        "sibling shard B should still contain its job"
     );
 }
 

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -339,6 +339,154 @@ async fn clone_closed_shard_with_split_wal() {
     );
 }
 
+// --- object-store layout tests ---
+
+/// Pins the absolute object keys for URL-style templates to the deployed
+/// double-nested layout, so shard resolution changes can never silently move
+/// existing shards' data.
+///
+/// slatedb roots a URL-resolved store at the URL's path component (a
+/// `PrefixStore`), so absolute keys are `<root-path>/<db-path>/…`. For a
+/// `gs://bucket/silo/%shard%` template every existing shard's objects live at
+/// `silo/<shard>/silo/<shard>/…`, which requires the store to resolve at the
+/// shared root `gs://bucket/silo` with database path `<shard>/silo/<shard>`.
+/// A bare-shard-name database path (keys `silo/<shard>/<shard>/…`) or a
+/// per-shard store root (keys `silo/<shard>/silo/<shard>/…` but with parent
+/// and children on distinct roots) both fail this pin.
+#[silo::test]
+fn url_template_resolves_shared_root_and_double_nested_db_path() {
+    let (root, db_path) = ShardFactory::object_store_layout(
+        &Backend::Gcs,
+        "gs://test-bucket/silo/%shard%",
+        "0a1b2c3d-0000-0000-0000-000000000000",
+    )
+    .expect("layout for gs template");
+    assert_eq!(root, "gs://test-bucket/silo");
+    assert_eq!(
+        db_path,
+        "0a1b2c3d-0000-0000-0000-000000000000/silo/0a1b2c3d-0000-0000-0000-000000000000"
+    );
+
+    // {shard} placeholder form resolves identically.
+    let (root, db_path) =
+        ShardFactory::object_store_layout(&Backend::Url, "s3://test-bucket/prefix/{shard}", "abc")
+            .expect("layout for s3 template");
+    assert_eq!(root, "s3://test-bucket/prefix");
+    assert_eq!(db_path, "abc/prefix/abc");
+}
+
+/// A template without a shard placeholder (test sentinels, the noop factory)
+/// degenerates to the whole path as the shared root and the store-path
+/// component as the database path — the same keys the template produces today.
+#[silo::test]
+fn url_template_without_placeholder_uses_store_path_component() {
+    let (root, db_path) = ShardFactory::object_store_layout(
+        &Backend::Gcs,
+        "gs://test-bucket/silo/fixed",
+        "ignored-shard",
+    )
+    .expect("layout for placeholder-free gs template");
+    assert_eq!(root, "gs://test-bucket/silo/fixed");
+    assert_eq!(db_path, "silo/fixed");
+
+    let (root, db_path) =
+        ShardFactory::object_store_layout(&Backend::Memory, "some-sentinel", "ignored-shard")
+            .expect("layout for placeholder-free memory template");
+    assert_eq!(root, "some-sentinel");
+    assert_eq!(db_path, "some-sentinel");
+}
+
+/// The Memory registry shares stores per root, so each noop factory needs a
+/// unique template root — otherwise every noop factory in the process would
+/// read and write one shared store.
+#[silo::test]
+fn noop_factories_use_unique_template_roots() {
+    let a = ShardFactory::new_noop();
+    let b = ShardFactory::new_noop();
+    assert_ne!(
+        a.template().path,
+        b.template().path,
+        "each noop factory must get its own template root"
+    );
+}
+
+/// Memory templates use the same layout arithmetic as URL backends — the
+/// store-path component is the raw expanded path — so in-memory tests exercise
+/// the production key nesting.
+#[silo::test]
+fn memory_template_layout_mirrors_url_arithmetic() {
+    let (root, db_path) =
+        ShardFactory::object_store_layout(&Backend::Memory, "mem-root/data/%shard%", "abc")
+            .expect("layout for memory template");
+    assert_eq!(root, "mem-root/data");
+    assert_eq!(db_path, "abc/mem-root/data/abc");
+}
+
+/// End-to-end pin of the Memory-backend key layout: objects written through a
+/// factory-opened shard land in the shared per-root store under the
+/// layout-preserving database path `<shard>/<root>/<shard>/…`, and are visible
+/// to a later independent resolution of the same root.
+#[silo::test]
+async fn memory_shard_objects_land_under_layout_preserving_keys() {
+    use futures::TryStreamExt;
+
+    let root = format!("layout-root-{}", ShardId::new());
+    let factory = Arc::new(ShardFactory::new(
+        DatabaseTemplate {
+            backend: Backend::Memory,
+            path: format!("{root}/%shard%"),
+            ..Default::default()
+        },
+        MockGubernatorClient::new_arc(),
+        None,
+    ));
+    let shard_id = ShardId::new();
+
+    let shard = factory
+        .open(&shard_id, &ShardRange::full())
+        .await
+        .expect("open shard");
+    shard
+        .enqueue(
+            "test-tenant",
+            Some("layout-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+    factory.close(&shard_id).await.expect("close shard");
+
+    // An independent resolution of the same root sees the shard's objects —
+    // and every key sits under the double-nested layout-preserving prefix.
+    let resolved =
+        silo::storage::resolve_object_store(&Backend::Memory, &root).expect("resolve shared root");
+    let objects: Vec<_> = resolved
+        .store
+        .list(None)
+        .try_collect()
+        .await
+        .expect("list store");
+    assert!(
+        !objects.is_empty(),
+        "the shard's objects must be visible under the shared root"
+    );
+    let expected_prefix = format!("{shard_id}/{root}/{shard_id}/");
+    for obj in &objects {
+        assert!(
+            obj.location.as_ref().starts_with(&expected_prefix),
+            "object key {} must start with layout-preserving prefix {}",
+            obj.location,
+            expected_prefix
+        );
+    }
+}
+
 // --- template path validation tests ---
 
 #[silo::test]

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -22,6 +22,24 @@ fn make_fs_factory(tmp: &tempfile::TempDir) -> Arc<ShardFactory> {
     ))
 }
 
+/// Helper to create a Memory-backed factory rooted at a unique shared root.
+///
+/// All shards opened through this factory share one in-memory store, so
+/// multi-shard clone/open round-trips exercise the same shared-root path
+/// semantics as a real object store (GCS/S3).
+fn make_memory_factory() -> Arc<ShardFactory> {
+    let template = DatabaseTemplate {
+        backend: Backend::Memory,
+        path: format!("{}/%shard%", ShardId::new()),
+        ..Default::default()
+    };
+    Arc::new(ShardFactory::new(
+        template,
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
 /// Helper to create a filesystem-backed factory with separate WAL dir
 fn make_fs_factory_with_wal(
     data_tmp: &tempfile::TempDir,
@@ -336,6 +354,206 @@ async fn clone_closed_shard_with_split_wal() {
     assert_eq!(
         right_counters.total_jobs, 1,
         "right child should have the parent's job"
+    );
+}
+
+// --- post-clone child verification tests ---
+
+/// A child that opens empty/short of the parent's job count is the
+/// object-store split data-loss signature. The pre-commit verification must
+/// detect it: a child whose whole-shard `total_jobs` differs from the parent's
+/// pre-close count fails verification so the split can abort before the
+/// shard-map commit.
+#[silo::test]
+async fn verify_cloned_children_detects_short_child() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("only-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    let parent_total = parent
+        .get_counters()
+        .await
+        .expect("parent counters")
+        .total_jobs;
+    assert_eq!(parent_total, 1);
+    parent.close().await.expect("close parent");
+
+    // A never-cloned child opens as an empty database -- total_jobs 0 -- the
+    // empty-child symptom of a misplaced clone. It must not match a parent
+    // that held one job.
+    let empty_child = ShardId::new();
+    let result = factory
+        .verify_cloned_children_match_parent(parent_total, &[empty_child])
+        .await;
+    assert!(
+        result.is_err(),
+        "an empty child must fail verification against a non-empty parent"
+    );
+}
+
+/// A successful clone -- each child a full copy of the parent -- must pass
+/// verification (no false positives), and the raw verification opens must not
+/// register the children in the factory's instance map. If they did, the
+/// post-commit `open(child)` would return the stale pre-commit handle.
+#[silo::test]
+async fn verify_cloned_children_accepts_full_clone_without_caching() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("only-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    let parent_total = parent
+        .get_counters()
+        .await
+        .expect("parent counters")
+        .total_jobs;
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard");
+
+    factory
+        .verify_cloned_children_match_parent(parent_total, &[left_child_id, right_child_id])
+        .await
+        .expect("full clones should pass verification");
+
+    // The raw verification open must leave no factory instance behind.
+    assert!(
+        !factory.owns_shard(&left_child_id),
+        "verification must not cache the left child in the instances map"
+    );
+    assert!(
+        !factory.owns_shard(&right_child_id),
+        "verification must not cache the right child in the instances map"
+    );
+    assert!(factory.get(&left_child_id).is_none());
+    assert!(factory.get(&right_child_id).is_none());
+
+    // The post-clone `open` returns a child that actually holds the parent's
+    // data (not a stale pre-commit handle).
+    let left_child = factory
+        .open(&left_child_id, &ShardRange::full())
+        .await
+        .expect("open left child after verification");
+    assert_eq!(
+        left_child
+            .get_counters()
+            .await
+            .expect("left counters")
+            .total_jobs,
+        parent_total,
+    );
+}
+
+/// When verification fails, the split aborts before touching the parent: the
+/// parent's data is untouched and the parent reopens with its full job set.
+/// (In the split state machine this maps to `PreCommitParentClosed`, which
+/// abandons the split and recovers the parent.)
+#[silo::test]
+async fn parent_reopens_intact_after_verification_mismatch() {
+    let factory = make_memory_factory();
+    let parent_id = ShardId::new();
+    let left_child_id = ShardId::new();
+    let right_child_id = ShardId::new();
+
+    let parent = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("open parent");
+    parent
+        .enqueue(
+            "test-tenant",
+            Some("survivor-job".to_string()),
+            5,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue to parent");
+    parent.close().await.expect("close parent");
+
+    factory
+        .clone_closed_shard(&parent_id, &left_child_id, &right_child_id)
+        .await
+        .expect("clone closed shard");
+
+    // Inject a mismatch by claiming the parent held more jobs than it did.
+    let result = factory
+        .verify_cloned_children_match_parent(99, &[left_child_id, right_child_id])
+        .await;
+    assert!(
+        result.is_err(),
+        "inflated parent count must fail verification"
+    );
+
+    // Recover the parent the way the split state machine does on a pre-commit
+    // abort: evict the stale closed factory entry, then reopen. The parent's
+    // data is untouched by the failed child verification, so it reopens intact.
+    factory
+        .close(&parent_id)
+        .await
+        .expect("evict stale parent entry");
+    let reopened = factory
+        .open(&parent_id, &ShardRange::full())
+        .await
+        .expect("reopen parent after failed verification");
+    assert_eq!(
+        reopened
+            .get_counters()
+            .await
+            .expect("parent counters")
+            .total_jobs,
+        1,
+        "parent should retain its data after a failed split verification"
+    );
+    assert!(
+        reopened
+            .get_job("test-tenant", "survivor-job")
+            .await
+            .expect("get job from reopened parent")
+            .is_some(),
+        "parent should still contain its job after a failed split verification"
     );
 }
 

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -640,7 +640,7 @@ async fn verify_cloned_children_detects_short_child() {
     // that held one job.
     let empty_child = ShardId::new();
     let result = factory
-        .verify_cloned_children_match_parent(parent_total, &[empty_child])
+        .verify_cloned_children_match_parent(&parent_id, &[empty_child])
         .await;
     assert!(
         result.is_err(),
@@ -690,7 +690,7 @@ async fn verify_cloned_children_accepts_full_clone_without_caching() {
         .expect("clone closed shard");
 
     factory
-        .verify_cloned_children_match_parent(parent_total, &[left_child_id, right_child_id])
+        .verify_cloned_children_match_parent(&parent_id, &[left_child_id, right_child_id])
         .await
         .expect("full clones should pass verification");
 
@@ -758,13 +758,14 @@ async fn parent_reopens_intact_after_verification_mismatch() {
         .await
         .expect("clone closed shard");
 
-    // Inject a mismatch by claiming the parent held more jobs than it did.
+    // Force a mismatch by verifying a child that was never cloned: it opens
+    // empty and cannot match the parent's job count.
     let result = factory
-        .verify_cloned_children_match_parent(99, &[left_child_id, right_child_id])
+        .verify_cloned_children_match_parent(&parent_id, &[ShardId::new()])
         .await;
     assert!(
         result.is_err(),
-        "inflated parent count must fail verification"
+        "a never-cloned child must fail verification"
     );
 
     // Recover the parent the way the split state machine does on a pre-commit
@@ -831,6 +832,27 @@ fn url_template_resolves_shared_root_and_double_nested_db_path() {
             .expect("layout for s3 template");
     assert_eq!(root, "s3://test-bucket/prefix");
     assert_eq!(db_path, "abc/prefix/abc");
+}
+
+/// URL-style templates must put the shard placeholder at a `/` boundary:
+/// off-boundary placeholders would resolve to different absolute keys than
+/// the per-shard resolution the deployed data was written under, silently
+/// moving every shard's data. Memory templates stay unrestricted — they are
+/// test sentinels with no deployed data.
+#[silo::test]
+fn url_template_with_non_boundary_placeholder_is_rejected() {
+    let result =
+        ShardFactory::object_store_layout(&Backend::Gcs, "gs://test-bucket/silo-%shard%", "abc");
+    assert!(
+        result.is_err(),
+        "off-boundary placeholder must be rejected for URL-style backends"
+    );
+
+    let (root, db_path) =
+        ShardFactory::object_store_layout(&Backend::Memory, "mem-0/shard-%shard%", "abc")
+            .expect("memory templates stay unrestricted");
+    assert_eq!(root, "mem-0/shard-");
+    assert_eq!(db_path, "abc/mem-0/shard-abc");
 }
 
 /// A template without a shard placeholder (test sentinels, the noop factory)

--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -1041,9 +1041,11 @@ async fn grpc_server_reset_shards_clears_memory_backend_data() -> anyhow::Result
     let _guard = tokio::time::timeout(std::time::Duration::from_secs(10), async {
         let test_shard_id = crate::grpc_integration_helpers::TEST_SHARD_ID;
 
-        // Use Memory backend to exercise the object store deletion path
+        // Use Memory backend to exercise the object store deletion path. The
+        // root is unique because Memory stores are shared per root
+        // process-wide and this test uses a fixed shard ID.
         let template = DatabaseTemplate {
-            path: "test-memory-%shard%".to_string(),
+            path: format!("test-memory-{}/%shard%", silo::shard_range::ShardId::new()),
             ..Default::default()
         };
         let rate_limiter = MockGubernatorClient::new_arc();

--- a/tests/none_coordinator_tests.rs
+++ b/tests/none_coordinator_tests.rs
@@ -5,11 +5,15 @@ use silo::coordination::{Coordinator, NoneCoordinator};
 use silo::factory::ShardFactory;
 use silo::gubernator::MockGubernatorClient;
 use silo::settings::DatabaseTemplate;
+use silo::shard_range::ShardId;
 
 fn make_test_factory() -> Arc<ShardFactory> {
     Arc::new(ShardFactory::new(
         DatabaseTemplate {
-            path: "unused".to_string(),
+            // Memory stores are shared per root, and NoneCoordinator opens
+            // every shard at startup — each factory needs its own root and a
+            // per-shard path so shards don't collide in one database.
+            path: format!("none-coord-{}/%shard%", ShardId::new()),
             ..Default::default()
         },
         MockGubernatorClient::new_arc(),

--- a/tests/turmoil_runner/helpers.rs
+++ b/tests/turmoil_runner/helpers.rs
@@ -319,8 +319,9 @@ pub async fn setup_server(port: u16) -> turmoil::Result<()> {
             // The Memory backend shares stores per root process-wide, and every
             // server here opens the same fixed TEST_SHARD_ID — so each server
             // instance gets its own root, keeping hosts (and repeated sims in
-            // one process) isolated from each other's storage. A deterministic
-            // counter, not a UUID, so DST runs stay reproducible.
+            // one process) isolated from each other's storage. A counter, not
+            // a UUID, so the root never depends on OS randomness; the value
+            // only namespaces storage.
             path: {
                 static NEXT_STORAGE_ROOT: std::sync::atomic::AtomicU64 =
                     std::sync::atomic::AtomicU64::new(0);

--- a/tests/turmoil_runner/helpers.rs
+++ b/tests/turmoil_runner/helpers.rs
@@ -316,7 +316,17 @@ pub async fn setup_server(port: u16) -> turmoil::Result<()> {
         logging: LoggingConfig::default(),
         metrics: silo::settings::MetricsConfig::default(),
         database: silo::settings::DatabaseTemplate {
-            path: "mem://shard-{shard}".to_string(),
+            // The Memory backend shares stores per root process-wide, and every
+            // server here opens the same fixed TEST_SHARD_ID — so each server
+            // instance gets its own root, keeping hosts (and repeated sims in
+            // one process) isolated from each other's storage. A deterministic
+            // counter, not a UUID, so DST runs stay reproducible.
+            path: {
+                static NEXT_STORAGE_ROOT: std::sync::atomic::AtomicU64 =
+                    std::sync::atomic::AtomicU64::new(0);
+                let n = NEXT_STORAGE_ROOT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                format!("mem-{n}/shard-{{shard}}")
+            },
             slatedb: Some(dst_slatedb_settings()),
             ..Default::default()
         },


### PR DESCRIPTION
Splitting a shard on an object-store backend (GCS in staging/production) silently loses the shard's data: `clone_closed_shard` resolved each shard's store at its own expanded template path, so child clones landed under the parent's per-shard prefix instead of the children's own canonical paths, and the children opened empty after the shard-map commit. A staging split dropped a tenant from roughly 8M jobs to 3 this way. An earlier fix (#377, reverted in #380) made clone destinations equal open paths but moved every existing shard's canonical keys, so deploying it wiped staging a second way.

This PR makes clone destinations equal open paths while keeping every deployed shard's absolute object keys byte-for-byte unchanged, so it deploys with no migration:

- `resolve_at_root`'s object-store branch resolves one shared store at the template root (the prefix before the `%shard%`/`{shard}` placeholder) and computes a layout-preserving database path: the expanded template relative to the root plus the expanded template's store-path component. For the deployed `gs://<bucket>/silo/%shard%` template this reproduces the existing double-nested keys `silo/<shard>/silo/<shard>/...` exactly, while parent and children now share one store -- so the existing clone code becomes correct by construction. Off-boundary placeholders on URL-style backends are rejected loudly instead of silently resolving to different keys.
- The Memory backend shares one in-memory store per root via a process-wide registry and uses the same path arithmetic, so in-memory tests exercise the production key layout. Tests that relied on fresh stores per resolution get unique roots.
- The split state machine verifies both children between clone completion and the shard-map commit: each child's whole-shard job count (an O(1) merged-counter read via a raw, uncached open) must equal the closed parent's, read the same way so the comparison cannot drift against background cleanup. A mismatch aborts the split through the existing parent-recovery path. The markers `cloning complete, verifying children before commit`, `children verified, updating shard map`, and `post-clone child verification failed` are shared constants asserted by tests and intended as runtime probes for deployment verification.
- A debug-build-only fault seam on the factory can skip one child's clone, letting a coordination-level test drive the full abort path (verification fails, shard map untouched, parent recovered and serving). A debug-only armable log-capture layer in `silo::trace` backs the marker assertions.

Regression coverage pins the mechanism itself: the clone round-trip test fails with an empty child if the shared-root arithmetic is reverted to per-shard resolution (verified once during development), and a coordination-level split on the shared-store Memory backend asserts every tenant's jobs survive in the owning child. The standalone compactor keeps reading the same absolute keys, so a lagging compactor image stays compatible.

Related to #377 and #380.