### PR TITLE
Delete scheduled jobs in one DeleteJob call

### DIFF
--- a/src/job_store_shard/cancel.rs
+++ b/src/job_store_shard/cancel.rs
@@ -161,127 +161,12 @@ impl JobStoreShard {
             let job_key = job_info_key(tenant, id);
             if let Some(job_bytes) = try_after_status!(txn.get(&job_key).await) {
                 let job_view = try_after_status!(JobView::new(job_bytes));
-                let task_group = job_view.task_group().to_string();
-                let priority = job_view.priority();
-                let limits = job_view.limits();
-
-                // Locate the pending task by identity (the trailing epoch_ms is
-                // write-only, so we prefix-scan instead of reconstructing the
-                // exact key).
-                let attempt_number = status.current_attempt.unwrap_or(1);
-                let start_time_ms = status.next_attempt_starts_after_ms.unwrap_or(0);
-                let task_found = match try_after_status!(
-                    find_task_by_identity(
-                        &txn,
-                        &task_group,
-                        start_time_ms,
-                        priority,
-                        id,
-                        attempt_number
-                    )
-                    .await
-                ) {
-                    Some(found) => Some(found),
-                    None => {
-                        // Fallback: try with time=0 (immediate scheduling case)
-                        try_after_status!(
-                            find_task_by_identity(
-                                &txn,
-                                &task_group,
-                                0,
-                                priority,
-                                id,
-                                attempt_number
-                            )
-                            .await
-                        )
-                    }
-                };
-
-                if let Some((found_key, task_raw)) = task_found {
-                    let decoded = try_after_status!(decode_task(&task_raw).map_err(|e| {
-                        JobStoreShardError::Codec(format!("cancel task decode: {e}"))
-                    }));
-
-                    // Delete the task from the DB queue
-                    try_after_status!(txn.delete(&found_key));
-                    deleted_task_key = Some(found_key);
-
-                    match decoded {
-                        Task::RunAttempt {
-                            id: tid,
-                            held_queues,
-                            ..
-                        } => {
-                            // Delete concurrency holders for each held queue
-                            for queue in held_queues {
-                                try_after_status!(
-                                    txn.delete(concurrency_holder_key(tenant, &queue, &tid))
-                                );
-                                holders_to_release.push((tid.clone(), queue));
-                            }
-                        }
-                        Task::RequestTicket {
-                            task_id: tid,
-                            held_queues,
-                            ..
-                        } => {
-                            // FutureRequestTaskWritten case: the RequestTicket
-                            // task is the pending request mechanism. Deleting
-                            // it stops the request. But a multi-limit chain
-                            // can reach this state with prior holders already
-                            // granted (carried on the ticket's `held_queues`);
-                            // those must be released or the slots leak.
-                            for queue in held_queues {
-                                try_after_status!(
-                                    txn.delete(concurrency_holder_key(tenant, &queue, &tid))
-                                );
-                                holders_to_release.push((tid.clone(), queue));
-                            }
-                        }
-                        Task::CheckRateLimit {
-                            task_id: tid,
-                            held_queues,
-                            ..
-                        } => {
-                            // A chain parked on a rate-limit step can carry
-                            // upstream concurrency grants on its
-                            // `held_queues`. Deleting the task stops the
-                            // chain, but the holders must be released too or
-                            // those slots leak.
-                            for queue in held_queues {
-                                try_after_status!(
-                                    txn.delete(concurrency_holder_key(tenant, &queue, &tid))
-                                );
-                                holders_to_release.push((tid.clone(), queue));
-                            }
-                        }
-                        _ => {
-                            // Other task types (RefreshFloatingLimit, etc.)
-                            // carry no chain-accumulated holders; deleting
-                            // the task key above is sufficient.
-                        }
-                    }
-                } else {
-                    // No task found - check for TicketRequested case (request record
-                    // exists but no task in DB queue). Scan for requests for this job.
-                    // A deferred concurrency request can carry `held_queues` from
-                    // upstream chain steps; those holders must be released too,
-                    // mirroring the future-RequestTicket path above.
-                    let released = self
-                        .delete_concurrency_requests_for_job(
-                            &txn,
-                            tenant,
-                            id,
-                            &limits,
-                            attempt_number,
-                            start_time_ms,
-                            priority,
-                        )
-                        .await;
-                    let released = try_after_status!(released);
-                    holders_to_release.extend(released);
-                }
+                let (task_key, released) = try_after_status!(
+                    self.remove_scheduled_job_execution_state(&txn, tenant, id, &status, &job_view)
+                        .await
+                );
+                deleted_task_key = task_key;
+                holders_to_release.extend(released);
             }
         }
         // For Running jobs, status stays Running - worker discovers on heartbeat.
@@ -338,6 +223,104 @@ impl JobStoreShard {
         }
 
         Ok(())
+    }
+
+    /// Remove a Scheduled job's pending execution state inside `txn`: locate
+    /// the pending task by identity (the trailing epoch_ms is write-only, so
+    /// this prefix-scans, with the time-0 fallback for immediate scheduling)
+    /// and delete it together with any chain-accumulated concurrency holders
+    /// on its `held_queues` — a multi-limit chain can park on a RequestTicket
+    /// or CheckRateLimit step with prior grants already held, and those slots
+    /// leak unless dropped with the task. When no task exists (TicketRequested
+    /// case), the job's concurrency request records are deleted and the
+    /// requester counters decremented instead.
+    ///
+    /// Shared by cancellation and scheduled-job deletion so the two paths
+    /// cannot silently diverge. Returns the deleted task key (for post-commit
+    /// broker-buffer eviction) and the `(task_id, queue)` holder pairs the
+    /// caller must release post-commit.
+    pub(crate) async fn remove_scheduled_job_execution_state(
+        &self,
+        txn: &crate::instrumented_db::InstrumentedDbTransaction,
+        tenant: &str,
+        id: &str,
+        status: &JobStatus,
+        job_view: &JobView,
+    ) -> Result<(Option<Vec<u8>>, Vec<(String, String)>), JobStoreShardError> {
+        let task_group = job_view.task_group().to_string();
+        let priority = job_view.priority();
+        let limits = job_view.limits();
+        let attempt_number = status.current_attempt.unwrap_or(1);
+        let start_time_ms = status.next_attempt_starts_after_ms.unwrap_or(0);
+
+        let mut holders_to_release: Vec<(String, String)> = Vec::new();
+        let mut deleted_task_key: Option<Vec<u8>> = None;
+
+        let task_found = match find_task_by_identity(
+            txn,
+            &task_group,
+            start_time_ms,
+            priority,
+            id,
+            attempt_number,
+        )
+        .await?
+        {
+            Some(found) => Some(found),
+            None => {
+                find_task_by_identity(txn, &task_group, 0, priority, id, attempt_number).await?
+            }
+        };
+
+        if let Some((found_key, task_raw)) = task_found {
+            let decoded = decode_task(&task_raw)
+                .map_err(|e| JobStoreShardError::Codec(format!("scheduled task decode: {e}")))?;
+            txn.delete(&found_key)?;
+            deleted_task_key = Some(found_key);
+
+            match decoded {
+                Task::RunAttempt {
+                    id: tid,
+                    held_queues,
+                    ..
+                }
+                | Task::RequestTicket {
+                    task_id: tid,
+                    held_queues,
+                    ..
+                }
+                | Task::CheckRateLimit {
+                    task_id: tid,
+                    held_queues,
+                    ..
+                } => {
+                    for queue in held_queues {
+                        txn.delete(concurrency_holder_key(tenant, &queue, &tid))?;
+                        holders_to_release.push((tid.clone(), queue));
+                    }
+                }
+                _ => {
+                    // Other task types (RefreshFloatingLimit, etc.) carry no
+                    // chain-accumulated holders; deleting the task key above
+                    // is sufficient.
+                }
+            }
+        } else {
+            let released = self
+                .delete_concurrency_requests_for_job(
+                    txn,
+                    tenant,
+                    id,
+                    &limits,
+                    attempt_number,
+                    start_time_ms,
+                    priority,
+                )
+                .await?;
+            holders_to_release.extend(released);
+        }
+
+        Ok((deleted_task_key, holders_to_release))
     }
 
     /// Delete concurrency request records for a specific job across all its concurrency queues.
@@ -434,7 +417,11 @@ impl JobStoreShard {
             attempt_number,
         );
         let end = end_bound(&prefix);
-        let mut iter = self.db.scan::<Vec<u8>, _>(prefix..end).await?;
+        // Scan through the transaction so the request enumeration reads the
+        // same snapshot as the deletes and joins the SSI read set — a
+        // concurrent grant of one of these requests then conflicts instead of
+        // racing the cleanup.
+        let mut iter = txn.scan::<Vec<u8>, _>(prefix..end).await?;
 
         let mut deleted_count: i64 = 0;
         while let Some(kv) = iter.next().await? {
@@ -459,7 +446,7 @@ impl JobStoreShard {
                         tracing::warn!(
                             job_id = %job_id,
                             queue = %queue_key,
-                            "cancel: concurrency request has unknown variant; holders (if any) cannot be recovered"
+                            "concurrency request has unknown variant; holders (if any) cannot be recovered"
                         );
                     }
                 }
@@ -468,7 +455,7 @@ impl JobStoreShard {
                         job_id = %job_id,
                         queue = %queue_key,
                         error = %e,
-                        "cancel: failed to decode concurrency request; holders (if any) cannot be recovered"
+                        "failed to decode concurrency request; holders (if any) cannot be recovered"
                     );
                 }
             }
@@ -477,7 +464,7 @@ impl JobStoreShard {
             tracing::debug!(
                 job_id = %job_id,
                 queue = %queue_key,
-                "cancel: deleted concurrency request for cancelled job"
+                "deleted concurrency request for job"
             );
         }
 

--- a/src/job_store_shard/delete.rs
+++ b/src/job_store_shard/delete.rs
@@ -2,19 +2,16 @@
 
 use slatedb::IsolationLevel;
 
-use crate::codec::decode_task;
 use crate::job::{JobStatusKind, JobView};
 use crate::job_store_shard::counters::encode_counter;
 use crate::job_store_shard::helpers::{
-    DbWriteBatcher, TxnWriter, WriteBatcher, decode_job_status_owned, find_task_by_identity,
-    retry_on_txn_conflict,
+    DbWriteBatcher, TxnWriter, WriteBatcher, decode_job_status_owned, retry_on_txn_conflict,
 };
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
     idx_metadata_key, idx_status_time_key, job_cancelled_key, job_info_key, job_status_key,
     status_index_timestamp, tenant_status_counter_key,
 };
-use crate::task::Task;
 
 /// Outcome of one transactional scheduled-delete attempt.
 enum ScheduledDeleteRoute {
@@ -49,6 +46,7 @@ impl JobStoreShard {
     /// re-reads the status as its first operation and acts on that value — a
     /// concurrent dequeue can otherwise lease the task between the status
     /// check and the deletes, leaving a live lease pointing at deleted rows.
+    #[tracing::instrument(skip_all, fields(shard = %self.name))]
     pub async fn delete_job(&self, tenant: &str, id: &str) -> Result<(), JobStoreShardError> {
         // The pre-transaction status read only routes; each branch authorizes
         // off its own re-read. The loop handles a status that flips between
@@ -115,91 +113,17 @@ impl JobStoreShard {
             None => None,
         };
 
-        // Track concurrency holders to release post-commit and the deleted
-        // task key for broker-buffer eviction.
-        let mut holders_to_release: Vec<(String, String)> = Vec::new();
-        let mut deleted_task_key: Option<Vec<u8>> = None;
-
-        if let Some(ref view) = job_view {
-            let task_group = view.task_group().to_string();
-            let priority = view.priority();
-            let limits = view.limits();
-            let attempt_number = status.current_attempt.unwrap_or(1);
-            let start_time_ms = status.next_attempt_starts_after_ms.unwrap_or(0);
-
-            // Locate the pending task by identity, with the time-0 fallback
-            // for immediate scheduling.
-            let task_found = match find_task_by_identity(
-                &txn,
-                &task_group,
-                start_time_ms,
-                priority,
-                id,
-                attempt_number,
-            )
-            .await?
-            {
-                Some(found) => Some(found),
-                None => {
-                    find_task_by_identity(&txn, &task_group, 0, priority, id, attempt_number)
-                        .await?
-                }
-            };
-
-            if let Some((found_key, task_raw)) = task_found {
-                let decoded = decode_task(&task_raw)
-                    .map_err(|e| JobStoreShardError::Codec(format!("delete task decode: {e}")))?;
-                txn.delete(&found_key)?;
-                deleted_task_key = Some(found_key);
-
-                // A pending task can carry chain-accumulated concurrency
-                // grants on its `held_queues`; those holders must be dropped
-                // with the task or the slots leak.
-                match decoded {
-                    Task::RunAttempt {
-                        id: tid,
-                        held_queues,
-                        ..
-                    }
-                    | Task::RequestTicket {
-                        task_id: tid,
-                        held_queues,
-                        ..
-                    }
-                    | Task::CheckRateLimit {
-                        task_id: tid,
-                        held_queues,
-                        ..
-                    } => {
-                        for queue in held_queues {
-                            txn.delete(crate::keys::concurrency_holder_key(tenant, &queue, &tid))?;
-                            holders_to_release.push((tid.clone(), queue));
-                        }
-                    }
-                    _ => {
-                        // Other task types carry no chain-accumulated
-                        // holders; deleting the task key is sufficient.
-                    }
-                }
-            } else {
-                // No task in the queue — TicketRequested case: request
-                // records exist instead. Deleting them also decrements the
-                // per-queue requester counters and recovers any upstream
-                // holders carried on the requests.
-                let released = self
-                    .delete_concurrency_requests_for_job(
-                        &txn,
-                        tenant,
-                        id,
-                        &limits,
-                        attempt_number,
-                        start_time_ms,
-                        priority,
-                    )
-                    .await?;
-                holders_to_release.extend(released);
+        // Pending task, concurrency holders, and request records — shared
+        // with the cancel path so the two cleanups cannot silently diverge.
+        // Returns the deleted task key for post-commit broker-buffer eviction
+        // and the holder pairs to release post-commit.
+        let (deleted_task_key, holders_to_release) = match job_view {
+            Some(ref view) => {
+                self.remove_scheduled_job_execution_state(&txn, tenant, id, &status, view)
+                    .await?
             }
-        }
+            None => (None, Vec::new()),
+        };
 
         // Index cleanup. Scheduled rows key the status-time index on the
         // next-attempt timestamp, not changed_at_ms.
@@ -217,6 +141,22 @@ impl JobStoreShard {
         txn.delete(&job_info_key_bytes)?;
         txn.delete(&status_key)?;
         txn.delete(job_cancelled_key(tenant, id))?;
+
+        // Attempt rows from prior attempts (retry case) carry no TTL until
+        // the job reaches a terminal status, which a deleted Scheduled job
+        // never does — sweep them here or they survive forever and resurface
+        // under a re-enqueued job with the same id.
+        let attempt_start = crate::keys::attempt_prefix(tenant, id);
+        let attempt_end = crate::keys::end_bound(&attempt_start);
+        let mut attempt_keys: Vec<Vec<u8>> = Vec::new();
+        let mut iter = txn.scan::<Vec<u8>, _>(attempt_start..attempt_end).await?;
+        while let Some(kv) = iter.next().await? {
+            attempt_keys.push(kv.key.to_vec());
+        }
+        drop(iter);
+        for key in &attempt_keys {
+            txn.delete(key)?;
+        }
 
         // Counter bookkeeping: total-jobs and the (Scheduled) tenant status
         // counter. No completed-jobs decrement — a Scheduled job was never

--- a/src/job_store_shard/delete.rs
+++ b/src/job_store_shard/delete.rs
@@ -1,0 +1,373 @@
+//! Job deletion operations.
+
+use slatedb::IsolationLevel;
+
+use crate::codec::decode_task;
+use crate::job::{JobStatusKind, JobView};
+use crate::job_store_shard::counters::encode_counter;
+use crate::job_store_shard::helpers::{
+    DbWriteBatcher, TxnWriter, WriteBatcher, decode_job_status_owned, find_task_by_identity,
+    retry_on_txn_conflict,
+};
+use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
+use crate::keys::{
+    idx_metadata_key, idx_status_time_key, job_cancelled_key, job_info_key, job_status_key,
+    status_index_timestamp, tenant_status_counter_key,
+};
+use crate::task::Task;
+
+/// Outcome of one transactional scheduled-delete attempt.
+enum ScheduledDeleteRoute {
+    /// The job was Scheduled and has been deleted.
+    Deleted,
+    /// The job no longer exists (idempotent success).
+    Missing,
+    /// The job's in-transaction status was not Scheduled; the caller
+    /// re-routes on a fresh status read.
+    NotScheduled,
+}
+
+/// Outcome of the non-transactional settled-status delete path.
+enum SettledDeleteOutcome {
+    /// The job was terminal or missing and has been deleted (or was already gone).
+    Done,
+    /// The status read showed Scheduled; the caller re-routes to the
+    /// transactional scheduled branch.
+    WasScheduled,
+}
+
+impl JobStoreShard {
+    /// Delete a job by id.
+    ///
+    /// Scheduled and terminal (Succeeded/Failed/Cancelled) jobs are deletable;
+    /// deleting a missing job is an idempotent success. Running jobs are
+    /// refused — cancel them or let them finish first.
+    ///
+    /// A Scheduled job's footprint goes beyond its job rows (pending task,
+    /// possibly concurrency holders/requests, broker-buffer entry), so the
+    /// scheduled branch runs inside a serializable-snapshot transaction that
+    /// re-reads the status as its first operation and acts on that value — a
+    /// concurrent dequeue can otherwise lease the task between the status
+    /// check and the deletes, leaving a live lease pointing at deleted rows.
+    pub async fn delete_job(&self, tenant: &str, id: &str) -> Result<(), JobStoreShardError> {
+        // The pre-transaction status read only routes; each branch authorizes
+        // off its own re-read. The loop handles a status that flips between
+        // the routing read and the branch's authorizing read (e.g. a
+        // Scheduled job dequeued to Running, or a Cancelled job restarted
+        // back to Scheduled).
+        const MAX_ROUTE_ATTEMPTS: usize = 3;
+        for _ in 0..MAX_ROUTE_ATTEMPTS {
+            let status = self.get_job_status(tenant, id).await?;
+            if status
+                .as_ref()
+                .is_some_and(|s| s.kind == JobStatusKind::Scheduled)
+            {
+                let route = retry_on_txn_conflict("delete_scheduled_job", || {
+                    self.delete_scheduled_job_inner(tenant, id)
+                })
+                .await?;
+                match route {
+                    ScheduledDeleteRoute::Deleted | ScheduledDeleteRoute::Missing => {
+                        return Ok(());
+                    }
+                    ScheduledDeleteRoute::NotScheduled => continue,
+                }
+            }
+            match self.delete_settled_job(tenant, id).await? {
+                SettledDeleteOutcome::Done => return Ok(()),
+                SettledDeleteOutcome::WasScheduled => continue,
+            }
+        }
+        Err(JobStoreShardError::TransactionConflict(
+            "delete_job".to_string(),
+        ))
+    }
+
+    /// Delete a Scheduled job inside a serializable-snapshot transaction,
+    /// performing the same cleanup a cancel-then-delete pair produces:
+    /// pending task removal, concurrency holder/request release, requester
+    /// counter decrement, index cleanup, and counter transitions — without an
+    /// intermediate observable Cancelled state.
+    async fn delete_scheduled_job_inner(
+        &self,
+        tenant: &str,
+        id: &str,
+    ) -> Result<ScheduledDeleteRoute, JobStoreShardError> {
+        let txn = self.db.begin(IsolationLevel::SerializableSnapshot).await?;
+
+        // Authorizing read: act only on the in-transaction status. A
+        // transition that committed before this transaction began produces no
+        // read-set conflict, so the outer routing read must never authorize.
+        let status_key = job_status_key(tenant, id);
+        let Some(status_raw) = txn.get(&status_key).await? else {
+            return Ok(ScheduledDeleteRoute::Missing);
+        };
+        let status = decode_job_status_owned(&status_raw)?;
+        if status.kind != JobStatusKind::Scheduled {
+            return Ok(ScheduledDeleteRoute::NotScheduled);
+        }
+
+        // Job info supplies task-key reconstruction fields, metadata indexes,
+        // and gauge metadata.
+        let job_info_key_bytes = job_info_key(tenant, id);
+        let job_view = match txn.get(&job_info_key_bytes).await? {
+            Some(raw) => Some(JobView::new(raw)?),
+            None => None,
+        };
+
+        // Track concurrency holders to release post-commit and the deleted
+        // task key for broker-buffer eviction.
+        let mut holders_to_release: Vec<(String, String)> = Vec::new();
+        let mut deleted_task_key: Option<Vec<u8>> = None;
+
+        if let Some(ref view) = job_view {
+            let task_group = view.task_group().to_string();
+            let priority = view.priority();
+            let limits = view.limits();
+            let attempt_number = status.current_attempt.unwrap_or(1);
+            let start_time_ms = status.next_attempt_starts_after_ms.unwrap_or(0);
+
+            // Locate the pending task by identity, with the time-0 fallback
+            // for immediate scheduling.
+            let task_found = match find_task_by_identity(
+                &txn,
+                &task_group,
+                start_time_ms,
+                priority,
+                id,
+                attempt_number,
+            )
+            .await?
+            {
+                Some(found) => Some(found),
+                None => {
+                    find_task_by_identity(&txn, &task_group, 0, priority, id, attempt_number)
+                        .await?
+                }
+            };
+
+            if let Some((found_key, task_raw)) = task_found {
+                let decoded = decode_task(&task_raw)
+                    .map_err(|e| JobStoreShardError::Codec(format!("delete task decode: {e}")))?;
+                txn.delete(&found_key)?;
+                deleted_task_key = Some(found_key);
+
+                // A pending task can carry chain-accumulated concurrency
+                // grants on its `held_queues`; those holders must be dropped
+                // with the task or the slots leak.
+                match decoded {
+                    Task::RunAttempt {
+                        id: tid,
+                        held_queues,
+                        ..
+                    }
+                    | Task::RequestTicket {
+                        task_id: tid,
+                        held_queues,
+                        ..
+                    }
+                    | Task::CheckRateLimit {
+                        task_id: tid,
+                        held_queues,
+                        ..
+                    } => {
+                        for queue in held_queues {
+                            txn.delete(crate::keys::concurrency_holder_key(tenant, &queue, &tid))?;
+                            holders_to_release.push((tid.clone(), queue));
+                        }
+                    }
+                    _ => {
+                        // Other task types carry no chain-accumulated
+                        // holders; deleting the task key is sufficient.
+                    }
+                }
+            } else {
+                // No task in the queue — TicketRequested case: request
+                // records exist instead. Deleting them also decrements the
+                // per-queue requester counters and recovers any upstream
+                // holders carried on the requests.
+                let released = self
+                    .delete_concurrency_requests_for_job(
+                        &txn,
+                        tenant,
+                        id,
+                        &limits,
+                        attempt_number,
+                        start_time_ms,
+                        priority,
+                    )
+                    .await?;
+                holders_to_release.extend(released);
+            }
+        }
+
+        // Index cleanup. Scheduled rows key the status-time index on the
+        // next-attempt timestamp, not changed_at_ms.
+        txn.delete(idx_status_time_key(
+            tenant,
+            status.kind.as_str(),
+            status_index_timestamp(&status),
+            id,
+        ))?;
+        if let Some(ref view) = job_view {
+            for (mk, mv) in view.metadata().into_iter() {
+                txn.delete(idx_metadata_key(tenant, &mk, &mv, id))?;
+            }
+        }
+        txn.delete(&job_info_key_bytes)?;
+        txn.delete(&status_key)?;
+        txn.delete(job_cancelled_key(tenant, id))?;
+
+        // Counter bookkeeping: total-jobs and the (Scheduled) tenant status
+        // counter. No completed-jobs decrement — a Scheduled job was never
+        // counted completed. Merges via TxnWriter are excluded from conflict
+        // detection.
+        let mut writer = TxnWriter(&txn);
+        self.decrement_total_jobs_counter(&mut writer)?;
+        writer.merge(
+            tenant_status_counter_key(tenant, status.kind.as_str()),
+            encode_counter(-1),
+        )?;
+
+        // In-memory queue gauge: decrement exactly once per deleted job,
+        // rolled back if this commit attempt fails so a conflict retry
+        // doesn't drift the gauge.
+        let gauge_info = job_view
+            .as_ref()
+            .map(|view| (view.task_group().to_string(), view.metadata()));
+        if let Some((task_group, metadata)) = gauge_info.as_ref() {
+            self.apply_background_action_queue_counter_delta(
+                tenant,
+                task_group,
+                JobStatusKind::Scheduled,
+                metadata,
+                -1,
+            );
+        }
+
+        if let Err(e) = txn.commit().await {
+            if let Some((task_group, metadata)) = gauge_info.as_ref() {
+                self.apply_background_action_queue_counter_delta(
+                    tenant,
+                    task_group,
+                    JobStatusKind::Scheduled,
+                    metadata,
+                    1,
+                );
+            }
+            return Err(e.into());
+        }
+
+        // ---- Post-commit: update in-memory state ----
+
+        // Evict the deleted task from the broker buffer
+        if let Some(ref key) = deleted_task_key {
+            self.brokers.evict_keys(std::slice::from_ref(key));
+        }
+
+        // Release concurrency holders from in-memory counts and signal the
+        // grant scanner so freed slots become grantable.
+        for (task_id, queue) in &holders_to_release {
+            self.concurrency
+                .counts()
+                .atomic_release(tenant, queue, task_id);
+            self.concurrency.request_grant(tenant, queue);
+        }
+
+        Ok(ScheduledDeleteRoute::Deleted)
+    }
+
+    /// Delete a terminal-status or missing job. Terminal jobs have no
+    /// dequeuable task, so a plain write batch suffices.
+    async fn delete_settled_job(
+        &self,
+        tenant: &str,
+        id: &str,
+    ) -> Result<SettledDeleteOutcome, JobStoreShardError> {
+        use slatedb::WriteBatch;
+
+        let status = self.get_job_status(tenant, id).await?;
+        if let Some(ref status) = status {
+            match status.kind {
+                JobStatusKind::Scheduled => return Ok(SettledDeleteOutcome::WasScheduled),
+                JobStatusKind::Running => {
+                    return Err(JobStoreShardError::JobInProgress(
+                        id.to_string(),
+                        status.kind,
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        // Check if job even exists (status.is_none() means job doesn't exist)
+        // If job doesn't exist, just return Ok (idempotent delete)
+        let job_info_key_bytes = job_info_key(tenant, id);
+        if status.is_none() && self.db.get(&job_info_key_bytes).await?.is_none() {
+            return Ok(SettledDeleteOutcome::Done);
+        }
+
+        let job_status_key_bytes = job_status_key(tenant, id);
+        let mut batch = WriteBatch::new();
+        // Clean up secondary index entries if present
+        if let Some(ref status) = status {
+            let timek = idx_status_time_key(tenant, status.kind.as_str(), status.changed_at_ms, id);
+            batch.delete(&timek);
+        }
+        // Clean up metadata index entries (load job info to enumerate metadata)
+        let job_metric_info = if let Some(raw) = self.db.get(&job_info_key_bytes).await? {
+            let view = JobView::new(raw)?;
+            for (mk, mv) in view.metadata().into_iter() {
+                let mkey = idx_metadata_key(tenant, &mk, &mv, id);
+                batch.delete(&mkey);
+            }
+            Some((view.task_group().to_string(), view.metadata()))
+        } else {
+            None
+        };
+        batch.delete(&job_info_key_bytes);
+        batch.delete(&job_status_key_bytes);
+        // Also delete cancellation record if present
+        batch.delete(job_cancelled_key(tenant, id));
+
+        // Update counters in the same batch
+        let mut writer = DbWriteBatcher::new(&self.db, &mut batch);
+        self.decrement_total_jobs_counter(&mut writer)?;
+        if let Some(ref status) = status {
+            // Job was in terminal state (we already checked above)
+            self.decrement_completed_jobs_counter(&mut writer)?;
+            // Decrement tenant status counter
+            let counter_key = tenant_status_counter_key(tenant, status.kind.as_str());
+            writer.merge(&counter_key, encode_counter(-1))?;
+        }
+
+        if let (Some(status), Some((task_group, metadata))) =
+            (status.as_ref(), job_metric_info.as_ref())
+        {
+            self.apply_background_action_queue_counter_transition(
+                tenant,
+                task_group,
+                Some(status.kind),
+                JobStatusKind::Succeeded,
+                metadata,
+            );
+        }
+
+        if let Err(e) = self.db.write(batch).await {
+            if let (Some(status), Some((task_group, metadata))) =
+                (status.as_ref(), job_metric_info.as_ref())
+            {
+                self.rollback_background_action_queue_counter_transition(
+                    tenant,
+                    task_group,
+                    Some(status.kind),
+                    JobStatusKind::Succeeded,
+                    metadata,
+                );
+            }
+            return Err(e.into());
+        }
+
+        Ok(SettledDeleteOutcome::Done)
+    }
+}

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -2,6 +2,7 @@
 mod cancel;
 mod cleanup;
 pub(crate) mod counters;
+mod delete;
 mod dequeue;
 mod drop_tenant_holders;
 mod enqueue;
@@ -30,8 +31,6 @@ pub use lease_task::JobNotLeaseableError;
 pub use restart::JobNotRestartableError;
 
 pub(crate) use enqueue::{LimitTaskParams, LimitTaskWriteResult};
-use helpers::DbWriteBatcher;
-use helpers::WriteBatcher;
 pub use helpers::now_epoch_ms;
 
 use slatedb_common::metrics::DefaultMetricsRecorder;
@@ -259,8 +258,8 @@ pub enum JobStoreShardError {
     JobAlreadyExists(String),
     #[error("job not found with id {0}")]
     JobNotFound(String),
-    #[error("cannot delete job {0}: job is currently running or has pending requests")]
-    JobInProgress(String),
+    #[error("cannot delete job {0}: job is {1:?}; cancel it or wait for it to finish")]
+    JobInProgress(String, JobStatusKind),
     #[error("job already cancelled with id {0}")]
     JobAlreadyCancelled(String),
     #[error("cannot cancel job {0}: job is already in terminal state {1:?}")]
@@ -1605,100 +1604,6 @@ impl JobStoreShard {
     ) -> Result<Option<JobAttemptView>, JobStoreShardError> {
         let attempts = self.get_job_attempts(tenant, job_id).await?;
         Ok(attempts.into_iter().last())
-    }
-
-    /// Delete a job by id.
-    ///
-    /// Returns an error if the job is currently running (has active leases/holders) or has pending tasks/requests. Jobs must finish or permanently fail before deletion.
-    pub async fn delete_job(&self, tenant: &str, id: &str) -> Result<(), JobStoreShardError> {
-        use crate::keys::idx_metadata_key;
-        use slatedb::WriteBatch;
-
-        // Check if job is running or has pending state
-        let status = self.get_job_status(tenant, id).await?;
-        if let Some(ref status) = status
-            && !status.is_terminal()
-        {
-            return Err(JobStoreShardError::JobInProgress(id.to_string()));
-        }
-
-        // Check if job even exists (status.is_none() means job doesn't exist)
-        // If job doesn't exist, just return Ok (idempotent delete)
-        let job_info_key_bytes = job_info_key(tenant, id);
-        if status.is_none() && self.db.get(&job_info_key_bytes).await?.is_none() {
-            return Ok(());
-        }
-
-        let job_status_key_bytes = job_status_key(tenant, id);
-        let mut batch = WriteBatch::new();
-        // Clean up secondary index entries if present
-        if let Some(ref status) = status {
-            let timek = crate::keys::idx_status_time_key(
-                tenant,
-                status.kind.as_str(),
-                status.changed_at_ms,
-                id,
-            );
-            batch.delete(&timek);
-        }
-        // Clean up metadata index entries (load job info to enumerate metadata)
-        let job_metric_info = if let Some(raw) = self.db.get(&job_info_key_bytes).await? {
-            let view = JobView::new(raw)?;
-            for (mk, mv) in view.metadata().into_iter() {
-                let mkey = idx_metadata_key(tenant, &mk, &mv, id);
-                batch.delete(&mkey);
-            }
-            Some((view.task_group().to_string(), view.metadata()))
-        } else {
-            None
-        };
-        batch.delete(&job_info_key_bytes);
-        batch.delete(&job_status_key_bytes);
-        // Also delete cancellation record if present
-        batch.delete(crate::keys::job_cancelled_key(tenant, id));
-
-        // Update counters in the same batch
-        let mut writer = DbWriteBatcher::new(&self.db, &mut batch);
-        self.decrement_total_jobs_counter(&mut writer)?;
-        if let Some(ref status) = status {
-            // Job was in terminal state (we already checked it's terminal above)
-            self.decrement_completed_jobs_counter(&mut writer)?;
-            // Decrement tenant status counter
-            let counter_key = crate::keys::tenant_status_counter_key(tenant, status.kind.as_str());
-            writer.merge(
-                &counter_key,
-                crate::job_store_shard::counters::encode_counter(-1),
-            )?;
-        }
-
-        if let (Some(status), Some((task_group, metadata))) =
-            (status.as_ref(), job_metric_info.as_ref())
-        {
-            self.apply_background_action_queue_counter_transition(
-                tenant,
-                task_group,
-                Some(status.kind),
-                JobStatusKind::Succeeded,
-                metadata,
-            );
-        }
-
-        if let Err(e) = self.db.write(batch).await {
-            if let (Some(status), Some((task_group, metadata))) =
-                (status.as_ref(), job_metric_info.as_ref())
-            {
-                self.rollback_background_action_queue_counter_transition(
-                    tenant,
-                    task_group,
-                    Some(status.kind),
-                    JobStatusKind::Succeeded,
-                    metadata,
-                );
-            }
-            return Err(e.into());
-        }
-
-        Ok(())
     }
 }
 

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -1607,16 +1607,9 @@ async fn delete_scheduled_job_with_pending_request() {
     let requests_after = count_concurrency_requests(shard.db()).await;
     assert_eq!(requests_after, 0, "pending request record should be gone");
     let requester_counter = shard
-        .db()
-        .get(&silo::keys::concurrency_requester_counter_key("-", &queue))
+        .get_concurrency_requester_count("-", &queue)
         .await
-        .expect("get requester counter")
-        .map(|b| {
-            let mut arr = [0u8; 8];
-            arr.copy_from_slice(&b);
-            i64::from_be_bytes(arr)
-        })
-        .unwrap_or(0);
+        .expect("get requester counter");
     assert_eq!(
         requester_counter, 0,
         "requester counter should be cleaned up"
@@ -1707,12 +1700,20 @@ async fn cannot_delete_job_running_after_queued_request_grant() {
         .await
         .expect("enqueue2");
 
-    // Complete job 1 so job 2 is granted and starts running
+    // Complete job 1 so job 2 is granted and starts running (grants are
+    // signaled to an async scanner, so poll with the file's bounded loop)
     shard
         .report_attempt_outcome(&t1, AttemptOutcome::Success { result: vec![] })
         .await
         .expect("report1");
-    let t2_vec = shard.dequeue("w", "default", 1).await.expect("deq2").tasks;
+    let mut t2_vec = Vec::new();
+    for _ in 0..20 {
+        t2_vec = shard.dequeue("w", "default", 1).await.expect("deq2").tasks;
+        if !t2_vec.is_empty() {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
     assert_eq!(t2_vec.len(), 1);
 
     // Delete while running - refused, and the error names the Running status
@@ -1728,7 +1729,7 @@ async fn cannot_delete_job_running_after_queued_request_grant() {
         other => panic!("expected JobInProgress, got {:?}", other),
     }
 
-    // Complete job 2; delete then succeeds (terminal-state behavior unchanged)
+    // Complete job 2; terminal jobs are deletable
     shard
         .report_attempt_outcome(
             t2_vec[0].attempt().task_id(),
@@ -2541,4 +2542,129 @@ async fn cancel_after_ticket_conversion_cleans_up_request() {
             "no phantom holder after cancelled requester's queue drains"
         );
     });
+}
+
+#[silo::test]
+async fn delete_scheduled_retry_job_cleans_attempts_holders_and_task() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "delete-retry-q".to_string();
+
+    // Retrying job: attempt 1 fails, attempt 2 sits Scheduled far in the
+    // future carrying the concurrency holder on its pending task
+    let job_id = shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            now,
+            Some(silo::retry::RetryPolicy {
+                retry_count: 1,
+                initial_interval_ms: 60_000,
+                max_interval_ms: i64::MAX,
+                randomize_interval: false,
+                backoff_factor: 1.0,
+            }),
+            test_helpers::msgpack_payload(&serde_json::json!({"j": "retry"})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+
+    let t1 = shard.dequeue("w", "default", 1).await.expect("deq").tasks[0]
+        .attempt()
+        .task_id()
+        .to_string();
+    shard
+        .report_attempt_outcome(
+            &t1,
+            AttemptOutcome::Error {
+                error_code: "E".to_string(),
+                error: vec![],
+            },
+        )
+        .await
+        .expect("report err");
+
+    // Job is Scheduled for attempt 2 with a persisted attempt row and a
+    // held concurrency slot on the pending task
+    let status = shard
+        .get_job_status("-", &job_id)
+        .await
+        .expect("get status")
+        .expect("exists");
+    assert_eq!(status.kind, silo::job::JobStatusKind::Scheduled);
+    assert_eq!(status.current_attempt, Some(2));
+    assert_eq!(
+        shard
+            .get_job_attempts("-", &job_id)
+            .await
+            .expect("attempts")
+            .len(),
+        1,
+        "attempt 1 row persisted"
+    );
+    assert_eq!(
+        count_task_keys(shard.db()).await,
+        1,
+        "retry task pending for attempt 2"
+    );
+
+    shard
+        .delete_job("-", &job_id)
+        .await
+        .expect("delete scheduled retry job");
+
+    assert!(
+        shard.get_job("-", &job_id).await.expect("get").is_none(),
+        "job info gone"
+    );
+    assert_eq!(count_task_keys(shard.db()).await, 0, "pending task gone");
+    assert_eq!(
+        count_concurrency_holders(shard.db()).await,
+        0,
+        "held concurrency slot released"
+    );
+    assert_eq!(
+        shard
+            .get_job_attempts("-", &job_id)
+            .await
+            .expect("attempts")
+            .len(),
+        0,
+        "attempt rows deleted with the job"
+    );
+
+    // Freed slot grantable to a fresh job on the same queue
+    let _j2 = shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue2");
+    let mut t2_vec = Vec::new();
+    for _ in 0..20 {
+        t2_vec = shard.dequeue("w", "default", 1).await.expect("deq2").tasks;
+        if !t2_vec.is_empty() {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+    assert_eq!(t2_vec.len(), 1, "slot grantable after delete");
 }

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -1439,7 +1439,7 @@ async fn concurrency_future_request_granted_after_time_passes() {
 }
 
 #[silo::test]
-async fn cannot_delete_job_with_future_request_ticket() {
+async fn delete_scheduled_job_with_future_request_ticket() {
     let (_tmp, shard) = open_temp_shard().await;
     let now = now_ms();
     let future = now + 200;
@@ -1496,34 +1496,58 @@ async fn cannot_delete_job_with_future_request_ticket() {
         .expect("exists");
     assert_eq!(status.kind, silo::job::JobStatusKind::Scheduled);
 
-    // Attempt to delete job 2 while it's scheduled - should fail
-    let err = shard
+    // Delete job 2 while it's scheduled with a pending RequestTicket task
+    shard
         .delete_job("-", &j2)
         .await
-        .expect_err("delete should fail");
-    match err {
-        silo::job_store_shard::JobStoreShardError::JobInProgress(jid) => {
-            assert_eq!(jid, j2);
-        }
-        other => panic!("expected JobInProgress, got {:?}", other),
-    }
+        .expect("delete scheduled job with request ticket");
 
-    // Job still exists (can't delete while scheduled)
     let job2 = shard.get_job("-", &j2).await.expect("get job2");
-    assert!(
-        job2.is_some(),
-        "job 2 should still exist (can't delete while scheduled)"
-    );
+    assert!(job2.is_none(), "job 2 should be deleted");
+    let tasks_after = count_task_keys(shard.db()).await;
+    assert_eq!(tasks_after, 0, "RequestTicket task should be gone");
 
-    // Complete job 1, which will eventually allow job 2 to run
+    // Complete job 1 to free the slot, then verify the queue still grants
+    // to a fresh job (the deleted job leaked nothing)
     shard
         .report_attempt_outcome(&t1, AttemptOutcome::Success { result: vec![] })
         .await
         .expect("report1");
+
+    let _j3 = shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 3})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue3");
+    let mut t3_vec = Vec::new();
+    for _ in 0..20 {
+        t3_vec = shard.dequeue("w", "default", 1).await.expect("deq3").tasks;
+        if !t3_vec.is_empty() {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        t3_vec.len(),
+        1,
+        "queue slot should be grantable to a fresh job after the scheduled job was deleted"
+    );
 }
 
 #[silo::test]
-async fn cannot_delete_job_with_pending_request() {
+async fn delete_scheduled_job_with_pending_request() {
     let (_tmp, shard) = open_temp_shard().await;
     let now = now_ms();
     let queue = "delete-request-q".to_string();
@@ -1572,48 +1596,139 @@ async fn cannot_delete_job_with_pending_request() {
     let requests = count_concurrency_requests(shard.db()).await;
     assert_eq!(requests, 1, "should have 1 queued request");
 
-    // Attempt to delete job 2 while it's scheduled (has pending request) - should fail
-    let err = shard
+    // Delete job 2 while it's scheduled with a pending concurrency request
+    shard
         .delete_job("-", &j2)
         .await
-        .expect_err("delete should fail");
-    match err {
-        silo::job_store_shard::JobStoreShardError::JobInProgress(jid) => {
-            assert_eq!(jid, j2);
-        }
-        other => panic!("expected JobInProgress, got {:?}", other),
-    }
+        .expect("delete scheduled job with pending request");
 
-    // Job 2 should still exist
     let job2 = shard.get_job("-", &j2).await.expect("get job2");
-    assert!(
-        job2.is_some(),
-        "job 2 should still exist (can't delete while scheduled)"
+    assert!(job2.is_none(), "job 2 should be deleted");
+    let requests_after = count_concurrency_requests(shard.db()).await;
+    assert_eq!(requests_after, 0, "pending request record should be gone");
+    let requester_counter = shard
+        .db()
+        .get(&silo::keys::concurrency_requester_counter_key("-", &queue))
+        .await
+        .expect("get requester counter")
+        .map(|b| {
+            let mut arr = [0u8; 8];
+            arr.copy_from_slice(&b);
+            i64::from_be_bytes(arr)
+        })
+        .unwrap_or(0);
+    assert_eq!(
+        requester_counter, 0,
+        "requester counter should be cleaned up"
     );
 
-    // Complete job 1 to allow job 2 to run
+    // Complete job 1 to free the slot, then verify a fresh job on the same
+    // queue is granted (nothing leaked to the deleted request)
     shard
         .report_attempt_outcome(&t1, AttemptOutcome::Success { result: vec![] })
         .await
         .expect("report1");
 
-    // Job 2 should now be granted
+    let _j3 = shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 3})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue3");
+    let mut t3_vec = Vec::new();
+    for _ in 0..20 {
+        t3_vec = shard.dequeue("w", "default", 1).await.expect("deq3").tasks;
+        if !t3_vec.is_empty() {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        t3_vec.len(),
+        1,
+        "queue slot should be grantable to a fresh job after the scheduled job was deleted"
+    );
+}
+
+#[silo::test]
+async fn cannot_delete_job_running_after_queued_request_grant() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    let queue = "delete-running-q".to_string();
+
+    // Job 1 takes the slot
+    let _j1 = shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue1");
+    let t1_vec = shard.dequeue("w", "default", 1).await.expect("deq1").tasks;
+    let t1 = t1_vec[0].attempt().task_id().to_string();
+
+    // Job 2 queued as request behind job 1
+    let j2 = shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            now,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![Limit::Concurrency(ConcurrencyLimit {
+                key: queue.clone(),
+                max_concurrency: 1,
+            })],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue2");
+
+    // Complete job 1 so job 2 is granted and starts running
+    shard
+        .report_attempt_outcome(&t1, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report1");
     let t2_vec = shard.dequeue("w", "default", 1).await.expect("deq2").tasks;
     assert_eq!(t2_vec.len(), 1);
 
-    // Attempt to delete while running - should still fail
-    let err2 = shard
+    // Delete while running - refused, and the error names the Running status
+    let err = shard
         .delete_job("-", &j2)
         .await
         .expect_err("delete should fail while running");
-    match err2 {
-        silo::job_store_shard::JobStoreShardError::JobInProgress(jid) => {
-            assert_eq!(jid, j2);
+    match &err {
+        silo::job_store_shard::JobStoreShardError::JobInProgress(jid, status) => {
+            assert_eq!(jid, &j2);
+            assert_eq!(*status, silo::job::JobStatusKind::Running);
         }
         other => panic!("expected JobInProgress, got {:?}", other),
     }
 
-    // Complete job 2
+    // Complete job 2; delete then succeeds (terminal-state behavior unchanged)
     shard
         .report_attempt_outcome(
             t2_vec[0].attempt().task_id(),
@@ -1621,14 +1736,10 @@ async fn cannot_delete_job_with_pending_request() {
         )
         .await
         .expect("report2");
-
-    // Now delete should succeed (job is in Succeeded state)
     shard
         .delete_job("-", &j2)
         .await
         .expect("delete should succeed now");
-
-    // Job should be gone
     let job2_final = shard.get_job("-", &j2).await.expect("get job2");
     assert!(job2_final.is_none(), "job 2 should be deleted");
 }

--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -1642,7 +1642,7 @@ async fn grpc_worker_rpcs_require_tenant_when_tenancy_enabled() -> anyhow::Resul
 /// When tenancy is disabled, worker RPCs should work without tenant_id.
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_worker_rpcs_skip_tenant_validation_when_tenancy_disabled() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
+    tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let mut cfg = AppConfig::load(None).unwrap();
         cfg.tenancy.enabled = false;
@@ -1726,7 +1726,7 @@ async fn grpc_worker_rpcs_skip_tenant_validation_when_tenancy_disabled() -> anyh
 /// When tenancy is enabled, worker RPCs should accept valid tenant_id and succeed.
 #[silo::test(flavor = "multi_thread")]
 async fn grpc_worker_rpcs_accept_valid_tenant_when_tenancy_enabled() -> anyhow::Result<()> {
-    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
+    tokio::time::timeout(std::time::Duration::from_millis(10000), async {
         let (factory, _tmp) = create_test_factory().await?;
         let mut cfg = AppConfig::load(None).unwrap();
         cfg.tenancy.enabled = true;
@@ -1802,6 +1802,131 @@ async fn grpc_worker_rpcs_accept_valid_tenant_when_tenancy_enabled() -> anyhow::
             res.is_ok(),
             "report_outcome should succeed with valid tenant_id: {:?}",
             res.err()
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// A future-dated scheduled job deletes with a single DeleteJob RPC and a
+/// follow-up GetJob returns NotFound.
+#[silo::test(flavor = "multi_thread")]
+async fn grpc_delete_job_deletes_scheduled_job_in_one_call() -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_millis(10000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let test_shard_id = crate::grpc_integration_helpers::TEST_SHARD_ID.to_string();
+        let future_ms = silo::job_store_shard::now_epoch_ms() + 60_000;
+
+        let enq = client
+            .enqueue(EnqueueRequest {
+                shard: test_shard_id.clone(),
+                id: "scheduled-purge-target".to_string(),
+                priority: 5,
+                start_at_ms: future_ms,
+                retry_policy: None,
+                payload: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({"seed": true})).unwrap(),
+                    )),
+                }),
+                limits: vec![],
+                tenant: None,
+                metadata: std::collections::HashMap::new(),
+                task_group: "default".to_string(),
+            })
+            .await?
+            .into_inner();
+
+        // One DeleteJob RPC, no cancel first
+        client
+            .delete_job(DeleteJobRequest {
+                shard: test_shard_id.clone(),
+                id: enq.id.clone(),
+                tenant: None,
+            })
+            .await?;
+
+        let err = client
+            .get_job(GetJobRequest {
+                shard: test_shard_id.clone(),
+                id: enq.id.clone(),
+                tenant: None,
+                include_attempts: false,
+            })
+            .await
+            .expect_err("job should be gone");
+        assert_eq!(err.code(), tonic::Code::NotFound);
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// DeleteJob on a running job returns an error whose message names the
+/// Running status.
+#[silo::test(flavor = "multi_thread")]
+async fn grpc_delete_job_refusal_names_running_status() -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_millis(10000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let test_shard_id = crate::grpc_integration_helpers::TEST_SHARD_ID.to_string();
+
+        let enq = client
+            .enqueue(EnqueueRequest {
+                shard: test_shard_id.clone(),
+                id: "running-delete-target".to_string(),
+                priority: 5,
+                start_at_ms: 0,
+                retry_policy: None,
+                payload: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({"seed": true})).unwrap(),
+                    )),
+                }),
+                limits: vec![],
+                tenant: None,
+                metadata: std::collections::HashMap::new(),
+                task_group: "default".to_string(),
+            })
+            .await?
+            .into_inner();
+
+        // Lease the task so the job transitions to Running
+        let lease = client
+            .lease_tasks(LeaseTasksRequest {
+                shard: Some(test_shard_id.clone()),
+                worker_id: "w".to_string(),
+                max_tasks: 1,
+                task_group: "default".to_string(),
+            })
+            .await?
+            .into_inner();
+        assert_eq!(lease.tasks.len(), 1);
+
+        let err = client
+            .delete_job(DeleteJobRequest {
+                shard: test_shard_id.clone(),
+                id: enq.id.clone(),
+                tenant: None,
+            })
+            .await
+            .expect_err("delete of a running job should be refused");
+        assert!(
+            err.message().contains("Running"),
+            "refusal should name the Running status, got: {}",
+            err.message()
         );
 
         shutdown_server(shutdown_tx, server).await?;

--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -1864,6 +1864,21 @@ async fn grpc_delete_job_deletes_scheduled_job_in_one_call() -> anyhow::Result<(
             .expect_err("job should be gone");
         assert_eq!(err.code(), tonic::Code::NotFound);
 
+        // The pending task went with the job -- nothing leasable remains
+        let lease = client
+            .lease_tasks(LeaseTasksRequest {
+                shard: Some(test_shard_id.clone()),
+                worker_id: "w".to_string(),
+                max_tasks: 1,
+                task_group: "default".to_string(),
+            })
+            .await?
+            .into_inner();
+        assert!(
+            lease.tasks.is_empty(),
+            "deleted scheduled job must leave no leasable task"
+        );
+
         shutdown_server(shutdown_tx, server).await?;
         Ok::<(), anyhow::Error>(())
     })
@@ -1923,6 +1938,7 @@ async fn grpc_delete_job_refusal_names_running_status() -> anyhow::Result<()> {
             })
             .await
             .expect_err("delete of a running job should be refused");
+        assert_eq!(err.code(), tonic::Code::Internal);
         assert!(
             err.message().contains("Running"),
             "refusal should name the Running status, got: {}",

--- a/tests/job_store_shard_enqueue_tests.rs
+++ b/tests/job_store_shard_enqueue_tests.rs
@@ -374,15 +374,23 @@ async fn cannot_delete_running_job() {
             .tasks;
         let task_id = tasks[0].attempt().task_id().to_string();
 
-        // Attempt to delete while running - should fail
+        // Attempt to delete while running - should fail with an error naming
+        // the job's actual status
         let err = shard
             .delete_job("-", &job_id)
             .await
             .expect_err("delete should fail");
-        match err {
-            JobStoreShardError::JobInProgress(jid) => assert_eq!(jid, job_id),
+        match &err {
+            JobStoreShardError::JobInProgress(jid, status) => {
+                assert_eq!(jid, &job_id);
+                assert_eq!(*status, JobStatusKind::Running);
+            }
             other => panic!("expected JobInProgress, got {:?}", other),
         }
+        assert!(
+            err.to_string().contains("Running"),
+            "refusal message should name the Running status, got: {err}"
+        );
 
         // Complete the job
         shard
@@ -408,18 +416,19 @@ async fn cannot_delete_running_job() {
 }
 
 #[silo::test]
-async fn cannot_delete_scheduled_job() {
+async fn delete_scheduled_job_removes_job_and_pending_task() {
     with_timeout!(20000, {
         let (_tmp, shard) = open_temp_shard().await;
         let payload_bytes = test_helpers::msgpack_payload(&serde_json::json!({"k": "v"}));
         let priority = 10u8;
-        let now = now_ms();
+        // Future-dated so the job stays Scheduled for the whole test
+        let future = now_ms() + 60_000;
         let job_id = shard
             .enqueue(
                 "-",
                 None,
                 priority,
-                now,
+                future,
                 None,
                 payload_bytes,
                 vec![],
@@ -429,46 +438,64 @@ async fn cannot_delete_scheduled_job() {
             .await
             .expect("enqueue");
 
-        // Job is scheduled but not yet dequeued
         let status = shard
             .get_job_status("-", &job_id)
             .await
             .expect("get status")
             .expect("exists");
         assert_eq!(status.kind, JobStatusKind::Scheduled);
+        assert_eq!(
+            count_task_keys(shard.db()).await,
+            1,
+            "pending task row should exist while scheduled"
+        );
 
-        // Attempt to delete - should fail
-        let err = shard
-            .delete_job("-", &job_id)
-            .await
-            .expect_err("delete should fail");
-        match err {
-            JobStoreShardError::JobInProgress(jid) => assert_eq!(jid, job_id),
-            other => panic!("expected JobInProgress, got {:?}", other),
-        }
-
-        // Complete the job first
-        let tasks = shard
-            .dequeue("w", "default", 1)
-            .await
-            .expect("dequeue")
-            .tasks;
-        let task_id = tasks[0].attempt().task_id().to_string();
-        shard
-            .report_attempt_outcome(
-                &task_id,
-                AttemptOutcome::Success {
-                    result: b"ok".to_vec(),
-                },
-            )
-            .await
-            .expect("report ok");
-
-        // Now delete should succeed
+        // A scheduled job deletes in one call
         shard
             .delete_job("-", &job_id)
             .await
-            .expect("delete after completion");
+            .expect("delete scheduled job");
+
+        assert!(
+            shard
+                .get_job("-", &job_id)
+                .await
+                .expect("get_job")
+                .is_none(),
+            "job info should be gone"
+        );
+        assert!(
+            shard
+                .get_job_status("-", &job_id)
+                .await
+                .expect("get status")
+                .is_none(),
+            "job status should be gone"
+        );
+        assert_eq!(
+            count_task_keys(shard.db()).await,
+            0,
+            "pending task row should be gone"
+        );
+        let scheduled_idx = shard
+            .scan_jobs_by_status("-", JobStatusKind::Scheduled, Some(10))
+            .await
+            .expect("scan by status");
+        assert!(
+            !scheduled_idx.contains(&job_id),
+            "status-time index entry should be gone"
+        );
+
+        let counters = shard.get_counters().await.expect("get_counters");
+        assert_eq!(
+            counters.total_jobs, 0,
+            "total jobs counter exact after delete"
+        );
+        assert_eq!(
+            counters.completed_jobs, 0,
+            "completed jobs counter untouched"
+        );
+        assert_eq!(counters.open_jobs(), 0, "open jobs derivation exact");
     });
 }
 

--- a/tests/tenant_status_counter_tests.rs
+++ b/tests/tenant_status_counter_tests.rs
@@ -933,7 +933,7 @@ async fn scheduled_delete_purge_keeps_counters_exact() {
 }
 
 #[silo::test]
-async fn cancel_then_delete_scheduled_job_still_works() {
+async fn cancel_then_delete_scheduled_job_removes_job_and_counters() {
     with_timeout!(20000, {
         let (_tmp, shard) = open_temp_shard().await;
         let tenant = "cancel-delete-tenant";

--- a/tests/tenant_status_counter_tests.rs
+++ b/tests/tenant_status_counter_tests.rs
@@ -821,3 +821,158 @@ async fn counter_scan_can_limit_to_exact_tenant() {
         assert_eq!(entries[0].2, 2);
     });
 }
+
+#[silo::test]
+async fn scheduled_delete_purge_keeps_counters_exact() {
+    with_timeout!(30000, {
+        let (_tmp, shard) = open_temp_shard().await;
+        let tenant = "purge-tenant";
+
+        // Seed 5 future-dated scheduled jobs carrying an explicit queue in
+        // metadata so the background-action queue gauge is exercised too.
+        let future = now_ms() + 60_000;
+        let mut job_ids = vec![];
+        for i in 0..5 {
+            let job_id = shard
+                .enqueue(
+                    tenant,
+                    None,
+                    10u8,
+                    future,
+                    None,
+                    msgpack_payload(&serde_json::json!({"i": i})),
+                    vec![],
+                    Some(vec![("queue".to_string(), "purge-q".to_string())]),
+                    "default",
+                )
+                .await
+                .expect("enqueue");
+            job_ids.push(job_id);
+        }
+
+        let counts = get_status_counts(&shard, tenant).await;
+        assert_eq!(counts.get("Scheduled").copied().unwrap_or(0), 5);
+        let counters = shard.get_counters().await.expect("get_counters");
+        assert_eq!(counters.total_jobs, 5);
+        assert_eq!(counters.completed_jobs, 0);
+        assert_eq!(counters.open_jobs(), 5);
+        let gauges = get_background_action_queue_counts(&shard, tenant).await;
+        let queue_size = gauges
+            .get(&(
+                "default".to_string(),
+                "queue_size".to_string(),
+                "explicit".to_string(),
+                "purge-q".to_string(),
+            ))
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(queue_size, 5, "queue gauge counts the scheduled jobs");
+
+        // Purge in two waves: after the first 3 deletes the gauge must read
+        // exactly 2 — the gauge floors at zero and drops entries, so only a
+        // mid-purge checkpoint can catch a per-delete double-decrement.
+        for job_id in &job_ids[..3] {
+            shard
+                .delete_job(tenant, job_id)
+                .await
+                .expect("delete scheduled job");
+        }
+        let gauges = get_background_action_queue_counts(&shard, tenant).await;
+        let queue_size = gauges
+            .get(&(
+                "default".to_string(),
+                "queue_size".to_string(),
+                "explicit".to_string(),
+                "purge-q".to_string(),
+            ))
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(
+            queue_size, 2,
+            "queue gauge decrements exactly once per deleted job"
+        );
+        let counts = get_status_counts(&shard, tenant).await;
+        assert_eq!(
+            counts.get("Scheduled").copied().unwrap_or(0),
+            2,
+            "tenant Scheduled counter exact mid-purge"
+        );
+
+        for job_id in &job_ids[3..] {
+            shard
+                .delete_job(tenant, job_id)
+                .await
+                .expect("delete scheduled job");
+        }
+
+        let counts = get_status_counts(&shard, tenant).await;
+        assert_eq!(
+            counts.get("Scheduled").copied().unwrap_or(0),
+            0,
+            "tenant Scheduled counter exact after purge: {counts:?}"
+        );
+        let counters = shard.get_counters().await.expect("get_counters");
+        assert_eq!(counters.total_jobs, 0, "total jobs exact after purge");
+        assert_eq!(
+            counters.completed_jobs, 0,
+            "completed jobs untouched by scheduled deletes"
+        );
+        assert_eq!(counters.open_jobs(), 0, "open jobs derivation exact");
+        let gauges = get_background_action_queue_counts(&shard, tenant).await;
+        assert!(
+            gauges.is_empty(),
+            "queue gauge decremented exactly once per deleted job: {gauges:?}"
+        );
+
+        // Every job is gone
+        for job_id in &job_ids {
+            let job = shard.get_job(tenant, job_id).await.expect("get job");
+            assert!(job.is_none(), "job {job_id} should be deleted");
+        }
+    });
+}
+
+#[silo::test]
+async fn cancel_then_delete_scheduled_job_still_works() {
+    with_timeout!(20000, {
+        let (_tmp, shard) = open_temp_shard().await;
+        let tenant = "cancel-delete-tenant";
+
+        let job_id = shard
+            .enqueue(
+                tenant,
+                None,
+                10u8,
+                now_ms() + 60_000,
+                None,
+                msgpack_payload(&serde_json::json!({"k": "v"})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+
+        // Existing operator scripts cancel first, then delete
+        shard.cancel_job(tenant, &job_id).await.expect("cancel");
+        shard.delete_job(tenant, &job_id).await.expect("delete");
+
+        let job = shard.get_job(tenant, &job_id).await.expect("get job");
+        assert!(job.is_none(), "job should be deleted");
+        let counts = get_status_counts(&shard, tenant).await;
+        assert_eq!(
+            counts.get("Scheduled").copied().unwrap_or(0),
+            0,
+            "no Scheduled counter residue"
+        );
+        assert_eq!(
+            counts.get("Cancelled").copied().unwrap_or(0),
+            0,
+            "no Cancelled counter residue"
+        );
+        let counters = shard.get_counters().await.expect("get_counters");
+        assert_eq!(counters.total_jobs, 0);
+        assert_eq!(counters.completed_jobs, 0);
+        assert_eq!(counters.open_jobs(), 0);
+    });
+}


### PR DESCRIPTION
Claude wanted to add this, but I'm guessing this breaks the alloy spec so you can just ignore this PR if you don't want this.

---

Purging scheduled jobs previously required two RPCs per job: `DeleteJob` refused every non-terminal status with `cannot delete job <id>: job is currently running or has pending requests` -- a message that is false for a `Scheduled` job -- so operators had to send a `CancelJob` first to make each job deletable. A staging fixture cleanup that purged 10,000 inert future-dated jobs paid that cost per job, and the misleading error text made the workaround undiscoverable.

`DeleteJob` now deletes `Scheduled` jobs directly. The scheduled branch runs inside the same serializable-snapshot transaction machinery cancellation uses, re-reads the job status as its first in-transaction operation (the pre-transaction read only routes), and performs the full cleanup a cancel-then-delete pair produces: pending task removal (with the time-0 fallback lookup), concurrency holder and request-record release with post-commit slot regrant and broker-buffer eviction, requester-counter decrement, status-time/metadata index cleanup, attempt-row sweep, and counter bookkeeping without the completed-jobs decrement that only terminal jobs carry. The in-memory queue gauge decrements exactly once per deleted job, with rollback on failed commit attempts so conflict retries cannot drift it. That cleanup logic is shared with the cancel path via one helper so the two cannot silently diverge.

`Running` jobs stay refused, and `JobInProgress` now carries the job's status so the error names what the job is actually doing (`job is Running; cancel it or wait for it to finish`). Terminal-status deletes and idempotent missing-job deletes are unchanged. No proto or siloctl changes -- the CLI's single-ID delete works on scheduled jobs as-is.

Review notes: the scheduled-refusal tests are repurposed as positive coverage (the double-duty pending-request test is split so its Running-refusal coverage survives); counter exactness is asserted mid-purge as well as at the end, since the queue gauge floors at zero and only a partial-purge checkpoint can catch a double decrement; gRPC tests pin the one-call delete (GetJob NotFound, no leasable task) and the status-naming refusal end-to-end.