### PR TITLE
Emit silo_leasable_to_start_latency_ms for worker-capacity scaling

### DIFF
--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -47,7 +47,8 @@ Leases represent tasks actively being processed by workers.
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `silo_task_leases_active` | Gauge | `shard`, `task_group` | Number of tasks currently leased to workers |
-| `silo_ready_to_start_latency_ms` | Histogram | `shard`, `task_group` | Time between when a task became ready and when it was first leased (in milliseconds) |
+| `silo_ready_to_start_latency_ms` | Histogram | `shard`, `task_group` | Time between a task's original scheduled start and when it was leased, including any wait for concurrency tickets or rate-limit clearance (in milliseconds) |
+| `silo_leasable_to_start_latency_ms` | Histogram | `shard`, `task_group` | Time a task spent leasable — eligible for a worker to pick up — before it was leased, excluding waits for concurrency tickets or rate-limit clearance (in milliseconds) |
 | `silo_lease_reaper_duration_seconds` | Histogram | `shard` | Duration of expired lease reaper scan operations |
 | `silo_lease_reaper_scans_total` | Counter | `shard` | Total number of expired lease reaper scan operations |
 
@@ -55,7 +56,8 @@ Leases represent tasks actively being processed by workers.
 - `silo_task_leases_active` shows in-flight work at any given moment
 - Sudden drops may indicate worker crashes or network issues
 - Compare against worker count to understand utilization
-- `silo_ready_to_start_latency_ms` measures scheduling delay — high values indicate workers aren't polling fast enough or broker scan intervals are too long. Unlike `silo_job_wait_time_seconds` (which measures total time from enqueue), this metric isolates the time a task sat ready but unleased
+- `silo_ready_to_start_latency_ms` measures overall queue time from a task's original scheduled start to its lease. Silo preserves the original scheduled start through tenant concurrency-limit chains, so a task that waited on concurrency tickets or rate limits reports that wait here — high values can mean worker saturation, but can also mean a tenant is self-throttling behind its own limits
+- `silo_leasable_to_start_latency_ms` measures only the time a task was leasable (all grants held, eligible for pickup) before a worker leased it. Waits for concurrency tickets or rate-limit clearance are excluded, so this metric only grows when workers are the bottleneck — it is the worker-capacity signal, while `silo_ready_to_start_latency_ms` is the customer-perceived queue-time signal
 - `silo_lease_reaper_duration_seconds` tracks how long the expired lease reaper takes to scan all leases per shard. High values indicate a large number of active leases or database pressure, and can contribute to increased CPU usage
 
 ### Broker Metrics

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -14,8 +14,8 @@ use crate::job_store_shard::helpers::{DbWriteBatcher, decode_job_status_owned, n
 use crate::job_store_shard::holder_release_guard::PendingHolderReleaseGuard;
 use crate::job_store_shard::{DequeueResult, JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
-    attempt_key, concurrency_holder_key, job_info_key, job_status_key, leased_task_key,
-    parse_task_key,
+    ParsedTaskKey, attempt_key, concurrency_holder_key, job_info_key, job_status_key,
+    leased_task_key, parse_task_key,
 };
 use crate::shard_range::ShardRange;
 use crate::task::{
@@ -1214,10 +1214,15 @@ impl JobStoreShard {
             task_id.to_string(),
         ));
 
-        // Record ready-to-start latency metric
+        // Record ready-to-start and leasable-to-start latency metrics
         if let (Some(m), Some(parsed)) = (&self.metrics, parse_task_key(task_key)) {
             let latency_ms = (now_ms - parsed.start_time_ms as i64).max(0) as f64;
             m.record_ready_to_start_latency_ms(self.name(), decoded.task_group(), latency_ms);
+            m.record_leasable_to_start_latency_ms(
+                self.name(),
+                decoded.task_group(),
+                leasable_to_start_latency_ms(&parsed, now_ms),
+            );
         }
 
         Ok(())
@@ -1280,6 +1285,21 @@ impl JobStoreShard {
 
         Ok((tasks, keys))
     }
+}
+
+/// Milliseconds a task spent leasable — eligible for a worker to pick up — before
+/// being leased at `now_ms`, clamped to ≥ 0.
+///
+/// The leasable moment is `max(start_time_ms, epoch_ms)`: `start_time_ms` is the
+/// scheduled start (preserved through concurrency-limit chains), and `epoch_ms` is
+/// the write-time disambiguator, so whichever is later is when the task actually
+/// became eligible. This relies on every `RunAttempt` key stamping `epoch_ms` at
+/// write time or later; `CheckRateLimit` keys may carry a back-dated
+/// `parent_epoch_ms + 1` via `rate_limit_retry_epoch_ms`, but those are never
+/// leased as `RunAttempt`.
+fn leasable_to_start_latency_ms(parsed: &ParsedTaskKey, now_ms: i64) -> f64 {
+    let leasable_ms = parsed.start_time_ms.max(parsed.epoch_ms) as i64;
+    (now_ms - leasable_ms).max(0) as f64
 }
 
 #[cfg(test)]
@@ -1382,5 +1402,48 @@ mod claimed_inflight_guard_tests {
             let _guard = ClaimedInflightGuard::new(&brokers, vec![]);
         }
         assert_eq!(brokers.inflight_len(), 0);
+    }
+}
+
+#[cfg(test)]
+mod leasable_latency_tests {
+    //! Unit tests for [`leasable_to_start_latency_ms`], pinning which task-key
+    //! field the leasable moment is measured from for each key shape.
+    use crate::keys::ParsedTaskKey;
+
+    fn parsed_key(start_time_ms: u64, epoch_ms: u64) -> ParsedTaskKey {
+        ParsedTaskKey {
+            task_group: "default".to_string(),
+            start_time_ms,
+            priority: 0,
+            job_id: "job-1".to_string(),
+            attempt: 1,
+            epoch_ms,
+        }
+    }
+
+    /// Concurrency-granted shape: the task was re-emitted after a grant, so its
+    /// write-time `epoch_ms` exceeds the preserved original `start_time_ms`.
+    /// Latency measures from the grant, not the original schedule.
+    #[test]
+    fn epoch_dominant_key_measures_from_epoch() {
+        let parsed = parsed_key(1_000, 5_000);
+        assert_eq!(super::leasable_to_start_latency_ms(&parsed, 5_250), 250.0);
+    }
+
+    /// Future-scheduled shape: a directly-enqueued task whose scheduled start
+    /// is past its write time. Latency measures from the scheduled start.
+    #[test]
+    fn start_time_dominant_key_measures_from_start_time() {
+        let parsed = parsed_key(10_000, 2_000);
+        assert_eq!(super::leasable_to_start_latency_ms(&parsed, 10_100), 100.0);
+    }
+
+    /// A lease can race slightly ahead of the leasable moment (clock skew,
+    /// scheduled start still in the future); latency clamps to zero.
+    #[test]
+    fn latency_clamps_to_zero() {
+        let parsed = parsed_key(10_000, 2_000);
+        assert_eq!(super::leasable_to_start_latency_ms(&parsed, 9_900), 0.0);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -160,6 +160,7 @@ pub struct Metrics {
     // Lease metrics
     task_leases_active: GaugeVec,
     ready_to_start_latency_ms: HistogramVec,
+    leasable_to_start_latency_ms: HistogramVec,
     lease_reaper_duration: HistogramVec,
     lease_reaper_scans_total: CounterVec,
     lease_reaper_leases_reaped_total: CounterVec,
@@ -563,6 +564,21 @@ impl Metrics {
     /// Record the latency between when a task became ready and when it was first leased, in milliseconds.
     pub fn record_ready_to_start_latency_ms(&self, shard: &str, task_group: &str, latency_ms: f64) {
         self.ready_to_start_latency_ms
+            .with_label_values(&[shard, task_group])
+            .observe(latency_ms);
+    }
+
+    /// Record the time a task spent leasable — eligible for a worker to pick up — before it
+    /// was leased, in milliseconds. Excludes time waiting for concurrency tickets or
+    /// rate-limit clearance, so unlike `silo_ready_to_start_latency_ms` it only grows when
+    /// workers are the bottleneck.
+    pub fn record_leasable_to_start_latency_ms(
+        &self,
+        shard: &str,
+        task_group: &str,
+        latency_ms: f64,
+    ) {
+        self.leasable_to_start_latency_ms
             .with_label_values(&[shard, task_group])
             .observe(latency_ms);
     }
@@ -2098,6 +2114,18 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let leasable_to_start_latency_ms = register(
+        &registry,
+        HistogramVec::new(
+            HistogramOpts::new(
+                "silo_leasable_to_start_latency_ms",
+                "Time a task spent leasable (eligible for a worker to pick up) before it was leased, in milliseconds — excludes waits for concurrency tickets or rate-limit clearance",
+            )
+            .buckets(READY_TO_START_LATENCY_MS_BUCKETS.to_vec()),
+            &["shard", "task_group"],
+        )?,
+    );
+
     let lease_reaper_duration = register(
         &registry,
         HistogramVec::new(
@@ -2424,6 +2452,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         poll_duration,
         task_leases_active,
         ready_to_start_latency_ms,
+        leasable_to_start_latency_ms,
         lease_reaper_duration,
         lease_reaper_scans_total,
         lease_reaper_leases_reaped_total,

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -232,6 +232,9 @@ async fn test_metrics_all_recording_methods() {
     // record_ready_to_start_latency_ms
     metrics.record_ready_to_start_latency_ms("0", "default", 42.0);
 
+    // record_leasable_to_start_latency_ms
+    metrics.record_leasable_to_start_latency_ms("0", "default", 17.0);
+
     // record_broker_scan_duration
     metrics.record_broker_scan_duration("0", 0.01);
 
@@ -327,6 +330,12 @@ async fn test_metrics_all_recording_methods() {
     assert!(
         body_str.contains("silo_ready_to_start_latency_ms"),
         "should contain ready-to-start latency metric"
+    );
+
+    // Verify leasable-to-start latency histogram was recorded
+    assert!(
+        body_str.contains("silo_leasable_to_start_latency_ms"),
+        "should contain leasable-to-start latency metric"
     );
 
     // Verify broker scan duration
@@ -765,6 +774,113 @@ async fn test_metrics_ready_to_start_latency() {
         shard1_count.as_ref().map_or(false, |l| l.ends_with(" 1")),
         "should have 1 observation for shard 1 default, found: {:?}",
         shard1_count
+    );
+}
+
+#[silo::test]
+async fn test_metrics_leasable_to_start_latency() {
+    let (metrics, _app) = create_metrics_router();
+
+    // Record latency observations for different shards and task groups
+    metrics.record_leasable_to_start_latency_ms("0", "default", 5.0);
+    metrics.record_leasable_to_start_latency_ms("0", "default", 150.0);
+    metrics.record_leasable_to_start_latency_ms("0", "high-priority", 2.0);
+    metrics.record_leasable_to_start_latency_ms("1", "default", 1000.0);
+
+    // The ready-to-start metric stays registered alongside the new one
+    metrics.record_ready_to_start_latency_ms("0", "default", 7.0);
+
+    let body_str = gather_metrics_text(&metrics);
+
+    // Should contain TYPE and HELP metadata
+    assert!(
+        body_str.contains("# TYPE silo_leasable_to_start_latency_ms histogram"),
+        "should be a histogram type"
+    );
+    assert!(
+        body_str.contains("# HELP silo_leasable_to_start_latency_ms"),
+        "should have a HELP description"
+    );
+
+    let find_line = |substrings: &[&str]| -> Option<String> {
+        body_str
+            .lines()
+            .find(|l| substrings.iter().all(|s| l.contains(s)))
+            .map(|s| s.to_string())
+    };
+
+    // Verify count for shard 0, default task group (2 observations)
+    let count_line = find_line(&[
+        "silo_leasable_to_start_latency_ms_count",
+        "shard=\"0\"",
+        "task_group=\"default\"",
+    ]);
+    assert!(
+        count_line.as_ref().is_some_and(|l| l.ends_with(" 2")),
+        "should have 2 observations for shard 0 default, found: {:?}",
+        count_line
+    );
+
+    // Verify sum for shard 0, default task group (5.0 + 150.0 = 155.0)
+    let sum_line = find_line(&[
+        "silo_leasable_to_start_latency_ms_sum",
+        "shard=\"0\"",
+        "task_group=\"default\"",
+    ]);
+    assert!(
+        sum_line.as_ref().is_some_and(|l| l.ends_with(" 155")),
+        "sum should be 155 for shard 0 default, found: {:?}",
+        sum_line
+    );
+
+    // Verify bucket series exist with labels — the prometheus-adapter's
+    // seriesQuery selects on `_bucket`, so its presence is load-bearing
+    let bucket_line = find_line(&[
+        "silo_leasable_to_start_latency_ms_bucket",
+        "shard=\"0\"",
+        "task_group=\"default\"",
+        "le=\"10\"",
+    ]);
+    assert!(
+        bucket_line.as_ref().is_some_and(|l| l.ends_with(" 1")),
+        "le=10 bucket should hold the 5ms observation for shard 0 default, found: {:?}",
+        bucket_line
+    );
+
+    // Verify count for shard 0, high-priority task group (1 observation)
+    let hp_count_line = find_line(&[
+        "silo_leasable_to_start_latency_ms_count",
+        "shard=\"0\"",
+        "task_group=\"high-priority\"",
+    ]);
+    assert!(
+        hp_count_line.as_ref().is_some_and(|l| l.ends_with(" 1")),
+        "should have 1 observation for shard 0 high-priority, found: {:?}",
+        hp_count_line
+    );
+
+    // Verify shard 1 is tracked separately
+    let shard1_count = find_line(&[
+        "silo_leasable_to_start_latency_ms_count",
+        "shard=\"1\"",
+        "task_group=\"default\"",
+    ]);
+    assert!(
+        shard1_count.as_ref().is_some_and(|l| l.ends_with(" 1")),
+        "should have 1 observation for shard 1 default, found: {:?}",
+        shard1_count
+    );
+
+    // Both metrics are emitted side by side
+    let ready_count = find_line(&[
+        "silo_ready_to_start_latency_ms_count",
+        "shard=\"0\"",
+        "task_group=\"default\"",
+    ]);
+    assert!(
+        ready_count.as_ref().is_some_and(|l| l.ends_with(" 1")),
+        "ready-to-start series should still be emitted, found: {:?}",
+        ready_count
     );
 }
 


### PR DESCRIPTION
## Why

The silo-worker HPAs scale on `silo_ready_to_start_latency_ms`, which measures from a task's original scheduled start -- deliberately preserved through tenant concurrency-limit chains. A tenant with a deep backlog behind a narrow concurrency queue therefore reports hours-long latencies on every lease, and adding workers cannot reduce them: the fleet pins at maxReplicas while worker CPU sits near-idle. That metric is the right customer-perceived queue-time signal, but the wrong capacity signal.

## What

Adds `silo_leasable_to_start_latency_ms`, a histogram (labels `shard`, `task_group`, same bucket layout as the existing metric) measuring only the time a `RunAttempt` task was leasable -- eligible for a worker to pick up -- before it was leased. It records at exactly one site, the `RunAttempt` lease path, next to the existing metric's recording there.

The leasable moment is derived from the existing task key with no encoding change: `max(start_time_ms, epoch_ms)`. For a future-scheduled task the scheduled start dominates; for a task re-emitted after a concurrency grant the write-time epoch (which is approximately the grant time) dominates. This relies on every `RunAttempt` write site stamping `epoch_ms` at write time or later, which holds across all of them; the one back-dating path (`rate_limit_retry_epoch_ms`) writes only `CheckRateLimit` tasks. The computation is a named function with unit tests pinning both key shapes.

`silo_ready_to_start_latency_ms` is untouched: registration, recorder, and both recording sites are byte-identical. Its docs entries are reworded to state what it actually measures (from the original scheduled start, through concurrency waits) so the two adjacent entries do not contradict.

Downstream, the prometheus-adapter gains a rule for the new metric and the silo-worker HPAs switch to it (separate PRs in global-infrastructure and gadget).

## Review notes

- The exposition test asserts `_count`, `_sum`, and `_bucket` -- the adapter's `seriesQuery` selects on `_bucket`, so its presence is load-bearing.
- The unit tests in `dequeue.rs` cover the epoch-dominant (concurrency-granted), start-time-dominant (future-scheduled), and clamp-to-zero shapes.