### PR TITLE
Stream grant scanner commits in chunks to cut leasable latency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,10 @@ required-features = ["server"]
 name = "task_scanner_profile"
 harness = false
 
+[[bench]]
+name = "grant_latency"
+harness = false
+
 [[test]]
 name = "turmoil_runner"
 path = "tests/turmoil_runner/main.rs"

--- a/benches/grant_latency.rs
+++ b/benches/grant_latency.rs
@@ -1,0 +1,698 @@
+//! Per-grant time-to-leasable latency through the concurrency grant scanner
+//! under object-store read latency.
+//!
+//! Models the production shape where a single tenant's gating queue is
+//! saturated: every RunAttempt flows through a deferred concurrency request
+//! that `process_grants` drains, and each chain-resume read pays an
+//! object-store round trip (cold block cache over GCS).
+//!
+//! Cases:
+//! 1. `grant_to_leasable` — free the gate's capacity, run one
+//!    `process_grants(GRANT_COUNT)` invocation while a concurrent dequeuer
+//!    timestamps each granted task as it becomes claimable. The p50/p99 of
+//!    (lease time - invocation start) is the metric the production
+//!    `silo_leasable_to_start_latency_ms` histogram degrades on.
+//! 2. `release_to_lease` — with the grant scanner running, release one holder
+//!    and measure until the next waiter is actually leased. Covers the
+//!    release -> nudge -> grant -> broker-wakeup -> claim pipeline.
+//! 3. Invocation-duration guard — total `process_grants` wall time from
+//!    case 1 must not regress; latency fixes must not trade away throughput.
+//!
+//! Thresholds are asserted at the end of the run; a failing run prints all
+//! measurements first.
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use silo::gubernator::NullGubernatorClient;
+use silo::job::{ConcurrencyLimit, FloatingConcurrencyLimit, Limit};
+use silo::job_attempt::AttemptOutcome;
+use silo::job_store_shard::{JobStoreShard, OpenShardOptions};
+use silo::shard_range::ShardRange;
+use slatedb::object_store::path::Path as ObjPath;
+use slatedb::object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as ObjectStoreResult,
+};
+use std::ops::Range;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+// ---------------------------------------------------------------------------
+// Workload shape
+// ---------------------------------------------------------------------------
+
+/// Injected latency per object-store GET, approximating production GCS reads
+/// (observed p50 ~23ms).
+const GET_LATENCY: Duration = Duration::from_millis(20);
+
+/// Gate queue capacity == grants per invocation. Production hot-queue
+/// invocations grant ~18-75 tasks each.
+const GRANT_COUNT: usize = 64;
+
+/// Pending deferred requests behind the gate.
+const WAITER_COUNT: usize = 512;
+
+/// Releases measured in the release->lease case.
+const RELEASE_ITERS: usize = 20;
+
+/// Capacity of the small queue used by the release->lease case.
+const SMALL_CAPACITY: usize = 8;
+const SMALL_WAITERS: usize = 128;
+
+const TENANT: &str = "bench-tenant";
+const TASK_GROUP: &str = "grant-bench";
+
+// ---------------------------------------------------------------------------
+// Targets (asserted). Baseline recorded before the fix:
+//   case 1: p50 ≈ full invocation duration (~GRANT_COUNT serial GETs)
+//   case 2: p50 ≈ fixed pipeline overhead
+// ---------------------------------------------------------------------------
+
+const CASE1_P50_TARGET: Duration = Duration::from_millis(300);
+const CASE1_P99_TARGET: Duration = Duration::from_millis(800);
+const CASE2_P50_TARGET: Duration = Duration::from_millis(250);
+/// Guard: chunked commits must not blow up total invocation time.
+const CASE3_INVOCATION_TARGET: Duration = Duration::from_millis(2500);
+
+// ---------------------------------------------------------------------------
+// Latency-injecting object store
+// ---------------------------------------------------------------------------
+
+/// Wraps an object store and injects `GET_LATENCY` on read operations when
+/// enabled. Writes stay fast, mirroring production (WAL and puts are cheap;
+/// reads pay a GCS round trip on block-cache miss).
+#[derive(Debug)]
+struct SlowReadStore {
+    inner: Arc<dyn ObjectStore>,
+    enabled: Arc<AtomicBool>,
+}
+
+impl SlowReadStore {
+    fn new(inner: Arc<dyn ObjectStore>) -> (Arc<Self>, Arc<AtomicBool>) {
+        let enabled = Arc::new(AtomicBool::new(false));
+        (
+            Arc::new(Self {
+                inner,
+                enabled: Arc::clone(&enabled),
+            }),
+            enabled,
+        )
+    }
+
+    async fn maybe_delay(&self) {
+        if self.enabled.load(Ordering::Relaxed) {
+            tokio::time::sleep(GET_LATENCY).await;
+        }
+    }
+}
+
+impl std::fmt::Display for SlowReadStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SlowReadStore({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for SlowReadStore {
+    async fn put_opts(
+        &self,
+        location: &ObjPath,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> ObjectStoreResult<PutResult> {
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &ObjPath,
+        opts: PutMultipartOptions,
+    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &ObjPath,
+        options: GetOptions,
+    ) -> ObjectStoreResult<GetResult> {
+        self.maybe_delay().await;
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn get_ranges(
+        &self,
+        location: &ObjPath,
+        ranges: &[Range<u64>],
+    ) -> ObjectStoreResult<Vec<bytes::Bytes>> {
+        self.maybe_delay().await;
+        self.inner.get_ranges(location, ranges).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, ObjectStoreResult<ObjPath>>,
+    ) -> BoxStream<'static, ObjectStoreResult<ObjPath>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&ObjPath>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&ObjPath>) -> ObjectStoreResult<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(
+        &self,
+        from: &ObjPath,
+        to: &ObjPath,
+        options: slatedb::object_store::CopyOptions,
+    ) -> ObjectStoreResult<()> {
+        self.inner.copy_opts(from, to, options).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64
+}
+
+/// Task group used only for fixture staging (floating-state warm jobs).
+const SETUP_TASK_GROUP: &str = "grant-bench-setup";
+
+/// Padding appended to each floating queue key so every floating-state row
+/// fills its own SST block. Production floating rows are scattered across a
+/// multi-GB keyspace where each point read fetches a distinct block; without
+/// padding this fixture's 64 adjacent rows would share ~3 blocks and one
+/// fetch would warm them all.
+const FLOATING_KEY_PAD: usize = 2048;
+
+fn floating_limit(gate_queue: &str, index: usize) -> FloatingConcurrencyLimit {
+    // Huge refresh interval keeps the refresh machinery out of the measurement.
+    FloatingConcurrencyLimit {
+        key: format!(
+            "{}-floating-{:06}-{}",
+            gate_queue,
+            index,
+            "p".repeat(FLOATING_KEY_PAD)
+        ),
+        default_max_concurrency: 1_000_000,
+        refresh_interval_ms: i64::MAX / 4,
+        metadata: Vec::new(),
+    }
+}
+
+/// Waiter `index` is gated by the shared queue, then a per-waiter floating
+/// hop. The distinct floating-state rows force one cold DB read per chain
+/// resume — the production shape that makes grant passes read-bound.
+fn waiter_limits(gate_queue: &str, capacity: usize, index: usize) -> Vec<Limit> {
+    vec![
+        Limit::Concurrency(ConcurrencyLimit {
+            key: gate_queue.to_string(),
+            max_concurrency: capacity as u32,
+        }),
+        Limit::FloatingConcurrency(floating_limit(gate_queue, index)),
+    ]
+}
+
+async fn open_shard(
+    dir: &str,
+    store: Arc<dyn ObjectStore>,
+    measured_phase: bool,
+) -> Arc<JobStoreShard> {
+    let mut settings = slatedb::config::Settings {
+        flush_interval: Some(Duration::from_millis(1)),
+        ..Default::default()
+    };
+    if !measured_phase {
+        // Setup phase: roll memtables to L0 aggressively so fixture rows land
+        // in SSTs. Otherwise the whole small dataset stays in the WAL, replays
+        // into the memtable on reopen, and measured reads never touch the
+        // (latency-injected) object store.
+        settings.l0_sst_size_bytes = 128 * 1024;
+    }
+    JobStoreShard::open_with_resolved_store(
+        "grant-bench".to_string(),
+        dir,
+        OpenShardOptions {
+            store,
+            wal_store: None,
+            wal_close_config: None,
+            slatedb_settings: Some(settings),
+            memory_cache: if measured_phase {
+                // Moderate block cache: the first touch of any fixture row
+                // pays the injected store latency (the grant path's cost —
+                // its rows are distinct-per-candidate), while re-reads of a
+                // just-loaded block stay warm (the claim path's reality in
+                // production, where the validate stage has already pulled the
+                // job rows into a large cache).
+                Some(silo::settings::MemoryCacheConfig {
+                    block_cache_bytes: Some(32 * 1024 * 1024),
+                    meta_cache_bytes: None,
+                })
+            } else {
+                None
+            },
+            rate_limiter: NullGubernatorClient::new(),
+            metrics: None,
+            // Keep the periodic reconciler out of the measurement window.
+            concurrency_reconcile_interval: Duration::from_secs(3600),
+            counter_reconciliation_seconds: None,
+            hydrate_all_at_startup: false,
+            completed_job_expire_s: None,
+            terminal_job_expire_s: None,
+            count_from_status_counters: true,
+            grant_scanner: silo::concurrency::GrantScannerConfig::default(),
+            concurrency_reconcile_scan_slice:
+                silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,
+            holder_drift_scan_slice: silo::settings::DEFAULT_HOLDER_DRIFT_SCAN_SLICE,
+        },
+        ShardRange::full(),
+    )
+    .await
+    .expect("open bench shard")
+}
+
+/// Build a saturated-queue fixture: `capacity` leased holders filling the gate
+/// and `waiters` deferred requests behind it, flushed to SSTs via a
+/// close/reopen so measured reads miss the block cache. Latency is off for the
+/// whole setup. Returns the reopened shard and the leased holder task ids.
+async fn build_saturated_fixture(
+    dir_name: &str,
+    gate_queue: &str,
+    capacity: usize,
+    waiters: usize,
+    stop_scanner: bool,
+) -> (Arc<JobStoreShard>, Arc<AtomicBool>, Vec<String>) {
+    let root = std::path::Path::new("./tmp/grant-latency-bench");
+    let shard_dir = root.join(dir_name);
+    let _ = std::fs::remove_dir_all(&shard_dir);
+    std::fs::create_dir_all(&shard_dir).expect("create bench dir");
+    let canonical_root = root
+        .canonicalize()
+        .expect("canonicalize bench root")
+        .to_string_lossy()
+        .to_string();
+
+    let local: Arc<dyn ObjectStore> = Arc::new(
+        slatedb::object_store::local::LocalFileSystem::new_with_prefix(&canonical_root)
+            .expect("create LocalFileSystem"),
+    );
+    let (slow_store, latency_enabled) = SlowReadStore::new(local);
+    let store: Arc<dyn ObjectStore> = slow_store;
+
+    let start = now_ms();
+
+    // Phase A: populate (fast, everything in memtable/WAL).
+    let shard = open_shard(dir_name, Arc::clone(&store), false).await;
+    shard.stop_grant_scanner();
+
+    for i in 0..capacity {
+        shard
+            .enqueue(
+                TENANT,
+                Some(format!("{}-holder-{:06}", dir_name, i)),
+                50,
+                start,
+                None,
+                vec![1, 2, 3],
+                waiter_limits(gate_queue, capacity, i),
+                None,
+                TASK_GROUP,
+            )
+            .await
+            .expect("enqueue holder");
+    }
+
+    let mut holder_task_ids = Vec::with_capacity(capacity);
+    while holder_task_ids.len() < capacity {
+        let batch = (capacity - holder_task_ids.len()).min(50);
+        let result = shard
+            .dequeue("bench-setup-worker", TASK_GROUP, batch)
+            .await
+            .expect("dequeue holders");
+        for task in &result.tasks {
+            holder_task_ids.push(task.attempt().task_id().to_string());
+        }
+    }
+
+    // Warm jobs: create each waiter's floating-state row now so the measured
+    // chain resume performs a genuine cold read of an existing distinct row
+    // (a missing row would short-circuit through the bloom filter). The warm
+    // jobs run in a setup-only task group and are never dequeued; their
+    // floating holders are irrelevant at 1M capacity.
+    for j in 0..waiters {
+        shard
+            .enqueue(
+                TENANT,
+                Some(format!("{}-warm-{:06}", dir_name, j)),
+                50,
+                start,
+                None,
+                vec![1, 2, 3],
+                vec![Limit::FloatingConcurrency(floating_limit(
+                    gate_queue,
+                    capacity + j,
+                ))],
+                None,
+                SETUP_TASK_GROUP,
+            )
+            .await
+            .expect("enqueue warm job");
+    }
+
+    shard.close().await.expect("close shard after setup");
+
+    // Phase B: reopen for measurement. The gate is still saturated by the
+    // durable holders, so nothing is grantable yet.
+    let shard = open_shard(dir_name, store, true).await;
+
+    if stop_scanner {
+        // stop_grant_scanner flips the run flag but cannot cancel an
+        // in-flight startup-sweep invocation; give it a moment to finish
+        // idle (no requests exist yet) before staging grantable state.
+        shard.stop_grant_scanner();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    // Waiters enqueue against the saturated gate and park as deferred
+    // requests. They are written post-reopen so the request front and the
+    // waiters' job rows are memtable-resident — matching production, where
+    // the hot queue's front is continuously rewritten by ticket conversions
+    // and stays warm. The cold rows are exactly the floating states above.
+    for j in 0..waiters {
+        shard
+            .enqueue(
+                TENANT,
+                Some(format!("{}-waiter-{:06}", dir_name, j)),
+                50,
+                start,
+                None,
+                vec![1, 2, 3],
+                waiter_limits(gate_queue, capacity, capacity + j),
+                None,
+                TASK_GROUP,
+            )
+            .await
+            .expect("enqueue waiter");
+    }
+
+    (shard, latency_enabled, holder_task_ids)
+}
+
+// ---------------------------------------------------------------------------
+// Measurement helpers
+// ---------------------------------------------------------------------------
+
+struct LatencyStats {
+    label: String,
+    sorted: Vec<Duration>,
+}
+
+impl LatencyStats {
+    fn from(label: &str, mut samples: Vec<Duration>) -> Self {
+        samples.sort();
+        Self {
+            label: label.to_string(),
+            sorted: samples,
+        }
+    }
+
+    fn p50(&self) -> Duration {
+        self.sorted[self.sorted.len() / 2]
+    }
+
+    fn p99(&self) -> Duration {
+        let idx = (self.sorted.len() as f64 * 0.99).ceil() as usize - 1;
+        self.sorted[idx.min(self.sorted.len() - 1)]
+    }
+
+    fn print(&self) {
+        println!(
+            "  {:<28} n={:<4} p50={:<10?} p99={:<10?} min={:<10?} max={:?}",
+            format!("{}:", self.label),
+            self.sorted.len(),
+            self.p50(),
+            self.p99(),
+            self.sorted.first().unwrap(),
+            self.sorted.last().unwrap(),
+        );
+    }
+}
+
+/// Number of concurrent dequeue pollers during measurement. Production runs
+/// hundreds of pollers against each shard; claim capacity must not be the
+/// bottleneck when measuring the grant pipeline.
+const COLLECTOR_WORKERS: usize = 4;
+
+/// Poll `dequeue` from several concurrent workers until `expected` tasks have
+/// been leased (or timeout), recording the instant each lease was observed.
+async fn collect_leases(
+    shard: Arc<JobStoreShard>,
+    expected: usize,
+    timeout: Duration,
+    lease_instants: Arc<Mutex<Vec<Instant>>>,
+) {
+    let deadline = Instant::now() + timeout;
+    let collected = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let mut workers = Vec::with_capacity(COLLECTOR_WORKERS);
+    for w in 0..COLLECTOR_WORKERS {
+        let shard = Arc::clone(&shard);
+        let lease_instants = Arc::clone(&lease_instants);
+        let collected = Arc::clone(&collected);
+        workers.push(tokio::spawn(async move {
+            let worker_id = format!("bench-measure-worker-{}", w);
+            while collected.load(Ordering::Relaxed) < expected && Instant::now() < deadline {
+                let result = shard
+                    .dequeue(&worker_id, TASK_GROUP, 16)
+                    .await
+                    .expect("measurement dequeue");
+                let observed = Instant::now();
+                if result.tasks.is_empty() {
+                    continue; // claim_ready_or_nudge already waited ~25ms internally
+                }
+                collected.fetch_add(result.tasks.len(), Ordering::Relaxed);
+                let mut instants = lease_instants.lock().unwrap();
+                for _ in &result.tasks {
+                    instants.push(observed);
+                }
+            }
+        }));
+    }
+    for worker in workers {
+        worker.await.expect("collector worker");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Case 1 + 3: grant_to_leasable and invocation duration
+// ---------------------------------------------------------------------------
+
+async fn bench_grant_to_leasable() -> (LatencyStats, Duration) {
+    println!(
+        "--- case 1: grant_to_leasable ({} grants, {} waiters, {:?} GET latency) ---",
+        GRANT_COUNT, WAITER_COUNT, GET_LATENCY
+    );
+    let gate_queue = "bench-gate";
+    // Case 1 drives process_grants directly; the fixture stops the background
+    // scanner (before any grantable state exists) so it cannot race the
+    // measured invocation for the released capacity.
+    let (shard, latency_enabled, holder_task_ids) =
+        build_saturated_fixture("case1", gate_queue, GRANT_COUNT, WAITER_COUNT, true).await;
+
+    for task_id in &holder_task_ids {
+        shard
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: Vec::new() })
+            .await
+            .expect("release holder");
+    }
+
+    // Sanity: nothing may be leasable before the measured invocation runs.
+    let pre = shard
+        .dequeue("bench-sanity-worker", TASK_GROUP, 1)
+        .await
+        .expect("sanity dequeue");
+    assert!(
+        pre.tasks.is_empty(),
+        "unexpected leasable task before process_grants; a racing grant occurred"
+    );
+
+    latency_enabled.store(true, Ordering::Relaxed);
+
+    let lease_instants = Arc::new(Mutex::new(Vec::with_capacity(GRANT_COUNT)));
+    let collector = tokio::spawn(collect_leases(
+        Arc::clone(&shard),
+        GRANT_COUNT,
+        Duration::from_secs(120),
+        Arc::clone(&lease_instants),
+    ));
+
+    let t0 = Instant::now();
+    let granted = shard
+        .process_concurrency_grants(TENANT, gate_queue, GRANT_COUNT as u32)
+        .await;
+    let invocation_duration = t0.elapsed();
+    assert_eq!(granted.len(), GRANT_COUNT, "expected all grants to land");
+
+    collector.await.expect("collector task");
+    latency_enabled.store(false, Ordering::Relaxed);
+
+    let samples: Vec<Duration> = lease_instants
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|leased_at| leased_at.duration_since(t0))
+        .collect();
+    assert_eq!(
+        samples.len(),
+        GRANT_COUNT,
+        "measurement dequeuer timed out before all grants were leased"
+    );
+
+    let stats = LatencyStats::from("grant_to_leasable", samples);
+    stats.print();
+    println!("  invocation_duration:         {:?}", invocation_duration);
+
+    shard.close().await.expect("close case1 shard");
+    println!();
+    (stats, invocation_duration)
+}
+
+// ---------------------------------------------------------------------------
+// Case 2: release_to_lease (grant scanner running)
+// ---------------------------------------------------------------------------
+
+async fn bench_release_to_lease() -> LatencyStats {
+    println!(
+        "--- case 2: release_to_lease ({} releases, scanner running, {:?} GET latency) ---",
+        RELEASE_ITERS, GET_LATENCY
+    );
+    let gate_queue = "bench-gate-small";
+    let (shard, latency_enabled, holder_task_ids) =
+        build_saturated_fixture("case2", gate_queue, SMALL_CAPACITY, SMALL_WAITERS, false).await;
+
+    latency_enabled.store(true, Ordering::Relaxed);
+
+    // Rolling release: complete one holder, wait for the scanner to grant and
+    // the dequeuer to lease its replacement, which becomes the next holder.
+    let mut current_holder = holder_task_ids[0].clone();
+    let mut samples = Vec::with_capacity(RELEASE_ITERS);
+    for _ in 0..RELEASE_ITERS {
+        let t0 = Instant::now();
+        shard
+            .report_attempt_outcome(
+                &current_holder,
+                AttemptOutcome::Success { result: Vec::new() },
+            )
+            .await
+            .expect("release holder");
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let leased = loop {
+            let result = shard
+                .dequeue("bench-measure-worker", TASK_GROUP, 1)
+                .await
+                .expect("measurement dequeue");
+            if let Some(task) = result.tasks.first() {
+                break task.attempt().task_id().to_string();
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for a lease after release"
+            );
+        };
+        samples.push(t0.elapsed());
+        current_holder = leased;
+    }
+
+    latency_enabled.store(false, Ordering::Relaxed);
+    let stats = LatencyStats::from("release_to_lease", samples);
+    stats.print();
+
+    shard.close().await.expect("close case2 shard");
+    println!();
+    stats
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("\n========================================");
+    println!("Grant Latency Benchmark");
+    println!("========================================\n");
+
+    let (case1, invocation_duration) = bench_grant_to_leasable().await;
+    let case2 = bench_release_to_lease().await;
+
+    println!("--- thresholds ---");
+    println!(
+        "  case1 p50 {:?} (target {:?}), p99 {:?} (target {:?})",
+        case1.p50(),
+        CASE1_P50_TARGET,
+        case1.p99(),
+        CASE1_P99_TARGET,
+    );
+    println!(
+        "  case2 p50 {:?} (target {:?})",
+        case2.p50(),
+        CASE2_P50_TARGET,
+    );
+    println!(
+        "  case3 invocation {:?} (target {:?})",
+        invocation_duration, CASE3_INVOCATION_TARGET,
+    );
+
+    let mut failures = Vec::new();
+    if case1.p50() > CASE1_P50_TARGET {
+        failures.push(format!(
+            "case1 p50 {:?} exceeds target {:?}",
+            case1.p50(),
+            CASE1_P50_TARGET
+        ));
+    }
+    if case1.p99() > CASE1_P99_TARGET {
+        failures.push(format!(
+            "case1 p99 {:?} exceeds target {:?}",
+            case1.p99(),
+            CASE1_P99_TARGET
+        ));
+    }
+    if case2.p50() > CASE2_P50_TARGET {
+        failures.push(format!(
+            "case2 p50 {:?} exceeds target {:?}",
+            case2.p50(),
+            CASE2_P50_TARGET
+        ));
+    }
+    if invocation_duration > CASE3_INVOCATION_TARGET {
+        failures.push(format!(
+            "case3 invocation {:?} exceeds target {:?}",
+            invocation_duration, CASE3_INVOCATION_TARGET
+        ));
+    }
+
+    if failures.is_empty() {
+        println!("\nAll grant-latency targets met.");
+    } else {
+        for f in &failures {
+            eprintln!("TARGET MISSED: {}", f);
+        }
+        std::process::exit(1);
+    }
+}

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -120,6 +120,12 @@ pub struct ResumeChainParams {
     /// `task_key(now_ms, …)` writes can't disagree with the `granted_at_ms`
     /// the scanner just wrote into the same batch.
     pub now_ms: i64,
+    /// Prefetched point reads (key → value as read from the DB) for rows the
+    /// chain walk is expected to read, e.g. downstream floating-limit state.
+    /// The resumer's writer serves `get`s from this overlay, letting the
+    /// scanner fetch many candidates' rows concurrently instead of paying one
+    /// object-store round trip per grant inside the serial reserve loop.
+    pub read_cache: Option<Arc<HashMap<Vec<u8>, slatedb::bytes::Bytes>>>,
 }
 
 /// Bridge between the grant scanner / `process_grants` and the shard-level
@@ -140,6 +146,12 @@ pub trait LimitChainResumer: Send + Sync {
         batch: &mut slatedb::WriteBatch,
         params: ResumeChainParams,
     ) -> Result<Vec<(String, String)>, ConcurrencyError>;
+
+    /// Wake the task brokers for `groups` after a durable grant commit, so
+    /// freshly written tasks become claimable without waiting for the grant
+    /// scanner's drain iteration to finish every other queue's pass. Default
+    /// is a no-op for resumers with no broker access.
+    fn wakeup_task_groups(&self, _groups: &[String]) {}
 }
 
 impl From<slatedb::Error> for ConcurrencyError {
@@ -813,6 +825,11 @@ pub struct GrantScannerConfig {
     /// Fraction of each queue's capacity the scanner leaves unfilled for
     /// immediate (live) grants.
     pub live_headroom_fraction: f64,
+    /// Max grants accumulated in a pass before their edits are committed and
+    /// their task groups' brokers woken. Smaller chunks stream grants out of a
+    /// long pass earlier (lower leasable latency); larger chunks amortize
+    /// commit overhead.
+    pub commit_chunk_size: usize,
 }
 
 impl Default for GrantScannerConfig {
@@ -825,6 +842,7 @@ impl Default for GrantScannerConfig {
             next_hop_skip_min_backlog:
                 crate::settings::DEFAULT_GRANT_SCANNER_NEXT_HOP_SKIP_MIN_BACKLOG,
             live_headroom_fraction: crate::settings::DEFAULT_GRANT_SCANNER_LIVE_HEADROOM_FRACTION,
+            commit_chunk_size: crate::settings::DEFAULT_GRANT_SCANNER_COMMIT_CHUNK_SIZE,
         }
     }
 }
@@ -955,6 +973,11 @@ pub struct ConcurrencyManager {
     /// `grant_scanner_live_headroom_fraction` (default 0.0); stored already
     /// clamped to `[0.0, 0.9]` with non-finite values treated as 0.0.
     grant_scanner_live_headroom_fraction: f64,
+    /// Max grants accumulated in a `process_grants` pass before their edits
+    /// are committed and their task groups' brokers woken. Configurable via
+    /// `grant_scanner_commit_chunk_size` (default 16); stored already clamped
+    /// to `>= 1`.
+    grant_scanner_commit_chunk_size: usize,
     /// State of the (possibly multi-tick) holder-drift pass. Maintained only
     /// by `report_holder_drift` (a single periodic task). See `DriftPass`.
     drift_pass: Mutex<DriftPass>,
@@ -1047,6 +1070,7 @@ impl ConcurrencyManager {
             } else {
                 0.0
             },
+            grant_scanner_commit_chunk_size: scanner.commit_chunk_size.max(1),
             drift_pass: Mutex::new(DriftPass::default()),
         }
     }
@@ -1245,13 +1269,8 @@ impl ConcurrencyManager {
         }
         // Look through rate limits to the next capacity-holding hop; a terminal
         // candidate (nothing, or only rate limits, after `limit_index`) never skips.
-        let mut probe = limit_index as usize + 1;
-        let next = loop {
-            match limits.get(probe) {
-                None => return false,
-                Some(Limit::RateLimit(_)) => probe += 1,
-                Some(other) => break other,
-            }
+        let Some(next) = Self::next_capacity_hop(limits, limit_index) else {
+            return false;
         };
         let next_queue = match next {
             Limit::Concurrency(cl) => cl.key.as_str(),
@@ -2342,7 +2361,6 @@ impl ConcurrencyManager {
             let needed = (count as usize - total_granted).min(self.grant_scanner_batch_size);
 
             let mut batch = WriteBatch::new();
-            let mut grants: Vec<(String, String)> = Vec::new();
             let mut stale_and_corrupt_count: usize = 0;
 
             // --- Scan batch of candidates ---
@@ -2513,48 +2531,6 @@ impl ConcurrencyManager {
                     max_concurrency = Some((l, lt));
                 }
 
-                // Defer candidates whose NEXT concurrency hop is saturated
-                // with a deep requester backlog: granting them cannot make
-                // the job runnable — the chain immediately parks a deferred
-                // request at that hop — so it only converts "waiting here"
-                // into a parked holder plus one more line entry (pure state
-                // inflation), while occupying this queue's slots with jobs
-                // that cannot run (the shared-queue wedge shape). The row is
-                // left in place — no grant, no delete, no counter decrement —
-                // and keeps its original start_time, so when it is eventually
-                // granted it parks at its age-correct position in the next
-                // hop's FIFO.
-                //
-                // A skipped row still consumed the per-invocation scan budget
-                // (`scanned_this_invocation` was already incremented above), so
-                // a front of >budget saturated candidates yields at the budget
-                // like any other non-grantable front and a grantable candidate
-                // anywhere within the budget window is still reached this
-                // invocation. Liveness for candidates past the window: the
-                // requester counter stays non-zero, so the periodic reconcile
-                // sweep re-drives this queue on its next cursor rotation. The
-                // min-backlog threshold is a heuristic that the hop stays
-                // saturated across that rotation — sound for a deep, slowly
-                // draining hop (the wedge shape this targets), but a small-cap
-                // hop that drains its whole line within a rotation is re-driven
-                // a rotation later than ideal (bounded staleness, no lost work;
-                // no reverse-edge nudge wakes upstream queues on desaturation).
-                if self
-                    .next_hop_should_skip(
-                        db,
-                        tenant,
-                        &limits,
-                        limit_index,
-                        &mut next_hop_skip_cache,
-                    )
-                    .await
-                {
-                    if let Some(ref m) = self.metrics {
-                        m.record_concurrency_grant_next_hop_skip(&self.shard);
-                    }
-                    continue;
-                }
-
                 scanned.push(ScannedRequest {
                     request_key: kv.key.to_vec(),
                     task_id: task_id_str,
@@ -2571,6 +2547,81 @@ impl ConcurrencyManager {
                     held_queues,
                     limits,
                 });
+            }
+
+            // --- Next-hop skip filter ---
+            // Defer candidates whose NEXT concurrency hop is saturated
+            // with a deep requester backlog: granting them cannot make
+            // the job runnable — the chain immediately parks a deferred
+            // request at that hop — so it only converts "waiting here"
+            // into a parked holder plus one more line entry (pure state
+            // inflation), while occupying this queue's slots with jobs
+            // that cannot run (the shared-queue wedge shape). The row is
+            // left in place — no grant, no delete, no counter decrement —
+            // and keeps its original start_time, so when it is eventually
+            // granted it parks at its age-correct position in the next
+            // hop's FIFO.
+            //
+            // A skipped row still consumed the per-invocation scan budget
+            // (`scanned_this_invocation` was incremented during the scan), so
+            // a front of >budget saturated candidates yields at the budget
+            // like any other non-grantable front and a grantable candidate
+            // anywhere within the budget window is still reached this
+            // invocation. Liveness for candidates past the window: the
+            // requester counter stays non-zero, so the periodic reconcile
+            // sweep re-drives this queue on its next cursor rotation. The
+            // min-backlog threshold is a heuristic that the hop stays
+            // saturated across that rotation — sound for a deep, slowly
+            // draining hop (the wedge shape this targets), but a small-cap
+            // hop that drains its whole line within a rotation is re-driven
+            // a rotation later than ideal (bounded staleness, no lost work;
+            // no reverse-edge nudge wakes upstream queues on desaturation).
+            //
+            // The per-hop durable reads are warmed for every distinct hop in
+            // this pass concurrently; the filter itself then runs against the
+            // warmed cache without further I/O in the common case.
+            if self.grant_scanner_next_hop_skip_min_backlog > 0 {
+                let mut new_hops: Vec<(String, Limit)> = Vec::new();
+                let mut seen_hops: HashSet<&str> = HashSet::new();
+                for req in &scanned {
+                    if let Some(hop) = Self::next_capacity_hop(&req.limits, req.limit_index) {
+                        let hop_queue = match hop {
+                            Limit::Concurrency(cl) => cl.key.as_str(),
+                            Limit::FloatingConcurrency(fl) => fl.key.as_str(),
+                            Limit::RateLimit(_) => continue,
+                        };
+                        if !next_hop_skip_cache.contains_key(hop_queue)
+                            && seen_hops.insert(hop_queue)
+                        {
+                            new_hops.push((hop_queue.to_string(), hop.clone()));
+                        }
+                    }
+                }
+                if !new_hops.is_empty() {
+                    self.prefetch_next_hop_reads(db, tenant, new_hops, &mut next_hop_skip_cache)
+                        .await;
+                }
+
+                let mut kept: Vec<ScannedRequest> = Vec::with_capacity(scanned.len());
+                for req in scanned {
+                    if self
+                        .next_hop_should_skip(
+                            db,
+                            tenant,
+                            &req.limits,
+                            req.limit_index,
+                            &mut next_hop_skip_cache,
+                        )
+                        .await
+                    {
+                        if let Some(ref m) = self.metrics {
+                            m.record_concurrency_grant_next_hop_skip(&self.shard);
+                        }
+                        continue;
+                    }
+                    kept.push(req);
+                }
+                scanned = kept;
             }
 
             // If the scan yielded no candidates, fall through to the per-pass
@@ -2657,6 +2708,65 @@ impl ConcurrencyManager {
                 }
             }
 
+            // --- Prefetch chain-resume reads ---
+            // The reserve loop below walks each grant's remaining limit chain
+            // serially. Rows that walk reads — downstream floating-limit
+            // state — and the downstream queue hydration each try_reserve
+            // consults are fetched here concurrently, so the serial loop runs
+            // against warm state instead of paying one object-store round
+            // trip per grant. The prefetched values are point-in-time DB
+            // reads served through the writer's read overlay, matching the
+            // writer's `get` semantics (batch edits are never visible to it).
+            let read_cache: Option<Arc<HashMap<Vec<u8>, slatedb::bytes::Bytes>>> =
+                if valid_requests.is_empty() {
+                    None
+                } else {
+                    // Owned keys/queues: the async closures below capture by
+                    // move, and borrowing across the stream's await points
+                    // trips HRTB inference.
+                    let mut floating_keys: BTreeSet<Vec<u8>> = BTreeSet::new();
+                    let mut downstream_queues: BTreeSet<String> = BTreeSet::new();
+                    for req in &valid_requests {
+                        for l in req.limits.iter().skip(req.limit_index as usize + 1) {
+                            match l {
+                                Limit::FloatingConcurrency(fl) => {
+                                    floating_keys.insert(floating_limit_state_key(tenant, &fl.key));
+                                    downstream_queues.insert(fl.key.clone());
+                                }
+                                Limit::Concurrency(cl) => {
+                                    downstream_queues.insert(cl.key.clone());
+                                }
+                                Limit::RateLimit(_) => {}
+                            }
+                        }
+                    }
+                    futures::stream::iter(downstream_queues.into_iter().map(|q| async move {
+                        if let Err(e) = self.counts.ensure_hydrated(db, range, tenant, &q).await {
+                            tracing::debug!(
+                                error = %e,
+                                queue = %q,
+                                "grant scanner: downstream hydration prefetch failed"
+                            );
+                        }
+                    }))
+                    .buffer_unordered(self.grant_scanner_buffer_size)
+                    .collect::<Vec<()>>()
+                    .await;
+                    let fetched: Vec<(Vec<u8>, Option<slatedb::bytes::Bytes>)> =
+                        futures::stream::iter(floating_keys.into_iter().map(|key| async move {
+                            let value = db.get(&key).await.ok().flatten();
+                            (key, value)
+                        }))
+                        .buffer_unordered(self.grant_scanner_buffer_size)
+                        .collect()
+                        .await;
+                    let cache: HashMap<Vec<u8>, slatedb::bytes::Bytes> = fetched
+                        .into_iter()
+                        .filter_map(|(key, value)| value.map(|v| (key, v)))
+                        .collect();
+                    (!cache.is_empty()).then(|| Arc::new(cache))
+                };
+
             // --- Reserve in-memory slots and accumulate grant edits ---
             //
             // For each valid request we: reserve the in-memory slot for this
@@ -2664,8 +2774,7 @@ impl ConcurrencyManager {
             // to the chain resumer to write the next limit step. The resumer
             // may make *additional* in-memory reservations (when a downstream
             // FloatingConcurrency/Concurrency limit grants immediately), so we
-            // collect all per-pass reservations into `pass_reservations` for
-            // rollback if the batch write fails.
+            // collect all reservations for rollback if a batch write fails.
             //
             // The scanner reserves against the headroom-reduced capacity so
             // the configured live share of slots stays reachable by immediate
@@ -2674,12 +2783,26 @@ impl ConcurrencyManager {
             // capacity — headroom applies only to the queue being scanned.
             let limit =
                 self.scanner_effective_capacity(max_concurrency.map(|(l, _)| l).unwrap_or(1));
-            // `(queue, task_id)` reservations to release if the per-pass batch
-            // write fails. Includes both the just-won queue and any further
-            // grants the chain resumer made.
-            let mut pass_reservations: Vec<(String, String)> = Vec::new();
+            // Grants stream out of the pass in chunks: every
+            // `grant_scanner_commit_chunk_size` grants, the accumulated batch
+            // is committed durably and the granted task groups' brokers are
+            // woken, so early grants in a long read-bound pass become
+            // leasable while later candidates are still being walked. Each
+            // chunk stamps a fresh `now_ms` so holder `granted_at_ms` and the
+            // resumed `task_key` epoch reflect commit-time reality rather
+            // than invocation start.
+            //
+            // `chunk_reservations` holds the `(queue, task_id)` in-memory
+            // reservations of the CURRENT (uncommitted) chunk only — both the
+            // just-won queue and any further grants the chain resumer made —
+            // for rollback if that chunk's write fails. Committed chunks
+            // stand.
+            let mut chunk_grants: Vec<(String, String)> = Vec::new();
+            let mut chunk_reservations: Vec<(String, String)> = Vec::new();
+            let mut chunk_stale = stale_and_corrupt_count;
+            let mut chunk_now = crate::job_store_shard::now_epoch_ms();
             for req in &valid_requests {
-                if total_granted + grants.len() >= count as usize {
+                if total_granted + chunk_grants.len() >= count as usize {
                     break;
                 }
 
@@ -2694,11 +2817,11 @@ impl ConcurrencyManager {
                     capacity_exhausted = true;
                     break;
                 }
-                pass_reservations.push((queue.to_string(), req.task_id.clone()));
+                chunk_reservations.push((queue.to_string(), req.task_id.clone()));
 
                 // [SILO-GRANT-3] Create holder for the just-won queue
                 let holder_val = encode_holder(&HolderRecord {
-                    granted_at_ms: now_ms,
+                    granted_at_ms: chunk_now,
                 });
                 batch.put(
                     concurrency_holder_key(tenant, queue, &req.task_id),
@@ -2712,21 +2835,19 @@ impl ConcurrencyManager {
                 // fresh deferred concurrency request (if next concurrency
                 // limit is full). It also accumulates further immediate
                 // grants on downstream Concurrency/FloatingConcurrency limits
-                // — those reservations are added to `pass_reservations`.
+                // — those reservations are added to `chunk_reservations`.
                 //
                 // If the chain resumer is unavailable (shard shutdown), abort
-                // this request: release the just-acquired slot and break out
-                // of the pass. The durable request key was already added to
-                // `batch` as a delete; restore it by NOT committing this
-                // pass's grants.
+                // this request: release the current chunk's reservations and
+                // bail. The uncommitted chunk's request deletes die with the
+                // uncommitted batch; committed chunks stand.
                 let Some(ref resumer) = chain_resumer else {
                     tracing::warn!(
                         queue = %queue,
                         task_id = %req.task_id,
                         "grant scanner: chain resumer not installed; aborting pass"
                     );
-                    // Release everything we reserved this pass and bail.
-                    for (q, tid) in &pass_reservations {
+                    for (q, tid) in &chunk_reservations {
                         self.counts.release_reservation(tenant, q, tid);
                     }
                     record_invocation(scanned_this_invocation, total_stale_deleted);
@@ -2747,23 +2868,24 @@ impl ConcurrencyManager {
                     held_queues: new_held,
                     task_group: req.task_group.clone(),
                     limits: req.limits.clone(),
-                    now_ms,
+                    now_ms: chunk_now,
+                    read_cache: read_cache.clone(),
                 };
 
                 match resumer.resume_chain(&mut batch, resume_params).await {
                     Ok(chain_grants) => {
                         // Each (queue, task_id) the chain reserved must roll back
-                        // alongside ours if the batch write fails.
-                        pass_reservations.extend(chain_grants);
+                        // alongside ours if this chunk's write fails.
+                        chunk_reservations.extend(chain_grants);
                     }
                     Err(e) => {
                         tracing::warn!(
                             error = %e,
                             queue = %queue,
                             task_id = %req.task_id,
-                            "grant scanner: chain resume failed; rolling back pass"
+                            "grant scanner: chain resume failed; rolling back chunk"
                         );
-                        for (q, tid) in &pass_reservations {
+                        for (q, tid) in &chunk_reservations {
                             self.counts.release_reservation(tenant, q, tid);
                         }
                         record_invocation(scanned_this_invocation, total_stale_deleted);
@@ -2771,80 +2893,67 @@ impl ConcurrencyManager {
                     }
                 }
 
-                grants.push((req.task_id.clone(), req.task_group.clone()));
+                chunk_grants.push((req.task_id.clone(), req.task_group.clone()));
+
+                if chunk_grants.len() >= self.grant_scanner_commit_chunk_size {
+                    let commit_batch = std::mem::replace(&mut batch, WriteBatch::new());
+                    let stale_deletes = std::mem::take(&mut chunk_stale);
+                    if self
+                        .commit_grant_chunk(
+                            db,
+                            tenant,
+                            queue,
+                            commit_batch,
+                            &chunk_grants,
+                            &chunk_reservations,
+                            stale_deletes,
+                            total_granted,
+                            &chain_resumer,
+                        )
+                        .await
+                        .is_err()
+                    {
+                        record_invocation(scanned_this_invocation, total_stale_deleted);
+                        return all_granted_groups;
+                    }
+                    total_granted += chunk_grants.len();
+                    total_stale_deleted += stale_deletes;
+                    all_granted_groups.extend(chunk_grants.drain(..).map(|(_, tg)| tg));
+                    chunk_reservations.clear();
+                    chunk_now = crate::job_store_shard::now_epoch_ms();
+                }
             }
 
-            // --- Per-pass commit ---
-            // Combined counter decrement for this pass's grants + stale/corrupt deletions.
-            let pass_decrement = grants.len() + stale_and_corrupt_count;
-            if pass_decrement > 0 {
-                batch.merge(
-                    concurrency_requester_counter_key(tenant, queue),
-                    encode_counter(-(pass_decrement as i64)),
-                );
-            }
-
-            // Skip the durable write if this pass produced no edits (e.g. every
-            // scanned status lookup returned an error). The iterator has still
+            // --- Final chunk commit ---
+            // Skip the durable write if nothing is pending (e.g. every scanned
+            // status lookup returned an error). The iterator has still
             // advanced, so the outer loop continues until iter_exhausted.
-            if grants.is_empty() && stale_and_corrupt_count == 0 {
+            if chunk_grants.is_empty() && chunk_stale == 0 {
                 continue;
             }
-
-            if let Err(e) = db
-                .write_with_options(
-                    batch,
-                    &WriteOptions {
-                        await_durable: true,
-                        ..Default::default()
-                    },
+            let commit_batch = std::mem::replace(&mut batch, WriteBatch::new());
+            let stale_deletes = std::mem::take(&mut chunk_stale);
+            if self
+                .commit_grant_chunk(
+                    db,
+                    tenant,
+                    queue,
+                    commit_batch,
+                    &chunk_grants,
+                    &chunk_reservations,
+                    stale_deletes,
+                    total_granted,
+                    &chain_resumer,
                 )
                 .await
+                .is_err()
             {
-                // Roll back ALL reservations made this pass — both the gating
-                // queue grants and any further reservations the chain resumer
-                // made on downstream limits. Prior committed passes stand.
-                for (q, tid) in &pass_reservations {
-                    self.counts.release_reservation(tenant, q, tid);
-                }
-                // The batch did not commit, so this queue's durable request
-                // rows and requester counter are untouched — the freed slots
-                // are grantable again immediately. Re-nudge the hot lane so the
-                // retry happens on the next drain iteration rather than waiting
-                // for the sliced reconcile sweep to rotate back to this queue
-                // (release_reservation alone does not wake the scanner).
-                self.request_grant(tenant, queue);
-                tracing::warn!(
-                    error = %e,
-                    pass_grants = grants.len(),
-                    pass_reservations = pass_reservations.len(),
-                    prior_grants = total_granted,
-                    "grant scanner: batch write failed, rolled back this pass's reservations"
-                );
                 record_invocation(scanned_this_invocation, total_stale_deleted);
                 return all_granted_groups;
             }
-
-            for (request_id, task_group) in &grants {
-                tracing::debug!(
-                    queue = %queue,
-                    request_id = %request_id,
-                    task_group = %task_group,
-                    "grant scanner: granted concurrency ticket"
-                );
-            }
-
-            if let Some(ref m) = self.metrics {
-                m.record_concurrency_tickets_granted(
-                    &self.shard,
-                    crate::metrics::GrantPath::Scanned,
-                    grants.len() as u64,
-                );
-            }
-
-            total_granted += grants.len();
-            total_stale_deleted += stale_and_corrupt_count;
-            all_granted_groups.extend(grants.into_iter().map(|(_, tg)| tg));
+            total_granted += chunk_grants.len();
+            total_stale_deleted += stale_deletes;
+            all_granted_groups.extend(chunk_grants.into_iter().map(|(_, tg)| tg));
         }
 
         // No silent cap: surface invocations that yielded on the scan budget so
@@ -2864,6 +2973,159 @@ impl ConcurrencyManager {
 
         record_invocation(scanned_this_invocation, total_stale_deleted);
         all_granted_groups
+    }
+
+    /// Durably commit one chunk of scanner grants: folds the requester-counter
+    /// decrement for the chunk's grants and carried stale deletes into
+    /// `batch`, writes it with `await_durable`, and wakes the granted task
+    /// groups' brokers so the tasks become claimable immediately.
+    ///
+    /// On write failure, rolls back the chunk's in-memory reservations and
+    /// re-nudges the queue's hot lane; previously committed chunks stand.
+    #[allow(clippy::too_many_arguments)]
+    async fn commit_grant_chunk(
+        &self,
+        db: &Arc<InstrumentedDb>,
+        tenant: &str,
+        queue: &str,
+        mut batch: WriteBatch,
+        chunk_grants: &[(String, String)],
+        chunk_reservations: &[(String, String)],
+        stale_deletes: usize,
+        prior_grants: usize,
+        chain_resumer: &Option<Arc<dyn LimitChainResumer>>,
+    ) -> Result<(), ()> {
+        let decrement = chunk_grants.len() + stale_deletes;
+        if decrement > 0 {
+            batch.merge(
+                concurrency_requester_counter_key(tenant, queue),
+                encode_counter(-(decrement as i64)),
+            );
+        }
+
+        if let Err(e) = db
+            .write_with_options(
+                batch,
+                &WriteOptions {
+                    await_durable: true,
+                    ..Default::default()
+                },
+            )
+            .await
+        {
+            for (q, tid) in chunk_reservations {
+                self.counts.release_reservation(tenant, q, tid);
+            }
+            // The batch did not commit, so this chunk's durable request rows
+            // and counter decrement are untouched — the freed slots are
+            // grantable again immediately. Re-nudge the hot lane so the retry
+            // happens on the next drain iteration rather than waiting for the
+            // sliced reconcile sweep to rotate back to this queue
+            // (release_reservation alone does not wake the scanner).
+            self.request_grant(tenant, queue);
+            tracing::warn!(
+                error = %e,
+                chunk_grants = chunk_grants.len(),
+                chunk_reservations = chunk_reservations.len(),
+                prior_grants,
+                "grant scanner: chunk write failed, rolled back this chunk's reservations"
+            );
+            return Err(());
+        }
+
+        for (request_id, task_group) in chunk_grants {
+            tracing::debug!(
+                queue = %queue,
+                request_id = %request_id,
+                task_group = %task_group,
+                "grant scanner: granted concurrency ticket"
+            );
+        }
+
+        if let Some(ref m) = self.metrics {
+            m.record_concurrency_tickets_granted(
+                &self.shard,
+                crate::metrics::GrantPath::Scanned,
+                chunk_grants.len() as u64,
+            );
+        }
+
+        // Wake the brokers for this chunk's task groups now that the tasks
+        // are durable; without this the tasks wait for a broker scan or for
+        // the drain iteration's post-fan-out wakeup.
+        if !chunk_grants.is_empty()
+            && let Some(resumer) = chain_resumer
+        {
+            let mut groups: Vec<String> = chunk_grants.iter().map(|(_, tg)| tg.clone()).collect();
+            groups.sort_unstable();
+            groups.dedup();
+            resumer.wakeup_task_groups(&groups);
+        }
+
+        Ok(())
+    }
+
+    /// The next capacity-holding hop after `limit_index`, looking through
+    /// rate limits. `None` when the chain is terminal from there.
+    fn next_capacity_hop(limits: &[Limit], limit_index: u32) -> Option<&Limit> {
+        let mut probe = limit_index as usize + 1;
+        loop {
+            match limits.get(probe) {
+                None => return None,
+                Some(Limit::RateLimit(_)) => probe += 1,
+                Some(other) => return Some(other),
+            }
+        }
+    }
+
+    /// Concurrently warm `next_hop_should_skip`'s per-hop durable reads for
+    /// every hop in `hops` (each not yet present in `cache`): the floating
+    /// capacity read, and — when the hop is saturated per that read — the
+    /// requester-counter depth read. Fixed hops compute saturation against
+    /// the supplied limit's embedded capacity; a candidate carrying a
+    /// different embedded value falls back to the skip check's own read.
+    async fn prefetch_next_hop_reads(
+        &self,
+        db: &Arc<InstrumentedDb>,
+        tenant: &str,
+        hops: Vec<(String, Limit)>,
+        cache: &mut HashMap<String, NextHopReads>,
+    ) {
+        let fetched: Vec<(String, NextHopReads)> =
+            futures::stream::iter(hops.into_iter().map(|(hop_queue, hop)| async move {
+                let mut reads = NextHopReads::default();
+                let capacity = match &hop {
+                    Limit::Concurrency(cl) => Some(cl.max_concurrency as usize),
+                    Limit::FloatingConcurrency(fl) => {
+                        let capacity = Self::floating_state_capacity(db, tenant, &hop_queue)
+                            .await
+                            .unwrap_or(fl.default_max_concurrency as usize);
+                        reads.floating_capacity = Some(capacity);
+                        Some(capacity)
+                    }
+                    Limit::RateLimit(_) => None,
+                };
+                if let Some(capacity) = capacity
+                    && self.counts.holder_count(tenant, &hop_queue) >= capacity
+                {
+                    reads.depth = Some(
+                        match db
+                            .get(&concurrency_requester_counter_key(tenant, &hop_queue))
+                            .await
+                        {
+                            Ok(Some(raw)) => decode_counter(&raw),
+                            _ => 0,
+                        },
+                    );
+                }
+                (hop_queue, reads)
+            }))
+            .buffer_unordered(self.grant_scanner_buffer_size)
+            .collect()
+            .await;
+        for (hop_queue, reads) in fetched {
+            cache.entry(hop_queue).or_insert(reads);
+        }
     }
 }
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -252,6 +252,7 @@ impl ShardFactory {
                             next_hop_skip_min_backlog: template
                                 .grant_scanner_next_hop_skip_min_backlog,
                             live_headroom_fraction: template.grant_scanner_live_headroom_fraction,
+                            commit_chunk_size: template.grant_scanner_commit_chunk_size,
                         },
                         concurrency_reconcile_scan_slice: template.concurrency_reconcile_scan_slice,
                         holder_drift_scan_slice: template.holder_drift_scan_slice,
@@ -952,6 +953,7 @@ impl ShardFactory {
                         .template
                         .grant_scanner_next_hop_skip_min_backlog,
                     live_headroom_fraction: self.template.grant_scanner_live_headroom_fraction,
+                    commit_chunk_size: self.template.grant_scanner_commit_chunk_size,
                 },
                 concurrency_reconcile_scan_slice: self.template.concurrency_reconcile_scan_slice,
                 holder_drift_scan_slice: self.template.holder_drift_scan_slice,

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -2,6 +2,8 @@
 use slatedb::WriteBatch;
 use slatedb::bytes::Bytes;
 use slatedb::config::{PutOptions, Ttl};
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::codec::encode_task;
@@ -84,14 +86,37 @@ pub(crate) trait WriteBatcher {
 /// Wrapper around `&mut WriteBatch` that implements `WriteBatcher`
 ///
 /// This combines a database reference for reads with a write batch for writes, allowing batch-based code paths to use the same trait as transaction-based ones.
+///
+/// `read_cache` optionally overlays prefetched point reads: `get` serves a
+/// cached value instead of hitting the DB. The cache holds values read from
+/// the DB moments earlier by the caller (the grant scanner prefetches the
+/// rows its chain resumes will read), so serving from it preserves `get`'s
+/// existing semantics — `get` never saw this batch's uncommitted writes.
 pub(crate) struct DbWriteBatcher<'a> {
     pub db: &'a InstrumentedDb,
     pub batch: &'a mut WriteBatch,
+    read_cache: Option<Arc<HashMap<Vec<u8>, Bytes>>>,
 }
 
 impl<'a> DbWriteBatcher<'a> {
     pub fn new(db: &'a InstrumentedDb, batch: &'a mut WriteBatch) -> Self {
-        Self { db, batch }
+        Self {
+            db,
+            batch,
+            read_cache: None,
+        }
+    }
+
+    pub fn new_with_read_cache(
+        db: &'a InstrumentedDb,
+        batch: &'a mut WriteBatch,
+        read_cache: Arc<HashMap<Vec<u8>, Bytes>>,
+    ) -> Self {
+        Self {
+            db,
+            batch,
+            read_cache: Some(read_cache),
+        }
     }
 }
 
@@ -136,6 +161,11 @@ impl WriteBatcher for DbWriteBatcher<'_> {
     }
 
     async fn get(&self, key: &[u8]) -> Result<Option<Bytes>, slatedb::Error> {
+        if let Some(cache) = &self.read_cache
+            && let Some(value) = cache.get(key)
+        {
+            return Ok(Some(value.clone()));
+        }
         self.db.get(key).await
     }
 

--- a/src/job_store_shard/limit_chain.rs
+++ b/src/job_store_shard/limit_chain.rs
@@ -72,7 +72,13 @@ impl LimitChainResumer for ShardChainResumer {
         // `handle_request_ticket` (dequeue.rs) — see
         // `project_broker_tombstone_chain_continuation`.
         let task_key_epoch_ms = now_ms;
-        let mut writer = DbWriteBatcher::new(&shard.db, batch);
+        // Serve chain-walk point reads from the scanner's prefetched overlay
+        // when one was supplied; the overlay holds point-in-time DB reads, so
+        // `get` semantics are unchanged.
+        let mut writer = match &params.read_cache {
+            Some(cache) => DbWriteBatcher::new_with_read_cache(&shard.db, batch, Arc::clone(cache)),
+            None => DbWriteBatcher::new(&shard.db, batch),
+        };
         let result = shard
             .enqueue_limit_task_at_index(
                 &mut writer,
@@ -106,6 +112,12 @@ impl LimitChainResumer for ShardChainResumer {
         }
 
         Ok(result.grants)
+    }
+
+    fn wakeup_task_groups(&self, groups: &[String]) {
+        if let Some(shard) = self.shard.upgrade() {
+            shard.brokers.wakeup_groups(groups);
+        }
     }
 }
 

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -419,6 +419,7 @@ impl JobStoreShard {
                     cold_batch_size: cfg.grant_scanner_cold_batch_size,
                     next_hop_skip_min_backlog: cfg.grant_scanner_next_hop_skip_min_backlog,
                     live_headroom_fraction: cfg.grant_scanner_live_headroom_fraction,
+                    commit_chunk_size: cfg.grant_scanner_commit_chunk_size,
                 },
                 concurrency_reconcile_scan_slice: cfg.concurrency_reconcile_scan_slice,
                 holder_drift_scan_slice: cfg.holder_drift_scan_slice,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -255,6 +255,17 @@ fn default_grant_scanner_live_headroom_fraction() -> f64 {
     DEFAULT_GRANT_SCANNER_LIVE_HEADROOM_FRACTION
 }
 
+/// Default for `grant_scanner_commit_chunk_size`: max grants a
+/// `process_grants` pass accumulates before committing their edits durably
+/// and waking the granted task groups' brokers. Smaller chunks stream grants
+/// out of a long read-bound pass earlier (lower leasable latency); larger
+/// chunks amortize commit overhead.
+pub const DEFAULT_GRANT_SCANNER_COMMIT_CHUNK_SIZE: usize = 16;
+
+fn default_grant_scanner_commit_chunk_size() -> usize {
+    DEFAULT_GRANT_SCANNER_COMMIT_CHUNK_SIZE
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseTemplate {
     pub backend: Backend,
@@ -346,6 +357,11 @@ pub struct DatabaseTemplate {
     /// Defaults to 0.0 (scanner may fill every slot).
     #[serde(default = "default_grant_scanner_live_headroom_fraction")]
     pub grant_scanner_live_headroom_fraction: f64,
+    /// Max grants a `process_grants` pass accumulates before committing their
+    /// edits durably and waking the granted task groups' brokers. Values
+    /// below 1 are treated as 1. Defaults to 16.
+    #[serde(default = "default_grant_scanner_commit_chunk_size")]
+    pub grant_scanner_commit_chunk_size: usize,
     /// When set, jobs that finished successfully (Succeeded) have all of their
     /// associated KV records re-put with a SlateDB row TTL expiring this many
     /// seconds in the future. `None` (the default) disables the behaviour for
@@ -420,6 +436,7 @@ impl Default for DatabaseTemplate {
             grant_scanner_next_hop_skip_min_backlog:
                 default_grant_scanner_next_hop_skip_min_backlog(),
             grant_scanner_live_headroom_fraction: default_grant_scanner_live_headroom_fraction(),
+            grant_scanner_commit_chunk_size: default_grant_scanner_commit_chunk_size(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             periodic_full_compaction_s: None,
@@ -775,6 +792,11 @@ pub struct DatabaseConfig {
     /// Defaults to 0.0.
     #[serde(default = "default_grant_scanner_live_headroom_fraction")]
     pub grant_scanner_live_headroom_fraction: f64,
+    /// Max grants per durable commit chunk in a `process_grants` pass. See
+    /// `DatabaseTemplate::grant_scanner_commit_chunk_size` for details.
+    /// Defaults to 16.
+    #[serde(default = "default_grant_scanner_commit_chunk_size")]
+    pub grant_scanner_commit_chunk_size: usize,
     /// TTL (seconds) applied to Succeeded jobs' associated records. See
     /// `DatabaseTemplate::completed_job_expire_s` for details.
     #[serde(default)]
@@ -825,6 +847,7 @@ impl Default for DatabaseConfig {
             grant_scanner_next_hop_skip_min_backlog:
                 default_grant_scanner_next_hop_skip_min_backlog(),
             grant_scanner_live_headroom_fraction: default_grant_scanner_live_headroom_fraction(),
+            grant_scanner_commit_chunk_size: default_grant_scanner_commit_chunk_size(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: default_count_from_status_counters(),


### PR DESCRIPTION
cc @airhorns @udnay @kirinrastogi -- I've been working on the silo worker hpas and noticed one of them was unnecessarily maxed out at 80 pods. Fable believes the hpa's [`silo_leasable_to_start_latency_ms`](https://github.com/gadget-inc/silo/pull/386) was inflated because the grant scanner is scanning too much at once, delaying jobs from running when they could have otherwise ran. The solution we went with is to grant more often in between the scan.

---

## Why

Production `silo_leasable_to_start_latency_ms` for the `app-green-all-background-actions-default-spot` task group runs p50 ~1.4-2.9s at ~50 leases/s while the group's 80 workers sit near-idle (~12% CPU) -- the HPA maxed out replicas during a >10x traffic ramp and latency kept climbing, so worker capacity is not the constraint. The latency concentrates on the single shard hosting the hot tenant, whose gating concurrency queue is at capacity: essentially every RunAttempt there flows through the grant scanner (29.5/s `scanned`-path grants vs 2.7/s `immediate`), and the leases in the 1-5s latency band match the scanner grant rate almost exactly.

The mechanism is in `process_grants`: a pass over a backlogged queue pays one object-store round trip per candidate serially (next-hop skip reads inside the scan loop, then downstream floating-limit state reads inside the serial reserve loop) and commits every grant in a single batch at the end of the pass. A granted task therefore becomes leasable only after the whole read-bound pass finishes -- seconds after its slot actually freed -- and its `task_key` epoch is stamped from the invocation's start, which also skews the leasable-latency histogram.

## What

- `process_grants` streams grants out in chunks: every `grant_scanner_commit_chunk_size` grants (new setting, default 16) the accumulated batch is committed durably with a fresh `now_ms`, so early grants in a long pass become leasable while later candidates are still being walked, and holder/epoch timestamps reflect commit time.
- The per-candidate reads are overlapped instead of serial: next-hop skip reads are warmed concurrently for the pass's distinct hops before the skip filter runs, and downstream floating-limit state plus queue hydration are prefetched into a read overlay that the chain resumer's writer serves `get`s from. The overlay holds point-in-time DB reads, matching the writer's existing `get` semantics (batch edits were never visible to it).
- Each chunk commit wakes the granted task groups' brokers through a new `LimitChainResumer::wakeup_task_groups` hook, instead of waiting for the grant scanner's drain iteration to finish every other queue's pass.
- A new `grant_latency` bench (`cargo bench --bench grant_latency`) reproduces the pathology and gates the fix: it injects 20ms object-store read latency, saturates a gate queue whose waiters each carry a distinct downstream floating hop (keys padded so each state row occupies its own SST block), keeps the request front memtable-warm like a continuously converting queue, and asserts per-grant time-to-leasable, end-to-end release-to-lease, and invocation-duration thresholds.

## Benchmark results

64-grant saturated queue, 20ms injected GET latency:

| Metric | main | this branch | threshold |
|---|---|---|---|
| grant -> leasable p50 | 2.81s | 87ms | 300ms |
| grant -> leasable p99 | 2.81s | 89ms | 800ms |
| `process_grants` invocation | 2.79s | 81ms | 2.5s |
| release -> lease, unsaturated path | 54ms | 55ms | 250ms |

The baseline is close to the production signature (hot shard p50 2.9s; healthy shards ~35ms), so the expectation is the production p50 drops into the low hundreds of ms. The remaining `ready_to_start` gap is genuine capacity wait at the app's concurrency limit and is unaffected by design.

## Testing

- `cargo test` main suite: 925 passed; the 9 failures are `rate_limit_tests` that require a locally running Gubernator and fail at connection setup before reaching this code.
- DST turmoil suite (`--features dst`): 32/32 passed, including the grant scanner scheduling scenario.
- The new bench fails on `main` and passes with this branch; the green result reproduced across runs within 3ms.

Two intentional behavior-parity notes: next-hop-skipped candidates now occupy pass slots (they consume the scan budget exactly as before), and a cross-chunk read of floating state through the prefetch overlay matches the within-pass staleness the batch write already had.