### PR TITLE
Fix msgpack decode failures for reaped attempt error bytes

### DIFF
--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -584,15 +584,20 @@ impl JobStoreShard {
                 // [SILO-REAP-3][SILO-REAP-4] Report as worker crashed
                 // SILO-REAP-3: Post: Set job status to Failed (via report_attempt_outcome)
                 // SILO-REAP-4: Post: Set attempt status to AttemptFailed
+                let message = format!(
+                    "lease expired at {} (now {}), worker={}",
+                    decoded.expiry_ms(),
+                    now_ms,
+                    decoded.worker_id()
+                );
+                // Readers treat attempt error bytes as msgpack, so encode the
+                // message as a msgpack string rather than raw UTF-8.
+                let mut error = Vec::new();
+                rmp::encode::write_str(&mut error, &message)
+                    .expect("msgpack encoding into a Vec cannot fail");
                 AttemptOutcome::Error {
                     error_code: "WORKER_CRASHED".to_string(),
-                    error: format!(
-                        "lease expired at {} (now {}), worker={}",
-                        decoded.expiry_ms(),
-                        now_ms,
-                        decoded.worker_id()
-                    )
-                    .into_bytes(),
+                    error,
                 }
             };
 

--- a/tests/job_store_shard_retry_tests.rs
+++ b/tests/job_store_shard_retry_tests.rs
@@ -1036,8 +1036,16 @@ async fn reap_marks_expired_lease_as_failed_and_enqueues_retry() {
         .expect("get a1")
         .expect("a1 exists");
     match a1.state() {
-        AttemptStatus::Failed { error_code, .. } => {
-            assert_eq!(error_code, "WORKER_CRASHED")
+        AttemptStatus::Failed {
+            error_code, error, ..
+        } => {
+            assert_eq!(error_code, "WORKER_CRASHED");
+            let message: String = rmp_serde::from_slice(&error)
+                .expect("reaped attempt error bytes should decode as a msgpack string");
+            assert!(
+                message.contains("lease expired"),
+                "unexpected reaped error message: {message}"
+            );
         }
         _ => panic!("expected Failed"),
     }

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -602,7 +602,7 @@ export interface JobAttempt<Result = unknown> {
   /** Error code if attempt failed */
   errorCode?: string;
   /** Error data if attempt failed */
-  errorData?: Record<string, unknown>;
+  errorData?: unknown;
 }
 
 /** Options for getJob */
@@ -1184,12 +1184,12 @@ function protoAttemptToPublic(attempt: ProtoJobAttempt): JobAttempt {
     finishedAtMs: attempt.finishedAtMs,
     result:
       attempt.result?.encoding.oneofKind === "msgpack"
-        ? decodeBytes(attempt.result.encoding.msgpack, "result")
+        ? tolerantDecodeAttemptBytes(attempt.result.encoding.msgpack, "result")
         : undefined,
     errorCode: attempt.errorCode,
     errorData:
       attempt.errorData?.encoding.oneofKind === "msgpack"
-        ? decodeBytes(attempt.errorData.encoding.msgpack, "errorData")
+        ? tolerantDecodeAttemptBytes(attempt.errorData.encoding.msgpack, "errorData")
         : undefined,
   };
 }
@@ -1993,7 +1993,7 @@ export class SiloGRPCClient {
           nextAttemptStartsAfterMs: response.nextAttemptStartsAfterMs,
           taskGroup: response.taskGroup,
           result: response.result
-            ? decodeBytes(
+            ? tolerantDecodeAttemptBytes(
                 response.result.encoding.oneofKind === "msgpack"
                   ? response.result.encoding.msgpack
                   : undefined,
@@ -2199,10 +2199,12 @@ export class SiloGRPCClient {
           let result: T | undefined;
           if (
             response.result.oneofKind === "successData" &&
-            response.result.successData.encoding.oneofKind === "msgpack" &&
-            response.result.successData.encoding.msgpack.length > 0
+            response.result.successData.encoding.oneofKind === "msgpack"
           ) {
-            result = decodeBytes<T>(response.result.successData.encoding.msgpack, "successData");
+            result = tolerantDecodeAttemptBytes<T>(
+              response.result.successData.encoding.msgpack,
+              "successData",
+            );
           }
           return { status: JobStatus.Succeeded, result };
         }
@@ -2211,10 +2213,12 @@ export class SiloGRPCClient {
           let errorData: unknown;
           if (
             response.result.oneofKind === "failure" &&
-            response.result.failure.errorData?.encoding.oneofKind === "msgpack" &&
-            response.result.failure.errorData.encoding.msgpack.length > 0
+            response.result.failure.errorData?.encoding.oneofKind === "msgpack"
           ) {
-            errorData = decodeBytes(response.result.failure.errorData.encoding.msgpack, "failure");
+            errorData = tolerantDecodeAttemptBytes(
+              response.result.failure.errorData.encoding.msgpack,
+              "failure",
+            );
           }
           return {
             status: JobStatus.Failed,
@@ -2613,4 +2617,29 @@ export function decodeBytes<T = unknown>(bytes: Uint8Array | undefined, field: s
     throw new Error(`No bytes to decode for field ${field}`);
   }
   return unpack(bytes) as T;
+}
+
+/**
+ * Decode attempt result/error bytes without failing the containing call.
+ * Stored attempt blobs are not guaranteed to be well-formed msgpack (some at
+ * rest are absent or raw UTF-8), and one bad blob must never fail a whole
+ * getJob/listing response. Empty or absent bytes decode to undefined; bytes
+ * that msgpack can't parse fall back to their UTF-8 string. Job payloads are
+ * always client-encoded msgpack and stay on the strict decodeBytes path.
+ * @param bytes The stored bytes to decode.
+ * @param _field The field name, kept for call-site symmetry with decodeBytes.
+ * @returns The decoded value, the UTF-8 fallback string, or undefined.
+ */
+export function tolerantDecodeAttemptBytes<T = unknown>(
+  bytes: Uint8Array | undefined,
+  _field: string,
+): T | undefined {
+  if (!bytes || bytes.length === 0) {
+    return undefined;
+  }
+  try {
+    return unpack(bytes) as T;
+  } catch {
+    return new TextDecoder().decode(bytes) as T;
+  }
 }

--- a/typescript_client/test/client.test.ts
+++ b/typescript_client/test/client.test.ts
@@ -20,6 +20,7 @@ import {
   isConnectivityError,
   encodeBytes,
   decodeBytes,
+  tolerantDecodeAttemptBytes,
   type EnqueueJobOptions,
   type SiloGRPCClientOptions,
   type AwaitJobOptions,
@@ -28,6 +29,13 @@ import {
   type QueryColumnInfo,
 } from "../src/client";
 import { JobHandle } from "../src/JobHandle";
+import {
+  JobStatus as ProtoJobStatus,
+  AttemptStatus as ProtoAttemptStatus,
+  type GetJobResponse,
+  type JobAttempt as ProtoJobAttempt,
+  type SerializedBytes,
+} from "../src/pb/silo";
 
 describe("encodeBytes", () => {
   it("encodes a string as msgpack bytes", () => {
@@ -90,6 +98,28 @@ describe("decodeBytes", () => {
     expect(() => decodeBytes(new Uint8Array(0), "test")).toThrow(
       "No bytes to decode for field test",
     );
+  });
+});
+
+describe("tolerantDecodeAttemptBytes", () => {
+  it("decodes valid msgpack bytes normally", () => {
+    const bytes = encodeBytes({ foo: "bar", count: 42 });
+    expect(tolerantDecodeAttemptBytes(bytes, "errorData")).toEqual({ foo: "bar", count: 42 });
+  });
+
+  it("falls back to the UTF-8 string for undecodable bytes", () => {
+    const raw = new TextEncoder().encode("lease expired at 123 (now 456), worker=w1");
+    expect(tolerantDecodeAttemptBytes(raw, "errorData")).toBe(
+      "lease expired at 123 (now 456), worker=w1",
+    );
+  });
+
+  it("returns undefined for empty bytes", () => {
+    expect(tolerantDecodeAttemptBytes(new Uint8Array(0), "errorData")).toBeUndefined();
+  });
+
+  it("returns undefined for undefined bytes", () => {
+    expect(tolerantDecodeAttemptBytes(undefined, "errorData")).toBeUndefined();
   });
 });
 
@@ -400,6 +430,122 @@ describe("SiloGRPCClient", () => {
       await expect(client.heartbeat("worker-a", "task-404", "shard-1")).rejects.toThrow(
         TaskNotFoundError,
       );
+    });
+  });
+
+  describe("attempt blob decode tolerance", () => {
+    const rawErrorText = "lease expired at 123 (now 456), worker=w1";
+    const rawErrorBytes = new TextEncoder().encode(rawErrorText);
+
+    const msgpackBytes = (value: unknown): SerializedBytes => ({
+      encoding: { oneofKind: "msgpack", msgpack: encodeBytes(value) },
+    });
+
+    const protoAttempt = (
+      attemptNumber: number,
+      overrides?: Partial<ProtoJobAttempt>,
+    ): ProtoJobAttempt => ({
+      jobId: "job-1",
+      attemptNumber,
+      taskId: `task-${attemptNumber}`,
+      status: ProtoAttemptStatus.FAILED,
+      startedAtMs: 1n,
+      finishedAtMs: 2n,
+      errorCode: "WORKER_CRASHED",
+      ...overrides,
+    });
+
+    const jobResponse = (overrides?: Partial<GetJobResponse>): GetJobResponse => ({
+      id: "job-1",
+      priority: 10,
+      enqueueTimeMs: 1n,
+      payload: msgpackBytes({ k: "v" }),
+      limits: [],
+      metadata: {},
+      status: ProtoJobStatus.FAILED,
+      statusChangedAtMs: 2n,
+      attempts: [],
+      taskGroup: "default",
+      ...overrides,
+    });
+
+    // Stubs topology + transport but NOT _withShardRetry, so getJob's decode
+    // body actually executes.
+    const stubTransport = (client: SiloGRPCClient, methods: Record<string, unknown>) => {
+      (client as any)._ensureTopology = vi.fn().mockResolvedValue(undefined);
+      (client as any)._getClientForTenant = vi
+        .fn()
+        .mockReturnValue({ shard: "shard-1", client: methods });
+    };
+
+    it("returns all attempts when one attempt's errorData is not msgpack", async () => {
+      const client = createClient({ servers: "localhost:7450", ...defaultOptions });
+      const response = jobResponse({
+        attempts: [
+          protoAttempt(1, {
+            errorData: { encoding: { oneofKind: "msgpack", msgpack: rawErrorBytes } },
+          }),
+          protoAttempt(2, { errorData: msgpackBytes({ code: "E", message: "boom" }) }),
+        ],
+      });
+      stubTransport(client, {
+        getJob: vi.fn().mockReturnValue({ response: Promise.resolve(response) }),
+      });
+
+      const job = await client.getJob("job-1", "tenant-a", { includeAttempts: true });
+
+      expect(job.attempts).toHaveLength(2);
+      expect(job.attempts?.[0].errorData).toBe(rawErrorText);
+      expect(job.attempts?.[1].errorData).toEqual({ code: "E", message: "boom" });
+    });
+
+    it("returns result undefined for a Succeeded job with zero-length result bytes", async () => {
+      const client = createClient({ servers: "localhost:7450", ...defaultOptions });
+      const response = jobResponse({
+        status: ProtoJobStatus.SUCCEEDED,
+        result: { encoding: { oneofKind: "msgpack", msgpack: new Uint8Array(0) } },
+        attempts: [
+          protoAttempt(1, {
+            status: ProtoAttemptStatus.SUCCEEDED,
+            errorCode: undefined,
+            result: { encoding: { oneofKind: "msgpack", msgpack: new Uint8Array(0) } },
+          }),
+        ],
+      });
+      stubTransport(client, {
+        getJob: vi.fn().mockReturnValue({ response: Promise.resolve(response) }),
+      });
+
+      const job = await client.getJob("job-1", "tenant-a", { includeAttempts: true });
+
+      expect(job.result).toBeUndefined();
+      expect(job.attempts?.[0].result).toBeUndefined();
+    });
+
+    it("returns the UTF-8 string when getJobResult failure data is not msgpack", async () => {
+      const client = createClient({ servers: "localhost:7450", ...defaultOptions });
+      stubTransport(client, {
+        getJobResult: vi.fn().mockReturnValue({
+          response: Promise.resolve({
+            id: "job-1",
+            status: ProtoJobStatus.FAILED,
+            finishedAtMs: 2n,
+            result: {
+              oneofKind: "failure",
+              failure: {
+                errorCode: "WORKER_CRASHED",
+                errorData: { encoding: { oneofKind: "msgpack", msgpack: rawErrorBytes } },
+              },
+            },
+          }),
+        }),
+      });
+
+      const result = await client.getJobResult("job-1", "tenant-a");
+
+      expect(result.status).toBe(JobStatus.Failed);
+      expect(result.errorCode).toBe("WORKER_CRASHED");
+      expect(result.errorData).toBe(rawErrorText);
     });
   });
 });


### PR DESCRIPTION
The Gadget editor's background actions page intermittently fails with "[GraphQL] Data read, but end of buffer not reached 108" (~30-170 occurrences/day across 15+ environments). Root cause is a writer/reader defect pair around attempt error bytes:

- The lease-expiry reaper stores its "lease expired at ... worker=..." message as raw UTF-8 in a field every reader decodes as msgpack. The first byte of "lease..." (0x6C = 108) decodes as the integer 108 with trailing bytes, so msgpackr throws.
- The TS client fails the entire getJob call when any single attempt blob is undecodable, so one corrupt attempt breaks the whole background-actions listing.

This PR fixes both ends:

- **Server**: `reap_expired_leases` now encodes the error message as a msgpack string via `rmp::encode::write_str`. An audit of the other `Encoding::Msgpack` construction sites found no other writer producing non-msgpack bytes (worker-reported outcomes pass client-encoded msgpack through untouched; the query path hand-encodes via `record_batches_to_msgpack`).
- **TS client**: attempt `result`/`errorData`, the job-level `getJob` result, and the `getJobResult` data decodes go through a new exported `tolerantDecodeAttemptBytes` helper: valid msgpack decodes as before, undecodable bytes fall back to their UTF-8 string, and empty/absent bytes yield `undefined` (zero-length blobs exist at rest and previously threw "No bytes to decode"). Job payload decodes and `decodeBytes` itself stay strict, and `JobAttempt.errorData` widens to `unknown` to admit the string fallback.

Corrupt blobs already at rest are handled by the reader fallback and age out with job retention; no data migration. Gadget's `parseFailureReason` already renders a plain-string `errorData` as `{ code, message }`, so reaped attempts show a readable failure reason in the editor.

Tested with a Rust regression test decoding a reaped attempt's error bytes as a msgpack string, unit tests for the tolerant helper, and mocked-transport `getJob`/`getJobResult` tests covering a corrupt attempt among valid ones, zero-length result bytes, and raw-UTF-8 failure data.