### PR TITLE
Plan multi-status jobs queries as unions of status index range scans

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -142,6 +142,10 @@ pub struct Metrics {
     /// stops early (LIMIT reached, deadline fired, stream dropped) stops
     /// advancing this counter — the signal that a query is not running as a zombie.
     query_scanned_keys: CounterVec,
+    /// Rows hydrated via job_info/status point-lookups by query scans, per
+    /// shard. Stays flat for index-only scans — the signal that an aggregate
+    /// shape rode the index-only path instead of per-row hydration.
+    query_point_lookups: CounterVec,
 
     // Shard/broker metrics
     shards_owned: Gauge,
@@ -431,6 +435,20 @@ impl Metrics {
     /// operational assertions that a scan stopped early.
     pub fn query_scanned_keys_value(&self, shard: &str) -> f64 {
         self.query_scanned_keys.with_label_values(&[shard]).get()
+    }
+
+    /// Add `n` to the per-shard query point-lookup counter. Called by the jobs
+    /// scanner for every batch of rows it hydrates via point-lookups.
+    pub fn record_query_point_lookups(&self, shard: &str, n: u64) {
+        self.query_point_lookups
+            .with_label_values(&[shard])
+            .inc_by(n as f64);
+    }
+
+    /// Read the current query point-lookup counter for a shard. Exposed for
+    /// tests and operational assertions that a scan stayed on the index-only path.
+    pub fn query_point_lookups_value(&self, shard: &str) -> f64 {
+        self.query_point_lookups.with_label_values(&[shard]).get()
     }
 
     /// Update the number of shards owned by this node (from coordinator).
@@ -1984,6 +2002,16 @@ pub fn init() -> anyhow::Result<Metrics> {
             &["shard"],
         )?,
     );
+    let query_point_lookups = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_query_point_lookups_total",
+                "Rows hydrated via job_info/status point-lookups by query scans per shard",
+            ),
+            &["shard"],
+        )?,
+    );
 
     // Shard/broker metrics
     let shards_owned = register(
@@ -2440,6 +2468,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         query_rejected,
         query_cancelled,
         query_scanned_keys,
+        query_point_lookups,
         shards_owned,
         coordination_shards_open,
         broker_buffer_size,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -142,7 +142,7 @@ pub struct Metrics {
     /// stops early (LIMIT reached, deadline fired, stream dropped) stops
     /// advancing this counter — the signal that a query is not running as a zombie.
     query_scanned_keys: CounterVec,
-    /// Rows hydrated via job_info/status point-lookups by query scans, per
+    /// Point-lookup keys requested from job_info/status by query scans, per
     /// shard. Stays flat for index-only scans — the signal that an aggregate
     /// shape rode the index-only path instead of per-row hydration.
     query_point_lookups: CounterVec,
@@ -438,7 +438,8 @@ impl Metrics {
     }
 
     /// Add `n` to the per-shard query point-lookup counter. Called by the jobs
-    /// scanner for every batch of rows it hydrates via point-lookups.
+    /// scanner for every batch of keys it requests via point-lookups (whether or
+    /// not each key resolves to a live row).
     pub fn record_query_point_lookups(&self, shard: &str, n: u64) {
         self.query_point_lookups
             .with_label_values(&[shard])
@@ -2007,7 +2008,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         CounterVec::new(
             Opts::new(
                 "silo_query_point_lookups_total",
-                "Rows hydrated via job_info/status point-lookups by query scans per shard",
+                "Point-lookup keys requested from job_info/status by query scans per shard",
             ),
             &["shard"],
         )?,

--- a/src/query.rs
+++ b/src/query.rs
@@ -634,6 +634,7 @@ pub fn parse_jobs_scan_strategy(filters: &[Expr]) -> JobsScanStrategy {
     let mut tenant_filter: Option<String> = None;
     let mut status_filter: Option<QueryStatusFilter> = None;
     let mut multi_status_filter: Option<Vec<QueryStatusFilter>> = None;
+    let mut state_shape_filter: Option<Vec<QueryStatusFilter>> = None;
     let mut id_filter: Option<String> = None;
     let mut metadata_filter: Option<(String, String)> = None;
     let mut metadata_prefix_filter: Option<(String, String)> = None;
@@ -648,6 +649,8 @@ pub fn parse_jobs_scan_strategy(filters: &[Expr]) -> JobsScanStrategy {
             }
         } else if let Some(statuses) = parse_multi_status_predicate(f) {
             multi_status_filter = Some(statuses);
+        } else if let Some(statuses) = parse_or_of_and_status_pins(f) {
+            state_shape_filter = Some(statuses);
         } else if metadata_filter.is_none() && metadata_prefix_filter.is_none() {
             if let Some((k, v)) = parse_metadata_eq_filter(f) {
                 metadata_filter = Some((k, v));
@@ -684,7 +687,9 @@ pub fn parse_jobs_scan_strategy(filters: &[Expr]) -> JobsScanStrategy {
             tenant: tenant_filter,
             status,
         }
-    } else if let Some(statuses) = multi_status_filter {
+    } else if let Some(statuses) = multi_status_filter.or(state_shape_filter) {
+        // Pure multi-status predicates take precedence over residue-carrying
+        // state shapes: their Exact classification saves the post-filter.
         match (statuses.len(), &tenant_filter) {
             // A one-element predicate is just the single-status strategy.
             (1, _) => JobsScanStrategy::Status {
@@ -725,6 +730,74 @@ fn parse_multi_status_predicate(expr: &Expr) -> Option<Vec<QueryStatusFilter>> {
     let mut statuses = Vec::new();
     collect_multi_status(expr, &mut statuses)?;
     (!statuses.is_empty()).then_some(statuses)
+}
+
+/// Parse the state-filter shape: an OR chain where every arm pins `status_kind` —
+/// directly (an equality, IN-list, or OR-of-equalities) or inside an AND group
+/// alongside non-status residue (e.g. `current_attempt` predicates). Returns the
+/// union of pinned statuses.
+///
+/// The residue is not answered by a union scan, so callers must keep the whole
+/// predicate Inexact: the union only bounds which index ranges are visited.
+/// Over-coverage (an arm with several pins unions them all) is safe under the
+/// post-filter; an arm with no pin makes the shape unusable (returns None),
+/// since its rows could live under any status.
+fn parse_or_of_and_status_pins(expr: &Expr) -> Option<Vec<QueryStatusFilter>> {
+    let is_or = matches!(
+        expr,
+        Expr::BinaryExpr(BinaryExpr {
+            op: Operator::Or,
+            ..
+        })
+    );
+    if !is_or {
+        return None;
+    }
+    let mut statuses = Vec::new();
+    collect_state_shape_arm(expr, &mut statuses)?;
+    (!statuses.is_empty()).then_some(statuses)
+}
+
+/// Recursive worker for `parse_or_of_and_status_pins`: descends OR chains; each
+/// arm is either a pure status pin or an AND group containing at least one pin.
+fn collect_state_shape_arm(expr: &Expr, out: &mut Vec<QueryStatusFilter>) -> Option<()> {
+    match expr {
+        Expr::BinaryExpr(BinaryExpr { left, op, right }) if *op == Operator::Or => {
+            collect_state_shape_arm(left, out)?;
+            collect_state_shape_arm(right, out)
+        }
+        Expr::BinaryExpr(BinaryExpr { op, .. }) if *op == Operator::And => {
+            let mut conjuncts = Vec::new();
+            flatten_and(expr, &mut conjuncts);
+            let mut arm_pinned = false;
+            for conjunct in conjuncts {
+                let mut pin = Vec::new();
+                if collect_multi_status(conjunct, &mut pin).is_some() && !pin.is_empty() {
+                    arm_pinned = true;
+                    for status in pin {
+                        if !out.contains(&status) {
+                            out.push(status);
+                        }
+                    }
+                }
+            }
+            arm_pinned.then_some(())
+        }
+        // A bare arm must be a pure pin (equality or IN-list).
+        other => collect_multi_status(other, out),
+    }
+}
+
+/// Flatten an AND chain into its conjunct expressions.
+fn flatten_and<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
+    if let Expr::BinaryExpr(BinaryExpr { left, op, right }) = expr
+        && *op == Operator::And
+    {
+        flatten_and(left, out);
+        flatten_and(right, out);
+    } else {
+        out.push(expr);
+    }
 }
 
 /// Recursive worker for `parse_multi_status_predicate`: descends OR chains and

--- a/src/query.rs
+++ b/src/query.rs
@@ -570,41 +570,20 @@ fn classify_filter_pushdown(
     if let Some((col, val)) = parse_eq_filter(expr) {
         let col_name = col.rsplit('.').next().unwrap_or(&col);
         return match (col_name, strategy) {
-            // Tenant scopes every strategy's scan range when present.
-            (
-                "tenant",
-                JobsScanStrategy::ExactId {
-                    tenant: Some(_), ..
-                },
-            )
-            | (
-                "tenant",
-                JobsScanStrategy::MetadataExact {
-                    tenant: Some(_), ..
-                },
-            )
-            | (
-                "tenant",
-                JobsScanStrategy::MetadataPrefix {
-                    tenant: Some(_), ..
-                },
-            )
-            | (
-                "tenant",
-                JobsScanStrategy::Status {
-                    tenant: Some(_), ..
-                },
-            )
-            | ("tenant", JobsScanStrategy::StatusUnion { .. })
-            | ("tenant", JobsScanStrategy::FullScan { tenant: Some(_) }) => Exact,
+            // An equality is Exact only when its value is the one the strategy
+            // actually planned — with conflicting duplicates (tenant='a' AND
+            // tenant='b') last-write-wins picks one, and the loser must stay an
+            // Inexact post-filter rather than being silently dropped.
+            ("tenant", _) if strategy_tenant(strategy) == Some(val.as_str()) => Exact,
             // ExactId with tenant: direct pair construction answers both filters.
             // Without tenant it falls back to scan_all_jobs + in-memory filter.
             (
                 "id",
                 JobsScanStrategy::ExactId {
-                    tenant: Some(_), ..
+                    tenant: Some(_),
+                    id,
                 },
-            ) => Exact,
+            ) if *id == val => Exact,
             ("status_kind", JobsScanStrategy::Status { status, .. })
                 if parse_status_kind(&val) == Some(*status) =>
             {
@@ -628,6 +607,18 @@ fn classify_filter_pushdown(
         };
     }
     Inexact
+}
+
+/// The tenant a strategy's scan is actually scoped to, if any.
+fn strategy_tenant(strategy: &JobsScanStrategy) -> Option<&str> {
+    match strategy {
+        JobsScanStrategy::ExactId { tenant, .. }
+        | JobsScanStrategy::MetadataExact { tenant, .. }
+        | JobsScanStrategy::MetadataPrefix { tenant, .. }
+        | JobsScanStrategy::Status { tenant, .. }
+        | JobsScanStrategy::FullScan { tenant } => tenant.as_deref(),
+        JobsScanStrategy::StatusUnion { tenant, .. } => Some(tenant),
+    }
 }
 
 pub fn parse_jobs_scan_strategy(filters: &[Expr]) -> JobsScanStrategy {
@@ -1089,23 +1080,14 @@ fn status_index_stream(
                     Some(scan_now),
                 )
             }
+            JobsScanStrategy::FullScan { tenant: Some(t) } => {
+                let start = crate::keys::idx_status_time_tenant_prefix(t);
+                let end = crate::keys::end_bound(&start);
+                (vec![(start, end)], None)
+            }
             _ => {
-                let tenant = match &strategy {
-                    JobsScanStrategy::FullScan { tenant } => tenant.clone(),
-                    _ => None,
-                };
-                let (start, end) = match &tenant {
-                    Some(t) => {
-                        let s = crate::keys::idx_status_time_tenant_prefix(t);
-                        let e = crate::keys::end_bound(&s);
-                        (s, e)
-                    }
-                    None => {
-                        let s = crate::keys::idx_status_time_all_prefix();
-                        let e = crate::keys::end_bound(&s);
-                        (s, e)
-                    }
-                };
+                let start = crate::keys::idx_status_time_all_prefix();
+                let end = crate::keys::end_bound(&start);
                 (vec![(start, end)], None)
             }
         };
@@ -1545,23 +1527,16 @@ fn pairs_scan_plans(
     now_ms: i64,
 ) -> Vec<(Vec<u8>, Vec<u8>, PairExtractor)> {
     if let JobsScanStrategy::StatusUnion { tenant, statuses } = strategy {
-        // Per-status ranges are disjoint at any instant (a job has exactly one
-        // stored status; the Waiting/FutureScheduled split partitions by time
-        // against the shared `now_ms` snapshot), so no cross-range dedup is needed.
+        // Per-status byte ranges are disjoint against the shared `now_ms`
+        // snapshot (a job has exactly one stored status; the virtual
+        // Waiting/FutureScheduled split partitions by time), so no cross-range
+        // dedup is performed. Each arm still opens its own cursor at its own DB
+        // snapshot, so a job transitioning between two union statuses mid-scan
+        // can straddle arms — the same tolerance today's index streams have for
+        // mid-scan transitions.
         return statuses
             .iter()
-            .map(|status| {
-                let (start, end) = status_index_range(tenant, *status, now_ms);
-                let tenant = tenant.clone();
-                let f: PairExtractor = Box::new(move |k: &[u8]| {
-                    ControlFlow::Continue(
-                        crate::keys::parse_status_time_index_key(k)
-                            .filter(|p| !p.job_id.is_empty())
-                            .map(|p| (tenant.clone(), p.job_id)),
-                    )
-                });
-                (start, end, f)
-            })
+            .map(|status| status_pairs_scan_plan(Some(tenant), *status, now_ms))
             .collect();
     }
     vec![single_pairs_scan_plan(strategy, now_ms)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -82,6 +82,9 @@ pub fn stream_with_deadline(
 /// closure so streaming scans can early-exit (`Break`) and skip (`Continue(None)`).
 type PairExtractor = Box<dyn Fn(&[u8]) -> ControlFlow<(), Option<(String, String)>> + Send>;
 
+/// An inclusive-start / exclusive-end key range for a range scan.
+type KeyRange = (Vec<u8>, Vec<u8>);
+
 /// Map any displayable error into a DataFusion execution error.
 fn exec_err(e: impl std::fmt::Display) -> DataFusionError {
     DataFusionError::Execution(e.to_string())
@@ -456,6 +459,14 @@ pub enum JobsScanStrategy {
         tenant: Option<String>,
         status: QueryStatusFilter,
     },
+    /// Union of per-status index range scans for a multi-status predicate
+    /// (a literal IN-list or an OR of equalities on status_kind). Tenant-gated:
+    /// without a tenant filter a union would make N full index passes where a
+    /// FullScan makes one, so it is never selected tenant-less.
+    StatusUnion {
+        tenant: String,
+        statuses: Vec<QueryStatusFilter>,
+    },
     /// Full scan (no index-backed filter)
     FullScan { tenant: Option<String> },
 }
@@ -487,6 +498,18 @@ impl std::fmt::Display for JobsScanStrategy {
             JobsScanStrategy::Status { tenant, status } => {
                 write!(f, "Status(tenant={:?}, status={})", tenant, status)
             }
+            JobsScanStrategy::StatusUnion { tenant, statuses } => {
+                let statuses = statuses
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                write!(
+                    f,
+                    "StatusUnion(tenant={:?}, statuses=[{}])",
+                    tenant, statuses
+                )
+            }
             JobsScanStrategy::FullScan { tenant } => {
                 write!(f, "FullScan(tenant={:?})", tenant)
             }
@@ -504,16 +527,9 @@ pub fn classify_jobs_filters(filters: &[&Expr]) -> Vec<TableProviderFilterPushDo
     let unqualified_filters: Vec<Expr> = filters.iter().map(|f| unqualify_expr(f)).collect();
     let strategy = parse_jobs_scan_strategy(&unqualified_filters);
 
-    filters
+    unqualified_filters
         .iter()
-        .map(|f| {
-            if let Some((col, _)) = parse_eq_filter(f) {
-                let col_name = col.rsplit('.').next().unwrap_or(&col);
-                classify_filter_pushdown(col_name, &strategy)
-            } else {
-                TableProviderFilterPushDown::Inexact
-            }
-        })
+        .map(|f| classify_filter_pushdown(f, &strategy))
         .collect()
 }
 
@@ -526,50 +542,98 @@ fn unqualify_expr(expr: &Expr) -> Expr {
             op: *op,
             right: Box::new(unqualify_expr(right)),
         }),
+        Expr::InList(inlist) => Expr::InList(datafusion::logical_expr::expr::InList {
+            expr: Box::new(unqualify_expr(&inlist.expr)),
+            list: inlist.list.iter().map(unqualify_expr).collect(),
+            negated: inlist.negated,
+        }),
         Expr::Column(col) => Expr::Column(datafusion::common::Column::new_unqualified(&col.name)),
         other => other.clone(),
     }
 }
 
-/// Determine if a specific filter column is Exact (fully handled) for the given strategy.
-/// A filter is Exact when the scan guarantees correct results without post-filtering.
+/// Determine if a filter expression is Exact (fully handled) for the given strategy.
+/// A filter is Exact only when the chosen scan guarantees correct results without
+/// re-applying it; everything else stays Inexact so DataFusion adds a post-filter.
+///
+/// Status predicates are matched against the strategy they produced: a status
+/// equality is Exact only under the single-status strategy for that same status,
+/// and a multi-status predicate (IN / OR-of-equalities) is Exact only when it is
+/// the union the strategy actually scans. When several status predicates are
+/// ANDed, only the one driving the scan is Exact — the rest must be re-applied,
+/// never silently dropped.
 fn classify_filter_pushdown(
-    col_name: &str,
+    expr: &Expr,
     strategy: &JobsScanStrategy,
 ) -> TableProviderFilterPushDown {
-    match strategy {
-        // ExactId with tenant: both filters are handled exactly (direct pair construction).
-        // ExactId without tenant: the scan falls back to scan_all_jobs + in-memory filter,
-        // so neither filter is exact (limit pushdown would truncate before filtering).
-        JobsScanStrategy::ExactId { tenant, .. } => match col_name {
-            "id" if tenant.is_some() => TableProviderFilterPushDown::Exact,
-            "tenant" if tenant.is_some() => TableProviderFilterPushDown::Exact,
-            _ => TableProviderFilterPushDown::Inexact,
-        },
-        // Status: tenant scopes the scan, status_kind selects the index range.
-        JobsScanStrategy::Status { tenant, .. } => match col_name {
-            "status_kind" => TableProviderFilterPushDown::Exact,
-            "tenant" if tenant.is_some() => TableProviderFilterPushDown::Exact,
-            _ => TableProviderFilterPushDown::Inexact,
-        },
-        // Metadata strategies: tenant is handled, but status_kind is NOT filtered
-        // by the metadata index scan, so it must remain Inexact.
-        JobsScanStrategy::MetadataExact { tenant, .. }
-        | JobsScanStrategy::MetadataPrefix { tenant, .. } => match col_name {
-            "tenant" if tenant.is_some() => TableProviderFilterPushDown::Exact,
-            _ => TableProviderFilterPushDown::Inexact,
-        },
-        // FullScan: tenant scopes the scan range but no other filters are handled.
-        JobsScanStrategy::FullScan { tenant } => match col_name {
-            "tenant" if tenant.is_some() => TableProviderFilterPushDown::Exact,
-            _ => TableProviderFilterPushDown::Inexact,
-        },
+    use TableProviderFilterPushDown::{Exact, Inexact};
+    if let Some((col, val)) = parse_eq_filter(expr) {
+        let col_name = col.rsplit('.').next().unwrap_or(&col);
+        return match (col_name, strategy) {
+            // Tenant scopes every strategy's scan range when present.
+            (
+                "tenant",
+                JobsScanStrategy::ExactId {
+                    tenant: Some(_), ..
+                },
+            )
+            | (
+                "tenant",
+                JobsScanStrategy::MetadataExact {
+                    tenant: Some(_), ..
+                },
+            )
+            | (
+                "tenant",
+                JobsScanStrategy::MetadataPrefix {
+                    tenant: Some(_), ..
+                },
+            )
+            | (
+                "tenant",
+                JobsScanStrategy::Status {
+                    tenant: Some(_), ..
+                },
+            )
+            | ("tenant", JobsScanStrategy::StatusUnion { .. })
+            | ("tenant", JobsScanStrategy::FullScan { tenant: Some(_) }) => Exact,
+            // ExactId with tenant: direct pair construction answers both filters.
+            // Without tenant it falls back to scan_all_jobs + in-memory filter.
+            (
+                "id",
+                JobsScanStrategy::ExactId {
+                    tenant: Some(_), ..
+                },
+            ) => Exact,
+            ("status_kind", JobsScanStrategy::Status { status, .. })
+                if parse_status_kind(&val) == Some(*status) =>
+            {
+                Exact
+            }
+            _ => Inexact,
+        };
     }
+    if let Some(statuses) = parse_multi_status_predicate(expr) {
+        return match strategy {
+            JobsScanStrategy::StatusUnion {
+                statuses: chosen, ..
+            } if *chosen == statuses => Exact,
+            // A one-element predicate collapses to the single-status strategy.
+            JobsScanStrategy::Status { status, .. }
+                if statuses.len() == 1 && statuses[0] == *status =>
+            {
+                Exact
+            }
+            _ => Inexact,
+        };
+    }
+    Inexact
 }
 
 pub fn parse_jobs_scan_strategy(filters: &[Expr]) -> JobsScanStrategy {
     let mut tenant_filter: Option<String> = None;
     let mut status_filter: Option<QueryStatusFilter> = None;
+    let mut multi_status_filter: Option<Vec<QueryStatusFilter>> = None;
     let mut id_filter: Option<String> = None;
     let mut metadata_filter: Option<(String, String)> = None;
     let mut metadata_prefix_filter: Option<(String, String)> = None;
@@ -582,6 +646,8 @@ pub fn parse_jobs_scan_strategy(filters: &[Expr]) -> JobsScanStrategy {
                 "id" => id_filter = Some(val),
                 _ => {}
             }
+        } else if let Some(statuses) = parse_multi_status_predicate(f) {
+            multi_status_filter = Some(statuses);
         } else if metadata_filter.is_none() && metadata_prefix_filter.is_none() {
             if let Some((k, v)) = parse_metadata_eq_filter(f) {
                 metadata_filter = Some((k, v));
@@ -611,13 +677,92 @@ pub fn parse_jobs_scan_strategy(filters: &[Expr]) -> JobsScanStrategy {
             prefix,
         }
     } else if let Some(status) = status_filter {
+        // When a single-status equality is ANDed with a multi-status predicate,
+        // the equality drives the scan (its range is a subset of any union) and
+        // the multi-status predicate stays an Inexact post-filter.
         JobsScanStrategy::Status {
             tenant: tenant_filter,
             status,
         }
+    } else if let Some(statuses) = multi_status_filter {
+        match (statuses.len(), &tenant_filter) {
+            // A one-element predicate is just the single-status strategy.
+            (1, _) => JobsScanStrategy::Status {
+                tenant: tenant_filter,
+                status: statuses[0],
+            },
+            // Tenant-gated: a tenant-less union would make N full index passes
+            // where a single FullScan makes one.
+            (_, Some(tenant)) => JobsScanStrategy::StatusUnion {
+                tenant: tenant.clone(),
+                statuses,
+            },
+            (_, None) => JobsScanStrategy::FullScan {
+                tenant: tenant_filter,
+            },
+        }
     } else {
         JobsScanStrategy::FullScan {
             tenant: tenant_filter,
+        }
+    }
+}
+
+/// Parse a multi-status predicate on `status_kind`: a non-negated literal
+/// IN-list, or an OR chain of pure `status_kind = '<literal>'` equalities.
+/// Returns the per-element status filters in predicate order (deduped), or
+/// None when the expression is any other shape — including any OR arm that is
+/// not a pure status equality, or any element that is not a recognized status.
+fn parse_multi_status_predicate(expr: &Expr) -> Option<Vec<QueryStatusFilter>> {
+    let is_candidate = match expr {
+        Expr::InList(inlist) => !inlist.negated,
+        Expr::BinaryExpr(BinaryExpr { op, .. }) => *op == Operator::Or,
+        _ => false,
+    };
+    if !is_candidate {
+        return None;
+    }
+    let mut statuses = Vec::new();
+    collect_multi_status(expr, &mut statuses)?;
+    (!statuses.is_empty()).then_some(statuses)
+}
+
+/// Recursive worker for `parse_multi_status_predicate`: descends OR chains and
+/// IN-lists, requiring every leaf to pin `status_kind` to a recognized status.
+fn collect_multi_status(expr: &Expr, out: &mut Vec<QueryStatusFilter>) -> Option<()> {
+    let mut push = |status: QueryStatusFilter| {
+        if !out.contains(&status) {
+            out.push(status);
+        }
+    };
+    match expr {
+        Expr::InList(inlist) if !inlist.negated => {
+            let Expr::Column(col) = inlist.expr.as_ref() else {
+                return None;
+            };
+            if col.name != "status_kind" {
+                return None;
+            }
+            for item in &inlist.list {
+                let Expr::Literal(s, _) = item else {
+                    return None;
+                };
+                push(parse_status_kind(&literal_to_string(s)?)?);
+            }
+            Some(())
+        }
+        Expr::BinaryExpr(BinaryExpr { left, op, right }) if *op == Operator::Or => {
+            collect_multi_status(left, out)?;
+            collect_multi_status(right, out)
+        }
+        _ => {
+            let (col, val) = parse_eq_filter(expr)?;
+            let col_name = col.rsplit('.').next().unwrap_or(&col);
+            if col_name != "status_kind" {
+                return None;
+            }
+            push(parse_status_kind(&val)?);
+            Some(())
         }
     }
 }
@@ -722,10 +867,14 @@ fn analyze_projection(projection: &SchemaRef, strategy: &JobsScanStrategy) -> Pr
     // When no job_info fields or status point-lookup fields are needed (including the
     // empty-projection case for COUNT(*)), scan the status/time index directly and skip
     // all get_jobs_batch / get_jobs_status_batch point-lookups.
-    // Only valid for FullScan — other strategies already have a bounded pair list.
+    // Valid for FullScan (whole index prefix) and StatusUnion (per-status ranges of the
+    // same index) — other strategies already have a bounded pair list.
     let use_status_index_path = !need_job_info
         && !need_status_point_lookup
-        && matches!(strategy, JobsScanStrategy::FullScan { .. });
+        && matches!(
+            strategy,
+            JobsScanStrategy::FullScan { .. } | JobsScanStrategy::StatusUnion { .. }
+        );
     // ExactId with a tenant synthesises the pair without scanning the DB, so we must
     // verify existence via get_jobs_batch even when job_info columns aren't projected.
     let needs_existence_check = matches!(
@@ -841,7 +990,9 @@ fn count_from_counters_stream(
 /// Streams the status/time index in bounded chunks, emitting RecordBatches with
 /// no point-lookups. Used when the projection only needs tenant, id,
 /// status_kind, or status_changed_at_ms (including the COUNT(*) fallback when
-/// counter-based counting is disabled).
+/// counter-based counting is disabled). Serves FullScan (one whole-prefix range)
+/// and StatusUnion (one range per status arm, all planned from a single clock
+/// snapshot that also fixes the emitted virtual-status labels).
 fn status_index_stream(
     shard: Arc<JobStoreShard>,
     projection: SchemaRef,
@@ -850,69 +1001,121 @@ fn status_index_stream(
     limit: Option<usize>,
 ) -> impl Stream<Item = DfResult<RecordBatch>> {
     async_stream::try_stream! {
-        let tenant = match &strategy {
-            JobsScanStrategy::FullScan { tenant } => tenant.clone(),
-            _ => None,
-        };
-        let (start, end) = match &tenant {
-            Some(t) => {
-                let s = crate::keys::idx_status_time_tenant_prefix(t);
-                let e = crate::keys::end_bound(&s);
-                (s, e)
+        // FullScan keeps its per-batch label clock (`None`); a union plans every
+        // arm's range from one snapshot and labels rows with that same snapshot,
+        // so a job crossing its scheduled-start time mid-scan cannot appear in
+        // two arms or carry a label inconsistent with the arm that produced it.
+        let (ranges, label_now): (Vec<KeyRange>, Option<i64>) = match &strategy {
+            JobsScanStrategy::StatusUnion { tenant, statuses } => {
+                let scan_now = crate::job_store_shard::helpers::now_epoch_ms();
+                (
+                    statuses
+                        .iter()
+                        .map(|status| status_index_range(tenant, *status, scan_now))
+                        .collect(),
+                    Some(scan_now),
+                )
             }
-            None => {
-                let s = crate::keys::idx_status_time_all_prefix();
-                let e = crate::keys::end_bound(&s);
-                (s, e)
+            _ => {
+                let tenant = match &strategy {
+                    JobsScanStrategy::FullScan { tenant } => tenant.clone(),
+                    _ => None,
+                };
+                let (start, end) = match &tenant {
+                    Some(t) => {
+                        let s = crate::keys::idx_status_time_tenant_prefix(t);
+                        let e = crate::keys::end_bound(&s);
+                        (s, e)
+                    }
+                    None => {
+                        let s = crate::keys::idx_status_time_all_prefix();
+                        let e = crate::keys::end_bound(&s);
+                        (s, e)
+                    }
+                };
+                (vec![(start, end)], None)
             }
         };
         let shard_id = shard.name().to_string();
-        let mut cursor = shard
-            .open_range_cursor(start, end, &crate::scan_options())
-            .await
-            .map_err(exec_err)?;
         let mut sent = 0usize;
-        loop {
-            if limit.is_some_and(|l| sent >= l) {
-                break;
-            }
-            // Never pull more index keys than the LIMIT still needs.
-            let want = limit.map_or(batch_size, |l| batch_size.min(l - sent));
-            let chunk = cursor.next_kv_chunk(want).await.map_err(exec_err)?;
-            if chunk.is_empty() {
-                break;
-            }
-            let mut rows: Vec<(String, String, String, i64)> = Vec::with_capacity(chunk.len());
-            for kv in &chunk {
-                let Some(p) = crate::keys::parse_status_time_index_key(&kv.key)
-                    .filter(|p| !p.job_id.is_empty())
-                else {
-                    continue;
-                };
-                let changed = p.changed_at_ms();
-                rows.push((p.tenant, p.job_id, p.status, changed));
-            }
-            if rows.is_empty() {
-                continue;
-            }
-            if let Some(l) = limit {
-                let remaining = l - sent;
-                if rows.len() > remaining {
-                    rows.truncate(remaining);
+        'ranges: for (start, end) in ranges {
+            let mut cursor = shard
+                .open_range_cursor(start, end, &crate::scan_options())
+                .await
+                .map_err(exec_err)?;
+            loop {
+                // Scan-limit short-circuit counts rows already emitted by prior arms.
+                if limit.is_some_and(|l| sent >= l) {
+                    break 'ranges;
                 }
+                // Never pull more index keys than the LIMIT still needs.
+                let want = limit.map_or(batch_size, |l| batch_size.min(l - sent));
+                let chunk = cursor.next_kv_chunk(want).await.map_err(exec_err)?;
+                if chunk.is_empty() {
+                    break;
+                }
+                let mut rows: Vec<(String, String, String, i64)> = Vec::with_capacity(chunk.len());
+                for kv in &chunk {
+                    let Some(p) = crate::keys::parse_status_time_index_key(&kv.key)
+                        .filter(|p| !p.job_id.is_empty())
+                    else {
+                        continue;
+                    };
+                    let changed = p.changed_at_ms();
+                    rows.push((p.tenant, p.job_id, p.status, changed));
+                }
+                if rows.is_empty() {
+                    continue;
+                }
+                if let Some(l) = limit {
+                    let remaining = l - sent;
+                    if rows.len() > remaining {
+                        rows.truncate(remaining);
+                    }
+                }
+                let batch_now =
+                    label_now.unwrap_or_else(crate::job_store_shard::helpers::now_epoch_ms);
+                let batch = build_status_index_batch(&projection, &shard_id, &rows, batch_now)?;
+                sent += batch.num_rows();
+                yield batch;
             }
-            let batch = build_status_index_batch(&projection, &shard_id, &rows)?;
-            sent += batch.num_rows();
-            yield batch;
+        }
+    }
+}
+
+/// Tenant-scoped status/time index range for one status filter arm. `now_ms`
+/// fixes the virtual Waiting / FutureScheduled boundary within the stored
+/// Scheduled range, so all arms of a union planned from the same snapshot
+/// partition the index without overlap.
+fn status_index_range(tenant: &str, status: QueryStatusFilter, now_ms: i64) -> KeyRange {
+    use crate::keys;
+    let inverted_now = u64::MAX - (now_ms.max(0) as u64);
+    match status {
+        QueryStatusFilter::Stored(kind) => {
+            let start = keys::idx_status_time_prefix(tenant, kind.as_str());
+            let end = keys::end_bound(&start);
+            (start, end)
+        }
+        QueryStatusFilter::Waiting => {
+            let start = keys::idx_status_time_prefix_with_time(tenant, "Scheduled", inverted_now);
+            let end = keys::end_bound(&keys::idx_status_time_prefix(tenant, "Scheduled"));
+            (start, end)
+        }
+        QueryStatusFilter::FutureScheduled => {
+            let start = keys::idx_status_time_prefix(tenant, "Scheduled");
+            let end = keys::idx_status_time_prefix_with_time(tenant, "Scheduled", inverted_now);
+            (start, end)
         }
     }
 }
 
 /// Build a RecordBatch for the status-index fast path from a chunk of index entries.
+/// `now_ms` is the clock used for the virtual Waiting/Scheduled label split.
 fn build_status_index_batch(
     projection: &SchemaRef,
     shard_id: &str,
     chunk: &[(String, String, String, i64)],
+    now_ms: i64,
 ) -> DfResult<RecordBatch> {
     let n = chunk.len();
     if projection.fields().is_empty() {
@@ -938,7 +1141,6 @@ fn build_status_index_batch(
                 // Apply the same Waiting/Scheduled logic as display_status_kind.
                 // For Scheduled jobs, the index timestamp is next_attempt_starts_after_ms
                 // (see status_index_timestamp). If that time has passed, the job is Waiting.
-                let now_ms = crate::job_store_shard::helpers::now_epoch_ms();
                 Arc::new(StringArray::from(
                     chunk
                         .iter()
@@ -1186,78 +1388,117 @@ fn job_pairs_stream(
             return;
         }
 
+        // All plans (one per union arm; a single plan otherwise) are computed from
+        // one clock snapshot, so a job crossing its scheduled-start time mid-scan
+        // cannot fall into two arms' ranges even on a quiescent shard.
         let now_ms = crate::job_store_shard::helpers::now_epoch_ms();
-        let (start, end, extractor) = pairs_scan_plan(&strategy, now_ms);
-        let mut cursor = shard
-            .open_range_cursor(start, end, &crate::scan_options())
-            .await
-            .map_err(exec_err)?;
+        let plans = pairs_scan_plans(&strategy, now_ms);
 
         let mut sent = 0usize;
-        let mut pending: Vec<(String, String)> = Vec::new();
-        let mut done = false;
-        loop {
-            if limit.is_some_and(|l| sent >= l) {
-                break;
-            }
-            // Fill `pending` up to a hydration batch, but never resolve more pairs
-            // than the LIMIT still needs (so a small LIMIT scans few index keys).
-            let want = limit.map_or(fetch_batch, |l| fetch_batch.min(l - sent));
-            while pending.len() < want && !done {
-                let chunk = cursor
-                    .next_kv_chunk(want - pending.len())
-                    .await
-                    .map_err(exec_err)?;
-                if chunk.is_empty() {
-                    done = true;
-                    break;
+        'plans: for (start, end, extractor) in plans {
+            let mut cursor = shard
+                .open_range_cursor(start, end, &crate::scan_options())
+                .await
+                .map_err(exec_err)?;
+
+            let mut pending: Vec<(String, String)> = Vec::new();
+            let mut done = false;
+            loop {
+                // Scan-limit short-circuit counts rows already emitted by prior arms.
+                if limit.is_some_and(|l| sent >= l) {
+                    break 'plans;
                 }
-                for kv in &chunk {
-                    match extractor(&kv.key) {
-                        ControlFlow::Continue(Some(pair)) => pending.push(pair),
-                        ControlFlow::Continue(None) => {}
-                        ControlFlow::Break(()) => {
-                            done = true;
-                            break;
+                // Fill `pending` up to a hydration batch, but never resolve more pairs
+                // than the LIMIT still needs (so a small LIMIT scans few index keys).
+                let want = limit.map_or(fetch_batch, |l| fetch_batch.min(l - sent));
+                while pending.len() < want && !done {
+                    let chunk = cursor
+                        .next_kv_chunk(want - pending.len())
+                        .await
+                        .map_err(exec_err)?;
+                    if chunk.is_empty() {
+                        done = true;
+                        break;
+                    }
+                    for kv in &chunk {
+                        match extractor(&kv.key) {
+                            ControlFlow::Continue(Some(pair)) => pending.push(pair),
+                            ControlFlow::Continue(None) => {}
+                            ControlFlow::Break(()) => {
+                                done = true;
+                                break;
+                            }
                         }
                     }
                 }
-            }
-            if pending.is_empty() {
-                break;
-            }
-            if let Some(l) = limit {
-                let remaining = l - sent;
-                if pending.len() > remaining {
-                    pending.truncate(remaining);
+                if pending.is_empty() {
+                    break;
                 }
-            }
-            let (jobs_map, status_map) = fetch_batch_data(&shard, &pending, &needs).await?;
-            // With job_info fetched, the map is the authoritative presence check;
-            // otherwise the index scan is the source of truth (scans skip tombstones).
-            let existing: Vec<&(String, String)> = if needs.need_job_info || needs.needs_existence_check {
-                pending.iter().filter(|pair| jobs_map.contains_key(*pair)).collect()
-            } else {
-                pending.iter().collect()
-            };
-            if !existing.is_empty() {
-                let batch =
-                    build_job_pairs_batch(&projection, &shard_id, &existing, &jobs_map, &status_map)?;
-                sent += batch.num_rows();
-                yield batch;
-            }
-            pending.clear();
-            if done {
-                break;
+                if let Some(l) = limit {
+                    let remaining = l - sent;
+                    if pending.len() > remaining {
+                        pending.truncate(remaining);
+                    }
+                }
+                let (jobs_map, status_map) = fetch_batch_data(&shard, &pending, &needs).await?;
+                // With job_info fetched, the map is the authoritative presence check;
+                // otherwise the index scan is the source of truth (scans skip tombstones).
+                let existing: Vec<&(String, String)> = if needs.need_job_info || needs.needs_existence_check {
+                    pending.iter().filter(|pair| jobs_map.contains_key(*pair)).collect()
+                } else {
+                    pending.iter().collect()
+                };
+                if !existing.is_empty() {
+                    let batch =
+                        build_job_pairs_batch(&projection, &shard_id, &existing, &jobs_map, &status_map)?;
+                    sent += batch.num_rows();
+                    yield batch;
+                }
+                pending.clear();
+                if done {
+                    break;
+                }
             }
         }
     }
 }
 
-/// Compute the `(start, end, extractor)` scan plan for a non-FullScan pair
-/// resolution. The extractor mirrors the `ControlFlow` contract of the
+/// Compute the `(start, end, extractor)` scan plans for a non-FullScan pair
+/// resolution — one plan per union arm for StatusUnion, a single plan for every
+/// other strategy. The extractor mirrors the `ControlFlow` contract of the
 /// collect-oriented `scan_*` helpers so early-exit and skip semantics are preserved.
-fn pairs_scan_plan(strategy: &JobsScanStrategy, now_ms: i64) -> (Vec<u8>, Vec<u8>, PairExtractor) {
+fn pairs_scan_plans(
+    strategy: &JobsScanStrategy,
+    now_ms: i64,
+) -> Vec<(Vec<u8>, Vec<u8>, PairExtractor)> {
+    if let JobsScanStrategy::StatusUnion { tenant, statuses } = strategy {
+        // Per-status ranges are disjoint at any instant (a job has exactly one
+        // stored status; the Waiting/FutureScheduled split partitions by time
+        // against the shared `now_ms` snapshot), so no cross-range dedup is needed.
+        return statuses
+            .iter()
+            .map(|status| {
+                let (start, end) = status_index_range(tenant, *status, now_ms);
+                let tenant = tenant.clone();
+                let f: PairExtractor = Box::new(move |k: &[u8]| {
+                    ControlFlow::Continue(
+                        crate::keys::parse_status_time_index_key(k)
+                            .filter(|p| !p.job_id.is_empty())
+                            .map(|p| (tenant.clone(), p.job_id)),
+                    )
+                });
+                (start, end, f)
+            })
+            .collect();
+    }
+    vec![single_pairs_scan_plan(strategy, now_ms)]
+}
+
+/// Single-range scan plan for every non-union strategy.
+fn single_pairs_scan_plan(
+    strategy: &JobsScanStrategy,
+    now_ms: i64,
+) -> (Vec<u8>, Vec<u8>, PairExtractor) {
     use crate::keys;
     match strategy {
         JobsScanStrategy::ExactId { tenant: None, id } => {
@@ -1328,6 +1569,13 @@ fn pairs_scan_plan(strategy: &JobsScanStrategy, now_ms: i64) -> (Vec<u8>, Vec<u8
             tenant: Some(_), ..
         }
         | JobsScanStrategy::FullScan { .. } => all_jobs_pairs_plan(),
+        // Unions are expanded into per-arm plans by `pairs_scan_plans` before this
+        // function is reached. Falling through to the all-jobs plan would silently
+        // scan every tenant while the union predicate is classified Exact — a
+        // correctness bug, not a perf bug — so fail loudly instead.
+        JobsScanStrategy::StatusUnion { .. } => {
+            unreachable!("StatusUnion is expanded by pairs_scan_plans")
+        }
     }
 }
 
@@ -1357,9 +1605,10 @@ fn status_pairs_scan_plan(
     use crate::keys;
     let inverted_now = u64::MAX - (now_ms.max(0) as u64);
     match (status, tenant) {
-        (QueryStatusFilter::Stored(kind), Some(t)) => {
-            let start = keys::idx_status_time_prefix(t, kind.as_str());
-            let end = keys::end_bound(&start);
+        // Tenant-scoped arms share one range planner with the union paths; the
+        // range fully constrains status and time, so the extractor is a plain parse.
+        (status, Some(t)) => {
+            let (start, end) = status_index_range(t, status, now_ms);
             let tenant = t.to_string();
             let f: PairExtractor = Box::new(move |k: &[u8]| {
                 ControlFlow::Continue(
@@ -1383,19 +1632,6 @@ fn status_pairs_scan_plan(
             });
             (start, end, f)
         }
-        (QueryStatusFilter::Waiting, Some(t)) => {
-            let start = keys::idx_status_time_prefix_with_time(t, "Scheduled", inverted_now);
-            let end = keys::end_bound(&keys::idx_status_time_prefix(t, "Scheduled"));
-            let tenant = t.to_string();
-            let f: PairExtractor = Box::new(move |k: &[u8]| {
-                ControlFlow::Continue(
-                    keys::parse_status_time_index_key(k)
-                        .filter(|p| !p.job_id.is_empty())
-                        .map(|p| (tenant.clone(), p.job_id)),
-                )
-            });
-            (start, end, f)
-        }
         (QueryStatusFilter::Waiting, None) => {
             let start = keys::idx_status_time_all_prefix();
             let end = keys::end_bound(&start);
@@ -1408,19 +1644,6 @@ fn status_pairs_scan_plan(
                                 && !p.job_id.is_empty()
                         })
                         .map(|p| (p.tenant, p.job_id)),
-                )
-            });
-            (start, end, f)
-        }
-        (QueryStatusFilter::FutureScheduled, Some(t)) => {
-            let start = keys::idx_status_time_prefix(t, "Scheduled");
-            let end = keys::idx_status_time_prefix_with_time(t, "Scheduled", inverted_now);
-            let tenant = t.to_string();
-            let f: PairExtractor = Box::new(move |k: &[u8]| {
-                ControlFlow::Continue(
-                    keys::parse_status_time_index_key(k)
-                        .filter(|p| !p.job_id.is_empty())
-                        .map(|p| (tenant.clone(), p.job_id)),
                 )
             });
             (start, end, f)
@@ -1474,6 +1697,11 @@ async fn fetch_batch_data(
     for (tenant, ids) in &by_tenant {
         let need_jobs = needs.need_job_info || needs.needs_existence_check;
         let need_status = needs.need_any_status();
+        if (need_jobs || need_status)
+            && let Some(metrics) = &shard.metrics
+        {
+            metrics.record_query_point_lookups(shard.name(), ids.len() as u64);
+        }
         let (jobs_result, status_result) = tokio::join!(
             async {
                 if need_jobs {

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -2880,22 +2880,172 @@ async fn strategy_or_arm_without_status_pin_stays_fullscan() {
 }
 
 #[silo::test]
-async fn strategy_or_of_and_stays_fullscan_for_now() {
+async fn strategy_or_of_and_with_status_pins_unionizes_and_stays_inexact() {
     let (_tmp, shard) = open_temp_shard().await;
     enqueue_job(&shard, "j1", 5, now_ms()).await;
     let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
 
-    // OR-of-AND state-filter shapes are not unionized yet; they stay FullScan.
+    // The combined state-filter shape: every OR arm pins status_kind, one arm
+    // carries a non-status residue. The pins union; the residue means the whole
+    // predicate must be re-applied, so it is never classified Exact.
+    let query = "SELECT id FROM jobs WHERE tenant='-' AND (status_kind IN ('Waiting','Running','Succeeded','Failed') OR (status_kind='Scheduled' AND current_attempt > 1))";
+    let strategy = strategy_for(&sql, query).await;
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::StatusUnion {
+            tenant: "-".to_string(),
+            statuses: vec![
+                QueryStatusFilter::Waiting,
+                QueryStatusFilter::Stored(JobStatusKind::Running),
+                QueryStatusFilter::Stored(JobStatusKind::Succeeded),
+                QueryStatusFilter::Stored(JobStatusKind::Failed),
+                QueryStatusFilter::FutureScheduled,
+            ],
+        }
+    );
+    let classes = classifications_for(&sql, query).await;
+    let or_class = classes
+        .iter()
+        .find(|(text, _)| text.contains("current_attempt"))
+        .expect("state-shape predicate should be pushed");
+    assert_eq!(
+        or_class.1,
+        TableProviderFilterPushDown::Inexact,
+        "residue-carrying predicate must stay a post-filter"
+    );
+}
+
+#[silo::test]
+async fn strategy_or_of_and_with_composite_pins_unionizes() {
+    let (_tmp, shard) = open_temp_shard().await;
+    enqueue_job(&shard, "j1", 5, now_ms()).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    // An arm's pin may itself be an OR-of-equalities (or an IN-list); the store
+    // emits such arms for state filters spanning several simple states.
     let strategy = strategy_for(
         &sql,
-        "SELECT id FROM jobs WHERE tenant='-' AND (status_kind IN ('Waiting','Running','Succeeded','Failed') OR (status_kind='Scheduled' AND current_attempt > 1))",
+        "SELECT id FROM jobs WHERE tenant='-' AND (((status_kind='Succeeded' OR status_kind='Failed') AND current_attempt > 0) OR status_kind='Running')",
     )
     .await;
     assert_eq!(
         strategy,
-        JobsScanStrategy::FullScan {
-            tenant: Some("-".to_string()),
+        JobsScanStrategy::StatusUnion {
+            tenant: "-".to_string(),
+            statuses: vec![
+                QueryStatusFilter::Stored(JobStatusKind::Succeeded),
+                QueryStatusFilter::Stored(JobStatusKind::Failed),
+                QueryStatusFilter::Stored(JobStatusKind::Running),
+            ],
         }
+    );
+}
+
+#[silo::test]
+async fn sql_state_filter_shape_applies_residue_on_seeded_shard() {
+    // Jobs matching an arm's status pin but failing its residue must be excluded:
+    // the union only bounds the scan; the whole predicate is re-applied.
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // retrying1: fails once with a retry budget and a long backoff → stored
+    // Scheduled with current_attempt = 2 and a future start time.
+    let policy = silo::retry::RetryPolicy {
+        retry_count: 3,
+        initial_interval_ms: 3_600_000,
+        max_interval_ms: i64::MAX,
+        randomize_interval: false,
+        backoff_factor: 2.0,
+    };
+    shard
+        .enqueue(
+            "-",
+            Some("retrying1".to_string()),
+            1,
+            now,
+            Some(policy),
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+    let tasks = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 1);
+    shard
+        .report_attempt_outcome(
+            tasks[0].attempt().task_id(),
+            silo::job_attempt::AttemptOutcome::Error {
+                error_code: "TEST_ERROR".to_string(),
+                error: vec![],
+            },
+        )
+        .await
+        .expect("report error");
+    // future1: never attempted, future start → matches the Scheduled pin but
+    // fails the current_attempt residue.
+    enqueue_job(&shard, "future1", 10, now + 3_600_000).await;
+    enqueue_job(&shard, "waiting1", 10, now).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND (status_kind='Waiting' OR (status_kind='Scheduled' AND current_attempt > 1)) ORDER BY id",
+    )
+    .await;
+    assert_eq!(got, vec!["retrying1", "waiting1"]);
+}
+
+#[silo::test]
+async fn sql_state_filter_shape_scanned_keys_bounded_by_matches() {
+    // The combined state-filter shape must visit only the pinned status ranges,
+    // not the tenant's terminal bulk.
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+
+    // Bulk: 40 Succeeded jobs outside the pinned statuses.
+    for i in 0..40 {
+        enqueue_job(&shard, &format!("done{i:02}"), 1, now).await;
+    }
+    let tasks = shard
+        .dequeue("w", "default", 40)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 40);
+    for task in &tasks {
+        shard
+            .report_attempt_outcome(
+                task.attempt().task_id(),
+                silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+            )
+            .await
+            .expect("report success");
+    }
+    // Matching ranges: 2 Waiting + 1 future-Scheduled.
+    enqueue_job(&shard, "w1", 10, now).await;
+    enqueue_job(&shard, "w2", 10, now).await;
+    enqueue_job(&shard, "sched1", 10, now + 3_600_000).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let before = metrics.query_scanned_keys_value(shard.name());
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND (status_kind='Waiting' OR (status_kind='Scheduled' AND current_attempt > 1)) ORDER BY id",
+    )
+    .await;
+    let scanned = metrics.query_scanned_keys_value(shard.name()) - before;
+
+    // sched1 sits in the pinned Scheduled range (scanned) but fails the residue.
+    assert_eq!(got, vec!["w1", "w2"]);
+    assert!(
+        scanned < 20.0,
+        "state-filter shape scanned {scanned} keys; expected the ~3 pinned entries, not the 43-job tenant"
     );
 }
 

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -1488,8 +1488,11 @@ async fn sql_multiple_order_by() {
     assert_eq!(got, vec!["c", "b", "a"]);
 }
 
+use datafusion::logical_expr::TableProviderFilterPushDown;
 use silo::job::{ConcurrencyLimit, JobStatusKind, Limit};
-use silo::query::{JobsScanStrategy, QueryStatusFilter, parse_jobs_scan_strategy};
+use silo::query::{
+    JobsScanStrategy, QueryStatusFilter, classify_jobs_filters, parse_jobs_scan_strategy,
+};
 
 // Helper to query queues table and extract queue names
 async fn query_queue_names(sql: &ShardQueryEngine, query: &str) -> Vec<String> {
@@ -2738,6 +2741,649 @@ async fn strategy_id_takes_priority_over_metadata() {
             tenant: Some("-".to_string()),
             id: "combo".to_string(),
         }
+    );
+}
+
+// ===== Status-union strategy tests =====
+// Multi-status predicates (IN-lists and OR-of-equalities on status_kind) plan as a
+// tenant-gated union of per-status index range scans instead of a FullScan, so
+// point-lookups scale with matching rows rather than tenant size.
+
+/// Helper: parse the strategy for a query's pushed-down filters.
+async fn strategy_for(sql: &ShardQueryEngine, query: &str) -> JobsScanStrategy {
+    let plan = sql.get_physical_plan(query).await.expect("plan");
+    let exprs =
+        ShardQueryEngine::extract_pushed_filter_exprs(&plan).expect("should have filter exprs");
+    parse_jobs_scan_strategy(&exprs)
+}
+
+/// Helper: classify each pushed-down filter, returning (expr-string, pushdown) pairs.
+async fn classifications_for(
+    sql: &ShardQueryEngine,
+    query: &str,
+) -> Vec<(String, TableProviderFilterPushDown)> {
+    let plan = sql.get_physical_plan(query).await.expect("plan");
+    let exprs =
+        ShardQueryEngine::extract_pushed_filter_exprs(&plan).expect("should have filter exprs");
+    let refs: Vec<&datafusion::prelude::Expr> = exprs.iter().collect();
+    let classes = classify_jobs_filters(&refs);
+    exprs.iter().map(|e| format!("{e}")).zip(classes).collect()
+}
+
+#[silo::test]
+async fn strategy_status_in_list_unionizes() {
+    let (_tmp, shard) = open_temp_shard().await;
+    enqueue_job(&shard, "j1", 5, now_ms()).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    // 4+ elements so the SQL optimizer keeps the literal IN-list (<=3 lowers to ORs)
+    let strategy = strategy_for(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND status_kind IN ('Succeeded','Failed','Cancelled','Running')",
+    )
+    .await;
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::StatusUnion {
+            tenant: "-".to_string(),
+            statuses: vec![
+                QueryStatusFilter::Stored(JobStatusKind::Succeeded),
+                QueryStatusFilter::Stored(JobStatusKind::Failed),
+                QueryStatusFilter::Stored(JobStatusKind::Cancelled),
+                QueryStatusFilter::Stored(JobStatusKind::Running),
+            ],
+        }
+    );
+}
+
+#[silo::test]
+async fn strategy_status_or_of_equalities_unionizes() {
+    let (_tmp, shard) = open_temp_shard().await;
+    enqueue_job(&shard, "j1", 5, now_ms()).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    let strategy = strategy_for(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND (status_kind='Succeeded' OR status_kind='Failed')",
+    )
+    .await;
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::StatusUnion {
+            tenant: "-".to_string(),
+            statuses: vec![
+                QueryStatusFilter::Stored(JobStatusKind::Succeeded),
+                QueryStatusFilter::Stored(JobStatusKind::Failed),
+            ],
+        }
+    );
+}
+
+#[silo::test]
+async fn strategy_status_union_maps_virtual_statuses() {
+    let (_tmp, shard) = open_temp_shard().await;
+    enqueue_job(&shard, "j1", 5, now_ms()).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    // Waiting and Scheduled are virtual splits of the stored Scheduled status; the
+    // union must preserve the per-element mapping.
+    let strategy = strategy_for(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND (status_kind='Waiting' OR status_kind='Scheduled')",
+    )
+    .await;
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::StatusUnion {
+            tenant: "-".to_string(),
+            statuses: vec![
+                QueryStatusFilter::Waiting,
+                QueryStatusFilter::FutureScheduled
+            ],
+        }
+    );
+}
+
+#[silo::test]
+async fn strategy_tenantless_multi_status_stays_fullscan() {
+    let (_tmp, shard) = open_temp_shard().await;
+    enqueue_job(&shard, "j1", 5, now_ms()).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    // Without a tenant, a union would make N full index passes where FullScan makes one.
+    let strategy = strategy_for(
+        &sql,
+        "SELECT id FROM jobs WHERE status_kind IN ('Succeeded','Failed','Cancelled','Running')",
+    )
+    .await;
+    assert_eq!(strategy, JobsScanStrategy::FullScan { tenant: None });
+}
+
+#[silo::test]
+async fn strategy_or_arm_without_status_pin_stays_fullscan() {
+    let (_tmp, shard) = open_temp_shard().await;
+    enqueue_job(&shard, "j1", 5, now_ms()).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    // An OR arm that doesn't pin status_kind cannot be unionized (permanently).
+    let strategy = strategy_for(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND (status_kind='Failed' OR id='some-id')",
+    )
+    .await;
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::FullScan {
+            tenant: Some("-".to_string()),
+        }
+    );
+}
+
+#[silo::test]
+async fn strategy_or_of_and_stays_fullscan_for_now() {
+    let (_tmp, shard) = open_temp_shard().await;
+    enqueue_job(&shard, "j1", 5, now_ms()).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    // OR-of-AND state-filter shapes are not unionized yet; they stay FullScan.
+    let strategy = strategy_for(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND (status_kind IN ('Waiting','Running','Succeeded','Failed') OR (status_kind='Scheduled' AND current_attempt > 1))",
+    )
+    .await;
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::FullScan {
+            tenant: Some("-".to_string()),
+        }
+    );
+}
+
+#[silo::test]
+async fn strategy_single_status_equality_stays_single_status() {
+    let (_tmp, shard) = open_temp_shard().await;
+    enqueue_job(&shard, "j1", 5, now_ms()).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    // A lone equality keeps the existing single-status strategy, not a 1-element union.
+    let strategy = strategy_for(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND status_kind='Succeeded'",
+    )
+    .await;
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::Status {
+            tenant: Some("-".to_string()),
+            status: QueryStatusFilter::Stored(JobStatusKind::Succeeded),
+        }
+    );
+}
+
+#[silo::test]
+async fn classify_anded_status_predicates_scans_one_keeps_other_inexact() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Seed: succeeded1 (Succeeded), fail-free job stays Scheduled
+    enqueue_job(&shard, "succeeded1", 5, now).await;
+    enqueue_job(&shard, "waiting1", 10, now).await;
+    let tasks = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    shard
+        .report_attempt_outcome(
+            tasks[0].attempt().task_id(),
+            silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("report success");
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let query = "SELECT id FROM jobs WHERE tenant='-' AND status_kind='Succeeded' AND status_kind IN ('Succeeded','Failed','Cancelled','Running')";
+
+    // The single-equality predicate drives the scan; the IN predicate must stay an
+    // Inexact post-filter (never silently dropped).
+    let strategy = strategy_for(&sql, query).await;
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::Status {
+            tenant: Some("-".to_string()),
+            status: QueryStatusFilter::Stored(JobStatusKind::Succeeded),
+        }
+    );
+    let classes = classifications_for(&sql, query).await;
+    let in_class = classes
+        .iter()
+        .find(|(text, _)| text.contains("IN"))
+        .expect("IN predicate should be pushed");
+    assert_eq!(in_class.1, TableProviderFilterPushDown::Inexact);
+
+    // Results match the AND of both predicates.
+    let got = query_ids(&sql, query).await;
+    assert_eq!(got, vec!["succeeded1"]);
+}
+
+#[silo::test]
+async fn classify_metadata_with_multi_status_keeps_status_inexact() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+
+    // Two jobs share the metadata key; only one is pending. Marking the status
+    // predicate Exact for the metadata strategy would silently drop it (the
+    // bulk-cancel-preview shape).
+    enqueue_job_with_metadata(
+        &shard,
+        "meta-pending",
+        10,
+        now,
+        vec![("queue".to_string(), "q1".to_string())],
+    )
+    .await;
+    enqueue_job_with_metadata(
+        &shard,
+        "meta-done",
+        5,
+        now,
+        vec![("queue".to_string(), "q1".to_string())],
+    )
+    .await;
+    let tasks = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    shard
+        .report_attempt_outcome(
+            tasks[0].attempt().task_id(),
+            silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("report success");
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let query = "SELECT id FROM jobs WHERE tenant='-' AND array_contains(element_at(metadata, 'queue'), 'q1') AND status_kind IN ('Waiting','Scheduled','Running','Failed')";
+
+    let strategy = strategy_for(&sql, query).await;
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::MetadataExact {
+            tenant: Some("-".to_string()),
+            key: "queue".to_string(),
+            value: "q1".to_string(),
+        }
+    );
+    let classes = classifications_for(&sql, query).await;
+    let in_class = classes
+        .iter()
+        .find(|(text, _)| text.contains("IN"))
+        .expect("IN predicate should be pushed");
+    assert_eq!(in_class.1, TableProviderFilterPushDown::Inexact);
+
+    let got = query_ids(&sql, query).await;
+    assert_eq!(got, vec!["meta-pending"]);
+}
+
+/// Seed a mixed-status tenant on `-`: waiting1, waiting2 (Waiting),
+/// future1 (Scheduled, +1h), running1 (Running), succeeded1 (Succeeded),
+/// failed1 (Failed). Priorities force the dequeue order used to reach each state.
+async fn seed_mixed_status_jobs(shard: &Arc<JobStoreShard>) {
+    let now = now_ms();
+    enqueue_job(shard, "succeeded1", 1, now).await;
+    enqueue_job(shard, "failed1", 2, now).await;
+    enqueue_job(shard, "running1", 3, now).await;
+    enqueue_job(shard, "waiting1", 10, now).await;
+    enqueue_job(shard, "waiting2", 10, now).await;
+    // Scheduled start far from the clock so the virtual Waiting/Scheduled labels
+    // stay deterministic mid-test.
+    enqueue_job(shard, "future1", 10, now + 3_600_000).await;
+
+    let tasks = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    shard
+        .report_attempt_outcome(
+            tasks[0].attempt().task_id(),
+            silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("report success");
+    let tasks = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    shard
+        .report_attempt_outcome(
+            tasks[0].attempt().task_id(),
+            silo::job_attempt::AttemptOutcome::Error {
+                error_code: "TEST_ERROR".to_string(),
+                error: vec![],
+            },
+        )
+        .await
+        .expect("report error");
+    // running1 stays leased (Running)
+    let tasks = shard
+        .dequeue("w", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 1, "running1 should be leased");
+}
+
+/// Extract (string, i64) column pairs from result batches (e.g. GROUP BY output).
+fn extract_string_i64_pairs(batches: &[RecordBatch]) -> Vec<(String, i64)> {
+    let mut out = Vec::new();
+    for batch in batches {
+        let keys = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string column");
+        let vals = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 column");
+        for i in 0..keys.len() {
+            out.push((keys.value(i).to_string(), vals.value(i)));
+        }
+    }
+    out
+}
+
+#[silo::test]
+async fn sql_multi_status_union_returns_expected_rows() {
+    // The correctness oracle is the hand-specified expected set — there is no way
+    // to force the same SQL through FullScan post-change.
+    let (_tmp, shard) = open_temp_shard().await;
+    seed_mixed_status_jobs(&shard).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    // Listing shape (sorts on a job_info column → point-lookup hydration path).
+    // future1 is excluded: its virtual status is Scheduled, not Waiting.
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND status_kind IN ('Waiting','Running','Succeeded','Failed') ORDER BY enqueue_time_ms DESC, id ASC",
+    )
+    .await;
+    assert_eq!(
+        got,
+        vec!["failed1", "running1", "succeeded1", "waiting1", "waiting2"]
+    );
+
+    // Virtual-status split on the index-only path: Waiting and Scheduled are
+    // disjoint halves of the stored Scheduled range.
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND (status_kind='Waiting' OR status_kind='Scheduled') ORDER BY id",
+    )
+    .await;
+    assert_eq!(got, vec!["future1", "waiting1", "waiting2"]);
+
+    // OR shape across a stored and a virtual status, hydration path.
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND (status_kind='Succeeded' OR status_kind='Scheduled') ORDER BY enqueue_time_ms DESC, id ASC",
+    )
+    .await;
+    assert_eq!(got, vec!["future1", "succeeded1"]);
+}
+
+#[silo::test]
+async fn sql_multi_status_group_by_stays_index_only() {
+    // Aggregate shapes over a multi-status filter must ride the index-only union
+    // path — regressing to per-row status lookups would put queue-stats rollups
+    // back on the point-lookup treadmill.
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    seed_mixed_status_jobs(&shard).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    let lookups_before = metrics.query_point_lookups_value(shard.name());
+    let scanned_before = metrics.query_scanned_keys_value(shard.name());
+    let batches = sql
+        .sql("SELECT status_kind, COUNT(*) as cnt FROM jobs WHERE tenant='-' AND status_kind IN ('Waiting','Scheduled','Running','Succeeded') GROUP BY status_kind ORDER BY status_kind")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    let lookups_after = metrics.query_point_lookups_value(shard.name());
+    let scanned = metrics.query_scanned_keys_value(shard.name()) - scanned_before;
+
+    assert_eq!(
+        extract_string_i64_pairs(&batches),
+        vec![
+            ("Running".to_string(), 1),
+            ("Scheduled".to_string(), 1),
+            ("Succeeded".to_string(), 1),
+            ("Waiting".to_string(), 2),
+        ]
+    );
+    assert_eq!(
+        lookups_after, lookups_before,
+        "index-only union must not hydrate rows via point-lookups"
+    );
+    // Only the matching status ranges are visited: 5 matching index entries, not
+    // the tenant's whole status prefix (failed1's range is skipped).
+    assert!(
+        scanned <= 10.0,
+        "index-only union scanned {scanned} keys; expected only the 5 matching entries"
+    );
+}
+
+#[silo::test]
+async fn sql_queue_stats_pending_shape_scans_only_matching_entries() {
+    // The queue-stats pending breakdown (2-element IN + metadata projection) must
+    // visit only the matching pending index entries, not the tenant's terminal bulk.
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+
+    // Bulk: 40 terminal (Succeeded) jobs.
+    for i in 0..40 {
+        enqueue_job(&shard, &format!("done{i:02}"), 1, now).await;
+    }
+    let tasks = shard
+        .dequeue("w", "default", 40)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 40);
+    for task in &tasks {
+        shard
+            .report_attempt_outcome(
+                task.attempt().task_id(),
+                silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+            )
+            .await
+            .expect("report success");
+    }
+    // Matching: 2 waiting + 1 future-scheduled, all in queue q1.
+    let queue_meta = vec![("queue".to_string(), "q1".to_string())];
+    enqueue_job_with_metadata(&shard, "p1", 10, now, queue_meta.clone()).await;
+    enqueue_job_with_metadata(&shard, "p2", 10, now, queue_meta.clone()).await;
+    enqueue_job_with_metadata(&shard, "p3", 10, now + 3_600_000, queue_meta).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let scanned_before = metrics.query_scanned_keys_value(shard.name());
+    let lookups_before = metrics.query_point_lookups_value(shard.name());
+    let batches = sql
+        .sql(
+            "SELECT queue_name, COUNT(*) as cnt FROM (SELECT array_any_value(element_at(metadata, 'queue')) as queue_name FROM jobs WHERE tenant='-' AND status_kind IN ('Waiting','Scheduled') LIMIT 10000) GROUP BY queue_name",
+        )
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    let scanned = metrics.query_scanned_keys_value(shard.name()) - scanned_before;
+    let lookups = metrics.query_point_lookups_value(shard.name()) - lookups_before;
+
+    assert_eq!(
+        extract_string_i64_pairs(&batches),
+        vec![("q1".to_string(), 3)]
+    );
+    assert!(
+        scanned < 20.0,
+        "pending breakdown scanned {scanned} keys; expected ~3 matching, not the 43-job tenant"
+    );
+    assert!(
+        lookups <= 3.0,
+        "pending breakdown hydrated {lookups} rows; only the 3 matches should be point-looked-up"
+    );
+}
+
+#[silo::test]
+async fn sql_multi_status_scanned_keys_bounded_by_matches() {
+    // A multi-status query's scan work scales with matching index entries, not
+    // tenant size — the property that makes admin listings safe on huge tenants.
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+
+    // Bulk: 60 Waiting jobs that must NOT be visited.
+    for i in 0..60 {
+        enqueue_job(&shard, &format!("bulk{i:02}"), 50, now).await;
+    }
+    // Matching: 3 Succeeded + 2 Failed.
+    for i in 0..5 {
+        enqueue_job(&shard, &format!("term{i}"), 1, now).await;
+    }
+    let tasks = shard
+        .dequeue("w", "default", 5)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 5);
+    for (i, task) in tasks.iter().enumerate() {
+        let outcome = if i < 3 {
+            silo::job_attempt::AttemptOutcome::Success { result: vec![] }
+        } else {
+            silo::job_attempt::AttemptOutcome::Error {
+                error_code: "TEST_ERROR".to_string(),
+                error: vec![],
+            }
+        };
+        shard
+            .report_attempt_outcome(task.attempt().task_id(), outcome)
+            .await
+            .expect("report outcome");
+    }
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let before = metrics.query_scanned_keys_value(shard.name());
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND status_kind IN ('Succeeded','Failed','Cancelled','Running') ORDER BY id",
+    )
+    .await;
+    let scanned = metrics.query_scanned_keys_value(shard.name()) - before;
+
+    assert_eq!(got, vec!["term0", "term1", "term2", "term3", "term4"]);
+    assert!(
+        scanned < 30.0,
+        "multi-status scan visited {scanned} keys; expected ~5 matching, not the 65-job tenant"
+    );
+}
+
+#[silo::test]
+async fn sql_multi_status_limit_stops_early_across_ranges() {
+    // A scan limit short-circuits across union arms: rows already emitted by an
+    // earlier arm count against the limit, and no arm over-scans past it.
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+
+    // 3 Failed + 30 Succeeded.
+    for i in 0..3 {
+        enqueue_job(&shard, &format!("f{i}"), 1, now).await;
+    }
+    for i in 0..30 {
+        enqueue_job(&shard, &format!("s{i:02}"), 2, now).await;
+    }
+    let tasks = shard
+        .dequeue("w", "default", 3)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 3);
+    for task in &tasks {
+        shard
+            .report_attempt_outcome(
+                task.attempt().task_id(),
+                silo::job_attempt::AttemptOutcome::Error {
+                    error_code: "TEST_ERROR".to_string(),
+                    error: vec![],
+                },
+            )
+            .await
+            .expect("report error");
+    }
+    let tasks = shard
+        .dequeue("w", "default", 30)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 30);
+    for task in &tasks {
+        shard
+            .report_attempt_outcome(
+                task.attempt().task_id(),
+                silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+            )
+            .await
+            .expect("report success");
+    }
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    // Limit spanning both arms: the Failed arm exhausts (3), Succeeded fills the rest.
+    let before = metrics.query_scanned_keys_value(shard.name());
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND status_kind IN ('Failed','Succeeded') LIMIT 10",
+    )
+    .await;
+    let scanned = metrics.query_scanned_keys_value(shard.name()) - before;
+    assert_eq!(got.len(), 10, "LIMIT 10 should return 10 rows");
+    assert!(
+        scanned < 25.0,
+        "LIMIT 10 scanned {scanned} keys; expected ~10, not all 33 matching rows"
+    );
+
+    // Limit satisfied inside the first arm: later arms must not be scanned.
+    let before = metrics.query_scanned_keys_value(shard.name());
+    let got = query_ids(
+        &sql,
+        "SELECT id FROM jobs WHERE tenant='-' AND status_kind IN ('Failed','Succeeded') LIMIT 2",
+    )
+    .await;
+    let scanned = metrics.query_scanned_keys_value(shard.name()) - before;
+    assert_eq!(got.len(), 2, "LIMIT 2 should return 2 rows");
+    assert!(
+        scanned < 10.0,
+        "LIMIT 2 scanned {scanned} keys; the Succeeded arm should not be visited"
+    );
+
+    // Same short-circuit on the point-lookup hydration path (projects a status
+    // record column, so rows are hydrated in bounded batches).
+    let lookups_before = metrics.query_point_lookups_value(shard.name());
+    let batches = sql
+        .sql("SELECT id, current_attempt FROM jobs WHERE tenant='-' AND status_kind IN ('Failed','Succeeded') LIMIT 4")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    let lookups = metrics.query_point_lookups_value(shard.name()) - lookups_before;
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 4, "LIMIT 4 should return 4 rows");
+    assert!(
+        lookups <= 4.0,
+        "LIMIT 4 hydrated {lookups} rows; hydration must not run ahead of the limit"
     );
 }
 

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -3128,19 +3128,22 @@ async fn classify_metadata_with_multi_status_keeps_status_inexact() {
 
     // Two jobs share the metadata key; only one is pending. Marking the status
     // predicate Exact for the metadata strategy would silently drop it (the
-    // bulk-cancel-preview shape).
+    // bulk-cancel-preview shape). meta-done is enqueued first with an earlier
+    // start time: the broker ingests task writes asynchronously, so dequeue
+    // order between concurrently-enqueued jobs is only guaranteed when arrival
+    // order and task-key order agree.
     enqueue_job_with_metadata(
         &shard,
-        "meta-pending",
-        10,
-        now,
+        "meta-done",
+        5,
+        now - 60_000,
         vec![("queue".to_string(), "q1".to_string())],
     )
     .await;
     enqueue_job_with_metadata(
         &shard,
-        "meta-done",
-        5,
+        "meta-pending",
+        10,
         now,
         vec![("queue".to_string(), "q1".to_string())],
     )
@@ -3150,6 +3153,11 @@ async fn classify_metadata_with_multi_status_keeps_status_inexact() {
         .await
         .expect("dequeue")
         .tasks;
+    assert_eq!(
+        tasks[0].job().id(),
+        "meta-done",
+        "expected meta-done (earlier start, lower priority value) to dequeue first"
+    );
     shard
         .report_attempt_outcome(
             tasks[0].attempt().task_id(),

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -2777,11 +2777,8 @@ async fn strategy_status_in_list_unionizes() {
     let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
 
     // 4+ elements so the SQL optimizer keeps the literal IN-list (<=3 lowers to ORs)
-    let strategy = strategy_for(
-        &sql,
-        "SELECT id FROM jobs WHERE tenant='-' AND status_kind IN ('Succeeded','Failed','Cancelled','Running')",
-    )
-    .await;
+    let query = "SELECT id FROM jobs WHERE tenant='-' AND status_kind IN ('Succeeded','Failed','Cancelled','Running')";
+    let strategy = strategy_for(&sql, query).await;
     assert_eq!(
         strategy,
         JobsScanStrategy::StatusUnion {
@@ -2794,6 +2791,14 @@ async fn strategy_status_in_list_unionizes() {
             ],
         }
     );
+    // The pure IN predicate is fully answered by the union scan, so it is
+    // classified Exact — no redundant post-filter.
+    let classes = classifications_for(&sql, query).await;
+    let in_class = classes
+        .iter()
+        .find(|(text, _)| text.contains("IN"))
+        .expect("IN predicate should be pushed");
+    assert_eq!(in_class.1, TableProviderFilterPushDown::Exact);
 }
 
 #[silo::test]
@@ -3195,6 +3200,11 @@ async fn seed_mixed_status_jobs(shard: &Arc<JobStoreShard>) {
         .await
         .expect("dequeue")
         .tasks;
+    assert_eq!(
+        tasks[0].job().id(),
+        "succeeded1",
+        "expected succeeded1 (priority 1) to dequeue first"
+    );
     shard
         .report_attempt_outcome(
             tasks[0].attempt().task_id(),
@@ -3207,6 +3217,11 @@ async fn seed_mixed_status_jobs(shard: &Arc<JobStoreShard>) {
         .await
         .expect("dequeue")
         .tasks;
+    assert_eq!(
+        tasks[0].job().id(),
+        "failed1",
+        "expected failed1 (priority 2) to dequeue second"
+    );
     shard
         .report_attempt_outcome(
             tasks[0].attempt().task_id(),
@@ -3224,6 +3239,11 @@ async fn seed_mixed_status_jobs(shard: &Arc<JobStoreShard>) {
         .expect("dequeue")
         .tasks;
     assert_eq!(tasks.len(), 1, "running1 should be leased");
+    assert_eq!(
+        tasks[0].job().id(),
+        "running1",
+        "expected running1 (priority 3) to dequeue third"
+    );
 }
 
 /// Extract (string, i64) column pairs from result batches (e.g. GROUP BY output).
@@ -3286,6 +3306,51 @@ async fn sql_multi_status_union_returns_expected_rows() {
 }
 
 #[silo::test]
+async fn sql_tenant_scoped_not_in_stays_fullscan_and_returns_complement() {
+    // NOT IN must never unionize — a union of the listed statuses would return
+    // exactly the rows the predicate excludes. It stays a tenant-scoped FullScan
+    // with the predicate re-applied.
+    let (_tmp, shard) = open_temp_shard().await;
+    seed_mixed_status_jobs(&shard).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    let query = "SELECT id FROM jobs WHERE tenant='-' AND status_kind NOT IN ('Succeeded','Failed','Cancelled') ORDER BY id";
+    let strategy = strategy_for(&sql, query).await;
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::FullScan {
+            tenant: Some("-".to_string()),
+        }
+    );
+    let got = query_ids(&sql, query).await;
+    assert_eq!(got, vec!["future1", "running1", "waiting1", "waiting2"]);
+}
+
+#[silo::test]
+async fn sql_overlapping_union_arms_dedupe_statuses_and_rows() {
+    // Arms pinning the same status collapse to one range scan, so a matching job
+    // appears exactly once even when several arms cover it.
+    let (_tmp, shard) = open_temp_shard().await;
+    seed_mixed_status_jobs(&shard).await;
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    let query = "SELECT id FROM jobs WHERE tenant='-' AND (status_kind='Failed' OR (status_kind='Failed' AND current_attempt > 0) OR status_kind='Succeeded') ORDER BY id";
+    let strategy = strategy_for(&sql, query).await;
+    assert_eq!(
+        strategy,
+        JobsScanStrategy::StatusUnion {
+            tenant: "-".to_string(),
+            statuses: vec![
+                QueryStatusFilter::Stored(JobStatusKind::Failed),
+                QueryStatusFilter::Stored(JobStatusKind::Succeeded),
+            ],
+        }
+    );
+    let got = query_ids(&sql, query).await;
+    assert_eq!(got, vec!["failed1", "succeeded1"]);
+}
+
+#[silo::test]
 async fn sql_multi_status_group_by_stays_index_only() {
     // Aggregate shapes over a multi-status filter must ride the index-only union
     // path — regressing to per-row status lookups would put queue-stats rollups
@@ -3319,11 +3384,12 @@ async fn sql_multi_status_group_by_stays_index_only() {
         lookups_after, lookups_before,
         "index-only union must not hydrate rows via point-lookups"
     );
-    // Only the matching status ranges are visited: 5 matching index entries, not
-    // the tenant's whole status prefix (failed1's range is skipped).
+    // Only the matching status ranges are visited: exactly the 5 matching index
+    // entries. The bound sits below the 6-entry tenant total so a regression to
+    // the whole-prefix FullScan (which would also visit failed1's entry) fails.
     assert!(
-        scanned <= 10.0,
-        "index-only union scanned {scanned} keys; expected only the 5 matching entries"
+        scanned < 6.0,
+        "index-only union scanned {scanned} keys; expected only the 5 matching entries, not failed1's range"
     );
 }
 


### PR DESCRIPTION
cc @airhorns @udnay @kirinrastogi -- claude believes this will help prevent timeouts on the queues and admin pages.

---

Multi-status predicates on `status_kind` -- the shapes the gadget admin and IDE background-action pages emit (`status_kind IN (...)`, OR-of-equalities, and OR-of-AND state filters) -- fell through the jobs-table planner to `FullScan`. On a large tenant (~380k jobs) that streams the entire job-info range regardless of how few rows match, blowing the 5s statement timeout. This makes those shapes scale with matching rows instead of tenant size, with no client-visible protocol or schema changes.

## Planner

- New tenant-gated `StatusUnion` strategy: literal `IN`-lists (parsed directly, since only lists of 3 or fewer lower to ORs), OR-of-equalities, and OR-of-AND shapes where every arm pins `status_kind` (pins may be equalities, `IN`-lists, or OR-of-equalities). Tenant-less multi-status predicates, `NOT IN`, arms without a status pin, and lone equalities keep their existing strategies.
- Filter classification now sees whole expressions instead of a single column name. Only the predicate driving the scan is `Exact`: pure `IN`/OR-of-equality unions that match the scanned statuses suppress the redundant post-filter, while OR-of-AND residue shapes, ANDed extra status predicates, and status predicates under a metadata strategy all stay `Inexact` so DataFusion re-applies them. Tenant/id equalities are `Exact` only when their value matches the planned strategy, so conflicting duplicates are post-filtered rather than silently dropped.

## Execution

- Unions run as sequential per-status index range scans in both the point-lookup hydration path and the index-only path, with all arms' ranges planned from a single clock snapshot so the virtual Waiting/Scheduled split partitions the stored `Scheduled` range without overlap, and emitted labels stay consistent with the arm that produced them. Scan limits short-circuit across arms.
- The index-only projection path (aggregates, `GROUP BY status_kind` counts) supports unions directly, so those shapes do not regress to per-row status lookups. The counter-served `COUNT(*)` fast path deliberately stays FullScan-only.
- A new `silo_query_point_lookups_total` per-shard counter makes the index-only vs hydration choice observable; tests use it to pin the no-regression property.

## Tests

Strategy/classification tests cover each recognized and rejected shape; integration tests on seeded shards assert hand-specified row sets (including the virtual Waiting/Scheduled mapping and OR-of-AND residue filtering), scanned-keys deltas bounded by matching entries rather than tenant size, and limit short-circuiting across union arms.