### PR TITLE
Fix split-child cleanup stranding on non-initiator nodes

### DIFF
--- a/src/coordination/etcd.rs
+++ b/src/coordination/etcd.rs
@@ -401,7 +401,7 @@ impl EtcdCoordinator {
                 }
             };
 
-            shard.maybe_spawn_background_cleanup(range, parent_shard_id);
+            let _ = shard.maybe_spawn_background_cleanup(range, parent_shard_id);
 
             {
                 let mut owned = self.base.owned.lock().await;
@@ -1151,10 +1151,8 @@ impl EtcdShardGuard {
 
                                     // Spawn background cleanup if this shard has pending cleanup work
                                     // (e.g., it's a split child or was re-acquired after a crash)
-                                    shard.maybe_spawn_background_cleanup(
-                                        range.clone(),
-                                        parent_shard_id,
-                                    );
+                                    let _ = shard
+                                        .maybe_spawn_background_cleanup(range, parent_shard_id);
 
                                     {
                                         let mut st = self.ctx.state.lock().await;

--- a/src/coordination/etcd.rs
+++ b/src/coordination/etcd.rs
@@ -401,7 +401,7 @@ impl EtcdCoordinator {
                 }
             };
 
-            let _ = shard.maybe_spawn_background_cleanup(range, parent_shard_id);
+            drop(shard.maybe_spawn_background_cleanup(range, parent_shard_id));
 
             {
                 let mut owned = self.base.owned.lock().await;
@@ -1151,8 +1151,12 @@ impl EtcdShardGuard {
 
                                     // Spawn background cleanup if this shard has pending cleanup work
                                     // (e.g., it's a split child or was re-acquired after a crash)
-                                    let _ = shard
-                                        .maybe_spawn_background_cleanup(range, parent_shard_id);
+                                    drop(
+                                        shard.maybe_spawn_background_cleanup(
+                                            range,
+                                            parent_shard_id,
+                                        ),
+                                    );
 
                                     {
                                         let mut st = self.ctx.state.lock().await;

--- a/src/coordination/etcd.rs
+++ b/src/coordination/etcd.rs
@@ -381,11 +381,11 @@ impl EtcdCoordinator {
         let mut opened_count = 0u32;
 
         for shard_id in &reclaimed {
-            // Look up range from shard map (short-lived lock)
-            let range = {
+            // Look up range and parent from shard map (short-lived lock)
+            let (range, parent_shard_id) = {
                 let shard_map = self.base.shard_map.lock().await;
                 match shard_map.get_shard(shard_id) {
-                    Some(info) => info.range.clone(),
+                    Some(info) => (info.range.clone(), info.parent_shard_id),
                     None => {
                         warn!(shard_id = %shard_id, "reclaim: shard not found in shard map, skipping");
                         continue;
@@ -401,7 +401,7 @@ impl EtcdCoordinator {
                 }
             };
 
-            shard.maybe_spawn_background_cleanup(range);
+            shard.maybe_spawn_background_cleanup(range, parent_shard_id);
 
             {
                 let mut owned = self.base.owned.lock().await;
@@ -1123,11 +1123,11 @@ impl EtcdShardGuard {
                             // Try to acquire ownership via KV put-if-absent transaction
                             match self.try_acquire_ownership().await {
                                 Ok(true) => {
-                                    // Look up the shard's range from the shard map
-                                    let range = {
+                                    // Look up the shard's range and parent from the shard map
+                                    let (range, parent_shard_id) = {
                                         let map = shard_map.lock().await;
                                         match map.get_shard(&self.ctx.shard_id) {
-                                            Some(info) => info.range.clone(),
+                                            Some(info) => (info.range.clone(), info.parent_shard_id),
                                             None => {
                                                 tracing::error!(shard_id = %self.ctx.shard_id, "shard not found in shard map");
                                                 let _ = self.release_ownership().await;
@@ -1151,7 +1151,10 @@ impl EtcdShardGuard {
 
                                     // Spawn background cleanup if this shard has pending cleanup work
                                     // (e.g., it's a split child or was re-acquired after a crash)
-                                    shard.maybe_spawn_background_cleanup(range.clone());
+                                    shard.maybe_spawn_background_cleanup(
+                                        range.clone(),
+                                        parent_shard_id,
+                                    );
 
                                     {
                                         let mut st = self.ctx.state.lock().await;

--- a/src/coordination/k8s.rs
+++ b/src/coordination/k8s.rs
@@ -1092,7 +1092,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                 }
             };
 
-            shard.maybe_spawn_background_cleanup(range, parent_shard_id);
+            let _ = shard.maybe_spawn_background_cleanup(range, parent_shard_id);
 
             {
                 let mut owned = self.base.owned.lock().await;
@@ -1729,8 +1729,8 @@ impl<B: K8sBackend> K8sShardGuard<B> {
 
                                 // Spawn background cleanup if this shard has pending cleanup work
                                 // (e.g., it's a split child or was re-acquired after a crash)
-                                shard
-                                    .maybe_spawn_background_cleanup(range.clone(), parent_shard_id);
+                                let _ =
+                                    shard.maybe_spawn_background_cleanup(range, parent_shard_id);
 
                                 // Check for shutdown BEFORE marking as Held. If shutdown was
                                 // triggered during the shard open, we should not claim ownership.

--- a/src/coordination/k8s.rs
+++ b/src/coordination/k8s.rs
@@ -1092,7 +1092,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                 }
             };
 
-            let _ = shard.maybe_spawn_background_cleanup(range, parent_shard_id);
+            drop(shard.maybe_spawn_background_cleanup(range, parent_shard_id));
 
             {
                 let mut owned = self.base.owned.lock().await;
@@ -1729,8 +1729,7 @@ impl<B: K8sBackend> K8sShardGuard<B> {
 
                                 // Spawn background cleanup if this shard has pending cleanup work
                                 // (e.g., it's a split child or was re-acquired after a crash)
-                                let _ =
-                                    shard.maybe_spawn_background_cleanup(range, parent_shard_id);
+                                drop(shard.maybe_spawn_background_cleanup(range, parent_shard_id));
 
                                 // Check for shutdown BEFORE marking as Held. If shutdown was
                                 // triggered during the shard open, we should not claim ownership.

--- a/src/coordination/k8s.rs
+++ b/src/coordination/k8s.rs
@@ -1072,11 +1072,11 @@ impl<B: K8sBackend> K8sCoordinator<B> {
         let mut opened_count = 0u32;
 
         for (shard_id, rv, uid) in &reclaimed {
-            // Look up range from shard map (short-lived lock)
-            let range = {
+            // Look up range and parent from shard map (short-lived lock)
+            let (range, parent_shard_id) = {
                 let shard_map = self.base.shard_map.lock().await;
                 match shard_map.get_shard(shard_id) {
-                    Some(info) => info.range.clone(),
+                    Some(info) => (info.range.clone(), info.parent_shard_id),
                     None => {
                         warn!(shard_id = %shard_id, "reclaim: shard not found in shard map, skipping");
                         continue;
@@ -1092,7 +1092,7 @@ impl<B: K8sBackend> K8sCoordinator<B> {
                 }
             };
 
-            shard.maybe_spawn_background_cleanup(range);
+            shard.maybe_spawn_background_cleanup(range, parent_shard_id);
 
             {
                 let mut owned = self.base.owned.lock().await;
@@ -1691,11 +1691,11 @@ impl<B: K8sBackend> K8sShardGuard<B> {
                                     elapsed_ms = lease_cas_started.elapsed().as_millis() as u64,
                                     "k8s acquire: lease CAS"
                                 );
-                                // Look up the shard's range from the shard map
-                                let range = {
+                                // Look up the shard's range and parent from the shard map
+                                let (range, parent_shard_id) = {
                                     let map = shard_map.lock().await;
                                     match map.get_shard(&self.ctx.shard_id) {
-                                        Some(info) => info.range.clone(),
+                                        Some(info) => (info.range.clone(), info.parent_shard_id),
                                         None => {
                                             tracing::error!(shard_id = %self.ctx.shard_id, "shard not found in shard map");
                                             let _ = self.release_lease_cas(&lease_name).await;
@@ -1729,7 +1729,8 @@ impl<B: K8sBackend> K8sShardGuard<B> {
 
                                 // Spawn background cleanup if this shard has pending cleanup work
                                 // (e.g., it's a split child or was re-acquired after a crash)
-                                shard.maybe_spawn_background_cleanup(range.clone());
+                                shard
+                                    .maybe_spawn_background_cleanup(range.clone(), parent_shard_id);
 
                                 // Check for shutdown BEFORE marking as Held. If shutdown was
                                 // triggered during the shard open, we should not claim ownership.

--- a/src/coordination/none.rs
+++ b/src/coordination/none.rs
@@ -67,7 +67,7 @@ impl NoneCoordinator {
                         ))
                     })?;
                 // Spawn background cleanup if this shard has pending cleanup work
-                shard.maybe_spawn_background_cleanup(
+                let _ = shard.maybe_spawn_background_cleanup(
                     shard_info.range.clone(),
                     shard_info.parent_shard_id,
                 );

--- a/src/coordination/none.rs
+++ b/src/coordination/none.rs
@@ -67,10 +67,10 @@ impl NoneCoordinator {
                         ))
                     })?;
                 // Spawn background cleanup if this shard has pending cleanup work
-                let _ = shard.maybe_spawn_background_cleanup(
+                drop(shard.maybe_spawn_background_cleanup(
                     shard_info.range.clone(),
                     shard_info.parent_shard_id,
-                );
+                ));
                 owned.insert(shard_info.id);
             }
         }

--- a/src/coordination/none.rs
+++ b/src/coordination/none.rs
@@ -67,7 +67,10 @@ impl NoneCoordinator {
                         ))
                     })?;
                 // Spawn background cleanup if this shard has pending cleanup work
-                shard.maybe_spawn_background_cleanup(shard_info.range.clone());
+                shard.maybe_spawn_background_cleanup(
+                    shard_info.range.clone(),
+                    shard_info.parent_shard_id,
+                );
                 owned.insert(shard_info.id);
             }
         }

--- a/src/coordination/split.rs
+++ b/src/coordination/split.rs
@@ -16,6 +16,8 @@ use crate::coordination::{CoordinationError, ShardOwnerMap};
 pub const MARKER_VERIFYING_CHILDREN: &str = "cloning complete, verifying children before commit";
 pub const MARKER_CHILDREN_VERIFIED: &str = "children verified, updating shard map";
 pub const MARKER_CHILD_VERIFICATION_FAILED: &str = "post-clone child verification failed";
+pub const MARKER_CHILD_INIT_FAILED: &str =
+    "post-clone child cleanup-metadata initialization failed";
 
 /// [SILO-COORD-INV-8] Status of post-split cleanup for a shard.
 ///
@@ -574,19 +576,30 @@ impl ShardSplitter {
                     // the child's open cannot see) fails here, aborting the split
                     // as PreCommitParentClosed so the shard map stays untouched
                     // and the parent is recovered/reopenable -- never silent data
-                    // loss.
+                    // loss. Each verified child then has its cleanup metadata
+                    // initialized to CleanupPending in the same pass, while the
+                    // initiator exclusively holds both cloned databases -- so
+                    // every acquirer, on any node, sees pending cleanup work. An
+                    // initialization failure aborts the same way, surfaced under
+                    // its own marker.
                     self.ctx
                         .factory
-                        .verify_cloned_children_match_parent(
+                        .verify_and_initialize_cloned_children(
                             &parent_shard_id,
                             &[split.left_child_id, split.right_child_id],
                         )
                         .await
                         .map_err(|e| {
+                            let marker = match &e {
+                                crate::factory::ShardFactoryError::ChildInitialization(_) => {
+                                    MARKER_CHILD_INIT_FAILED
+                                }
+                                _ => MARKER_CHILD_VERIFICATION_FAILED,
+                            };
                             SplitExecutionError::PreCommitParentClosed(
                                 CoordinationError::BackendError(format!(
                                     "{} for split of {}: {}",
-                                    MARKER_CHILD_VERIFICATION_FAILED, parent_shard_id, e
+                                    marker, parent_shard_id, e
                                 )),
                             )
                         })?;
@@ -678,7 +691,11 @@ impl ShardSplitter {
                         }
                     }
 
-                    // Open the child shards we own and set their cleanup status
+                    // Open the child shards we own. Their cleanup metadata was
+                    // already initialized pre-commit, so there is no status
+                    // write here -- which also means a concurrent shard-guard
+                    // acquisition cannot observe a child before its status
+                    // exists.
                     for child_id in children_we_own {
                         // Look up the child's range from the reloaded shard map
                         let range = {
@@ -699,20 +716,6 @@ impl ShardSplitter {
                                     format!("failed to open child shard {}: {}", child_id, e),
                                 ))
                             })?;
-
-                        if let Some(shard) = self.ctx.factory.get(&child_id) {
-                            shard
-                                .set_cleanup_status(SplitCleanupStatus::CleanupPending)
-                                .await
-                                .map_err(|e| {
-                                    SplitExecutionError::PostCommit(
-                                        CoordinationError::BackendError(format!(
-                                            "failed to set cleanup status for child shard {}: {}",
-                                            child_id, e
-                                        )),
-                                    )
-                                })?;
-                        }
 
                         info!(
                             child_shard_id = %child_id,

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -66,6 +66,11 @@ pub struct ShardFactory {
     /// unless a test arms it.
     #[cfg(debug_assertions)]
     clone_skip_child: std::sync::Mutex<Option<ShardId>>,
+    /// Test-only initialization fault: when armed, the pre-commit cleanup
+    /// metadata initialization for this child fails. Debug builds only;
+    /// inert unless a test arms it.
+    #[cfg(debug_assertions)]
+    init_fail_child: std::sync::Mutex<Option<ShardId>>,
 }
 
 impl ShardFactory {
@@ -82,6 +87,8 @@ impl ShardFactory {
             close_timeout: DEFAULT_CLOSE_TIMEOUT,
             #[cfg(debug_assertions)]
             clone_skip_child: std::sync::Mutex::new(None),
+            #[cfg(debug_assertions)]
+            init_fail_child: std::sync::Mutex::new(None),
         }
     }
 
@@ -107,6 +114,8 @@ impl ShardFactory {
             close_timeout: DEFAULT_CLOSE_TIMEOUT,
             #[cfg(debug_assertions)]
             clone_skip_child: std::sync::Mutex::new(None),
+            #[cfg(debug_assertions)]
+            init_fail_child: std::sync::Mutex::new(None),
         }
     }
 
@@ -137,6 +146,42 @@ impl ShardFactory {
         #[cfg(not(debug_assertions))]
         {
             None
+        }
+    }
+
+    /// Arm the test-only initialization fault: the pre-commit cleanup
+    /// metadata initialization for `child_id` fails, letting tests drive the
+    /// init-failure abort path, which a healthy shard cannot reach through
+    /// the public interface. `pub` because integration tests compile as a
+    /// separate crate.
+    #[doc(hidden)]
+    #[cfg(debug_assertions)]
+    pub fn inject_child_init_failure(&self, child_id: ShardId) {
+        *self
+            .init_fail_child
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(child_id);
+    }
+
+    /// Disarm and report whether the initialization fault was armed for this
+    /// child. Always `false` in release builds.
+    fn take_injected_init_failure(&self, child_id: &ShardId) -> bool {
+        #[cfg(debug_assertions)]
+        {
+            let mut armed = self
+                .init_fail_child
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if armed.as_ref() == Some(child_id) {
+                armed.take();
+                return true;
+            }
+            false
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            let _ = child_id;
+            false
         }
     }
 
@@ -892,37 +937,156 @@ impl ShardFactory {
     /// This is a manifest-landed tripwire keyed on the empty-child signature,
     /// not a full row-integrity audit: a clone that landed the counter key but
     /// corrupted rows would still pass.
-    pub async fn verify_cloned_children_match_parent(
+    ///
+    /// After a child's count check passes, its cleanup metadata is initialized
+    /// in the same raw open (see
+    /// [`JobStoreShard::initialize_split_cleanup_metadata`]): every acquirer
+    /// of the committed child, on any node, then sees `CleanupPending` rather
+    /// than the absent-or-inherited state a byte-for-byte clone carries. The
+    /// per-child ordering (count check before initialize write) keeps the two
+    /// failure classes distinguishable. The parent is only counted, never
+    /// initialized -- resetting it to `CleanupPending` would make a
+    /// subsequently aborted split recover a parent that spuriously scans its
+    /// whole keyspace.
+    pub async fn verify_and_initialize_cloned_children(
         &self,
         parent_id: &ShardId,
         child_ids: &[ShardId],
     ) -> Result<(), ShardFactoryError> {
         let parent_total_jobs = self.read_closed_shard_total_jobs(parent_id).await?;
         for child_id in child_ids {
-            let child_total_jobs = self.read_closed_shard_total_jobs(child_id).await?;
+            self.verify_and_initialize_cloned_child(child_id, parent_id, parent_total_jobs)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Verify one freshly cloned child against the parent's job count, then
+    /// initialize its cleanup metadata -- a single raw open per child, count
+    /// check first.
+    async fn verify_and_initialize_cloned_child(
+        &self,
+        child_id: &ShardId,
+        parent_id: &ShardId,
+        parent_total_jobs: i64,
+    ) -> Result<(), ShardFactoryError> {
+        let shard = self.open_closed_shard_raw(child_id).await?;
+
+        let result = async {
+            let child_total_jobs = shard
+                .get_counters()
+                .await
+                .map_err(ShardFactoryError::ShardError)?
+                .total_jobs;
             if child_total_jobs != parent_total_jobs {
                 return Err(ShardFactoryError::ChildVerification(format!(
                     "cloned child {child_id} holds {child_total_jobs} jobs but parent {parent_id} \
                      held {parent_total_jobs}; aborting split before commit to avoid data loss"
                 )));
             }
+
+            if self.take_injected_init_failure(child_id) {
+                return Err(ShardFactoryError::ChildInitialization(format!(
+                    "injected cleanup-metadata initialization failure for child {child_id}"
+                )));
+            }
+
+            shard
+                .initialize_split_cleanup_metadata()
+                .await
+                .map_err(|e| {
+                    ShardFactoryError::ChildInitialization(format!(
+                        "failed to initialize cleanup metadata for cloned child {child_id}: {e}"
+                    ))
+                })
         }
+        .await;
+
+        // Always close the raw handle -- JobStoreShard has no Drop. Surface
+        // the verification/initialization error before any close error.
+        let close_result = shard.close().await;
+        result?;
+        close_result?;
         Ok(())
     }
 
     /// Open a closed shard's database with the raw `open_with_resolved_store`
     /// primitive, read its whole-shard `total_jobs`, and close it.
     ///
-    /// Uses the raw open -- NOT `open` -- so the shard is never registered in the
-    /// `instances` map: `open` caches the instance in the per-shard OnceCell, and
-    /// the post-commit `open(child)` would then return this stale pre-commit
-    /// handle instead of opening the committed child. Hydration is disabled and
-    /// `get_counters` reads single merged counter keys, so the check is O(1)
-    /// even on a multi-million-job shard.
+    /// Hydration is disabled and `get_counters` reads single merged counter
+    /// keys, so the check is O(1) even on a multi-million-job shard.
     async fn read_closed_shard_total_jobs(
         &self,
         shard_id: &ShardId,
     ) -> Result<i64, ShardFactoryError> {
+        let shard = self.open_closed_shard_raw(shard_id).await?;
+
+        // Always close the raw handle, even if the counter read fails, so the
+        // shard's SlateDB instance and its spawned background tasks (grant
+        // scanner, reconcilers) are released -- JobStoreShard has no Drop.
+        // Surface the counter-read error (the verification signal) before any
+        // close error.
+        let counters = shard.get_counters().await;
+        let close_result = shard.close().await;
+        let total_jobs = counters?.total_jobs;
+        close_result?;
+        Ok(total_jobs)
+    }
+
+    /// Read the split-cleanup metadata stored in a closed shard's database via
+    /// the raw non-registering open. `pub` because integration tests compile
+    /// as a separate crate and need to observe child metadata without
+    /// registering the child in the factory.
+    #[doc(hidden)]
+    pub async fn read_closed_shard_cleanup_metadata(
+        &self,
+        shard_id: &ShardId,
+    ) -> Result<ClosedShardCleanupMetadata, ShardFactoryError> {
+        let shard = self.open_closed_shard_raw(shard_id).await?;
+        let metadata = Self::collect_cleanup_metadata(&shard).await;
+        let close_result = shard.close().await;
+        let metadata = metadata?;
+        close_result?;
+        Ok(metadata)
+    }
+
+    async fn collect_cleanup_metadata(
+        shard: &JobStoreShard,
+    ) -> Result<ClosedShardCleanupMetadata, ShardFactoryError> {
+        let status = shard.get_cleanup_status_raw().await?;
+        let progress_key_present = shard
+            .db()
+            .get(&crate::keys::cleanup_progress_key())
+            .await
+            .map_err(JobStoreShardError::from)?
+            .is_some();
+        let complete_marker_present = shard
+            .db()
+            .get(&crate::keys::cleanup_complete_key())
+            .await
+            .map_err(JobStoreShardError::from)?
+            .is_some();
+        let cleanup_completed_at_ms = shard.get_cleanup_completed_at_ms().await?;
+        Ok(ClosedShardCleanupMetadata {
+            status,
+            progress_key_present,
+            complete_marker_present,
+            cleanup_completed_at_ms,
+        })
+    }
+
+    /// Open a closed shard's database with the raw `open_with_resolved_store`
+    /// primitive.
+    ///
+    /// Uses the raw open -- NOT `open` -- so the shard is never registered in the
+    /// `instances` map: `open` caches the instance in the per-shard OnceCell, and
+    /// the post-commit `open(child)` would then return this stale pre-commit
+    /// handle instead of opening the committed child. The caller MUST close the
+    /// returned handle -- JobStoreShard has no Drop.
+    async fn open_closed_shard_raw(
+        &self,
+        shard_id: &ShardId,
+    ) -> Result<Arc<JobStoreShard>, ShardFactoryError> {
         let name = shard_id.to_string();
         let (resolved, db_path) =
             Self::resolve_at_root(&self.template.backend, &self.template.path, &name)?;
@@ -965,22 +1129,29 @@ impl ShardFactory {
         )
         .await?;
 
-        // Always close the raw handle, even if the counter read fails, so the
-        // shard's SlateDB instance and its spawned background tasks (grant
-        // scanner, reconcilers) are released -- JobStoreShard has no Drop.
-        // Surface the counter-read error (the verification signal) before any
-        // close error.
-        let counters = shard.get_counters().await;
-        let close_result = shard.close().await;
-        let total_jobs = counters?.total_jobs;
-        close_result?;
-        Ok(total_jobs)
+        Ok(shard)
     }
 
     /// Get the database template used by this factory.
     pub fn template(&self) -> &DatabaseTemplate {
         &self.template
     }
+}
+
+/// Split-cleanup metadata read from a closed shard's database. Field-level
+/// key presence lets tests assert a full metadata reset without holding a
+/// live handle to the shard.
+#[doc(hidden)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClosedShardCleanupMetadata {
+    /// Raw cleanup status: `None` when no status key is present.
+    pub status: Option<crate::coordination::SplitCleanupStatus>,
+    /// Whether the cleanup progress key is present.
+    pub progress_key_present: bool,
+    /// Whether the legacy cleanup complete-marker key is present.
+    pub complete_marker_present: bool,
+    /// Cleanup completion timestamp, if recorded.
+    pub cleanup_completed_at_ms: Option<i64>,
 }
 
 #[derive(Debug, Error)]
@@ -1002,6 +1173,9 @@ pub enum ShardFactoryError {
 
     #[error("child verification error: {0}")]
     ChildVerification(String),
+
+    #[error("child initialization error: {0}")]
+    ChildInitialization(String),
 
     #[error("storage error: {0}")]
     Storage(#[from] crate::storage::StorageError),

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -970,9 +970,7 @@ impl ShardFactory {
         parent_id: &ShardId,
         parent_total_jobs: i64,
     ) -> Result<(), ShardFactoryError> {
-        let shard = self.open_closed_shard_raw(child_id).await?;
-
-        let result = async {
+        self.with_closed_shard_raw(child_id, |shard| async move {
             let child_total_jobs = shard
                 .get_counters()
                 .await
@@ -999,19 +997,34 @@ impl ShardFactory {
                         "failed to initialize cleanup metadata for cloned child {child_id}: {e}"
                     ))
                 })
-        }
-        .await;
-
-        // Always close the raw handle -- JobStoreShard has no Drop. Surface
-        // the verification/initialization error before any close error.
-        let close_result = shard.close().await;
-        result?;
-        close_result?;
-        Ok(())
+        })
+        .await
     }
 
-    /// Open a closed shard's database with the raw `open_with_resolved_store`
-    /// primitive, read its whole-shard `total_jobs`, and close it.
+    /// Open a closed shard raw, run `f` against it, and always close the
+    /// handle -- JobStoreShard has no Drop, so a leaked handle strands the
+    /// shard's SlateDB instance and its spawned background tasks (grant
+    /// scanner, reconcilers). The operation's error is surfaced before any
+    /// close error.
+    async fn with_closed_shard_raw<T, F, Fut>(
+        &self,
+        shard_id: &ShardId,
+        f: F,
+    ) -> Result<T, ShardFactoryError>
+    where
+        F: FnOnce(Arc<JobStoreShard>) -> Fut,
+        Fut: std::future::Future<Output = Result<T, ShardFactoryError>>,
+    {
+        let shard = self.open_closed_shard_raw(shard_id).await?;
+        let result = f(Arc::clone(&shard)).await;
+        let close_result = shard.close().await;
+        let value = result?;
+        close_result?;
+        Ok(value)
+    }
+
+    /// Read a closed shard's whole-shard `total_jobs` via the raw
+    /// non-registering open.
     ///
     /// Hydration is disabled and `get_counters` reads single merged counter
     /// keys, so the check is O(1) even on a multi-million-job shard.
@@ -1019,18 +1032,10 @@ impl ShardFactory {
         &self,
         shard_id: &ShardId,
     ) -> Result<i64, ShardFactoryError> {
-        let shard = self.open_closed_shard_raw(shard_id).await?;
-
-        // Always close the raw handle, even if the counter read fails, so the
-        // shard's SlateDB instance and its spawned background tasks (grant
-        // scanner, reconcilers) are released -- JobStoreShard has no Drop.
-        // Surface the counter-read error (the verification signal) before any
-        // close error.
-        let counters = shard.get_counters().await;
-        let close_result = shard.close().await;
-        let total_jobs = counters?.total_jobs;
-        close_result?;
-        Ok(total_jobs)
+        self.with_closed_shard_raw(shard_id, |shard| async move {
+            Ok(shard.get_counters().await?.total_jobs)
+        })
+        .await
     }
 
     /// Read the split-cleanup metadata stored in a closed shard's database via
@@ -1042,12 +1047,10 @@ impl ShardFactory {
         &self,
         shard_id: &ShardId,
     ) -> Result<ClosedShardCleanupMetadata, ShardFactoryError> {
-        let shard = self.open_closed_shard_raw(shard_id).await?;
-        let metadata = Self::collect_cleanup_metadata(&shard).await;
-        let close_result = shard.close().await;
-        let metadata = metadata?;
-        close_result?;
-        Ok(metadata)
+        self.with_closed_shard_raw(shard_id, |shard| async move {
+            Self::collect_cleanup_metadata(&shard).await
+        })
+        .await
     }
 
     async fn collect_cleanup_metadata(

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -516,7 +516,7 @@ impl JobStoreShard {
     /// `flush()` call would select a WAL flush when a WAL store is
     /// configured -- with a node-local WAL that leaves the write invisible
     /// to whichever node later acquires the child.
-    pub async fn initialize_split_cleanup_metadata(&self) -> Result<(), JobStoreShardError> {
+    pub(crate) async fn initialize_split_cleanup_metadata(&self) -> Result<(), JobStoreShardError> {
         let status_data = serde_json::to_vec(&SplitCleanupStatus::CleanupPending)?;
         let mut batch = WriteBatch::new();
         batch.put(keys::cleanup_status_key(), &status_data);
@@ -594,11 +594,14 @@ impl JobStoreShard {
     /// * `parent_shard_id` - The parent recorded in this shard's map entry, if
     ///   any. Consulted only when the database has no status key, as a
     ///   backfill hint for split children stranded without one.
+    ///
+    /// Returns the spawned task's handle. Dropping it detaches the task;
+    /// tests await it to observe the decision deterministically.
     pub fn maybe_spawn_background_cleanup(
         self: &std::sync::Arc<Self>,
         range: ShardRange,
         parent_shard_id: Option<crate::shard_range::ShardId>,
-    ) {
+    ) -> tokio::task::JoinHandle<()> {
         let shard = std::sync::Arc::clone(self);
         let shard_name = self.name.clone();
 
@@ -653,10 +656,11 @@ impl JobStoreShard {
                         parent_shard_id = %parent_shard_id,
                         "backfilling cleanup status for stranded split child"
                     );
-                    if let Err(e) = shard
-                        .set_cleanup_status(SplitCleanupStatus::CleanupPending)
-                        .await
-                    {
+                    // Full reset, not just a status write: the stranded child
+                    // may also have inherited its parent's progress record,
+                    // whose `complete` flag would short-circuit the cleanup
+                    // below as "already complete".
+                    if let Err(e) = shard.initialize_split_cleanup_metadata().await {
                         tracing::error!(
                             shard = %shard_name,
                             error = %e,
@@ -721,7 +725,7 @@ impl JobStoreShard {
                     );
                 }
             }
-        });
+        })
     }
 }
 

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -442,34 +442,49 @@ impl JobStoreShard {
         Ok(progress.complete)
     }
 
-    /// Get the cleanup status stored in this shard's database.
+    /// Get the cleanup status stored in this shard's database, distinguishing
+    /// an absent status key (`None`) from a present one.
     ///
     /// This is the authoritative source of truth for the shard's cleanup state.
-    /// Returns `CompactionDone` if no status has been set (e.g., for shards that
-    /// were not created by a split).
-    pub async fn get_cleanup_status(&self) -> Result<SplitCleanupStatus, JobStoreShardError> {
+    /// The key is absent for shards that never had a status written (e.g.,
+    /// shards that were not created by a split).
+    pub async fn get_cleanup_status_raw(
+        &self,
+    ) -> Result<Option<SplitCleanupStatus>, JobStoreShardError> {
         match self.db.get(&keys::cleanup_status_key()).await? {
             Some(data) => {
                 let status: SplitCleanupStatus = serde_json::from_slice(&data)?;
-                Ok(status)
+                Ok(Some(status))
             }
-            None => Ok(SplitCleanupStatus::CompactionDone),
+            None => Ok(None),
         }
+    }
+
+    /// Get the cleanup status stored in this shard's database, defaulting an
+    /// absent status key to `CompactionDone` ("nothing to do").
+    pub async fn get_cleanup_status(&self) -> Result<SplitCleanupStatus, JobStoreShardError> {
+        Ok(self
+            .get_cleanup_status_raw()
+            .await?
+            .unwrap_or(SplitCleanupStatus::CompactionDone))
     }
 
     /// [SILO-COORD-INV-8] Set the cleanup status in this shard's database.
     ///
     /// This updates the authoritative cleanup status for this shard.
     /// Status can only progress forward: Pending -> Running -> Done -> CompactionDone.
-    /// Attempting to set a status that would regress is logged as a warning but
-    /// allowed (for crash recovery scenarios where we may re-process).
+    /// A write into a shard with no status key is a valid first transition.
+    /// Attempting to set a status that would regress from a present status is
+    /// logged as a warning but allowed (for crash recovery scenarios where we
+    /// may re-process).
     pub async fn set_cleanup_status(
         &self,
         status: SplitCleanupStatus,
     ) -> Result<(), JobStoreShardError> {
         // Check current status to validate forward progression
-        let current = self.get_cleanup_status().await?;
-        if !current.can_transition_to(status) {
+        if let Some(current) = self.get_cleanup_status_raw().await?
+            && !current.can_transition_to(status)
+        {
             tracing::warn!(
                 shard = %self.name,
                 current = %current,

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -591,13 +591,20 @@ impl JobStoreShard {
     ///
     /// # Arguments
     /// * `range` - The tenant range for this shard (used for cleanup filtering)
-    pub fn maybe_spawn_background_cleanup(self: &std::sync::Arc<Self>, range: ShardRange) {
+    /// * `parent_shard_id` - The parent recorded in this shard's map entry, if
+    ///   any. Consulted only when the database has no status key, as a
+    ///   backfill hint for split children stranded without one.
+    pub fn maybe_spawn_background_cleanup(
+        self: &std::sync::Arc<Self>,
+        range: ShardRange,
+        parent_shard_id: Option<crate::shard_range::ShardId>,
+    ) {
         let shard = std::sync::Arc::clone(self);
         let shard_name = self.name.clone();
 
         tokio::spawn(async move {
             // Check if cleanup is needed
-            let status = match shard.get_cleanup_status().await {
+            let status = match shard.get_cleanup_status_raw().await {
                 Ok(s) => s,
                 Err(e) => {
                     tracing::error!(
@@ -606,6 +613,58 @@ impl JobStoreShard {
                         "failed to check cleanup status"
                     );
                     return;
+                }
+            };
+
+            let status = match status {
+                Some(status) => status,
+                // No status key: consult the shard map's parent record. A
+                // split child with no status was stranded by an initiator
+                // that never wrote one -- backfill it so its cleanup runs.
+                None => {
+                    let Some(parent_shard_id) = parent_shard_id else {
+                        tracing::debug!(
+                            shard = %shard_name,
+                            "no cleanup status and no parent recorded; original shard needs no cleanup"
+                        );
+                        return;
+                    };
+                    let completed_at = match shard.get_cleanup_completed_at_ms().await {
+                        Ok(v) => v,
+                        Err(e) => {
+                            tracing::error!(
+                                shard = %shard_name,
+                                error = %e,
+                                "failed to check cleanup completion timestamp"
+                            );
+                            return;
+                        }
+                    };
+                    if completed_at.is_some() {
+                        info!(
+                            shard = %shard_name,
+                            parent_shard_id = %parent_shard_id,
+                            "split child has no cleanup status but cleanup already completed; skipping"
+                        );
+                        return;
+                    }
+                    info!(
+                        shard = %shard_name,
+                        parent_shard_id = %parent_shard_id,
+                        "backfilling cleanup status for stranded split child"
+                    );
+                    if let Err(e) = shard
+                        .set_cleanup_status(SplitCleanupStatus::CleanupPending)
+                        .await
+                    {
+                        tracing::error!(
+                            shard = %shard_name,
+                            error = %e,
+                            "failed to backfill cleanup status"
+                        );
+                        return;
+                    }
+                    SplitCleanupStatus::CleanupPending
                 }
             };
 

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -498,6 +498,40 @@ impl JobStoreShard {
         Ok(())
     }
 
+    /// Initialize split-cleanup metadata for a freshly cloned child shard.
+    ///
+    /// A clone is byte-for-byte, so a child inherits whichever cleanup keys
+    /// its parent carried; an inherited terminal status -- or the `complete`
+    /// flag inside inherited progress, which is what the cleanup loop
+    /// consults -- would short-circuit the child's own cleanup as "already
+    /// complete". This reset unconditionally overwrites the status to
+    /// `CleanupPending` (bypassing the forward-transition check; it runs only
+    /// pre-commit on a freshly cloned database the initiator exclusively
+    /// holds) and clears the progress, legacy complete-marker, and completion
+    /// timestamp keys.
+    ///
+    /// The explicit MemTable-type flush makes the write durable in shared
+    /// storage on the paths a clean close's built-in flush does not cover
+    /// (failed-state close, crash between write and close). The plain
+    /// `flush()` call would select a WAL flush when a WAL store is
+    /// configured -- with a node-local WAL that leaves the write invisible
+    /// to whichever node later acquires the child.
+    pub async fn initialize_split_cleanup_metadata(&self) -> Result<(), JobStoreShardError> {
+        let status_data = serde_json::to_vec(&SplitCleanupStatus::CleanupPending)?;
+        let mut batch = WriteBatch::new();
+        batch.put(keys::cleanup_status_key(), &status_data);
+        batch.delete(keys::cleanup_progress_key());
+        batch.delete(keys::cleanup_complete_key());
+        batch.delete(keys::cleanup_completed_at_key());
+        self.db.write(batch).await?;
+        self.db
+            .flush_with_options(slatedb::config::FlushOptions {
+                flush_type: slatedb::config::FlushType::MemTable,
+            })
+            .await?;
+        Ok(())
+    }
+
     /// Get the timestamp (ms) when this shard was first created/initialized.
     /// Returns None if not set (e.g., older shards without this metadata).
     pub async fn get_created_at_ms(&self) -> Result<Option<i64>, JobStoreShardError> {

--- a/tests/cleanup_reacquire_tests.rs
+++ b/tests/cleanup_reacquire_tests.rs
@@ -103,7 +103,7 @@ async fn background_cleanup_spawns_when_cleanup_pending() {
             .expect("reopen shard");
 
         // Trigger the background cleanup (this is what coordination backends call)
-        shard.maybe_spawn_background_cleanup(range.clone(), None);
+        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Poll until cleanup reaches its terminal state, rather than sleeping
         // for a fixed amount of time — under CI load the transition through
@@ -193,7 +193,7 @@ async fn background_cleanup_resumes_when_cleanup_was_running() {
             .expect("reopen shard");
 
         // Trigger background cleanup
-        shard.maybe_spawn_background_cleanup(range.clone(), None);
+        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Poll until cleanup reaches its terminal state, rather than sleeping
         // for a fixed amount of time — under CI load the transition through
@@ -271,7 +271,7 @@ async fn background_cleanup_runs_compaction_when_cleanup_done() {
             .expect("reopen shard");
 
         // Trigger background cleanup (should just run compaction since cleanup is done)
-        shard.maybe_spawn_background_cleanup(range.clone(), None);
+        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Wait for compaction
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
@@ -337,7 +337,7 @@ async fn no_cleanup_when_already_complete() {
             .expect("reopen shard");
 
         // Trigger background cleanup
-        shard.maybe_spawn_background_cleanup(range.clone(), None);
+        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Wait a bit
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
@@ -388,7 +388,7 @@ async fn cleanup_cancelled_on_shard_close() {
         .expect("set cleanup pending");
 
     // Start background cleanup
-    shard.maybe_spawn_background_cleanup(range.clone(), None);
+    let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
 
     // Immediately close the shard (should trigger cancellation)
     // Give a tiny bit of time for cleanup to start
@@ -598,7 +598,7 @@ async fn cleanup_handles_multiple_close_calls() {
         .expect("set cleanup pending");
 
     // Start background cleanup
-    shard.maybe_spawn_background_cleanup(range.clone(), None);
+    let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
 
     // First close
     shard.close().await.expect("first close");
@@ -657,7 +657,7 @@ async fn full_reacquisition_cycle_triggers_cleanup() {
             .expect("reopen shard");
 
         // This is what the coordination backend would call after factory.open()
-        shard.maybe_spawn_background_cleanup(range.clone(), None);
+        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Poll until cleanup reaches its terminal state, rather than sleeping
         // for a fixed amount of time — under CI load the transition through
@@ -707,7 +707,7 @@ async fn full_reacquisition_cycle_triggers_cleanup() {
         assert_eq!(status, SplitCleanupStatus::CompactionDone);
 
         // Trigger background cleanup - should be a no-op
-        shard.maybe_spawn_background_cleanup(range.clone(), None);
+        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Jobs should be unchanged
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
@@ -771,7 +771,7 @@ async fn interrupted_cleanup_resumes_on_reacquisition() {
             .expect("reopen shard");
 
         // Background cleanup should complete the work
-        shard.maybe_spawn_background_cleanup(range.clone(), None);
+        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Wait for completion
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
@@ -793,26 +793,6 @@ async fn interrupted_cleanup_resumes_on_reacquisition() {
 /// filtering alone cannot prevent.
 static LOG_CAPTURE_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-/// Open a shard with a unique name so captured log lines can be attributed
-/// to the calling test even when unrelated tests log concurrently.
-async fn open_named_shard(
-    name: &str,
-    range: &ShardRange,
-) -> (tempfile::TempDir, Arc<JobStoreShard>) {
-    let tmp = tempfile::tempdir().unwrap();
-    let cfg = DatabaseConfig {
-        name: name.to_string(),
-        backend: Backend::Fs,
-        path: tmp.path().to_string_lossy().to_string(),
-        slatedb: Some(fast_flush_slatedb_settings()),
-        ..Default::default()
-    };
-    let shard = JobStoreShard::open(&cfg, MockGubernatorClient::new_arc(), None, range.clone())
-        .await
-        .expect("open shard");
-    (tmp, shard)
-}
-
 /// A stranded split child -- no status key, a parent recorded in the shard
 /// map, no completion timestamp -- is backfilled to `CleanupPending` on
 /// acquisition (logged at info) and its defunct keys are actually deleted.
@@ -824,7 +804,7 @@ async fn stranded_split_child_is_backfilled_and_cleaned_on_acquisition() {
 
     let shard_name = "stranded-child-backfill-probe";
     let range = ShardRange::new("", RANGE_BOUNDARY);
-    let (_tmp, shard) = open_named_shard(shard_name, &range).await;
+    let (_tmp, shard) = test_helpers::open_temp_shard_with_name(shard_name, &range).await;
 
     // bbb/zzz are in range, aaa is out of range -- the defunct data.
     enqueue_jobs_for_tenants(&shard, &["bbb", "zzz", "aaa"], 3).await;
@@ -839,26 +819,17 @@ async fn stranded_split_child_is_backfilled_and_cleaned_on_acquisition() {
     );
 
     silo::trace::start_log_capture();
-    shard.maybe_spawn_background_cleanup(range.clone(), Some(ShardId::new()));
-
-    // Backfill writes CleanupPending and cleanup advances it to
-    // CompactionDone; poll the RAW reader so an absent key (spawn decided
-    // not to run) cannot satisfy the terminal check.
-    let poll_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-    loop {
-        let status = shard.get_cleanup_status_raw().await.expect("raw status");
-        if status == Some(SplitCleanupStatus::CompactionDone) {
-            break;
-        }
-        assert!(
-            std::time::Instant::now() < poll_deadline,
-            "cleanup did not reach CompactionDone within 30s; last raw status: {:?}",
-            status,
-        );
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-    }
+    shard
+        .maybe_spawn_background_cleanup(range.clone(), Some(ShardId::new()))
+        .await
+        .expect("cleanup task");
     let logs = silo::trace::stop_log_capture();
 
+    assert_eq!(
+        shard.get_cleanup_status_raw().await.expect("raw status"),
+        Some(SplitCleanupStatus::CompactionDone),
+        "backfilled cleanup must run to its terminal status"
+    );
     shard.db().flush().await.unwrap();
     assert_eq!(
         count_job_info_keys(shard.db()).await,
@@ -871,6 +842,7 @@ async fn stranded_split_child_is_backfilled_and_cleaned_on_acquisition() {
         .lines()
         .filter(|l| l.contains("backfilling cleanup status for stranded split child"))
         .filter(|l| l.contains(shard_name))
+        .filter(|l| l.contains("INFO"))
         .collect();
     assert!(
         !backfill_lines.is_empty(),
@@ -878,22 +850,82 @@ async fn stranded_split_child_is_backfilled_and_cleaned_on_acquisition() {
     );
 }
 
+/// A stranded child can inherit its parent's cleanup progress record from
+/// the byte-for-byte clone; the `complete` flag inside it would short-circuit
+/// cleanup as "already complete". The backfill must reset that inherited
+/// state, not just write a status key.
+#[silo::test]
+async fn backfill_resets_inherited_complete_progress_before_cleaning() {
+    use silo::job_store_shard::CleanupProgress;
+    use silo::shard_range::ShardId;
+
+    let range = ShardRange::new("", RANGE_BOUNDARY);
+    let (_tmp, shard) =
+        test_helpers::open_temp_shard_with_name("inherited-progress-backfill-probe", &range).await;
+
+    enqueue_jobs_for_tenants(&shard, &["bbb", "zzz", "aaa"], 3).await;
+
+    // The inherited shape: a complete progress record without a status key,
+    // as cloned from a parent that had finished its own cleanup. The
+    // progress key is written directly -- no in-repo path writes progress
+    // without a status.
+    let inherited = CleanupProgress {
+        last_key: None,
+        keys_deleted: 0,
+        keys_scanned: 0,
+        complete: true,
+    };
+    shard
+        .db()
+        .put(
+            &silo::keys::cleanup_progress_key(),
+            &serde_json::to_vec(&inherited).unwrap(),
+        )
+        .await
+        .expect("write inherited progress");
+    shard.db().flush().await.unwrap();
+    assert_eq!(
+        shard.get_cleanup_status_raw().await.expect("raw status"),
+        None,
+        "precondition: no status key alongside the inherited progress"
+    );
+
+    shard
+        .maybe_spawn_background_cleanup(range.clone(), Some(ShardId::new()))
+        .await
+        .expect("cleanup task");
+
+    assert_eq!(
+        shard.get_cleanup_status_raw().await.expect("raw status"),
+        Some(SplitCleanupStatus::CompactionDone),
+        "backfilled cleanup must run to its terminal status"
+    );
+    shard.db().flush().await.unwrap();
+    assert_eq!(
+        count_job_info_keys(shard.db()).await,
+        6,
+        "backfilled cleanup must delete defunct jobs despite the inherited complete progress"
+    );
+    assert_eq!(count_job_info_keys_for_tenant(shard.db(), "aaa").await, 0);
+}
+
 /// An original shard -- no status key, no parent in the shard map -- is left
 /// completely untouched by the spawn decision: no status write, no scan.
 #[silo::test]
 async fn original_shard_without_status_is_untouched() {
     let range = ShardRange::new("", RANGE_BOUNDARY);
-    let (_tmp, shard) = open_named_shard("original-shard-noop-probe", &range).await;
+    let (_tmp, shard) =
+        test_helpers::open_temp_shard_with_name("original-shard-noop-probe", &range).await;
 
     // Out-of-range jobs that a spurious cleanup would delete.
     enqueue_jobs_for_tenants(&shard, &["bbb", "aaa"], 2).await;
     shard.db().flush().await.unwrap();
 
-    shard.maybe_spawn_background_cleanup(range.clone(), None);
+    shard
+        .maybe_spawn_background_cleanup(range.clone(), None)
+        .await
+        .expect("cleanup task");
 
-    // No observable side effect marks the no-op, so give the spawned task
-    // ample time to have run before asserting nothing changed.
-    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
     assert_eq!(
         shard.get_cleanup_status_raw().await.expect("raw status"),
         None,
@@ -918,7 +950,7 @@ async fn absent_status_with_completion_timestamp_skips_cleanup_with_info_log() {
 
     let shard_name = "completed-timestamp-noop-probe";
     let range = ShardRange::new("", RANGE_BOUNDARY);
-    let (_tmp, shard) = open_named_shard(shard_name, &range).await;
+    let (_tmp, shard) = test_helpers::open_temp_shard_with_name(shard_name, &range).await;
 
     enqueue_jobs_for_tenants(&shard, &["bbb", "aaa"], 2).await;
     shard
@@ -933,8 +965,10 @@ async fn absent_status_with_completion_timestamp_skips_cleanup_with_info_log() {
     );
 
     silo::trace::start_log_capture();
-    shard.maybe_spawn_background_cleanup(range.clone(), Some(ShardId::new()));
-    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+    shard
+        .maybe_spawn_background_cleanup(range.clone(), Some(ShardId::new()))
+        .await
+        .expect("cleanup task");
     let logs = silo::trace::stop_log_capture();
 
     assert_eq!(
@@ -951,6 +985,7 @@ async fn absent_status_with_completion_timestamp_skips_cleanup_with_info_log() {
         .lines()
         .filter(|l| l.contains("cleanup already completed"))
         .filter(|l| l.contains(shard_name))
+        .filter(|l| l.contains("INFO"))
         .collect();
     assert!(
         !skip_lines.is_empty(),
@@ -966,7 +1001,8 @@ async fn present_status_passes_through_needs_work_unchanged() {
     use silo::shard_range::ShardId;
 
     let range = ShardRange::new("", RANGE_BOUNDARY);
-    let (_tmp, shard) = open_named_shard("present-status-passthrough-probe", &range).await;
+    let (_tmp, shard) =
+        test_helpers::open_temp_shard_with_name("present-status-passthrough-probe", &range).await;
 
     enqueue_jobs_for_tenants(&shard, &["bbb", "aaa"], 2).await;
     shard
@@ -975,9 +1011,11 @@ async fn present_status_passes_through_needs_work_unchanged() {
         .expect("set terminal status");
     shard.db().flush().await.unwrap();
 
-    shard.maybe_spawn_background_cleanup(range.clone(), Some(ShardId::new()));
+    shard
+        .maybe_spawn_background_cleanup(range.clone(), Some(ShardId::new()))
+        .await
+        .expect("cleanup task");
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
     assert_eq!(
         shard.get_cleanup_status_raw().await.expect("raw status"),
         Some(SplitCleanupStatus::CompactionDone),

--- a/tests/cleanup_reacquire_tests.rs
+++ b/tests/cleanup_reacquire_tests.rs
@@ -103,7 +103,7 @@ async fn background_cleanup_spawns_when_cleanup_pending() {
             .expect("reopen shard");
 
         // Trigger the background cleanup (this is what coordination backends call)
-        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
+        drop(shard.maybe_spawn_background_cleanup(range.clone(), None));
 
         // Poll until cleanup reaches its terminal state, rather than sleeping
         // for a fixed amount of time — under CI load the transition through
@@ -193,7 +193,7 @@ async fn background_cleanup_resumes_when_cleanup_was_running() {
             .expect("reopen shard");
 
         // Trigger background cleanup
-        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
+        drop(shard.maybe_spawn_background_cleanup(range.clone(), None));
 
         // Poll until cleanup reaches its terminal state, rather than sleeping
         // for a fixed amount of time — under CI load the transition through
@@ -271,7 +271,7 @@ async fn background_cleanup_runs_compaction_when_cleanup_done() {
             .expect("reopen shard");
 
         // Trigger background cleanup (should just run compaction since cleanup is done)
-        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
+        drop(shard.maybe_spawn_background_cleanup(range.clone(), None));
 
         // Wait for compaction
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
@@ -337,7 +337,7 @@ async fn no_cleanup_when_already_complete() {
             .expect("reopen shard");
 
         // Trigger background cleanup
-        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
+        drop(shard.maybe_spawn_background_cleanup(range.clone(), None));
 
         // Wait a bit
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
@@ -388,7 +388,7 @@ async fn cleanup_cancelled_on_shard_close() {
         .expect("set cleanup pending");
 
     // Start background cleanup
-    let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
+    drop(shard.maybe_spawn_background_cleanup(range.clone(), None));
 
     // Immediately close the shard (should trigger cancellation)
     // Give a tiny bit of time for cleanup to start
@@ -598,7 +598,7 @@ async fn cleanup_handles_multiple_close_calls() {
         .expect("set cleanup pending");
 
     // Start background cleanup
-    let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
+    drop(shard.maybe_spawn_background_cleanup(range.clone(), None));
 
     // First close
     shard.close().await.expect("first close");
@@ -657,7 +657,7 @@ async fn full_reacquisition_cycle_triggers_cleanup() {
             .expect("reopen shard");
 
         // This is what the coordination backend would call after factory.open()
-        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
+        drop(shard.maybe_spawn_background_cleanup(range.clone(), None));
 
         // Poll until cleanup reaches its terminal state, rather than sleeping
         // for a fixed amount of time — under CI load the transition through
@@ -707,7 +707,7 @@ async fn full_reacquisition_cycle_triggers_cleanup() {
         assert_eq!(status, SplitCleanupStatus::CompactionDone);
 
         // Trigger background cleanup - should be a no-op
-        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
+        drop(shard.maybe_spawn_background_cleanup(range.clone(), None));
 
         // Jobs should be unchanged
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
@@ -771,7 +771,7 @@ async fn interrupted_cleanup_resumes_on_reacquisition() {
             .expect("reopen shard");
 
         // Background cleanup should complete the work
-        let _ = shard.maybe_spawn_background_cleanup(range.clone(), None);
+        drop(shard.maybe_spawn_background_cleanup(range.clone(), None));
 
         // Wait for completion
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;

--- a/tests/cleanup_reacquire_tests.rs
+++ b/tests/cleanup_reacquire_tests.rs
@@ -103,7 +103,7 @@ async fn background_cleanup_spawns_when_cleanup_pending() {
             .expect("reopen shard");
 
         // Trigger the background cleanup (this is what coordination backends call)
-        shard.maybe_spawn_background_cleanup(range.clone());
+        shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Poll until cleanup reaches its terminal state, rather than sleeping
         // for a fixed amount of time — under CI load the transition through
@@ -193,7 +193,7 @@ async fn background_cleanup_resumes_when_cleanup_was_running() {
             .expect("reopen shard");
 
         // Trigger background cleanup
-        shard.maybe_spawn_background_cleanup(range.clone());
+        shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Poll until cleanup reaches its terminal state, rather than sleeping
         // for a fixed amount of time — under CI load the transition through
@@ -271,7 +271,7 @@ async fn background_cleanup_runs_compaction_when_cleanup_done() {
             .expect("reopen shard");
 
         // Trigger background cleanup (should just run compaction since cleanup is done)
-        shard.maybe_spawn_background_cleanup(range.clone());
+        shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Wait for compaction
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
@@ -337,7 +337,7 @@ async fn no_cleanup_when_already_complete() {
             .expect("reopen shard");
 
         // Trigger background cleanup
-        shard.maybe_spawn_background_cleanup(range.clone());
+        shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Wait a bit
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
@@ -388,7 +388,7 @@ async fn cleanup_cancelled_on_shard_close() {
         .expect("set cleanup pending");
 
     // Start background cleanup
-    shard.maybe_spawn_background_cleanup(range.clone());
+    shard.maybe_spawn_background_cleanup(range.clone(), None);
 
     // Immediately close the shard (should trigger cancellation)
     // Give a tiny bit of time for cleanup to start
@@ -598,7 +598,7 @@ async fn cleanup_handles_multiple_close_calls() {
         .expect("set cleanup pending");
 
     // Start background cleanup
-    shard.maybe_spawn_background_cleanup(range.clone());
+    shard.maybe_spawn_background_cleanup(range.clone(), None);
 
     // First close
     shard.close().await.expect("first close");
@@ -657,7 +657,7 @@ async fn full_reacquisition_cycle_triggers_cleanup() {
             .expect("reopen shard");
 
         // This is what the coordination backend would call after factory.open()
-        shard.maybe_spawn_background_cleanup(range.clone());
+        shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Poll until cleanup reaches its terminal state, rather than sleeping
         // for a fixed amount of time — under CI load the transition through
@@ -707,7 +707,7 @@ async fn full_reacquisition_cycle_triggers_cleanup() {
         assert_eq!(status, SplitCleanupStatus::CompactionDone);
 
         // Trigger background cleanup - should be a no-op
-        shard.maybe_spawn_background_cleanup(range.clone());
+        shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Jobs should be unchanged
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
@@ -771,7 +771,7 @@ async fn interrupted_cleanup_resumes_on_reacquisition() {
             .expect("reopen shard");
 
         // Background cleanup should complete the work
-        shard.maybe_spawn_background_cleanup(range.clone());
+        shard.maybe_spawn_background_cleanup(range.clone(), None);
 
         // Wait for completion
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
@@ -786,4 +786,206 @@ async fn interrupted_cleanup_resumes_on_reacquisition() {
 
         shard.close().await.expect("close shard");
     }
+}
+
+/// Serializes tests that arm the process-global log capture buffer: a
+/// sibling's `stop_log_capture` drains the buffer mid-test, which shard-id
+/// filtering alone cannot prevent.
+static LOG_CAPTURE_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Open a shard with a unique name so captured log lines can be attributed
+/// to the calling test even when unrelated tests log concurrently.
+async fn open_named_shard(
+    name: &str,
+    range: &ShardRange,
+) -> (tempfile::TempDir, Arc<JobStoreShard>) {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = DatabaseConfig {
+        name: name.to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        ..Default::default()
+    };
+    let shard = JobStoreShard::open(&cfg, MockGubernatorClient::new_arc(), None, range.clone())
+        .await
+        .expect("open shard");
+    (tmp, shard)
+}
+
+/// A stranded split child -- no status key, a parent recorded in the shard
+/// map, no completion timestamp -- is backfilled to `CleanupPending` on
+/// acquisition (logged at info) and its defunct keys are actually deleted.
+#[silo::test]
+async fn stranded_split_child_is_backfilled_and_cleaned_on_acquisition() {
+    use silo::shard_range::ShardId;
+
+    let _capture_guard = LOG_CAPTURE_MUTEX.lock().await;
+
+    let shard_name = "stranded-child-backfill-probe";
+    let range = ShardRange::new("", RANGE_BOUNDARY);
+    let (_tmp, shard) = open_named_shard(shard_name, &range).await;
+
+    // bbb/zzz are in range, aaa is out of range -- the defunct data.
+    enqueue_jobs_for_tenants(&shard, &["bbb", "zzz", "aaa"], 3).await;
+    shard.db().flush().await.unwrap();
+    assert_eq!(count_job_info_keys(shard.db()).await, 9);
+
+    // The stranded-child shape: no status key was ever written.
+    assert_eq!(
+        shard.get_cleanup_status_raw().await.expect("raw status"),
+        None,
+        "precondition: the stranded child has no status key"
+    );
+
+    silo::trace::start_log_capture();
+    shard.maybe_spawn_background_cleanup(range.clone(), Some(ShardId::new()));
+
+    // Backfill writes CleanupPending and cleanup advances it to
+    // CompactionDone; poll the RAW reader so an absent key (spawn decided
+    // not to run) cannot satisfy the terminal check.
+    let poll_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        let status = shard.get_cleanup_status_raw().await.expect("raw status");
+        if status == Some(SplitCleanupStatus::CompactionDone) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < poll_deadline,
+            "cleanup did not reach CompactionDone within 30s; last raw status: {:?}",
+            status,
+        );
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+    let logs = silo::trace::stop_log_capture();
+
+    shard.db().flush().await.unwrap();
+    assert_eq!(
+        count_job_info_keys(shard.db()).await,
+        6,
+        "defunct out-of-range jobs must be deleted"
+    );
+    assert_eq!(count_job_info_keys_for_tenant(shard.db(), "aaa").await, 0);
+
+    let backfill_lines: Vec<&str> = logs
+        .lines()
+        .filter(|l| l.contains("backfilling cleanup status for stranded split child"))
+        .filter(|l| l.contains(shard_name))
+        .collect();
+    assert!(
+        !backfill_lines.is_empty(),
+        "backfill must be logged at info level for this shard, captured:\n{logs}"
+    );
+}
+
+/// An original shard -- no status key, no parent in the shard map -- is left
+/// completely untouched by the spawn decision: no status write, no scan.
+#[silo::test]
+async fn original_shard_without_status_is_untouched() {
+    let range = ShardRange::new("", RANGE_BOUNDARY);
+    let (_tmp, shard) = open_named_shard("original-shard-noop-probe", &range).await;
+
+    // Out-of-range jobs that a spurious cleanup would delete.
+    enqueue_jobs_for_tenants(&shard, &["bbb", "aaa"], 2).await;
+    shard.db().flush().await.unwrap();
+
+    shard.maybe_spawn_background_cleanup(range.clone(), None);
+
+    // No observable side effect marks the no-op, so give the spawned task
+    // ample time to have run before asserting nothing changed.
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+    assert_eq!(
+        shard.get_cleanup_status_raw().await.expect("raw status"),
+        None,
+        "original shard must not receive a backfilled status"
+    );
+    assert_eq!(
+        count_job_info_keys(shard.db()).await,
+        4,
+        "original shard's jobs must not be scanned away"
+    );
+}
+
+/// Defensive row: absent status but a completion timestamp present -- the
+/// spawn skips cleanup and says so at info level. Unreachable through
+/// in-repo writes (status and timestamp are always written together), so the
+/// state is constructed by writing the timestamp key directly.
+#[silo::test]
+async fn absent_status_with_completion_timestamp_skips_cleanup_with_info_log() {
+    use silo::shard_range::ShardId;
+
+    let _capture_guard = LOG_CAPTURE_MUTEX.lock().await;
+
+    let shard_name = "completed-timestamp-noop-probe";
+    let range = ShardRange::new("", RANGE_BOUNDARY);
+    let (_tmp, shard) = open_named_shard(shard_name, &range).await;
+
+    enqueue_jobs_for_tenants(&shard, &["bbb", "aaa"], 2).await;
+    shard
+        .set_cleanup_completed_at_ms()
+        .await
+        .expect("write completion timestamp directly");
+    shard.db().flush().await.unwrap();
+    assert_eq!(
+        shard.get_cleanup_status_raw().await.expect("raw status"),
+        None,
+        "precondition: no status key alongside the timestamp"
+    );
+
+    silo::trace::start_log_capture();
+    shard.maybe_spawn_background_cleanup(range.clone(), Some(ShardId::new()));
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+    let logs = silo::trace::stop_log_capture();
+
+    assert_eq!(
+        shard.get_cleanup_status_raw().await.expect("raw status"),
+        None,
+        "defensive no-op must not write a status"
+    );
+    assert_eq!(
+        count_job_info_keys(shard.db()).await,
+        4,
+        "defensive no-op must not delete anything"
+    );
+    let skip_lines: Vec<&str> = logs
+        .lines()
+        .filter(|l| l.contains("cleanup already completed"))
+        .filter(|l| l.contains(shard_name))
+        .collect();
+    assert!(
+        !skip_lines.is_empty(),
+        "the defensive skip must be logged at info level for this shard, captured:\n{logs}"
+    );
+}
+
+/// Present-status pass-through: a shard with a status key follows
+/// `needs_work()` exactly as before -- a terminal status spawns nothing,
+/// even when the map records a parent and no timestamp exists.
+#[silo::test]
+async fn present_status_passes_through_needs_work_unchanged() {
+    use silo::shard_range::ShardId;
+
+    let range = ShardRange::new("", RANGE_BOUNDARY);
+    let (_tmp, shard) = open_named_shard("present-status-passthrough-probe", &range).await;
+
+    enqueue_jobs_for_tenants(&shard, &["bbb", "aaa"], 2).await;
+    shard
+        .set_cleanup_status(SplitCleanupStatus::CompactionDone)
+        .await
+        .expect("set terminal status");
+    shard.db().flush().await.unwrap();
+
+    shard.maybe_spawn_background_cleanup(range.clone(), Some(ShardId::new()));
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+    assert_eq!(
+        shard.get_cleanup_status_raw().await.expect("raw status"),
+        Some(SplitCleanupStatus::CompactionDone),
+        "a present terminal status must be left untouched"
+    );
+    assert_eq!(
+        count_job_info_keys(shard.db()).await,
+        4,
+        "a terminal-status shard must not be cleaned"
+    );
 }

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -730,6 +730,211 @@ async fn split_with_empty_child_aborts_before_commit_and_recovers_parent() {
     h1.abort();
 }
 
+/// End-to-end cross-node flow over a shared data root with per-node WAL
+/// roots: two live nodes, one parent shard. Bounded-load rendezvous caps
+/// each node at ceil(2 shards / 2 nodes) = 1 child, so after the split the
+/// initiator owns exactly one child and the OTHER node deterministically
+/// acquires the other -- a child the initiator never opened -- and its
+/// cleanup runs to completion, deleting the defunct half of the parent's
+/// data. The shared-data-root / per-node-WAL factory is load-bearing: with
+/// fully per-node roots the second node would open a fresh empty database
+/// and the test would pass vacuously.
+#[silo::test(flavor = "multi_thread", worker_threads = 4)]
+async fn non_initiator_node_cleans_children_after_split() {
+    use silo::coordination::SplitCleanupStatus;
+
+    let _guard = acquire_test_mutex().await;
+
+    let prefix = unique_prefix();
+    let root = format!("silo-cross-node-cleanup-{prefix}");
+    let num_shards: u32 = 1;
+    let cfg = silo::settings::AppConfig::load(None).expect("load default config");
+
+    let factory1 = test_helpers::make_shared_data_root_memory_factory(&root, "n1");
+    let factory2 = test_helpers::make_shared_data_root_memory_factory(&root, "n2");
+    let (c1, h1) = EtcdCoordinator::start(
+        &cfg.coordination.etcd_endpoints,
+        &prefix,
+        "n1",
+        "http://127.0.0.1:7450",
+        num_shards,
+        10,
+        Arc::clone(&factory1),
+        Vec::new(),
+    )
+    .await
+    .expect("start coordinator n1");
+    let (c2, h2) = EtcdCoordinator::start(
+        &cfg.coordination.etcd_endpoints,
+        &prefix,
+        "n2",
+        "http://127.0.0.1:7451",
+        num_shards,
+        10,
+        Arc::clone(&factory2),
+        Vec::new(),
+    )
+    .await
+    .expect("start coordinator n2");
+    assert!(c1.wait_converged(Duration::from_secs(10)).await);
+    assert!(c2.wait_converged(Duration::from_secs(10)).await);
+
+    // Whichever node owns the single parent shard is the initiator.
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let (shard_id, initiator, init_factory, non_initiator, non_init_factory) = loop {
+        if let Some(&shard_id) = c1.owned_shards().await.first() {
+            break (shard_id, &c1, &factory1, &c2, &factory2);
+        }
+        if let Some(&shard_id) = c2.owned_shards().await.first() {
+            break (shard_id, &c2, &factory2, &c1, &factory1);
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "neither node acquired the parent shard"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+    let parent_range = {
+        let map = initiator.get_shard_map().await.expect("get shard map");
+        map.get_shard(&shard_id).unwrap().range.clone()
+    };
+    let parent = loop {
+        if let Some(parent) = init_factory.get(&shard_id) {
+            break parent;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "initiator never opened the parent shard"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+
+    // Three tenants hash below the midpoint boundary, three at or above --
+    // each child inherits all sixty jobs and owes thirty deletions.
+    let low = ["bbb", "mmm", "nnn"];
+    let high = ["aaa", "lll", "yyy"];
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    for tenant in low.iter().chain(high.iter()) {
+        for i in 0..10 {
+            parent
+                .enqueue(
+                    tenant,
+                    Some(format!("{tenant}-job-{i}")),
+                    5,
+                    now_ms,
+                    None,
+                    rmp_serde::to_vec(&serde_json::json!({"i": i})).unwrap(),
+                    vec![],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue to parent");
+        }
+    }
+    let per_child_in_range = (low.len() + high.len()) * 10 / 2;
+
+    let splitter = ShardSplitter::new(Arc::new(initiator.clone()));
+    let split_point = silo::shard_range::format_hash_boundary(
+        parent_range.midpoint().expect("parent range has midpoint"),
+    );
+    let split = splitter
+        .request_split(shard_id, split_point.clone())
+        .await
+        .expect("request split");
+    let init_for_owner_map = initiator.clone();
+    splitter
+        .execute_split(shard_id, move || {
+            let c = init_for_owner_map.clone();
+            async move { c.get_shard_owner_map().await }
+        })
+        .await
+        .expect("execute split");
+
+    // Bounded-load rendezvous gives each node exactly one child. Find the
+    // non-initiator's child and which tenant set is in its range.
+    let poll_deadline = std::time::Instant::now() + Duration::from_secs(60);
+    let remote_child_id = loop {
+        let owned = non_initiator.owned_shards().await;
+        if let Some(&child_id) = owned
+            .iter()
+            .find(|id| **id == split.left_child_id || **id == split.right_child_id)
+        {
+            break child_id;
+        }
+        assert!(
+            std::time::Instant::now() < poll_deadline,
+            "the non-initiator node never acquired a child (owned: {owned:?})"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+    let (in_range_tenants, out_of_range_tenants) = if remote_child_id == split.left_child_id {
+        (low, high)
+    } else {
+        (high, low)
+    };
+
+    // The initiator never desired, opened, or cleaned this child, so every
+    // deletion observed below is the non-initiator's work.
+    let child = loop {
+        if let Some(child) = non_init_factory.get(&remote_child_id) {
+            break child;
+        }
+        assert!(
+            std::time::Instant::now() < poll_deadline,
+            "the non-initiator node never opened its child"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+    loop {
+        let status = child.get_cleanup_status_raw().await.expect("child status");
+        if matches!(
+            status,
+            Some(SplitCleanupStatus::CleanupDone | SplitCleanupStatus::CompactionDone)
+        ) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < poll_deadline,
+            "child {remote_child_id} cleanup did not complete on the non-initiator node; \
+             last status: {status:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    child.db().flush().await.expect("flush child");
+
+    // The clone verification guaranteed this child held the parent's full
+    // job set at commit; retaining exactly the in-range jobs proves the
+    // non-initiator's cleanup deleted the defunct half.
+    assert_eq!(
+        test_helpers::count_job_info_keys(child.db()).await,
+        per_child_in_range,
+        "child {remote_child_id} must retain exactly its in-range jobs"
+    );
+    for tenant in in_range_tenants {
+        assert_eq!(
+            test_helpers::count_job_info_keys_for_tenant(child.db(), tenant).await,
+            10,
+            "child {remote_child_id} must keep tenant {tenant}'s jobs"
+        );
+    }
+    for tenant in out_of_range_tenants {
+        assert_eq!(
+            test_helpers::count_job_info_keys_for_tenant(child.db(), tenant).await,
+            0,
+            "child {remote_child_id} must have deleted tenant {tenant}'s defunct jobs"
+        );
+    }
+
+    c1.shutdown().await.expect("shutdown n1");
+    c2.shutdown().await.expect("shutdown n2");
+    h1.abort();
+    h2.abort();
+}
+
 /// Drive a full split on the shared-root Memory backend (an object store,
 /// with a separate WAL store) and assert every enqueued job survives in the
 /// child that owns its tenant's range. This is the object-store analogue of

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -1,3 +1,5 @@
+mod test_helpers;
+
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -2461,5 +2463,686 @@ mod splitter_unit_tests {
             shard_recovered.get_job("test", "nonexistent").await.is_ok(),
             "shard should be usable after factory.close + factory.open"
         );
+    }
+
+    /// Guard-free harness for asserting exact child cleanup metadata: a
+    /// cloning-capable factory driven by the mock split backend, with no
+    /// coordinator or shard guards attached that could race the status.
+    struct CloningSplitHarness {
+        shard_map: Arc<Mutex<silo::shard_range::ShardMap>>,
+        owned: Arc<Mutex<HashSet<ShardId>>>,
+        factory: Arc<ShardFactory>,
+        splitter: ShardSplitter,
+        parent_id: ShardId,
+        parent_range: silo::shard_range::ShardRange,
+    }
+
+    /// Tenants with known hash placement relative to the full-range midpoint
+    /// boundary `8000000000000000`: three hash below it, three at or above.
+    const TENANTS_LOW_HALF: [&str; 3] = ["bbb", "mmm", "nnn"];
+    const TENANTS_HIGH_HALF: [&str; 3] = ["aaa", "lll", "yyy"];
+
+    async fn setup_cloning_harness(test_name: &str) -> CloningSplitHarness {
+        setup_cloning_harness_with_factory(make_test_factory_for_unit_test(test_name)).await
+    }
+
+    async fn setup_cloning_harness_with_factory(factory: Arc<ShardFactory>) -> CloningSplitHarness {
+        let shard_map = Arc::new(Mutex::new(
+            silo::shard_range::ShardMap::create_initial(1).unwrap(),
+        ));
+        let owned = Arc::new(Mutex::new(HashSet::new()));
+        let mock = Arc::new(MockSplitBackend::new(
+            shard_map.clone(),
+            owned.clone(),
+            factory.clone(),
+        ));
+        let splitter = ShardSplitter::new(Arc::clone(&mock) as Arc<dyn Coordinator>);
+
+        let parent_id = shard_map.lock().await.shard_ids()[0];
+        owned.lock().await.insert(parent_id);
+        let parent_range = shard_map
+            .lock()
+            .await
+            .get_shard(&parent_id)
+            .unwrap()
+            .range
+            .clone();
+        factory.open(&parent_id, &parent_range).await.unwrap();
+
+        CloningSplitHarness {
+            shard_map,
+            owned,
+            factory,
+            splitter,
+            parent_id,
+            parent_range,
+        }
+    }
+
+    /// Enqueue one job per tenant into the given open shard.
+    async fn seed_jobs(shard: &silo::job_store_shard::JobStoreShard, tenants: &[&str]) {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+        for tenant in tenants {
+            shard
+                .enqueue(
+                    tenant,
+                    Some(format!("{tenant}-job")),
+                    5,
+                    now_ms,
+                    None,
+                    rmp_serde::to_vec(&serde_json::json!({"k": "v"})).unwrap(),
+                    vec![],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue job");
+        }
+    }
+
+    /// Owner-map closure that assigns both children to `other-node`, away
+    /// from the mock initiator (`mock-node`), so the post-commit loop opens
+    /// no child and nothing can race the initialized metadata.
+    fn owner_map_assigning_children_away(
+        shard_map: Arc<Mutex<silo::shard_range::ShardMap>>,
+        left: ShardId,
+        right: ShardId,
+    ) -> impl Fn() -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<ShardOwnerMap, CoordinationError>> + Send>,
+    > {
+        move || {
+            let shard_map = shard_map.clone();
+            Box::pin(async move {
+                let mut shard_to_node = HashMap::new();
+                shard_to_node.insert(left, "other-node".to_string());
+                shard_to_node.insert(right, "other-node".to_string());
+                Ok(ShardOwnerMap {
+                    shard_map: shard_map.lock().await.clone(),
+                    shard_to_node,
+                    shard_to_addr: HashMap::new(),
+                })
+            })
+        }
+    }
+
+    /// After the cloning phase commits, both children carry exactly
+    /// `CleanupPending` with fully reset cleanup metadata -- regardless of
+    /// which node will own them -- observed through the factory's raw
+    /// non-registering reader, and neither child is registered in the
+    /// factory's instance map.
+    #[silo::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn split_initializes_both_children_cleanup_metadata_before_commit() {
+        use silo::coordination::SplitCleanupStatus;
+
+        let h = setup_cloning_harness("children-init-pending").await;
+        let parent = h.factory.get(&h.parent_id).unwrap();
+        seed_jobs(
+            &parent,
+            &[TENANTS_LOW_HALF.as_slice(), TENANTS_HIGH_HALF.as_slice()].concat(),
+        )
+        .await;
+
+        let split_point = silo::shard_range::format_hash_boundary(
+            h.parent_range.midpoint().expect("full range has midpoint"),
+        );
+        let split = h
+            .splitter
+            .request_split(h.parent_id, split_point)
+            .await
+            .expect("request split");
+        h.splitter
+            .execute_split(
+                h.parent_id,
+                owner_map_assigning_children_away(
+                    h.shard_map.clone(),
+                    split.left_child_id,
+                    split.right_child_id,
+                ),
+            )
+            .await
+            .expect("execute split");
+
+        for child_id in [split.left_child_id, split.right_child_id] {
+            assert!(
+                h.factory.get(&child_id).is_none(),
+                "child {child_id} must not be registered in the factory after the cloning phase"
+            );
+            let meta = h
+                .factory
+                .read_closed_shard_cleanup_metadata(&child_id)
+                .await
+                .expect("read child cleanup metadata");
+            assert_eq!(
+                meta.status,
+                Some(SplitCleanupStatus::CleanupPending),
+                "child {child_id} must be initialized to CleanupPending, got {meta:?}"
+            );
+            assert!(
+                !meta.progress_key_present,
+                "child {child_id} must have no inherited cleanup progress"
+            );
+            assert!(
+                !meta.complete_marker_present,
+                "child {child_id} must have no inherited legacy complete marker"
+            );
+            assert_eq!(
+                meta.cleanup_completed_at_ms, None,
+                "child {child_id} must have no inherited completion timestamp"
+            );
+        }
+    }
+
+    /// The initialized `CleanupPending` metadata is durable in the SHARED
+    /// data store, not just the initiator's node-local WAL: a passive second
+    /// factory sharing the data root but carrying its own WAL root reads the
+    /// exact metadata. Guard-free with both children away from the initiator
+    /// and no coordinator on either factory, so nothing can manufacture the
+    /// key or fence the reader.
+    #[silo::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn initialized_child_metadata_visible_through_passive_second_factory() {
+        use silo::coordination::SplitCleanupStatus;
+
+        let root = format!(
+            "silo-split-shared-root-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let initiator_factory =
+            super::test_helpers::make_shared_data_root_memory_factory(&root, "n1");
+        let h = setup_cloning_harness_with_factory(initiator_factory).await;
+        let parent = h.factory.get(&h.parent_id).unwrap();
+        seed_jobs(
+            &parent,
+            &[TENANTS_LOW_HALF.as_slice(), TENANTS_HIGH_HALF.as_slice()].concat(),
+        )
+        .await;
+
+        let split_point = silo::shard_range::format_hash_boundary(
+            h.parent_range.midpoint().expect("full range has midpoint"),
+        );
+        let split = h
+            .splitter
+            .request_split(h.parent_id, split_point)
+            .await
+            .expect("request split");
+        h.splitter
+            .execute_split(
+                h.parent_id,
+                owner_map_assigning_children_away(
+                    h.shard_map.clone(),
+                    split.left_child_id,
+                    split.right_child_id,
+                ),
+            )
+            .await
+            .expect("execute split");
+
+        // The initiator opened no post-commit child handles (both children
+        // are remote) and its raw pre-commit handles are closed, so the
+        // passive factory's open cannot fence a live writer.
+        let passive_factory =
+            super::test_helpers::make_shared_data_root_memory_factory(&root, "n2");
+        for child_id in [split.left_child_id, split.right_child_id] {
+            let meta = passive_factory
+                .read_closed_shard_cleanup_metadata(&child_id)
+                .await
+                .expect("read child cleanup metadata through passive factory");
+            assert_eq!(
+                meta.status,
+                Some(SplitCleanupStatus::CleanupPending),
+                "child {child_id} status must be visible through a factory that does not share \
+                 the initiator's WAL, got {meta:?}"
+            );
+            assert!(!meta.progress_key_present);
+            assert!(!meta.complete_marker_present);
+            assert_eq!(meta.cleanup_completed_at_ms, None);
+        }
+    }
+
+    /// Splitting a child whose own cleanup completed (status `CleanupDone`,
+    /// progress marker still present, completion timestamp set) yields
+    /// grandchildren with fresh metadata whose cleanup actually deletes
+    /// defunct keys -- not an inherited-"complete" no-op -- and the whole
+    /// two-generation flow emits no status-regression WARN.
+    #[silo::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn second_generation_split_yields_fresh_grandchild_metadata() {
+        use silo::coordination::SplitCleanupStatus;
+
+        // Capture discipline: the buffer is process-global, so hold the
+        // suite mutex and filter captured lines by this test's shard ids.
+        let _guard = super::acquire_test_mutex().await;
+
+        let h = setup_cloning_harness("second-generation-split").await;
+        let parent = h.factory.get(&h.parent_id).unwrap();
+        seed_jobs(
+            &parent,
+            &[TENANTS_LOW_HALF.as_slice(), TENANTS_HIGH_HALF.as_slice()].concat(),
+        )
+        .await;
+
+        silo::trace::start_log_capture();
+
+        // First generation: split the full-range parent at its midpoint.
+        let split_point = silo::shard_range::format_hash_boundary(
+            h.parent_range.midpoint().expect("full range has midpoint"),
+        );
+        let split = h
+            .splitter
+            .request_split(h.parent_id, split_point)
+            .await
+            .expect("request split");
+        h.splitter
+            .execute_split(
+                h.parent_id,
+                owner_map_assigning_children_away(
+                    h.shard_map.clone(),
+                    split.left_child_id,
+                    split.right_child_id,
+                ),
+            )
+            .await
+            .expect("execute first-generation split");
+
+        // Drive the left child's cleanup to completion: status CleanupDone,
+        // progress marker present (complete=true), completion timestamp set
+        // -- the exact state a to-be-split shard carries in production.
+        let left_id = split.left_child_id;
+        let left_range = h
+            .shard_map
+            .lock()
+            .await
+            .get_shard(&left_id)
+            .unwrap()
+            .range
+            .clone();
+        let left = h
+            .factory
+            .open(&left_id, &left_range)
+            .await
+            .expect("open left child");
+        let result = left
+            .after_split_cleanup_defunct_data(&left_range, 100)
+            .await
+            .expect("left child cleanup");
+        assert!(result.complete, "left child cleanup must complete");
+        assert!(
+            result.keys_deleted > 0,
+            "left child must have deleted the high-half tenants' keys"
+        );
+        assert_eq!(
+            left.get_cleanup_status_raw().await.expect("status"),
+            Some(SplitCleanupStatus::CleanupDone)
+        );
+        assert!(
+            left.get_cleanup_completed_at_ms()
+                .await
+                .expect("completed at")
+                .is_some(),
+            "left child must carry a completion timestamp before the second split"
+        );
+
+        // Second generation: split the cleaned left child at ITS midpoint.
+        h.owned.lock().await.insert(left_id);
+        let second_split_point = silo::shard_range::format_hash_boundary(
+            left_range.midpoint().expect("left range has midpoint"),
+        );
+        let second = h
+            .splitter
+            .request_split(left_id, second_split_point)
+            .await
+            .expect("request second-generation split");
+        h.splitter
+            .execute_split(
+                left_id,
+                owner_map_assigning_children_away(
+                    h.shard_map.clone(),
+                    second.left_child_id,
+                    second.right_child_id,
+                ),
+            )
+            .await
+            .expect("execute second-generation split");
+
+        // Both grandchildren must carry fresh metadata despite the parent's
+        // terminal state at clone time.
+        for grandchild_id in [second.left_child_id, second.right_child_id] {
+            let meta = h
+                .factory
+                .read_closed_shard_cleanup_metadata(&grandchild_id)
+                .await
+                .expect("read grandchild cleanup metadata");
+            assert_eq!(
+                meta.status,
+                Some(SplitCleanupStatus::CleanupPending),
+                "grandchild {grandchild_id} must be reset to CleanupPending, got {meta:?}"
+            );
+            assert!(
+                !meta.progress_key_present,
+                "grandchild {grandchild_id} must not inherit the complete progress record"
+            );
+            assert!(!meta.complete_marker_present);
+            assert_eq!(
+                meta.cleanup_completed_at_ms, None,
+                "grandchild {grandchild_id} must not inherit the completion timestamp"
+            );
+        }
+
+        // The low-half tenants all hash below the second split point, so the
+        // right grandchild holds only defunct keys -- its cleanup must
+        // actually delete them, not no-op on inherited state. The guard-free
+        // harness has no acquisition machinery, so drive cleanup directly on
+        // an opened grandchild handle.
+        let right_grandchild_id = second.right_child_id;
+        let right_range = h
+            .shard_map
+            .lock()
+            .await
+            .get_shard(&right_grandchild_id)
+            .unwrap()
+            .range
+            .clone();
+        let right_grandchild = h
+            .factory
+            .open(&right_grandchild_id, &right_range)
+            .await
+            .expect("open right grandchild");
+        let result = right_grandchild
+            .after_split_cleanup_defunct_data(&right_range, 100)
+            .await
+            .expect("right grandchild cleanup");
+        assert!(result.complete, "grandchild cleanup must run to completion");
+        assert!(
+            result.keys_deleted > 0,
+            "grandchild cleanup must delete the low-half tenants' defunct keys, not skip as \
+             inherited-complete"
+        );
+
+        let logs = silo::trace::stop_log_capture();
+        let own_ids = [
+            h.parent_id,
+            split.left_child_id,
+            split.right_child_id,
+            second.left_child_id,
+            second.right_child_id,
+        ];
+        let regressions: Vec<&str> = logs
+            .lines()
+            .filter(|l| l.contains("cleanup status regression"))
+            .filter(|l| own_ids.iter().any(|id| l.contains(&id.to_string())))
+            .collect();
+        assert!(
+            regressions.is_empty(),
+            "no status-regression WARN may fire across two split generations, got:\n{}",
+            regressions.join("\n")
+        );
+    }
+
+    /// A child cleanup-metadata initialization failure aborts the split
+    /// pre-commit: the shard map keeps routing to the parent, the split
+    /// record is abandoned, the parent is recovered with its own metadata
+    /// untouched, and neither child is registered in the factory. Driven
+    /// through the factory's init-failure fault seam and surfaced under the
+    /// dedicated init marker so a verification miscount cannot fake a pass.
+    #[silo::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn child_init_failure_aborts_split_pre_commit_and_recovers_parent() {
+        let h = setup_cloning_harness("child-init-failure-abort").await;
+        let parent = h.factory.get(&h.parent_id).unwrap();
+        seed_jobs(&parent, &TENANTS_LOW_HALF).await;
+
+        let split_point = silo::shard_range::format_hash_boundary(
+            h.parent_range.midpoint().expect("full range has midpoint"),
+        );
+        let split = h
+            .splitter
+            .request_split(h.parent_id, split_point)
+            .await
+            .expect("request split");
+
+        // Fail the SECOND child's initialization so the first child's
+        // count-check-then-initialize sequence has already run -- a
+        // pre-commit abort may leave one child initialized, which is
+        // harmless because the clones are discarded.
+        h.factory.inject_child_init_failure(split.right_child_id);
+
+        let result = h
+            .splitter
+            .execute_split(
+                h.parent_id,
+                owner_map_assigning_children_away(
+                    h.shard_map.clone(),
+                    split.left_child_id,
+                    split.right_child_id,
+                ),
+            )
+            .await;
+        let err = result.expect_err("split must abort on child initialization failure");
+        let err_text = format!("{err}");
+        assert!(
+            err_text.contains(silo::coordination::split::MARKER_CHILD_INIT_FAILED),
+            "abort must surface the dedicated init-failure marker, got: {err_text}"
+        );
+        assert!(
+            !err_text.contains(silo::coordination::split::MARKER_CHILD_VERIFICATION_FAILED),
+            "abort must not be attributed to a verification miscount, got: {err_text}"
+        );
+
+        // Pre-commit abort: the shard map still routes to the parent only.
+        {
+            let map = h.shard_map.lock().await;
+            assert!(map.get_shard(&h.parent_id).is_some());
+            assert!(map.get_shard(&split.left_child_id).is_none());
+            assert!(map.get_shard(&split.right_child_id).is_none());
+        }
+        assert!(
+            h.splitter
+                .get_split_status(h.parent_id)
+                .await
+                .expect("get split status")
+                .is_none(),
+            "split record must be abandoned"
+        );
+
+        // Neither child may linger in the factory's instance map.
+        assert!(h.factory.get(&split.left_child_id).is_none());
+        assert!(h.factory.get(&split.right_child_id).is_none());
+
+        // The parent is recovered, serves reads, and its own cleanup
+        // metadata is untouched -- no status key was ever written to it, so
+        // its next acquisition does not spuriously scan the keyspace.
+        let recovered = h
+            .factory
+            .get(&h.parent_id)
+            .expect("parent reopened in factory after abort");
+        assert_eq!(
+            recovered
+                .get_counters()
+                .await
+                .expect("recovered parent counters")
+                .total_jobs,
+            TENANTS_LOW_HALF.len() as i64,
+            "recovered parent must hold its jobs"
+        );
+        assert_eq!(
+            recovered
+                .get_cleanup_status_raw()
+                .await
+                .expect("parent raw status"),
+            None,
+            "parent cleanup status must be untouched by the aborted split"
+        );
+    }
+
+    /// A normal split's happy path emits no status-regression WARN, and the
+    /// observed statuses move forward only: `CleanupPending` at
+    /// post-commit-pre-cleanup, `CleanupDone` after cleanup completes.
+    #[silo::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn normal_split_emits_no_status_regression_warn() {
+        use silo::coordination::SplitCleanupStatus;
+
+        // Capture discipline: hold the suite mutex, filter by own shard ids.
+        let _guard = super::acquire_test_mutex().await;
+
+        let h = setup_cloning_harness("normal-split-no-warn").await;
+        let parent = h.factory.get(&h.parent_id).unwrap();
+        seed_jobs(
+            &parent,
+            &[TENANTS_LOW_HALF.as_slice(), TENANTS_HIGH_HALF.as_slice()].concat(),
+        )
+        .await;
+
+        silo::trace::start_log_capture();
+
+        let split_point = silo::shard_range::format_hash_boundary(
+            h.parent_range.midpoint().expect("full range has midpoint"),
+        );
+        let split = h
+            .splitter
+            .request_split(h.parent_id, split_point)
+            .await
+            .expect("request split");
+        h.splitter
+            .execute_split(
+                h.parent_id,
+                owner_map_assigning_children_away(
+                    h.shard_map.clone(),
+                    split.left_child_id,
+                    split.right_child_id,
+                ),
+            )
+            .await
+            .expect("execute split");
+
+        // Post-commit, pre-cleanup: both children sit at CleanupPending.
+        for child_id in [split.left_child_id, split.right_child_id] {
+            let meta = h
+                .factory
+                .read_closed_shard_cleanup_metadata(&child_id)
+                .await
+                .expect("read child cleanup metadata");
+            assert_eq!(meta.status, Some(SplitCleanupStatus::CleanupPending));
+        }
+
+        // The guard-free harness has no acquisition machinery to spawn
+        // cleanup, so drive it directly on an opened child handle.
+        let left_id = split.left_child_id;
+        let left_range = h
+            .shard_map
+            .lock()
+            .await
+            .get_shard(&left_id)
+            .unwrap()
+            .range
+            .clone();
+        let left = h
+            .factory
+            .open(&left_id, &left_range)
+            .await
+            .expect("open left child");
+        let result = left
+            .after_split_cleanup_defunct_data(&left_range, 100)
+            .await
+            .expect("left child cleanup");
+        assert!(result.complete);
+
+        // Post-cleanup-completion: forward progression landed on CleanupDone.
+        assert_eq!(
+            left.get_cleanup_status_raw().await.expect("status"),
+            Some(SplitCleanupStatus::CleanupDone)
+        );
+
+        let logs = silo::trace::stop_log_capture();
+        let own_ids = [h.parent_id, split.left_child_id, split.right_child_id];
+        let regressions: Vec<&str> = logs
+            .lines()
+            .filter(|l| l.contains("cleanup status regression"))
+            .filter(|l| own_ids.iter().any(|id| l.contains(&id.to_string())))
+            .collect();
+        assert!(
+            regressions.is_empty(),
+            "a normal split must not trip the status-regression WARN, got:\n{}",
+            regressions.join("\n")
+        );
+    }
+
+    /// When the initiator owns the children, the post-commit open returns
+    /// handles carrying the committed child ranges -- not the full range the
+    /// raw pre-commit opens used -- and the pre-commit initialization is
+    /// visible through those handles without any post-commit status write.
+    #[silo::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn initiator_owned_children_open_with_committed_ranges() {
+        use silo::coordination::SplitCleanupStatus;
+
+        let h = setup_cloning_harness("initiator-owned-children").await;
+        let parent = h.factory.get(&h.parent_id).unwrap();
+        seed_jobs(
+            &parent,
+            &[TENANTS_LOW_HALF.as_slice(), TENANTS_HIGH_HALF.as_slice()].concat(),
+        )
+        .await;
+
+        let split_point = silo::shard_range::format_hash_boundary(
+            h.parent_range.midpoint().expect("full range has midpoint"),
+        );
+        let split = h
+            .splitter
+            .request_split(h.parent_id, split_point.clone())
+            .await
+            .expect("request split");
+
+        // Assign both children to the initiator ("mock-node") so the
+        // post-commit loop opens them.
+        let shard_map = h.shard_map.clone();
+        let (left_id, right_id) = (split.left_child_id, split.right_child_id);
+        h.splitter
+            .execute_split(h.parent_id, move || {
+                let shard_map = shard_map.clone();
+                async move {
+                    let mut shard_to_node = HashMap::new();
+                    shard_to_node.insert(left_id, "mock-node".to_string());
+                    shard_to_node.insert(right_id, "mock-node".to_string());
+                    Ok(ShardOwnerMap {
+                        shard_map: shard_map.lock().await.clone(),
+                        shard_to_node,
+                        shard_to_addr: HashMap::new(),
+                    })
+                }
+            })
+            .await
+            .expect("execute split");
+
+        for child_id in [left_id, right_id] {
+            let committed_range = h
+                .shard_map
+                .lock()
+                .await
+                .get_shard(&child_id)
+                .unwrap()
+                .range
+                .clone();
+            assert_ne!(
+                committed_range, h.parent_range,
+                "committed child range must be narrower than the parent's full range"
+            );
+            let child = h
+                .factory
+                .get(&child_id)
+                .expect("initiator-owned child must be registered post-commit");
+            assert_eq!(
+                child.get_range(),
+                committed_range,
+                "child {child_id} handle must carry the committed range, not the full range \
+                 the raw pre-commit open used"
+            );
+            assert_eq!(
+                child.get_cleanup_status_raw().await.expect("status"),
+                Some(SplitCleanupStatus::CleanupPending),
+                "pre-commit initialization must be visible through the post-commit handle"
+            );
+        }
     }
 }

--- a/tests/coordination_split_tests.rs
+++ b/tests/coordination_split_tests.rs
@@ -2903,9 +2903,18 @@ mod splitter_unit_tests {
                 "child {child_id} status must be visible through a factory that does not share \
                  the initiator's WAL, got {meta:?}"
             );
-            assert!(!meta.progress_key_present);
-            assert!(!meta.complete_marker_present);
-            assert_eq!(meta.cleanup_completed_at_ms, None);
+            assert!(
+                !meta.progress_key_present,
+                "child {child_id} must have no inherited cleanup progress, got {meta:?}"
+            );
+            assert!(
+                !meta.complete_marker_present,
+                "child {child_id} must have no inherited legacy complete marker, got {meta:?}"
+            );
+            assert_eq!(
+                meta.cleanup_completed_at_ms, None,
+                "child {child_id} must have no inherited completion timestamp"
+            );
         }
     }
 
@@ -3030,7 +3039,10 @@ mod splitter_unit_tests {
                 !meta.progress_key_present,
                 "grandchild {grandchild_id} must not inherit the complete progress record"
             );
-            assert!(!meta.complete_marker_present);
+            assert!(
+                !meta.complete_marker_present,
+                "grandchild {grandchild_id} must not inherit the legacy complete marker"
+            );
             assert_eq!(
                 meta.cleanup_completed_at_ms, None,
                 "grandchild {grandchild_id} must not inherit the completion timestamp"

--- a/tests/factory_tests.rs
+++ b/tests/factory_tests.rs
@@ -640,7 +640,7 @@ async fn verify_cloned_children_detects_short_child() {
     // that held one job.
     let empty_child = ShardId::new();
     let result = factory
-        .verify_cloned_children_match_parent(&parent_id, &[empty_child])
+        .verify_and_initialize_cloned_children(&parent_id, &[empty_child])
         .await;
     assert!(
         result.is_err(),
@@ -690,7 +690,7 @@ async fn verify_cloned_children_accepts_full_clone_without_caching() {
         .expect("clone closed shard");
 
     factory
-        .verify_cloned_children_match_parent(&parent_id, &[left_child_id, right_child_id])
+        .verify_and_initialize_cloned_children(&parent_id, &[left_child_id, right_child_id])
         .await
         .expect("full clones should pass verification");
 
@@ -761,7 +761,7 @@ async fn parent_reopens_intact_after_verification_mismatch() {
     // Force a mismatch by verifying a child that was never cloned: it opens
     // empty and cannot match the parent's job count.
     let result = factory
-        .verify_cloned_children_match_parent(&parent_id, &[ShardId::new()])
+        .verify_and_initialize_cloned_children(&parent_id, &[ShardId::new()])
         .await;
     assert!(
         result.is_err(),

--- a/tests/shard_cleanup_tests.rs
+++ b/tests/shard_cleanup_tests.rs
@@ -799,3 +799,131 @@ async fn cleanup_completed_at_only_set_on_actual_completion() {
         "cleanup_completed_at should be set after cleanup completes"
     );
 }
+
+/// Serializes tests that arm the process-global log capture buffer: a
+/// sibling's `stop_log_capture` drains the buffer mid-test, which shard-id
+/// filtering alone cannot prevent.
+static LOG_CAPTURE_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Extract the captured log lines that mention the given shard name.
+fn lines_for_shard(logs: &str, shard_name: &str) -> Vec<String> {
+    logs.lines()
+        .filter(|l| l.contains(shard_name))
+        .map(str::to_string)
+        .collect()
+}
+
+/// A first status write into a shard with no status key is a valid initial
+/// transition, not a regression; a genuine backward transition between two
+/// present statuses still warns and is still allowed.
+#[silo::test]
+async fn first_status_write_into_absent_key_does_not_warn() {
+    use silo::coordination::SplitCleanupStatus;
+    use silo::gubernator::MockGubernatorClient;
+    use silo::job_store_shard::JobStoreShard;
+    use silo::settings::{Backend, DatabaseConfig};
+    use test_helpers::fast_flush_slatedb_settings;
+
+    let _capture_guard = LOG_CAPTURE_MUTEX.lock().await;
+
+    // Unique shard name so captured lines can be attributed to this test even
+    // if unrelated tests log concurrently.
+    let shard_name = "first-write-warn-probe";
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = DatabaseConfig {
+        name: shard_name.to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        ..Default::default()
+    };
+    let shard = JobStoreShard::open(
+        &cfg,
+        MockGubernatorClient::new_arc(),
+        None,
+        ShardRange::full(),
+    )
+    .await
+    .expect("open shard");
+
+    // First write into an absent status key: must land without a regression WARN.
+    silo::trace::start_log_capture();
+    shard
+        .set_cleanup_status(SplitCleanupStatus::CleanupPending)
+        .await
+        .expect("first status write");
+    let logs = silo::trace::stop_log_capture();
+
+    let own_lines = lines_for_shard(&logs, shard_name);
+    assert!(
+        !own_lines
+            .iter()
+            .any(|l| l.contains("cleanup status regression")),
+        "first write into an absent status key must not warn, got:\n{}",
+        own_lines.join("\n")
+    );
+    assert_eq!(
+        shard.get_cleanup_status().await.expect("get status"),
+        SplitCleanupStatus::CleanupPending,
+        "first write must land"
+    );
+
+    // Advance to a later status, then genuinely regress: the WARN fires and
+    // the write still lands (crash-recovery allowance).
+    shard
+        .set_cleanup_status(SplitCleanupStatus::CleanupDone)
+        .await
+        .expect("forward status write");
+
+    silo::trace::start_log_capture();
+    shard
+        .set_cleanup_status(SplitCleanupStatus::CleanupPending)
+        .await
+        .expect("backward status write");
+    let logs = silo::trace::stop_log_capture();
+
+    let own_lines = lines_for_shard(&logs, shard_name);
+    assert!(
+        own_lines
+            .iter()
+            .any(|l| l.contains("cleanup status regression")),
+        "a backward transition between present statuses must warn, got:\n{}",
+        own_lines.join("\n")
+    );
+    assert_eq!(
+        shard.get_cleanup_status().await.expect("get status"),
+        SplitCleanupStatus::CleanupPending,
+        "backward write must still land"
+    );
+}
+
+/// The raw reader distinguishes an absent status key from a present one,
+/// while the defaulted reader maps absence to `CompactionDone`.
+#[silo::test]
+async fn raw_cleanup_status_reader_distinguishes_absent_from_present() {
+    use silo::coordination::SplitCleanupStatus;
+
+    let (_tmp, shard) = open_temp_shard().await;
+
+    assert_eq!(
+        shard.get_cleanup_status_raw().await.expect("raw status"),
+        None,
+        "fresh shard has no status key"
+    );
+    assert_eq!(
+        shard.get_cleanup_status().await.expect("defaulted status"),
+        SplitCleanupStatus::CompactionDone,
+        "defaulted reader maps absence to CompactionDone"
+    );
+
+    shard
+        .set_cleanup_status(SplitCleanupStatus::CleanupRunning)
+        .await
+        .expect("set status");
+
+    assert_eq!(
+        shard.get_cleanup_status_raw().await.expect("raw status"),
+        Some(SplitCleanupStatus::CleanupRunning),
+        "raw reader returns the present status"
+    );
+}

--- a/tests/shard_cleanup_tests.rs
+++ b/tests/shard_cleanup_tests.rs
@@ -819,32 +819,14 @@ fn lines_for_shard(logs: &str, shard_name: &str) -> Vec<String> {
 #[silo::test]
 async fn first_status_write_into_absent_key_does_not_warn() {
     use silo::coordination::SplitCleanupStatus;
-    use silo::gubernator::MockGubernatorClient;
-    use silo::job_store_shard::JobStoreShard;
-    use silo::settings::{Backend, DatabaseConfig};
-    use test_helpers::fast_flush_slatedb_settings;
 
     let _capture_guard = LOG_CAPTURE_MUTEX.lock().await;
 
     // Unique shard name so captured lines can be attributed to this test even
     // if unrelated tests log concurrently.
     let shard_name = "first-write-warn-probe";
-    let tmp = tempfile::tempdir().unwrap();
-    let cfg = DatabaseConfig {
-        name: shard_name.to_string(),
-        backend: Backend::Fs,
-        path: tmp.path().to_string_lossy().to_string(),
-        slatedb: Some(fast_flush_slatedb_settings()),
-        ..Default::default()
-    };
-    let shard = JobStoreShard::open(
-        &cfg,
-        MockGubernatorClient::new_arc(),
-        None,
-        ShardRange::full(),
-    )
-    .await
-    .expect("open shard");
+    let (_tmp, shard) =
+        test_helpers::open_temp_shard_with_name(shard_name, &ShardRange::full()).await;
 
     // First write into an absent status key: must land without a regression WARN.
     silo::trace::start_log_capture();

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -17,6 +17,35 @@ pub fn fast_flush_slatedb_settings() -> slatedb::config::Settings {
     }
 }
 
+/// Factory for cross-node split tests: a shared DATA root with a PER-NODE WAL
+/// root, all on the process-global Memory store (memoized by exact path
+/// string). Two factories built with the same `root` but different `node`
+/// share shard data while each keeps its own WAL -- like production nodes
+/// over shared object storage with node-local WALs. A fully shared root
+/// would share the WAL store too, making cross-node durability assertions
+/// vacuous (a write stranded in the WAL would still be visible); fully
+/// per-node roots would keep one node from seeing the other's shards at all.
+pub fn make_shared_data_root_memory_factory(
+    root: &str,
+    node: &str,
+) -> Arc<silo::factory::ShardFactory> {
+    use silo::settings::{DatabaseTemplate, WalConfig};
+
+    Arc::new(silo::factory::ShardFactory::new(
+        DatabaseTemplate {
+            backend: Backend::Memory,
+            path: format!("{root}/data/%shard%"),
+            wal: Some(WalConfig {
+                backend: Backend::Memory,
+                path: format!("{root}/wal-{node}/%shard%"),
+            }),
+            ..Default::default()
+        },
+        MockGubernatorClient::new_arc(),
+        None,
+    ))
+}
+
 // Helper: enforce a tight timeout for async tests likely to hang
 #[macro_export]
 macro_rules! with_timeout {

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -17,6 +17,26 @@ pub fn fast_flush_slatedb_settings() -> slatedb::config::Settings {
     }
 }
 
+/// Open a temp shard with a caller-chosen name, so captured log lines can be
+/// attributed to the calling test even when unrelated tests log concurrently.
+pub async fn open_temp_shard_with_name(
+    name: &str,
+    range: &ShardRange,
+) -> (tempfile::TempDir, Arc<JobStoreShard>) {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = DatabaseConfig {
+        name: name.to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        ..Default::default()
+    };
+    let shard = JobStoreShard::open(&cfg, MockGubernatorClient::new_arc(), None, range.clone())
+        .await
+        .expect("open shard");
+    (tmp, shard)
+}
+
 /// Factory for cross-node split tests: a shared DATA root with a PER-NODE WAL
 /// root, all on the process-global Memory store (memoized by exact path
 /// string). Two factories built with the same `root` but different `node`


### PR DESCRIPTION
## Problem

After a shard split, a child's defunct-data cleanup only runs if `CleanupPending` exists in its database -- and that status was written post-commit, only for children the split initiator ended up owning itself. A child acquired by a different node had no status key at all, and the absent key reads as `CompactionDone` ("nothing to do"), so the acquiring node silently skipped cleanup and the child retained every key outside its range indefinitely. The 2026-08-10 cleanup gameday on silo-staging hit exactly this: child `2c04b378` was acquired by a non-initiator node, never ran cleanup, and still holds ~581k defunct jobs. The initiator's own children were exposed too: a fast shard-guard acquisition could read the absent key in the window between the post-commit open and the status write.

## Fix (three cooperating changes)

1. **Initialize cleanup metadata at clone time.** Both children get `CleanupPending` -- with inherited progress, legacy complete marker, and completion timestamp cleared, since a clone is byte-for-byte and inherited terminal state would short-circuit cleanup as "already complete" -- inside the clone-verification pass, before the shard-map commit, while the initiator exclusively holds both cloned databases. An explicit MemTable-type flush lands the write in shared storage rather than only the initiator's node-local WAL. Initialization failure aborts the split pre-commit under its own log marker. The post-commit per-owner status write is removed, which also closes the acquire-before-status race.
2. **Status plumbing distinguishes "absent" from `CompactionDone`.** A raw reader returns `Option<SplitCleanupStatus>`; the defaulted reader keeps its name and semantics for display callers. A first write into a shard with no status key is a valid initial transition; the regression WARN now fires only for a genuine backward transition between two present statuses, so a normal split's happy path is WARN-free.
3. **Auto-backfill stranded children on acquisition.** The background-cleanup spawn takes the shard map's parent record alongside the range. When the database has no status key: a recorded parent with no completion timestamp means the child was stranded by the pre-fix path, so the acquirer resets its cleanup metadata (logged at info) and cleans it; a present completion timestamp skips with an info log; no recorded parent is an original shard and stays untouched. Any present status follows `needs_work()` exactly as before. All five coordinator spawn sites pass the metadata, so existing stranded children (staging's included) heal on their next acquisition without operator action.

Known limit: a child stranded pre-fix whose parent had completed its own cleanup inherited a present terminal status from the clone, so the absent-status signal cannot identify it; no such shard is known to exist today.

## Testing

- Guard-free mock-split harness asserts both children carry exactly `CleanupPending` with fully reset metadata pre-commit, with no coordinator or shard guards racing the value, read through a non-registering factory helper.
- Cross-node visibility: a passive second factory sharing the data root but carrying its own WAL root reads the initialized metadata -- fully shared or fully per-node roots would make this assertion vacuous.
- End-to-end two-node etcd test: bounded-load rendezvous caps each node at one child, so the non-initiator deterministically acquires a child the initiator never opened and its cleanup deletes the defunct half of the parent's data.
- Second-generation split: grandchildren of a cleanup-complete child get fresh metadata and their cleanup actually deletes keys; the whole flow emits no regression WARN.
- Init-failure abort (via a debug-only fault seam), the full backfill decision table including the inherited-complete-progress shape, and registry non-poisoning are each covered; the spawn returns its task handle so tests await decisions instead of sleeping.