### PR TITLE
Resolve clone-inherited SSTs in the standalone compactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
         env:
           SILO_DEBUG_LOG_FILE: test-debug.log
         run: cargo test -- --skip k8s_ --skip etcd_ --skip coordination_split_tests --skip cluster_two_nodes
+      - name: Run silo-compactor tests
+        shell: bash
+        # Plain `cargo test` above only covers the workspace's root package, so
+        # the compactor crate needs its own invocation.
+        run: cargo test -p silo-compactor
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/silo-compactor/src/assignment.rs
+++ b/silo-compactor/src/assignment.rs
@@ -14,9 +14,7 @@ pub fn compute_assignment(
     mut shards: Vec<ShardId>,
     max_shards: usize,
 ) -> Vec<ShardId> {
-    let total_pods = pods.len();
-    let n = shards.len();
-    if n == 0 || total_pods == 0 {
+    if shards.is_empty() || pods.is_empty() {
         return Vec::new();
     }
 
@@ -24,6 +22,12 @@ pub fn compute_assignment(
     pods.dedup();
     shards.sort_by_key(|s| s.0);
     shards.dedup();
+
+    // Counts must be taken after dedup: the range arithmetic below indexes
+    // into the deduped vecs, and a duplicated pod count would shrink (or,
+    // for duplicated shards, overrun) every pod's slice.
+    let total_pods = pods.len();
+    let n = shards.len();
 
     let Some(my_idx) = pods.iter().position(|n| n == self_name) else {
         return Vec::new();

--- a/silo-compactor/src/external_sst.rs
+++ b/silo-compactor/src/external_sst.rs
@@ -172,10 +172,7 @@ impl ObjectStore for ExternalSstReadRedirect {
         self.inner.list(prefix)
     }
 
-    async fn list_with_delimiter(
-        &self,
-        prefix: Option<&Path>,
-    ) -> object_store::Result<ListResult> {
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
         self.inner.list_with_delimiter(prefix).await
     }
 

--- a/silo-compactor/src/external_sst.rs
+++ b/silo-compactor/src/external_sst.rs
@@ -1,0 +1,190 @@
+//! Compactor construction for a resolved shard store.
+//!
+//! `slatedb::Db`'s open path reads the manifest and resolves SSTs delegated
+//! to an external DB (a split child's clone parent) against that DB's
+//! recorded path. `CompactorBuilder::build` resolves every SST against the
+//! shard's own root, so a standalone compactor reading clone-inherited SSTs
+//! gets `NotFound` on every compaction and the shard never drains its L0s.
+//! Until slatedb's compactor is manifest-aware, the store handed to
+//! `CompactorBuilder` is wrapped so reads of externally-owned SST paths are
+//! redirected to the owning DB's path.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use object_store::path::Path;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult,
+};
+use slatedb::admin::Admin;
+use slatedb::compactor::Compactor;
+use slatedb::manifest::SsTableId;
+use slatedb_common::metrics::DefaultMetricsRecorder;
+
+use crate::error::CompactorError;
+
+/// Build the slatedb compactor for a shard whose object store and canonical
+/// path are already resolved. When the shard's manifest delegates SSTs to an
+/// external DB (the shard is a split child that has not yet re-localized its
+/// inherited data), the store is wrapped so reads of those SSTs go to the
+/// external DB's path.
+pub async fn build_shard_compactor(
+    canonical_path: String,
+    store: Arc<dyn ObjectStore>,
+    compactor_options: Option<slatedb::config::CompactorOptions>,
+    recorder: Option<Arc<DefaultMetricsRecorder>>,
+) -> Result<Compactor, CompactorError> {
+    let redirects = external_sst_redirects(&canonical_path, Arc::clone(&store)).await?;
+    let store: Arc<dyn ObjectStore> = if redirects.is_empty() {
+        store
+    } else {
+        tracing::info!(
+            path = %canonical_path,
+            external_ssts = redirects.len(),
+            "shard manifest delegates SSTs to an external DB; redirecting compactor reads"
+        );
+        Arc::new(ExternalSstReadRedirect {
+            inner: store,
+            redirects,
+        })
+    };
+
+    let mut builder = slatedb::CompactorBuilder::new(canonical_path, store)
+        .with_merge_operator(silo::job_store_shard::counter_merge_operator());
+    if let Some(opts) = compactor_options {
+        builder = builder.with_options(opts);
+    }
+    if let Some(rec) = recorder {
+        builder =
+            builder.with_metrics_recorder(rec as Arc<dyn slatedb_common::metrics::MetricsRecorder>);
+    }
+    Ok(builder.build())
+}
+
+/// Read the shard's latest manifest and map each externally-owned SST from
+/// the path the compactor will resolve (under the shard's own root) to the
+/// path recorded for its owning DB. Empty when the manifest is absent or
+/// references no external DBs.
+async fn external_sst_redirects(
+    canonical_path: &str,
+    store: Arc<dyn ObjectStore>,
+) -> Result<HashMap<Path, Path>, CompactorError> {
+    let admin = Admin::builder(canonical_path.to_string(), store).build();
+    let manifest = admin
+        .read_manifest(None)
+        .await
+        .map_err(|e| CompactorError::Slatedb(e.to_string()))?;
+    let Some(manifest) = manifest else {
+        return Ok(HashMap::new());
+    };
+
+    let own_root = Path::from(canonical_path);
+    let mut redirects = HashMap::new();
+    for external_db in manifest.external_dbs() {
+        let external_root = Path::from(external_db.path.as_str());
+        for sst_id in &external_db.sst_ids {
+            redirects.insert(
+                table_path(&own_root, sst_id),
+                table_path(&external_root, sst_id),
+            );
+        }
+    }
+    Ok(redirects)
+}
+
+/// SST object path under `root`, matching slatedb's `PathResolver` layout.
+fn table_path(root: &Path, id: &SsTableId) -> Path {
+    match id {
+        SsTableId::Wal(id) => Path::from(format!("{root}/wal/{id:020}.sst")),
+        SsTableId::Compacted(ulid) => Path::from(format!("{root}/compacted/{ulid}.sst")),
+    }
+}
+
+/// Object store wrapper that redirects reads of externally-owned SST paths to
+/// the owning DB's path. Writes, deletes, copies, and listings are never
+/// redirected: external objects are shared with the parent DB and the sibling
+/// child, so only reads may cross DB roots.
+struct ExternalSstReadRedirect {
+    inner: Arc<dyn ObjectStore>,
+    redirects: HashMap<Path, Path>,
+}
+
+impl ExternalSstReadRedirect {
+    fn resolve<'a>(&'a self, location: &'a Path) -> &'a Path {
+        self.redirects.get(location).unwrap_or(location)
+    }
+}
+
+impl fmt::Debug for ExternalSstReadRedirect {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExternalSstReadRedirect")
+            .field("inner", &self.inner)
+            .field("redirects", &self.redirects.len())
+            .finish()
+    }
+}
+
+impl fmt::Display for ExternalSstReadRedirect {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ExternalSstReadRedirect({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for ExternalSstReadRedirect {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        self.inner.get_opts(self.resolve(location), options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        prefix: Option<&Path>,
+    ) -> object_store::Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        self.inner.copy_opts(from, to, options).await
+    }
+}

--- a/silo-compactor/src/lib.rs
+++ b/silo-compactor/src/lib.rs
@@ -2,6 +2,7 @@ pub mod assignment;
 pub mod config;
 pub mod coordinator;
 pub mod error;
+pub mod external_sst;
 pub mod metrics;
 pub mod pod_discovery;
 pub mod shard_loader;

--- a/silo-compactor/src/storage.rs
+++ b/silo-compactor/src/storage.rs
@@ -98,3 +98,67 @@ pub fn resolve_object_store(backend: &Backend, path: &str) -> Result<ResolvedSto
 pub fn path_for_shard(template: &str, shard_id: &ShardId) -> String {
     template.replace("%shard%", &shard_id.to_string())
 }
+
+/// Resolve a shard's object store at the shared template root -- the store
+/// rooted at the template prefix before `%shard%`, with the shard's database
+/// path expressed relative to that root -- mirroring the serving factory's
+/// `ShardFactory::resolve_at_root`. A store scoped to the shard's own prefix
+/// cannot address the external-DB paths a clone's manifest records, so the
+/// compactor could never read clone-inherited SSTs regardless of how those
+/// paths are rewritten. Absolute object keys are unchanged by the re-rooting.
+pub fn resolve_object_store_at_root(
+    backend: &Backend,
+    path_template: &str,
+    shard_id: &ShardId,
+) -> Result<ResolvedStore, StorageError> {
+    let shard_name = shard_id.to_string();
+    match backend {
+        Backend::Fs => {
+            let Some(pos) = path_template.find("%shard%") else {
+                // Placeholder-free template: no shared root to resolve at.
+                return resolve_object_store(backend, path_template);
+            };
+            let root = path_template[..pos].trim_end_matches('/');
+            let root = if root.is_empty() { "/" } else { root };
+            let resolved = resolve_object_store(backend, root)?;
+            Ok(ResolvedStore {
+                store: resolved.store,
+                canonical_path: shard_name,
+                root_path: resolved.root_path,
+            })
+        }
+        // Memory stores are per-resolve sentinels used in tests; there is no
+        // shared root to re-root at.
+        Backend::Memory => resolve_object_store(backend, &path_for_shard(path_template, shard_id)),
+        Backend::S3 | Backend::Gcs | Backend::Url => {
+            let (root, db_path) = silo::factory::ShardFactory::object_store_layout(
+                &to_silo_backend(backend),
+                path_template,
+                &shard_name,
+            )
+            .map_err(|e| {
+                StorageError::InvalidUrl(format!(
+                    "shared-root layout for template '{path_template}': {e}"
+                ))
+            })?;
+            let store = Db::resolve_object_store(&root)?;
+            Ok(ResolvedStore {
+                store,
+                canonical_path: db_path,
+                root_path: root,
+            })
+        }
+    }
+}
+
+/// Map the compactor's backend enum onto silo's, which drives the shared-root
+/// layout arithmetic.
+fn to_silo_backend(backend: &Backend) -> silo::settings::Backend {
+    match backend {
+        Backend::Fs => silo::settings::Backend::Fs,
+        Backend::S3 => silo::settings::Backend::S3,
+        Backend::Gcs => silo::settings::Backend::Gcs,
+        Backend::Memory => silo::settings::Backend::Memory,
+        Backend::Url => silo::settings::Backend::Url,
+    }
+}

--- a/silo-compactor/src/worker.rs
+++ b/silo-compactor/src/worker.rs
@@ -137,17 +137,13 @@ async fn run_once(
         .is_some()
         .then(|| Arc::new(DefaultMetricsRecorder::new()));
 
-    let mut builder = slatedb::CompactorBuilder::new(canonical_path, Arc::clone(&store))
-        .with_merge_operator(silo::job_store_shard::counter_merge_operator());
-    if let Some(opts) = compactor_options {
-        builder = builder.with_options(opts);
-    }
-    if let Some(rec) = &recorder {
-        builder = builder.with_metrics_recorder(
-            Arc::clone(rec) as Arc<dyn slatedb_common::metrics::MetricsRecorder>
-        );
-    }
-    let compactor = builder.build();
+    let compactor = crate::external_sst::build_shard_compactor(
+        canonical_path,
+        Arc::clone(&store),
+        compactor_options,
+        recorder.clone(),
+    )
+    .await?;
 
     if let Some(m) = metrics {
         m.record_compactor_started(&shard_label);

--- a/silo-compactor/src/worker.rs
+++ b/silo-compactor/src/worker.rs
@@ -9,7 +9,7 @@ use tracing::{Instrument, info, info_span, warn};
 use crate::error::CompactorError;
 use crate::metrics::CompactorMetrics;
 use crate::shard_map::ShardId;
-use crate::storage::{Backend, path_for_shard, resolve_object_store};
+use crate::storage::{Backend, resolve_object_store_at_root};
 
 /// Period at which per-shard slatedb stats are polled and translated into
 /// Prometheus instruments. Roughly matches silo's per-shard cadence.
@@ -118,8 +118,7 @@ async fn run_once(
     cancel: &CancellationToken,
 ) -> Result<(), CompactorError> {
     let shard_label = shard_id.to_string();
-    let shard_path = path_for_shard(path_template, shard_id);
-    let resolved = resolve_object_store(backend, &shard_path)?;
+    let resolved = resolve_object_store_at_root(backend, path_template, shard_id)?;
 
     info!(
         shard = %shard_id,

--- a/silo-compactor/tests/cloned_shard_compaction_tests.rs
+++ b/silo-compactor/tests/cloned_shard_compaction_tests.rs
@@ -1,0 +1,139 @@
+//! The standalone compactor must read clone-inherited (external) SSTs from
+//! the DB path recorded in the manifest's external-DB entries, the same way
+//! `slatedb::Db`'s open path does. A split child's manifest delegates the
+//! parent's SSTs; resolving them against the child's own root yields
+//! `NotFound` on every compaction, so the child's L0s never drain.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use slatedb::admin::Admin;
+use slatedb::compactor::{CompactionSpec, CompactionStatus, SourceId};
+use slatedb::config::{FlushOptions, FlushType};
+use slatedb::object_store::ObjectStore;
+use slatedb::object_store::memory::InMemory;
+
+use silo_compactor::external_sst::build_shard_compactor;
+
+const PARENT_PATH: &str = "shards/parent";
+const CHILD_PATH: &str = "shards/child";
+
+#[tokio::test]
+async fn compactor_reads_clone_inherited_ssts_from_parent_path() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+
+    // Parent DB with data flushed into compacted/ SSTs, then closed.
+    let parent = slatedb::Db::builder(PARENT_PATH, Arc::clone(&store))
+        .build()
+        .await
+        .expect("open parent db");
+    for i in 0..500u32 {
+        parent
+            .put(
+                format!("key-{i:05}").as_bytes(),
+                format!("value-{i}").as_bytes(),
+            )
+            .await
+            .expect("put");
+    }
+    parent
+        .flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .expect("flush parent memtable");
+    parent.close().await.expect("close parent");
+
+    // Shallow clone: the child's manifest delegates the parent's SSTs as
+    // external, exactly how a split creates its children.
+    let admin = Admin::builder(CHILD_PATH, Arc::clone(&store)).build();
+    admin
+        .create_clone_builder(PARENT_PATH, None)
+        .build()
+        .await
+        .expect("clone parent into child");
+
+    let manifest = admin
+        .read_manifest(None)
+        .await
+        .expect("read child manifest")
+        .expect("child manifest exists");
+    assert!(
+        !manifest.external_dbs().is_empty(),
+        "clone should delegate parent SSTs via external_dbs"
+    );
+
+    // Standalone compactor, assembled exactly as the worker does. Started
+    // before submission: its startup creates the compactions file.
+    let compactor = build_shard_compactor(CHILD_PATH.to_string(), Arc::clone(&store), None, None)
+        .await
+        .expect("build compactor");
+    let run_task = tokio::spawn({
+        let compactor = compactor.clone();
+        async move { compactor.run().await }
+    });
+
+    // Compact the child's (externally-owned) L0 views into sorted run 0.
+    // Submission is retried until the compactor's startup has created the
+    // compactions file.
+    let sources: Vec<SourceId> = manifest
+        .l0()
+        .iter()
+        .map(|view| SourceId::SstView(view.id))
+        .collect();
+    assert!(
+        !sources.is_empty(),
+        "cloned child should surface the parent's L0 views"
+    );
+    let submit_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let compaction = loop {
+        match admin
+            .submit_compaction(CompactionSpec::new(sources.clone(), 0))
+            .await
+        {
+            Ok(compaction) => break compaction,
+            Err(e) if tokio::time::Instant::now() > submit_deadline => {
+                panic!("submit compaction: {e}")
+            }
+            Err(_) => tokio::time::sleep(Duration::from_millis(200)).await,
+        }
+    };
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+    let final_status = loop {
+        let current = admin
+            .read_compaction(compaction.id(), None)
+            .await
+            .expect("read compaction")
+            .expect("compaction record exists");
+        let status = current.status();
+        if matches!(
+            status,
+            CompactionStatus::Completed | CompactionStatus::Failed
+        ) || tokio::time::Instant::now() > deadline
+        {
+            break status;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    };
+    compactor.stop().await.expect("stop compactor");
+    let _ = run_task.await;
+
+    assert_eq!(
+        final_status,
+        CompactionStatus::Completed,
+        "compaction of clone-inherited SSTs should complete; Failed means the \
+         compactor resolved external SSTs against the child root instead of \
+         the parent path recorded in the manifest"
+    );
+
+    // The compaction re-localized the inherited data: fully readable from
+    // the child's own SSTs.
+    let child = slatedb::Db::builder(CHILD_PATH, Arc::clone(&store))
+        .build()
+        .await
+        .expect("open child db");
+    let got = child.get(b"key-00042").await.expect("get");
+    assert_eq!(got.as_deref(), Some(b"value-42".as_ref()));
+    child.close().await.expect("close child");
+}

--- a/silo-compactor/tests/cloned_shard_compaction_tests.rs
+++ b/silo-compactor/tests/cloned_shard_compaction_tests.rs
@@ -8,22 +8,28 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use slatedb::admin::Admin;
-use slatedb::compactor::{CompactionSpec, CompactionStatus, SourceId};
+use slatedb::compactor::{CompactionSpec, CompactionStatus, Compactor, SourceId};
 use slatedb::config::{FlushOptions, FlushType};
 use slatedb::object_store::ObjectStore;
 use slatedb::object_store::memory::InMemory;
+use uuid::Uuid;
 
 use silo_compactor::external_sst::build_shard_compactor;
+use silo_compactor::shard_map::ShardId;
+use silo_compactor::storage::{Backend, resolve_object_store_at_root};
 
 const PARENT_PATH: &str = "shards/parent";
 const CHILD_PATH: &str = "shards/child";
 
-#[tokio::test]
-async fn compactor_reads_clone_inherited_ssts_from_parent_path() {
-    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-
-    // Parent DB with data flushed into compacted/ SSTs, then closed.
-    let parent = slatedb::Db::builder(PARENT_PATH, Arc::clone(&store))
+/// Seed a parent DB with data flushed into compacted/ SSTs, close it, and
+/// shallow-clone it to `child_path` on the same store -- the way a split
+/// creates its children. Returns an admin handle for the child.
+async fn seed_parent_and_clone(
+    store: &Arc<dyn ObjectStore>,
+    parent_path: &str,
+    child_path: &str,
+) -> Admin {
+    let parent = slatedb::Db::builder(parent_path, Arc::clone(store))
         .build()
         .await
         .expect("open parent db");
@@ -44,15 +50,19 @@ async fn compactor_reads_clone_inherited_ssts_from_parent_path() {
         .expect("flush parent memtable");
     parent.close().await.expect("close parent");
 
-    // Shallow clone: the child's manifest delegates the parent's SSTs as
-    // external, exactly how a split creates its children.
-    let admin = Admin::builder(CHILD_PATH, Arc::clone(&store)).build();
+    let admin = Admin::builder(child_path.to_string(), Arc::clone(store)).build();
     admin
-        .create_clone_builder(PARENT_PATH, None)
+        .create_clone_builder(parent_path, None)
         .build()
         .await
         .expect("clone parent into child");
+    admin
+}
 
+/// Start `compactor`, submit a compaction over the child's clone-inherited L0
+/// views, wait for a terminal status (or time out), stop the compactor, and
+/// return the final status.
+async fn run_compaction_of_inherited_l0s(admin: &Admin, compactor: Compactor) -> CompactionStatus {
     let manifest = admin
         .read_manifest(None)
         .await
@@ -62,20 +72,6 @@ async fn compactor_reads_clone_inherited_ssts_from_parent_path() {
         !manifest.external_dbs().is_empty(),
         "clone should delegate parent SSTs via external_dbs"
     );
-
-    // Standalone compactor, assembled exactly as the worker does. Started
-    // before submission: its startup creates the compactions file.
-    let compactor = build_shard_compactor(CHILD_PATH.to_string(), Arc::clone(&store), None, None)
-        .await
-        .expect("build compactor");
-    let run_task = tokio::spawn({
-        let compactor = compactor.clone();
-        async move { compactor.run().await }
-    });
-
-    // Compact the child's (externally-owned) L0 views into sorted run 0.
-    // Submission is retried until the compactor's startup has created the
-    // compactions file.
     let sources: Vec<SourceId> = manifest
         .l0()
         .iter()
@@ -85,6 +81,14 @@ async fn compactor_reads_clone_inherited_ssts_from_parent_path() {
         !sources.is_empty(),
         "cloned child should surface the parent's L0 views"
     );
+
+    let run_task = tokio::spawn({
+        let compactor = compactor.clone();
+        async move { compactor.run().await }
+    });
+
+    // Submission is retried until the compactor's startup has created the
+    // compactions file.
     let submit_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     let compaction = loop {
         match admin
@@ -118,6 +122,18 @@ async fn compactor_reads_clone_inherited_ssts_from_parent_path() {
     };
     compactor.stop().await.expect("stop compactor");
     let _ = run_task.await;
+    final_status
+}
+
+#[tokio::test]
+async fn compactor_reads_clone_inherited_ssts_from_parent_path() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let admin = seed_parent_and_clone(&store, PARENT_PATH, CHILD_PATH).await;
+
+    let compactor = build_shard_compactor(CHILD_PATH.to_string(), Arc::clone(&store), None, None)
+        .await
+        .expect("build compactor");
+    let final_status = run_compaction_of_inherited_l0s(&admin, compactor).await;
 
     assert_eq!(
         final_status,
@@ -136,4 +152,51 @@ async fn compactor_reads_clone_inherited_ssts_from_parent_path() {
     let got = child.get(b"key-00042").await.expect("get");
     assert_eq!(got.as_deref(), Some(b"value-42".as_ref()));
     child.close().await.expect("close child");
+}
+
+/// The deployed shape: each shard's template expands to its own prefix, so a
+/// store resolved at the shard's full path cannot address the parent's
+/// objects at all. The worker must resolve the store at the shared template
+/// root (as the serving factory does) for the external-SST redirect to have
+/// any effect.
+#[tokio::test]
+async fn worker_resolution_reaches_parent_ssts_under_shared_root() {
+    let root_dir = tempfile::tempdir().expect("tempdir");
+    let root = root_dir.path().to_str().expect("utf-8 tempdir path");
+    let parent_id = ShardId(Uuid::new_v4());
+    let child_id = ShardId(Uuid::new_v4());
+
+    // Seed parent and clone through a root-scoped store with per-shard db
+    // paths -- the layout the serving factory produces for Fs backends.
+    let seed_store: Arc<dyn ObjectStore> = Arc::new(
+        slatedb::object_store::local::LocalFileSystem::new_with_prefix(root)
+            .expect("root-scoped local store"),
+    );
+    seed_parent_and_clone(&seed_store, &parent_id.to_string(), &child_id.to_string()).await;
+
+    // Resolve the child's store the way the worker does, from the deployed
+    // template shape, and run the standalone compactor on it.
+    let template = format!("{root}/%shard%");
+    let resolved = resolve_object_store_at_root(&Backend::Fs, &template, &child_id)
+        .expect("resolve child store at shared root");
+    let admin =
+        Admin::builder(resolved.canonical_path.clone(), Arc::clone(&resolved.store)).build();
+    let compactor = build_shard_compactor(
+        resolved.canonical_path.clone(),
+        Arc::clone(&resolved.store),
+        None,
+        None,
+    )
+    .await
+    .expect("build compactor");
+    let final_status = run_compaction_of_inherited_l0s(&admin, compactor).await;
+
+    assert_eq!(
+        final_status,
+        CompactionStatus::Completed,
+        "compaction must complete through the worker's store resolution; \
+         Failed means the store is scoped to the child's own prefix and the \
+         clone-inherited parent SSTs are unreachable no matter how their \
+         paths are rewritten"
+    );
 }


### PR DESCRIPTION
## Problem

The standalone silo-compactor fails every compaction on a shard database created by slatedb clone (a split child), for two stacked reasons:

1. A child's manifest delegates the parent's SSTs as external references, and slatedb's serving open path resolves those against the external DB's recorded path -- but `CompactorBuilder::build` constructs its table store with a resolver rooted only at the shard's own path, so the compactor looks for inherited SSTs under the child's prefix and gets object-store `NotFound` (upstream slatedb has the same asymmetry on main; the in-process compactor is unaffected because it shares the `Db`'s table store).
2. Even with those paths rewritten, the worker resolved its object store at the shard's expanded template path, which yields a store prefix-scoped to that one shard -- the parent's objects are unaddressable from it on GCS, S3, and Fs backends.

The consequence chain on silo-staging (2026-08-13, both children of the 2026-08-10 gameday split): compaction never succeeds, L0 never drains, slatedb throttles memtable flushes into permanent backpressure (1.07 GB unflushed), and the owning pods OOM-loop. It also blocks the acquisition-time cleanup backfill (#390) from making progress on the stranded child.

## Fix

- The worker resolves each shard's store at the shared template root -- the prefix before `%shard%` -- with the shard's database path expressed relative to that root, mirroring the serving factory's `ShardFactory::object_store_layout` so absolute object keys stay byte-identical (no data moves).
- `build_shard_compactor` (extracted from the worker's per-shard assembly so it is testable) reads the shard's latest manifest via slatedb's public `Admin::read_manifest` and, when the manifest delegates SSTs to an external DB, wraps the object store handed to `CompactorBuilder` in a redirect layer: reads (`get_opts`, which `get`/`get_range`/`head` funnel through) of an externally-owned SST path are sent to the external DB's path instead. Writes, deletes, copies, and listings are never redirected -- external objects are shared with the parent DB and the sibling child, so a redirected delete would destroy shared data. As compaction re-localizes inherited data into child-owned SSTs, the manifest prunes its external references and the redirect map goes inert.

## Also in this PR

- `compute_assignment` captured pod and shard counts before dedup, so duplicate pod names shrank every pod's shard slice (a regression from the earlier short-circuit refactor, caught by an existing test that CI never ran). Counts are now taken after sort-and-dedup.
- CI's Rust tests job runs plain `cargo test`, which only covers the workspace's root package -- the silo-compactor crate's tests never ran in CI at all. The job now runs `cargo test -p silo-compactor` as its own step.

## Testing

- Regression test: parent DB in a shared in-memory store, shallow-cloned the way a split does, compacted through the exact assembly the worker uses -- the compaction must reach `Completed` (it reached `Failed` before the redirect) and the re-localized data must be readable from the child.
- Store-scoping regression test: parent and child under one filesystem root, resolved through the worker's own template resolution -- fails when the store is scoped to the child's prefix, passes with the shared-root resolution.
- The full silo-compactor suite (including the previously-failing `duplicate_pods_collapsed`) passes and is now enforced by CI.
