### PR TITLE
Sample the coordinator's owned set into silo_shards_owned

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod job_store_shard;
 pub mod keys;
 pub mod metrics;
 pub mod pb_convert;
+pub mod placement_metrics;
 #[cfg(feature = "server")]
 pub mod query;
 pub mod retry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,17 @@ async fn main() -> anyhow::Result<()> {
         ))
     });
 
+    // Periodic placement sample: reports the coordinator's owned shard set so
+    // dashboards and alerts see what this node actually owns.
+    let placement_metrics_handle = metrics.as_ref().map(|m| {
+        let shutdown = shutdown_tx.subscribe();
+        tokio::spawn(silo::placement_metrics::run_sampler(
+            coordinator.clone(),
+            m.clone(),
+            shutdown,
+        ))
+    });
+
     // Periodic jemalloc stats scrape: lets us distinguish purgeable retained
     // pages from genuinely live allocations vs non-jemalloc mmaps.
     #[cfg(unix)]
@@ -290,6 +301,9 @@ async fn main() -> anyhow::Result<()> {
         let _ = handle.await;
     }
     if let Some(handle) = tokio_metrics_handle {
+        let _ = handle.await;
+    }
+    if let Some(handle) = placement_metrics_handle {
         let _ = handle.await;
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2017,7 +2017,14 @@ pub fn init() -> anyhow::Result<Metrics> {
     // Shard/broker metrics
     let shards_owned = register(
         &registry,
-        Gauge::new("silo_shards_owned", "Number of shards owned by this node")?,
+        Gauge::new(
+            "silo_shards_owned",
+            format!(
+                "Number of shards this node owns (acquired from the coordinator and opened); \
+                 sampled every {}s, which bounds staleness",
+                crate::placement_metrics::SAMPLE_INTERVAL.as_secs()
+            ),
+        )?,
     );
 
     let coordination_shards_open = register(

--- a/src/placement_metrics.rs
+++ b/src/placement_metrics.rs
@@ -1,0 +1,56 @@
+//! Placement metrics sampled from the coordinator.
+//!
+//! The coordinator's owned set changes at shard acquisition, release and split
+//! time across several backends. Rather than hooking every mutation site, a
+//! periodic driver reads the owned shard list from the `Coordinator` trait
+//! object and feeds it to a single-pass sampler that sets the gauges, so the
+//! gauges are scrape-time values that lag reality by at most one interval.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::broadcast;
+use tracing::debug;
+
+use crate::coordination::Coordinator;
+use crate::metrics::Metrics;
+use crate::shard_range::ShardId;
+
+/// How often the driver samples the coordinator. Bounds the staleness of the
+/// placement gauges; the HELP text of each gauge quotes this value.
+pub const SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// One sampler pass: set `silo_shards_owned` from this node's owned shard list.
+pub fn sample(metrics: &Metrics, owned: &[ShardId]) {
+    metrics.set_shards_owned(owned.len() as u64);
+}
+
+/// Drive [`sample`] from the coordinator every [`SAMPLE_INTERVAL`] until the
+/// shutdown broadcast fires. Spawned from `main` when metrics are enabled.
+pub async fn run_sampler(
+    coordinator: Arc<dyn Coordinator>,
+    metrics: Metrics,
+    mut shutdown: broadcast::Receiver<()>,
+) {
+    let mut ticker = tokio::time::interval(SAMPLE_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    debug!(
+        interval_ms = SAMPLE_INTERVAL.as_millis() as u64,
+        "placement metrics sampler started"
+    );
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.recv() => {
+                debug!("placement metrics sampler shutting down");
+                break;
+            }
+            _ = ticker.tick() => {
+                let owned = coordinator.owned_shards().await;
+                sample(&metrics, &owned);
+            }
+        }
+    }
+}

--- a/tests/placement_metrics_tests.rs
+++ b/tests/placement_metrics_tests.rs
@@ -1,0 +1,50 @@
+//! Tests for the placement metrics sampler: the pass that turns the
+//! coordinator's owned shard list into `silo_shards_owned`.
+
+use silo::metrics::{self, Metrics};
+use silo::placement_metrics;
+use silo::shard_range::ShardId;
+
+/// Read a plain (unlabelled) gauge back out of the metrics registry.
+fn gauge_value(metrics: &Metrics, name: &str) -> f64 {
+    let family = metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|f| f.get_name() == name)
+        .unwrap_or_else(|| panic!("metric {name} not registered"));
+    let metric = family
+        .get_metric()
+        .first()
+        .unwrap_or_else(|| panic!("metric {name} has no samples"));
+    metric.get_gauge().get_value()
+}
+
+#[silo::test]
+fn sample_sets_shards_owned_to_owned_count() {
+    let metrics = metrics::init().expect("init metrics");
+    let owned = vec![ShardId::new(), ShardId::new(), ShardId::new()];
+
+    placement_metrics::sample(&metrics, &owned);
+
+    assert_eq!(
+        gauge_value(&metrics, "silo_shards_owned"),
+        3.0,
+        "silo_shards_owned after one pass over {} owned shards",
+        owned.len()
+    );
+}
+
+#[silo::test]
+fn later_pass_replaces_shards_owned() {
+    let metrics = metrics::init().expect("init metrics");
+
+    placement_metrics::sample(&metrics, &[ShardId::new(), ShardId::new(), ShardId::new()]);
+    placement_metrics::sample(&metrics, &[ShardId::new()]);
+
+    assert_eq!(
+        gauge_value(&metrics, "silo_shards_owned"),
+        1.0,
+        "silo_shards_owned after a second pass over one owned shard"
+    );
+}


### PR DESCRIPTION
## Why

During the placement-rings gameday on silo-staging (2026-08-19), `silo_shards_owned` read 0 on every pod, including pods owning shards. The gauge is registered, but `Metrics::set_shards_owned` has no production caller, so any dashboard or alert built on it reflects nothing. This is phase 1 of hardening placement rings: make what a node owns visible, without touching the assignment algorithm or the coordinator backends.

## What

- New `placement_metrics` module: a single-pass `sample` that sets `silo_shards_owned` from an owned shard list, and a `run_sampler` driver that reads `owned_shards()` from the `Coordinator` trait object on a fixed interval and exits on the shutdown broadcast.
- `main` spawns the driver beside the tokio-runtime metrics scraper, only when metrics are enabled, and awaits its join handle at shutdown.
- The gauge's HELP text states what it counts (shards this node has acquired and opened -- the owned set is inserted into only after a successful open on every backend) and that it is sampled every 5s, so the staleness bound is visible to anyone building on it.

## Review notes

- `src/coordination/` is untouched; the sampler only reads through the trait.
- Tests (`tests/placement_metrics_tests.rs`) assert the gauge by gathering the registry after a pass over a hand-built owned list, so they need no coordinator.
- Later PRs in this stack add the per-ring unassigned gauge and strand logging on top of this sampler.
