### PR TITLE
Export silo_shards_unassigned per ring and log strand transitions

### DIFF
--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -33,7 +33,7 @@
 //! and potentially lose the crashed node's WAL data.
 
 use async_trait::async_trait;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, Notify, watch};
@@ -125,7 +125,29 @@ impl ShardOwnerMap {
     pub fn get_node(&self, shard_id: &ShardId) -> Option<&String> {
         self.shard_to_node.get(shard_id)
     }
+
+    /// Shards in the shard map that the assignment left without an owner,
+    /// keyed by shard id with the ring each shard is on (the default ring
+    /// rendered as [`DEFAULT_RING_LABEL`]).
+    ///
+    /// This is the desired assignment from current membership, so a shard
+    /// appears here only when no member is eligible for its ring -- not while
+    /// an eligible owner is still acquiring it.
+    pub fn unassigned_shards(&self) -> BTreeMap<ShardId, String> {
+        self.shard_map
+            .shards()
+            .iter()
+            .filter(|shard| !self.shard_to_node.contains_key(&shard.id))
+            .map(|shard| {
+                let ring = shard.placement_ring().unwrap_or(DEFAULT_RING_LABEL);
+                (shard.id, ring.to_string())
+            })
+            .collect()
+    }
 }
+
+/// Label under which default-ring shards are reported (metrics, logs).
+pub const DEFAULT_RING_LABEL: &str = "default";
 
 /// Error type for coordination operations
 #[derive(Debug, thiserror::Error)]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -149,6 +149,9 @@ pub struct Metrics {
 
     // Shard/broker metrics
     shards_owned: Gauge,
+    /// Shards the desired assignment leaves without an owner, per ring.
+    /// Driven by the placement metrics sampler.
+    shards_unassigned: GaugeVec,
     coordination_shards_open: Gauge,
     broker_buffer_size: GaugeVec,
     broker_inflight_size: GaugeVec,
@@ -455,6 +458,21 @@ impl Metrics {
     /// Update the number of shards owned by this node (from coordinator).
     pub fn set_shards_owned(&self, count: u64) {
         self.shards_owned.set(count as f64);
+    }
+
+    /// Update the number of shards on `ring` that the desired assignment
+    /// leaves without an owner.
+    pub fn set_shards_unassigned(&self, ring: &str, count: u64) {
+        self.shards_unassigned
+            .with_label_values(&[ring])
+            .set(count as f64);
+    }
+
+    /// Drop the `silo_shards_unassigned` series for `ring` once no shard on
+    /// it is unassigned, so a recovered ring stops being exported rather than
+    /// lingering at 0.
+    pub fn clear_shards_unassigned(&self, ring: &str) {
+        let _ = self.shards_unassigned.remove_label_values(&[ring]);
     }
 
     /// Update the number of shards currently open in this process.
@@ -2027,6 +2045,24 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let shards_unassigned = register(
+        &registry,
+        GaugeVec::new(
+            Opts::new(
+                "silo_shards_unassigned",
+                format!(
+                    "Number of shards on each placement ring (label `ring`, the default ring \
+                     labelled `default`) that the desired assignment leaves without an owner \
+                     because no current member is eligible for that ring -- this reflects \
+                     desired assignment, not acquisition state; sampled every {}s, which \
+                     bounds staleness",
+                    crate::placement_metrics::SAMPLE_INTERVAL.as_secs()
+                ),
+            ),
+            &["ring"],
+        )?,
+    );
+
     let coordination_shards_open = register(
         &registry,
         Gauge::new(
@@ -2478,6 +2514,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         query_scanned_keys,
         query_point_lookups,
         shards_owned,
+        shards_unassigned,
         coordination_shards_open,
         broker_buffer_size,
         broker_inflight_size,

--- a/src/placement_metrics.rs
+++ b/src/placement_metrics.rs
@@ -1,18 +1,21 @@
 //! Placement metrics sampled from the coordinator.
 //!
 //! The coordinator's owned set changes at shard acquisition, release and split
-//! time across several backends. Rather than hooking every mutation site, a
-//! periodic driver reads the owned shard list from the `Coordinator` trait
-//! object and feeds it to a single-pass sampler that sets the gauges, so the
-//! gauges are scrape-time values that lag reality by at most one interval.
+//! time across several backends, and the desired assignment changes with
+//! membership. Rather than hooking every mutation site, a periodic driver
+//! reads the owned shard list and the shard owner map from the `Coordinator`
+//! trait object and feeds them to a single-pass sampler that sets the gauges
+//! and logs strand transitions, so the gauges are scrape-time values that lag
+//! reality by at most one interval.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::broadcast;
-use tracing::debug;
+use tracing::{debug, info, warn};
 
-use crate::coordination::Coordinator;
+use crate::coordination::{Coordinator, ShardOwnerMap};
 use crate::metrics::Metrics;
 use crate::shard_range::ShardId;
 
@@ -20,9 +23,83 @@ use crate::shard_range::ShardId;
 /// placement gauges; the HELP text of each gauge quotes this value.
 pub const SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
 
-/// One sampler pass: set `silo_shards_owned` from this node's owned shard list.
-pub fn sample(metrics: &Metrics, owned: &[ShardId]) {
+/// Unassigned shards keyed by id, each with the ring it is stranded on.
+pub type UnassignedShards = BTreeMap<ShardId, String>;
+
+/// The shards that changed unassigned state between two sampler passes.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct UnassignedTransitions {
+    /// Shards unassigned now that were assigned on the previous pass.
+    pub newly_unassigned: Vec<(ShardId, String)>,
+    /// Shards assigned now that were unassigned on the previous pass, with the
+    /// ring they were stranded on.
+    pub resolved: Vec<(ShardId, String)>,
+}
+
+/// Diff two passes' unassigned sets so transitions can be logged exactly once.
+pub fn unassigned_transitions(
+    previous: &UnassignedShards,
+    current: &UnassignedShards,
+) -> UnassignedTransitions {
+    let only_in = |from: &UnassignedShards, other: &UnassignedShards| {
+        from.iter()
+            .filter(|(id, _)| !other.contains_key(id))
+            .map(|(id, ring)| (*id, ring.clone()))
+            .collect()
+    };
+    UnassignedTransitions {
+        newly_unassigned: only_in(current, previous),
+        resolved: only_in(previous, current),
+    }
+}
+
+/// One sampler pass.
+///
+/// Sets `silo_shards_owned` from this node's owned shard list and
+/// `silo_shards_unassigned{ring}` from the owner map, clearing ring labels
+/// that no longer have unassigned shards. Logs a `warn` for each shard that
+/// became unassigned since `previous` and an `info` for each that regained an
+/// owner, and returns the current unassigned set for the next pass.
+pub fn sample(
+    metrics: &Metrics,
+    owned: &[ShardId],
+    owner_map: &ShardOwnerMap,
+    previous: &UnassignedShards,
+) -> UnassignedShards {
     metrics.set_shards_owned(owned.len() as u64);
+
+    let current = owner_map.unassigned_shards();
+
+    let mut per_ring: BTreeMap<&str, u64> = BTreeMap::new();
+    for ring in current.values() {
+        *per_ring.entry(ring).or_default() += 1;
+    }
+    for (ring, count) in &per_ring {
+        metrics.set_shards_unassigned(ring, *count);
+    }
+    for ring in previous.values() {
+        if !per_ring.contains_key(ring.as_str()) {
+            metrics.clear_shards_unassigned(ring);
+        }
+    }
+
+    let transitions = unassigned_transitions(previous, &current);
+    for (shard_id, ring) in &transitions.newly_unassigned {
+        warn!(
+            shard_id = %shard_id,
+            ring = %ring,
+            "shard has no eligible owner: no member is in its placement ring"
+        );
+    }
+    for (shard_id, ring) in &transitions.resolved {
+        info!(
+            shard_id = %shard_id,
+            ring = %ring,
+            "shard is assigned again: its placement ring has a member"
+        );
+    }
+
+    current
 }
 
 /// Drive [`sample`] from the coordinator every [`SAMPLE_INTERVAL`] until the
@@ -34,6 +111,7 @@ pub async fn run_sampler(
 ) {
     let mut ticker = tokio::time::interval(SAMPLE_INTERVAL);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut previous = UnassignedShards::new();
 
     debug!(
         interval_ms = SAMPLE_INTERVAL.as_millis() as u64,
@@ -48,8 +126,15 @@ pub async fn run_sampler(
                 break;
             }
             _ = ticker.tick() => {
+                let owner_map = match coordinator.get_shard_owner_map().await {
+                    Ok(map) => map,
+                    Err(e) => {
+                        warn!(error = %e, "placement metrics sampler: could not read the shard owner map, skipping this pass");
+                        continue;
+                    }
+                };
                 let owned = coordinator.owned_shards().await;
-                sample(&metrics, &owned);
+                previous = sample(&metrics, &owned, &owner_map, &previous);
             }
         }
     }

--- a/tests/coordination_mod_tests.rs
+++ b/tests/coordination_mod_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for coordination module types: ShardGuardState, ShardGuardContext,
 //! CoordinatorBase, and ShardOwnerMap.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -163,6 +163,74 @@ fn shard_owner_map_get_addr_and_node() {
     let unknown = ShardId::new();
     assert_eq!(owner_map.get_addr(&unknown), None);
     assert_eq!(owner_map.get_node(&unknown), None);
+}
+
+/// Build an owner map over `rings.len()` shards, pinning shard `i` to
+/// `rings[i]` (`None` = default ring) and assigning an owner to every shard
+/// except those listed in `unowned`.
+fn owner_map_with_rings(rings: &[Option<&str>], unowned: &[usize]) -> ShardOwnerMap {
+    let mut shard_map = ShardMap::create_initial(rings.len() as u32).expect("create shard map");
+    let shard_ids = shard_map.shard_ids();
+    for (i, ring) in rings.iter().enumerate() {
+        shard_map
+            .get_shard_mut(&shard_ids[i])
+            .expect("shard exists")
+            .set_placement_ring(ring.map(str::to_string));
+    }
+
+    let mut shard_to_addr = HashMap::new();
+    let mut shard_to_node = HashMap::new();
+    for (i, id) in shard_ids.iter().enumerate() {
+        if unowned.contains(&i) {
+            continue;
+        }
+        shard_to_addr.insert(*id, format!("http://node-{}", id));
+        shard_to_node.insert(*id, format!("node-{}", id));
+    }
+
+    ShardOwnerMap {
+        shard_map,
+        shard_to_addr,
+        shard_to_node,
+    }
+}
+
+#[silo::test]
+fn unassigned_shards_reports_named_ring_shard_absent_from_assignments() {
+    let owner_map = owner_map_with_rings(&[Some("heavy"), None], &[0]);
+    let stranded = owner_map.shard_ids()[0];
+
+    let unassigned = owner_map.unassigned_shards();
+
+    assert_eq!(
+        unassigned,
+        BTreeMap::from([(stranded, "heavy".to_string())]),
+        "only the heavy-ring shard lacks an owner"
+    );
+}
+
+#[silo::test]
+fn unassigned_shards_reports_default_ring_shard_under_default_label() {
+    let owner_map = owner_map_with_rings(&[Some("heavy"), None], &[1]);
+    let stranded = owner_map.shard_ids()[1];
+
+    let unassigned = owner_map.unassigned_shards();
+
+    assert_eq!(
+        unassigned,
+        BTreeMap::from([(stranded, "default".to_string())]),
+        "a default-ring shard is reported under the `default` label"
+    );
+}
+
+#[silo::test]
+fn unassigned_shards_is_empty_when_every_shard_is_assigned() {
+    let owner_map = owner_map_with_rings(&[Some("heavy"), None, None], &[]);
+
+    assert!(
+        owner_map.unassigned_shards().is_empty(),
+        "every shard has an owner"
+    );
 }
 
 // --- ShardGuardContext tests ---

--- a/tests/placement_metrics_tests.rs
+++ b/tests/placement_metrics_tests.rs
@@ -1,35 +1,80 @@
 //! Tests for the placement metrics sampler: the pass that turns the
-//! coordinator's owned shard list into `silo_shards_owned`.
+//! coordinator's owned shard list and owner map into `silo_shards_owned` and
+//! `silo_shards_unassigned{ring}`, plus the pure transition diff that decides
+//! when a strand is logged.
 
+use std::collections::{BTreeMap, HashMap};
+
+use silo::coordination::ShardOwnerMap;
 use silo::metrics::{self, Metrics};
-use silo::placement_metrics;
-use silo::shard_range::ShardId;
+use silo::placement_metrics::{self, UnassignedShards, UnassignedTransitions};
+use silo::shard_range::{ShardId, ShardMap};
 
-/// Read a plain (unlabelled) gauge back out of the metrics registry.
-fn gauge_value(metrics: &Metrics, name: &str) -> f64 {
+/// Read a gauge back out of the metrics registry, matching `labels` exactly
+/// (an empty slice selects an unlabelled gauge). `None` when no sample with
+/// those labels is exported -- a labelled family with no live series is
+/// omitted from `gather()` entirely.
+fn gauge_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> Option<f64> {
     let family = metrics
         .registry()
         .gather()
         .into_iter()
-        .find(|f| f.get_name() == name)
-        .unwrap_or_else(|| panic!("metric {name} not registered"));
-    let metric = family
+        .find(|f| f.get_name() == name)?;
+    family
         .get_metric()
-        .first()
-        .unwrap_or_else(|| panic!("metric {name} has no samples"));
-    metric.get_gauge().get_value()
+        .iter()
+        .find(|m| {
+            let got: Vec<(&str, &str)> = m
+                .get_label()
+                .iter()
+                .map(|l| (l.get_name(), l.get_value()))
+                .collect();
+            got == labels
+        })
+        .map(|m| m.get_gauge().get_value())
+}
+
+/// Build an owner map over `rings.len()` shards, pinning shard `i` to
+/// `rings[i]` (`None` = default ring) and assigning an owner to every shard
+/// except those listed in `unowned`.
+fn owner_map_with_rings(rings: &[Option<&str>], unowned: &[usize]) -> ShardOwnerMap {
+    let mut shard_map = ShardMap::create_initial(rings.len() as u32).expect("create shard map");
+    let shard_ids = shard_map.shard_ids();
+    for (i, ring) in rings.iter().enumerate() {
+        shard_map
+            .get_shard_mut(&shard_ids[i])
+            .expect("shard exists")
+            .set_placement_ring(ring.map(str::to_string));
+    }
+
+    let mut shard_to_addr = HashMap::new();
+    let mut shard_to_node = HashMap::new();
+    for (i, id) in shard_ids.iter().enumerate() {
+        if unowned.contains(&i) {
+            continue;
+        }
+        shard_to_addr.insert(*id, format!("http://node-{}", id));
+        shard_to_node.insert(*id, format!("node-{}", id));
+    }
+
+    ShardOwnerMap {
+        shard_map,
+        shard_to_addr,
+        shard_to_node,
+    }
 }
 
 #[silo::test]
 fn sample_sets_shards_owned_to_owned_count() {
     let metrics = metrics::init().expect("init metrics");
     let owned = vec![ShardId::new(), ShardId::new(), ShardId::new()];
+    let owner_map = owner_map_with_rings(&[None], &[]);
 
-    placement_metrics::sample(&metrics, &owned);
+    placement_metrics::sample(&metrics, &owned, &owner_map, &UnassignedShards::new());
 
     assert_eq!(
-        gauge_value(&metrics, "silo_shards_owned"),
-        3.0,
+        gauge_value(&metrics, "silo_shards_owned", &[]),
+        Some(3.0),
         "silo_shards_owned after one pass over {} owned shards",
         owned.len()
     );
@@ -38,13 +83,108 @@ fn sample_sets_shards_owned_to_owned_count() {
 #[silo::test]
 fn later_pass_replaces_shards_owned() {
     let metrics = metrics::init().expect("init metrics");
+    let owner_map = owner_map_with_rings(&[None], &[]);
+    let none = UnassignedShards::new();
 
-    placement_metrics::sample(&metrics, &[ShardId::new(), ShardId::new(), ShardId::new()]);
-    placement_metrics::sample(&metrics, &[ShardId::new()]);
+    placement_metrics::sample(
+        &metrics,
+        &[ShardId::new(), ShardId::new(), ShardId::new()],
+        &owner_map,
+        &none,
+    );
+    placement_metrics::sample(&metrics, &[ShardId::new()], &owner_map, &none);
 
     assert_eq!(
-        gauge_value(&metrics, "silo_shards_owned"),
-        1.0,
+        gauge_value(&metrics, "silo_shards_owned", &[]),
+        Some(1.0),
         "silo_shards_owned after a second pass over one owned shard"
     );
+}
+
+#[silo::test]
+fn sample_reports_unassigned_shard_under_its_ring_and_clears_when_assigned() {
+    let metrics = metrics::init().expect("init metrics");
+    let stranded = owner_map_with_rings(&[Some("heavy"), None], &[0]);
+    let recovered = owner_map_with_rings(&[Some("heavy"), None], &[]);
+
+    let unassigned = placement_metrics::sample(&metrics, &[], &stranded, &UnassignedShards::new());
+
+    assert_eq!(
+        gauge_value(&metrics, "silo_shards_unassigned", &[("ring", "heavy")]),
+        Some(1.0),
+        "silo_shards_unassigned{{ring=\"heavy\"}} while the heavy-ring shard has no owner"
+    );
+    assert_eq!(
+        unassigned,
+        BTreeMap::from([(stranded.shard_ids()[0], "heavy".to_string())]),
+        "the pass returns the unassigned set for the next pass to diff against"
+    );
+
+    let unassigned = placement_metrics::sample(&metrics, &[], &recovered, &unassigned);
+
+    let heavy = gauge_value(&metrics, "silo_shards_unassigned", &[("ring", "heavy")]);
+    assert!(
+        heavy.is_none_or(|v| v == 0.0),
+        "silo_shards_unassigned{{ring=\"heavy\"}} after the shard regains an owner: expected absent or 0, got {heavy:?}"
+    );
+    assert!(unassigned.is_empty(), "no shard is unassigned any more");
+}
+
+#[silo::test]
+fn unassigned_transitions_fire_only_on_changes() {
+    let a = ShardId::new();
+    let b = ShardId::new();
+    let set = |entries: &[(ShardId, &str)]| -> BTreeMap<ShardId, String> {
+        entries
+            .iter()
+            .map(|(id, ring)| (*id, ring.to_string()))
+            .collect()
+    };
+
+    struct Case {
+        name: &'static str,
+        previous: BTreeMap<ShardId, String>,
+        current: BTreeMap<ShardId, String>,
+        want: UnassignedTransitions,
+    }
+    let cases = [
+        Case {
+            name: "newly unassigned",
+            previous: set(&[]),
+            current: set(&[(a, "heavy")]),
+            want: UnassignedTransitions {
+                newly_unassigned: vec![(a, "heavy".to_string())],
+                resolved: vec![],
+            },
+        },
+        Case {
+            name: "newly resolved",
+            previous: set(&[(a, "heavy")]),
+            current: set(&[]),
+            want: UnassignedTransitions {
+                newly_unassigned: vec![],
+                resolved: vec![(a, "heavy".to_string())],
+            },
+        },
+        Case {
+            name: "unchanged",
+            previous: set(&[(a, "heavy"), (b, "default")]),
+            current: set(&[(a, "heavy"), (b, "default")]),
+            want: UnassignedTransitions::default(),
+        },
+        Case {
+            name: "one resolved while another appears",
+            previous: set(&[(a, "heavy")]),
+            current: set(&[(b, "default")]),
+            want: UnassignedTransitions {
+                newly_unassigned: vec![(b, "default".to_string())],
+                resolved: vec![(a, "heavy".to_string())],
+            },
+        },
+    ];
+
+    for case in cases {
+        let got = placement_metrics::unassigned_transitions(&case.previous, &case.current);
+        assert_eq!(got, case.want, "case `{}`", case.name);
+    }
 }


### PR DESCRIPTION
## Why

When a shard's placement ring has no eligible member, the assignment loop skips the ring with a bare `continue`: no metric, no log line. In the silo-staging gameday the only signals that a shard had gone dark were client-side errors and an operator-run topology diff; a quiet shard would have produced nothing at all. This PR makes a stranded shard visible from the silo side, still without changing how rings assign shards.

## What

- `ShardOwnerMap::unassigned_shards()`: shards in the shard map with no assigned owner, keyed by id with their ring (default ring rendered as `default`). Derived from the owner map the cluster-info RPC already computes; `compute_all_shard_assignments`, `member_in_ring` and rendezvous scoring are unchanged.
- `silo_shards_unassigned{ring}` gauge registered beside `silo_shards_owned`, with set/clear accessors. The placement sampler now also reads `get_shard_owner_map()`, sets one series per ring with unassigned shards, and removes a ring's series once it drops to zero so a recovered ring stops being exported rather than lingering at 0.
- Strand logging rides the sampler: a pure `unassigned_transitions` diff between passes drives one `warn` (shard id, ring) when a shard becomes unassigned and one `info` when it regains an owner, so steady-state reconciles stay quiet during a long incident.
- HELP text says the gauge reflects desired assignment (no eligible member for the shard's ring), not acquisition state, and quotes the sampling interval.

## Review notes

- Because the gauge comes from the desired assignment, a shard being acquired by an eligible owner does not appear here.
- Logging is emitted by the sampler, which runs only when metrics are enabled; every deployed silo config enables metrics.
- Tests hand-build `ShardOwnerMap`s and assert via the registry and the pure diff; no coordinator or tracing subscriber is needed.
