### PR TITLE
Refuse configure_shard onto a ring no member advertises

### DIFF
--- a/proto/silo.proto
+++ b/proto/silo.proto
@@ -538,6 +538,11 @@ message GetNodeInfoResponse {
 message ConfigureShardRequest {
   string shard = 1;                   // The shard ID (UUID) to configure.
   optional string placement_ring = 2; // The placement ring to assign (empty/null = default ring).
+  // A placement_ring that no current cluster member advertises is refused with
+  // FAILED_PRECONDITION, because the shard would have no eligible owner. Set
+  // this to override that check and pin the shard to a ring whose nodes have
+  // not joined yet. Ignored when placement_ring is unset.
+  bool allow_unpopulated_ring = 3;
   optional string tenant = 100;       // Optional tenant ID (for multi-tenant mode).
 }
 

--- a/siloctl/src/lib.rs
+++ b/siloctl/src/lib.rs
@@ -1027,12 +1027,14 @@ pub async fn shard_split_status<W: Write>(
 ///
 /// This command changes which placement ring a shard belongs to. After changing
 /// the ring, the shard will be handed off to a node that participates in the
-/// new ring.
+/// new ring. The server refuses a ring no current member advertises unless
+/// `allow_unpopulated_ring` is set (for staging a ring before its nodes join).
 pub async fn shard_configure<W: Write>(
     opts: &GlobalOptions,
     out: &mut W,
     shard: &str,
     ring: Option<String>,
+    allow_unpopulated_ring: bool,
 ) -> anyhow::Result<()> {
     let mut client =
         connect_to_shard_owner(&opts.address, shard, opts.auth_token.as_deref()).await?;
@@ -1042,6 +1044,7 @@ pub async fn shard_configure<W: Write>(
             tenant: opts.tenant.clone(),
             shard: shard.to_string(),
             placement_ring: ring.clone(),
+            allow_unpopulated_ring,
         })
         .await?
         .into_inner();

--- a/siloctl/src/main.rs
+++ b/siloctl/src/main.rs
@@ -149,6 +149,10 @@ enum ShardAction {
         /// Placement ring name (omit to move to default ring)
         #[arg(long)]
         ring: Option<String>,
+        /// Pin the shard to --ring even if no current member advertises that
+        /// ring (the shard has no eligible owner until one joins)
+        #[arg(long, requires = "ring")]
+        allow_unpopulated_ring: bool,
     },
     /// Force-release a shard lease (for operator recovery when a node is permanently lost)
     ForceRelease {
@@ -312,8 +316,19 @@ async fn run(args: Args) -> anyhow::Result<()> {
             ShardAction::SplitStatus { shard } => {
                 siloctl::shard_split_status(&opts, &mut stdout, shard).await
             }
-            ShardAction::Configure { shard, ring } => {
-                siloctl::shard_configure(&opts, &mut stdout, shard, ring.clone()).await
+            ShardAction::Configure {
+                shard,
+                ring,
+                allow_unpopulated_ring,
+            } => {
+                siloctl::shard_configure(
+                    &opts,
+                    &mut stdout,
+                    shard,
+                    ring.clone(),
+                    *allow_unpopulated_ring,
+                )
+                .await
             }
             ShardAction::ForceRelease { shard } => {
                 siloctl::shard_force_release(&opts, &mut stdout, shard).await
@@ -354,6 +369,56 @@ async fn main() -> ExitCode {
         Err(e) => {
             eprintln!("Error: {}", e);
             ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SHARD: &str = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+    #[test]
+    fn allow_unpopulated_ring_requires_ring() {
+        let err = Args::try_parse_from([
+            "siloctl",
+            "shard",
+            "configure",
+            SHARD,
+            "--allow-unpopulated-ring",
+        ])
+        .expect_err("--allow-unpopulated-ring without --ring must be rejected");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn allow_unpopulated_ring_is_accepted_with_ring() {
+        let args = Args::try_parse_from([
+            "siloctl",
+            "shard",
+            "configure",
+            SHARD,
+            "--ring",
+            "heavy",
+            "--allow-unpopulated-ring",
+        ])
+        .expect("--allow-unpopulated-ring with --ring parses");
+
+        match args.command {
+            Command::Shard {
+                action:
+                    ShardAction::Configure {
+                        shard,
+                        ring,
+                        allow_unpopulated_ring,
+                    },
+            } => {
+                assert_eq!(shard, SHARD);
+                assert_eq!(ring.as_deref(), Some("heavy"));
+                assert!(allow_unpopulated_ring);
+            }
+            other => panic!("unexpected command: {other:?}"),
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2213,26 +2213,42 @@ impl Silo for SiloService {
     ) -> Result<Response<ConfigureShardResponse>, Status> {
         let r = req.into_inner();
         let shard_id = Self::parse_shard_id(&r.shard)?;
+        // The request contract is "empty/null = default ring", so an explicit
+        // empty string is the default ring, never a ring named ''.
+        let ring = r.placement_ring.as_deref().filter(|s| !s.is_empty());
 
         // Refuse a ring no current member is in: the shard would have no
         // eligible owner. Moving to the default ring is never refused -- it is
         // the recovery path, even when no member is on the default ring either.
-        if let Some(ring) = r
-            .placement_ring
-            .as_deref()
-            .filter(|_| !r.allow_unpopulated_ring)
-        {
+        if let Some(ring) = ring.filter(|_| !r.allow_unpopulated_ring) {
             let members = self
                 .coordinator
                 .get_members()
                 .await
                 .map_err(|e| Status::internal(e.to_string()))?;
             if !members.iter().any(|m| member_in_ring(m, Some(ring))) {
+                let mut advertised: Vec<&str> = members
+                    .iter()
+                    .flat_map(|m| {
+                        if m.placement_rings.is_empty() {
+                            vec!["default"]
+                        } else {
+                            m.placement_rings.iter().map(String::as_str).collect()
+                        }
+                    })
+                    .collect();
+                advertised.sort_unstable();
+                advertised.dedup();
+                let advertised = if advertised.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    advertised.join(", ")
+                };
                 return Err(Status::failed_precondition(format!(
-                    "placement ring '{}' has no members: no current cluster member advertises it, \
-                     so the shard would have no eligible owner (pass allow_unpopulated_ring to \
-                     pin it anyway)",
-                    ring
+                    "placement ring '{}' has no members: no current cluster member advertises it \
+                     (members advertise: {}), so the shard would have no eligible owner; set \
+                     allow_unpopulated_ring to pin it anyway",
+                    ring, advertised
                 )));
             }
         }
@@ -2240,7 +2256,7 @@ impl Silo for SiloService {
         // Update the shard's placement ring via the coordinator
         let (previous, current) = self
             .coordinator
-            .update_shard_placement_ring(&shard_id, r.placement_ring.as_deref())
+            .update_shard_placement_ring(&shard_id, ring)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -26,7 +26,7 @@ use datafusion::common::{ParamValues, ScalarValue};
 /// File descriptor set for gRPC reflection
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("silo_descriptor");
 
-use crate::coordination::{Coordinator, ShardSplitter};
+use crate::coordination::{Coordinator, ShardSplitter, member_in_ring};
 use crate::factory::ShardFactory;
 use crate::job::{GubernatorAlgorithm, GubernatorRateLimit, JobStatusKind, RateLimitRetryPolicy};
 use crate::job_attempt::AttemptOutcome;
@@ -2213,6 +2213,29 @@ impl Silo for SiloService {
     ) -> Result<Response<ConfigureShardResponse>, Status> {
         let r = req.into_inner();
         let shard_id = Self::parse_shard_id(&r.shard)?;
+
+        // Refuse a ring no current member is in: the shard would have no
+        // eligible owner. Moving to the default ring is never refused -- it is
+        // the recovery path, even when no member is on the default ring either.
+        if let Some(ring) = r
+            .placement_ring
+            .as_deref()
+            .filter(|_| !r.allow_unpopulated_ring)
+        {
+            let members = self
+                .coordinator
+                .get_members()
+                .await
+                .map_err(|e| Status::internal(e.to_string()))?;
+            if !members.iter().any(|m| member_in_ring(m, Some(ring))) {
+                return Err(Status::failed_precondition(format!(
+                    "placement ring '{}' has no members: no current cluster member advertises it, \
+                     so the shard would have no eligible owner (pass allow_unpopulated_ring to \
+                     pin it anyway)",
+                    ring
+                )));
+            }
+        }
 
         // Update the shard's placement ring via the coordinator
         let (previous, current) = self

--- a/tests/grpc_integration_helpers.rs
+++ b/tests/grpc_integration_helpers.rs
@@ -93,6 +93,23 @@ pub async fn setup_multi_shard_server(
     Arc<ShardFactory>,
     tempfile::TempDir,
 )> {
+    setup_multi_shard_server_with_rings(initial_shard_count, config, Vec::new()).await
+}
+
+/// Like [`setup_multi_shard_server`], but the single `none`-coordinator member
+/// advertises `placement_rings` (empty = default ring only), so tests can
+/// exercise ring-aware behaviour such as `configure_shard` validation.
+pub async fn setup_multi_shard_server_with_rings(
+    initial_shard_count: u32,
+    config: AppConfig,
+    placement_rings: Vec<String>,
+) -> anyhow::Result<(
+    tokio::sync::broadcast::Sender<()>,
+    tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>,
+    SocketAddr,
+    Arc<ShardFactory>,
+    tempfile::TempDir,
+)> {
     let tmp = tempfile::tempdir()?;
     let template = DatabaseTemplate {
         backend: Backend::Fs,
@@ -112,7 +129,7 @@ pub async fn setup_multi_shard_server(
             format!("http://{}", addr),
             initial_shard_count,
             factory.clone(),
-            Vec::new(),
+            placement_rings,
         )
         .await
         .unwrap(),

--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -1944,3 +1944,40 @@ async fn configure_shard_accepts_ring_a_member_advertises() -> anyhow::Result<()
     shutdown_server(shutdown_tx, server).await?;
     Ok(())
 }
+
+#[silo::test(flavor = "multi_thread")]
+async fn configure_shard_treats_empty_ring_as_default() -> anyhow::Result<()> {
+    // The request field's contract is "empty/null = default ring", so an
+    // explicit empty string must behave exactly like omitting the ring: never
+    // validated, and recorded as the default ring.
+    let (mut client, shard_id, shutdown_tx, server, _tmp) = setup_ring_server(&["heavy"]).await?;
+
+    let response = client
+        .configure_shard(ConfigureShardRequest {
+            shard: shard_id.clone(),
+            placement_ring: Some(String::new()),
+            allow_unpopulated_ring: false,
+            tenant: None,
+        })
+        .await?
+        .into_inner();
+    assert_eq!(response.current_ring, "", "shard is on the default ring");
+
+    let cluster_info = client
+        .get_cluster_info(GetClusterInfoRequest {})
+        .await?
+        .into_inner();
+    let shard = cluster_info
+        .shard_owners
+        .iter()
+        .find(|s| s.shard_id == shard_id)
+        .expect("shard still listed");
+    assert_eq!(
+        shard.placement_ring.as_deref(),
+        None,
+        "an empty ring is stored as no ring, not as a ring named ''"
+    );
+
+    shutdown_server(shutdown_tx, server).await?;
+    Ok(())
+}

--- a/tests/grpc_misc_tests.rs
+++ b/tests/grpc_misc_tests.rs
@@ -3,7 +3,9 @@ mod grpc_integration_helpers;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use grpc_integration_helpers::{create_test_factory, setup_test_server, shutdown_server};
+use grpc_integration_helpers::{
+    create_test_factory, setup_multi_shard_server_with_rings, setup_test_server, shutdown_server,
+};
 use silo::coordination::NoneCoordinator;
 use silo::factory::ShardFactory;
 use silo::gubernator::MockGubernatorClient;
@@ -1809,5 +1811,136 @@ async fn grpc_worker_rpcs_accept_valid_tenant_when_tenancy_enabled() -> anyhow::
     })
     .await
     .expect("test timed out")?;
+    Ok(())
+}
+
+// --- configure_shard placement-ring validation ---
+
+/// Start a single-member server whose member advertises `member_rings`, and
+/// return a client plus the id of one of its shards (from cluster info).
+async fn setup_ring_server(
+    member_rings: &[&str],
+) -> anyhow::Result<(
+    SiloClient<tonic::transport::Channel>,
+    String,
+    tokio::sync::broadcast::Sender<()>,
+    tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>,
+    tempfile::TempDir,
+)> {
+    let rings = member_rings.iter().map(|r| r.to_string()).collect();
+    let (shutdown_tx, server, addr, _factory, tmp) =
+        setup_multi_shard_server_with_rings(1, AppConfig::load(None).unwrap(), rings).await?;
+    let channel = tonic::transport::Endpoint::new(format!("http://{}", addr))?
+        .connect()
+        .await?;
+    let mut client = SiloClient::new(channel);
+    let cluster_info = client
+        .get_cluster_info(GetClusterInfoRequest {})
+        .await?
+        .into_inner();
+    let shard_id = cluster_info.shard_owners[0].shard_id.clone();
+    Ok((client, shard_id, shutdown_tx, server, tmp))
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn configure_shard_refuses_ring_no_member_advertises() -> anyhow::Result<()> {
+    let (mut client, shard_id, shutdown_tx, server, _tmp) = setup_ring_server(&[]).await?;
+
+    let err = client
+        .configure_shard(ConfigureShardRequest {
+            shard: shard_id,
+            placement_ring: Some("nobody-is-in-this-ring".to_string()),
+            allow_unpopulated_ring: false,
+            tenant: None,
+        })
+        .await
+        .expect_err("configuring a ring no member advertises must fail");
+
+    assert_eq!(
+        err.code(),
+        tonic::Code::FailedPrecondition,
+        "status for an unadvertised ring: {err:?}"
+    );
+    assert!(
+        err.message().contains("nobody-is-in-this-ring"),
+        "message should name the ring: {}",
+        err.message()
+    );
+
+    shutdown_server(shutdown_tx, server).await?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn configure_shard_override_pins_to_unpopulated_ring() -> anyhow::Result<()> {
+    let (mut client, shard_id, shutdown_tx, server, _tmp) = setup_ring_server(&[]).await?;
+
+    let response = client
+        .configure_shard(ConfigureShardRequest {
+            shard: shard_id.clone(),
+            placement_ring: Some("staged-ring".to_string()),
+            allow_unpopulated_ring: true,
+            tenant: None,
+        })
+        .await?
+        .into_inner();
+    assert_eq!(response.current_ring, "staged-ring");
+
+    let cluster_info = client
+        .get_cluster_info(GetClusterInfoRequest {})
+        .await?
+        .into_inner();
+    let shard = cluster_info
+        .shard_owners
+        .iter()
+        .find(|s| s.shard_id == shard_id)
+        .expect("shard still listed");
+    assert_eq!(
+        shard.placement_ring.as_deref(),
+        Some("staged-ring"),
+        "the override pins the ring even though no member is in it"
+    );
+
+    shutdown_server(shutdown_tx, server).await?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn configure_shard_clearing_ring_is_never_validated() -> anyhow::Result<()> {
+    // The member is on a named ring only, so nobody is on the default ring --
+    // clearing must still succeed (it is the recovery path).
+    let (mut client, shard_id, shutdown_tx, server, _tmp) = setup_ring_server(&["heavy"]).await?;
+
+    let response = client
+        .configure_shard(ConfigureShardRequest {
+            shard: shard_id,
+            placement_ring: None,
+            allow_unpopulated_ring: false,
+            tenant: None,
+        })
+        .await?
+        .into_inner();
+    assert_eq!(response.current_ring, "", "shard moved to the default ring");
+
+    shutdown_server(shutdown_tx, server).await?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn configure_shard_accepts_ring_a_member_advertises() -> anyhow::Result<()> {
+    let (mut client, shard_id, shutdown_tx, server, _tmp) = setup_ring_server(&["heavy"]).await?;
+
+    let response = client
+        .configure_shard(ConfigureShardRequest {
+            shard: shard_id,
+            placement_ring: Some("heavy".to_string()),
+            allow_unpopulated_ring: false,
+            tenant: None,
+        })
+        .await?
+        .into_inner();
+    assert_eq!(response.current_ring, "heavy");
+
+    shutdown_server(shutdown_tx, server).await?;
     Ok(())
 }

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -906,7 +906,8 @@ async fn siloctl_shard_configure() -> anyhow::Result<()> {
         let (_client, shutdown_tx, server, addr) =
             setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
 
-        // Test shard configure command - set a ring
+        // Test shard configure command - set a ring. The test member advertises
+        // no rings, so pinning a named ring needs the unpopulated-ring override.
         let opts = opts_for_addr(&addr);
         let mut output = Vec::new();
         siloctl::shard_configure(
@@ -914,6 +915,7 @@ async fn siloctl_shard_configure() -> anyhow::Result<()> {
             &mut output,
             crate::grpc_integration_helpers::TEST_SHARD_ID,
             Some("gpu-ring".to_string()),
+            true,
         )
         .await?;
         let stdout = String::from_utf8(output)?;
@@ -941,6 +943,7 @@ async fn siloctl_shard_configure() -> anyhow::Result<()> {
             &mut output2,
             crate::grpc_integration_helpers::TEST_SHARD_ID,
             None,
+            false,
         )
         .await?;
         let stdout2 = String::from_utf8(output2)?;
@@ -976,7 +979,8 @@ async fn siloctl_shard_configure_json_output() -> anyhow::Result<()> {
         let (_client, shutdown_tx, server, addr) =
             setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
 
-        // Test shard configure command with JSON output - set a ring
+        // Test shard configure command with JSON output - set a ring. The test
+        // member advertises no rings, so named rings need the override.
         let opts = opts_for_addr_json(&addr);
         let mut output = Vec::new();
         siloctl::shard_configure(
@@ -984,6 +988,7 @@ async fn siloctl_shard_configure_json_output() -> anyhow::Result<()> {
             &mut output,
             crate::grpc_integration_helpers::TEST_SHARD_ID,
             Some("high-memory".to_string()),
+            true,
         )
         .await?;
         let stdout = String::from_utf8(output)?;
@@ -1012,6 +1017,7 @@ async fn siloctl_shard_configure_json_output() -> anyhow::Result<()> {
             &mut output2,
             crate::grpc_integration_helpers::TEST_SHARD_ID,
             Some("gpu-ring".to_string()),
+            true,
         )
         .await?;
         let stdout2 = String::from_utf8(output2)?;
@@ -1051,6 +1057,7 @@ async fn siloctl_shard_configure_invalid_shard() -> anyhow::Result<()> {
             &mut output,
             "ffffffff-ffff-ffff-ffff-ffffffffffff",
             Some("test-ring".to_string()),
+            false,
         )
         .await;
 
@@ -1063,6 +1070,64 @@ async fn siloctl_shard_configure_invalid_shard() -> anyhow::Result<()> {
                 || err_str.contains("ShardNotFound"),
             "error should mention shard not found: {}",
             err_str
+        );
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn siloctl_shard_configure_unpopulated_ring_needs_override() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(30000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (_client, shutdown_tx, server, addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+        let opts = opts_for_addr(&addr);
+        let shard = crate::grpc_integration_helpers::TEST_SHARD_ID;
+
+        // Without the override the server refuses the ring and siloctl
+        // surfaces the server's message.
+        let mut output = Vec::new();
+        let err = siloctl::shard_configure(
+            &opts,
+            &mut output,
+            shard,
+            Some("nobody-is-in-this-ring".to_string()),
+            false,
+        )
+        .await
+        .expect_err("an unadvertised ring must be refused without the override");
+        let err_str = err.to_string();
+        assert!(
+            err_str.contains("nobody-is-in-this-ring") && err_str.contains("no members"),
+            "error should carry the server's validation message: {}",
+            err_str
+        );
+        assert!(
+            output.is_empty(),
+            "nothing should be printed on failure: {}",
+            String::from_utf8_lossy(&output)
+        );
+
+        // With the override the same request succeeds and the ring is set.
+        let mut output = Vec::new();
+        siloctl::shard_configure(
+            &opts,
+            &mut output,
+            shard,
+            Some("nobody-is-in-this-ring".to_string()),
+            true,
+        )
+        .await?;
+        let stdout = String::from_utf8(output)?;
+        assert!(
+            stdout.contains("Current ring:  nobody-is-in-this-ring"),
+            "output should show the pinned ring: {}",
+            stdout
         );
 
         shutdown_server(shutdown_tx, server).await?;

--- a/typescript_client/src/pb/silo.ts
+++ b/typescript_client/src/pb/silo.ts
@@ -1447,6 +1447,15 @@ export interface ConfigureShardRequest {
      */
     placementRing?: string; // The placement ring to assign (empty/null = default ring).
     /**
+     * A placement_ring that no current cluster member advertises is refused with
+     * FAILED_PRECONDITION, because the shard would have no eligible owner. Set
+     * this to override that check and pin the shard to a ring whose nodes have
+     * not joined yet. Ignored when placement_ring is unset.
+     *
+     * @generated from protobuf field: bool allow_unpopulated_ring = 3
+     */
+    allowUnpopulatedRing: boolean;
+    /**
      * @generated from protobuf field: optional string tenant = 100
      */
     tenant?: string; // Optional tenant ID (for multi-tenant mode).
@@ -6234,12 +6243,14 @@ class ConfigureShardRequest$Type extends MessageType<ConfigureShardRequest> {
         super("silo.v1.ConfigureShardRequest", [
             { no: 1, name: "shard", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "placement_ring", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "allow_unpopulated_ring", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 100, name: "tenant", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<ConfigureShardRequest>): ConfigureShardRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.shard = "";
+        message.allowUnpopulatedRing = false;
         if (value !== undefined)
             reflectionMergePartial<ConfigureShardRequest>(this, message, value);
         return message;
@@ -6254,6 +6265,9 @@ class ConfigureShardRequest$Type extends MessageType<ConfigureShardRequest> {
                     break;
                 case /* optional string placement_ring */ 2:
                     message.placementRing = reader.string();
+                    break;
+                case /* bool allow_unpopulated_ring */ 3:
+                    message.allowUnpopulatedRing = reader.bool();
                     break;
                 case /* optional string tenant */ 100:
                     message.tenant = reader.string();
@@ -6276,6 +6290,9 @@ class ConfigureShardRequest$Type extends MessageType<ConfigureShardRequest> {
         /* optional string placement_ring = 2; */
         if (message.placementRing !== undefined)
             writer.tag(2, WireType.LengthDelimited).string(message.placementRing);
+        /* bool allow_unpopulated_ring = 3; */
+        if (message.allowUnpopulatedRing !== false)
+            writer.tag(3, WireType.Varint).bool(message.allowUnpopulatedRing);
         /* optional string tenant = 100; */
         if (message.tenant !== undefined)
             writer.tag(100, WireType.LengthDelimited).string(message.tenant);


### PR DESCRIPTION
## Why

`siloctl shard configure <shard> --ring nobody-is-in-this-ring` succeeded in the silo-staging gameday. Nothing checks that any member advertises the requested ring, so a typo -- or a config revert while a pin is still in place -- strands a shard silently, and the fleet-wide form (`placement_rings = ["heavy"]` without `"default"`) strands every shard.

## What

- `ConfigureShardRequest` gains `bool allow_unpopulated_ring = 3`. Proto3-default false, so existing callers keep their behaviour except that an unpopulated ring is now refused. The TypeScript client's checked-in bindings are regenerated.
- The gRPC `configure_shard` handler fetches current members and applies the same eligibility rule the assignment uses (`member_in_ring`). If no member is in the requested ring and the override is false, it returns `FAILED_PRECONDITION` naming the ring and listing the rings members do advertise, so a typo is obvious next to the real name. Clearing the ring is never validated: moving back to the default ring is the recovery path, and in the fleet-wide strand no member is on the default ring either. An explicit empty `placement_ring` is the default ring, per the field's documented contract ("empty/null = default ring"), not a ring named `''`.
- Validation lives in the server handler, not the coordinator trait method (which is also the internal path and has no member list); `update_shard_placement_ring` is unchanged on every backend.
- `siloctl shard configure --ring <ring> --allow-unpopulated-ring` sets the field for the deliberate stage-a-ring-before-its-nodes-join case; clap rejects the flag without `--ring`.

## Review notes

- gRPC tests use a new `setup_multi_shard_server_with_rings` helper so the single `none` member can advertise rings; the existing helper delegates to it with no rings.
- The two `siloctl` round-trip tests that pin named rings against the no-rings test server now pass the override; their subject is the round-trip of the ring value, not validation.
