### PR TITLE
Treat an empty owner address as a routing error in RoutingClient

### DIFF
--- a/src/bin/silo-bench.rs
+++ b/src/bin/silo-bench.rs
@@ -82,8 +82,8 @@ struct Args {
     #[arg(long, default_value = "1")]
     report_interval_secs: u64,
 
-    /// Tenant ID prefix for multi-tenant mode. When tenant_count > 1, tenants are
-    /// named "{tenant_prefix}-0", "{tenant_prefix}-1", etc.
+    /// Tenant ID prefix. Tenants are always named "{tenant_prefix}-0" through
+    /// "{tenant_prefix}-{tenant_count-1}", even when tenant_count is 1.
     #[arg(long, default_value = "bench")]
     tenant_prefix: String,
 
@@ -276,7 +276,7 @@ async fn worker_loop(
                 // grants against changing capacity.
                 for rt in refresh_tasks {
                     let report_shard = rt.shard.clone();
-                    let mut refresh_client = match client.client_for_shard(&report_shard) {
+                    let mut refresh_client = match client.client_for_shard(&report_shard).await {
                         Ok(c) => c,
                         Err(_) => silo_client.clone(),
                     };
@@ -332,7 +332,7 @@ async fn worker_loop(
                     let task_shard = task.shard.clone();
                     let task_tenant = task.tenant_id.clone();
 
-                    let mut report_client = match client.client_for_shard(&task_shard) {
+                    let mut report_client = match client.client_for_shard(&task_shard).await {
                         Ok(c) => c,
                         Err(_) => silo_client.clone(),
                     };
@@ -351,7 +351,9 @@ async fn worker_loop(
                             // Try handling routing error for outcome reporting
                             if client.handle_routing_error(&e, &task_shard).await.is_some() {
                                 // Retry once with updated routing
-                                if let Ok(mut retry_client) = client.client_for_shard(&task_shard) {
+                                if let Ok(mut retry_client) =
+                                    client.client_for_shard(&task_shard).await
+                                {
                                     let retry_req = make_success_outcome_request(
                                         task_shard,
                                         task.id.clone(),
@@ -454,7 +456,7 @@ async fn enqueuer_loop(
 
         let mut retries = 0u32;
         loop {
-            let (mut silo_client, shard) = match client.client_for_tenant(&tenant) {
+            let (mut silo_client, shard) = match client.client_for_tenant(&tenant).await {
                 Ok(pair) => pair,
                 Err(e) => {
                     warn!(enqueuer_id = %enqueuer_id, tenant = %tenant, error = %e, "No shard for tenant");
@@ -808,7 +810,7 @@ async fn audit_holder_leaks(client: &RoutingClient) -> anyhow::Result<HolderAudi
     let topo = client.topology();
     let mut audit = HolderAudit::default();
     for owner in &topo.shard_owners {
-        let mut silo_client = match client.client_for_shard(&owner.shard_id) {
+        let mut silo_client = match client.client_for_shard(&owner.shard_id).await {
             Ok(c) => c,
             Err(e) => {
                 warn!(shard = %owner.shard_id, error = %e, "audit: could not get client");

--- a/src/bin/silo-bench.rs
+++ b/src/bin/silo-bench.rs
@@ -243,7 +243,7 @@ async fn worker_loop(
     floating_default_max: u32,
 ) {
     while running.load(Ordering::Relaxed) {
-        let (mut silo_client, shard) = match client.client_for_random_shard() {
+        let (mut silo_client, shard) = match client.client_for_random_shard().await {
             Ok(pair) => pair,
             Err(e) => {
                 warn!(worker_id = %worker_id, error = %e, "Worker failed to get client");

--- a/src/routing_client.rs
+++ b/src/routing_client.rs
@@ -11,6 +11,7 @@
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use tokio::sync::Mutex;
@@ -71,28 +72,53 @@ impl ClusterTopology {
             .map(|owner| owner.grpc_addr.as_str())
     }
 
-    /// Get a random shard ID.
+    /// Get a random shard ID among the shards that have an effective address
+    /// (redirect override or owner). Unowned shards are never drawn.
     pub fn random_shard(&self) -> Option<&str> {
-        if self.shard_owners.is_empty() {
+        let routable: Vec<&str> = self
+            .shard_owners
+            .iter()
+            .map(|owner| owner.shard_id.as_str())
+            .filter(|shard_id| {
+                self.address_for_shard(shard_id)
+                    .is_some_and(|addr| !addr.is_empty())
+            })
+            .collect();
+        if routable.is_empty() {
             return None;
         }
-        let idx = rand::random_range(0..self.shard_owners.len());
-        Some(&self.shard_owners[idx].shard_id)
+        Some(routable[rand::random_range(0..routable.len())])
     }
 
-    /// Get all unique server addresses (including overrides).
+    /// Get all unique server addresses (including overrides). Shards with no
+    /// owner contribute nothing -- an empty address is not a server.
     pub fn all_addresses(&self) -> Vec<String> {
         let mut addrs: Vec<String> = self
             .shard_owners
             .iter()
             .map(|owner| owner.grpc_addr.clone())
             .chain(self.shard_addr_overrides.values().cloned())
+            .filter(|addr| !addr.is_empty())
             .collect();
         addrs.sort();
         addrs.dedup();
         addrs
     }
 }
+
+/// The shard exists in the topology but the cluster's desired assignment
+/// gives it no owner (no member is in its placement ring), so there is no
+/// address to connect to. The client marks its topology stale when it
+/// returns this, so a later call re-discovers once the shard has an owner.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("shard `{shard_id}` has no owner")]
+pub struct ShardUnownedError {
+    pub shard_id: String,
+}
+
+/// Minimum spacing between topology refreshes triggered by the stale flag, so
+/// a caller hammering an unowned shard re-discovers at most this often.
+pub const STALE_REFRESH_MIN_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Result of classifying a gRPC error for retry purposes.
 #[derive(Debug)]
@@ -172,6 +198,14 @@ pub struct RoutingClient {
     /// Result of the most recent refresh attempt, used by waiters to reuse the
     /// in-flight refresh result instead of re-running discovery.
     last_refresh_succeeded: AtomicBool,
+    /// Set when a lookup hit a shard with no owner address; the next
+    /// `client_for_tenant` / `client_for_shard` refreshes the topology first
+    /// (rate-limited by [`STALE_REFRESH_MIN_INTERVAL`]) so a recovered shard
+    /// is picked up without an RPC having to fail.
+    topology_stale: AtomicBool,
+    /// When the last stale-triggered refresh started; `None` until the first
+    /// one, so the first stale call after a failure refreshes immediately.
+    last_stale_refresh: std::sync::Mutex<Option<Instant>>,
 }
 
 impl RoutingClient {
@@ -197,6 +231,8 @@ impl RoutingClient {
             refresh_mutex: Mutex::new(()),
             refresh_generation: AtomicU64::new(0),
             last_refresh_succeeded: AtomicBool::new(false),
+            topology_stale: AtomicBool::new(false),
+            last_stale_refresh: std::sync::Mutex::new(None),
         });
 
         // Pre-populate the connection pool for all known servers. Since connections
@@ -247,10 +283,16 @@ impl RoutingClient {
 
     /// Get a client and shard ID for the given tenant.
     /// Returns (client, shard_id).
-    pub fn client_for_tenant(
+    ///
+    /// Fails with [`ShardUnownedError`] when the tenant's shard has no owner
+    /// address; the topology is then marked stale so a later call refreshes
+    /// it before resolving.
+    pub async fn client_for_tenant(
         &self,
         tenant: &str,
     ) -> anyhow::Result<(InterceptedSiloClient, String)> {
+        self.refresh_if_stale().await;
+
         let (shard_id, addr) = {
             let topo = self.topology.read().expect("topology lock poisoned");
             let owner = topo
@@ -264,8 +306,52 @@ impl RoutingClient {
             (shard_id, addr)
         };
 
-        let client = self.get_or_connect(&addr)?;
+        let client = self.connect_to_owner(&shard_id, &addr)?;
         Ok((client, shard_id))
+    }
+
+    /// Connect to `addr` for `shard_id`, treating an empty address as an
+    /// unowned shard: mark the topology stale and return
+    /// [`ShardUnownedError`] instead of building a connection to nowhere.
+    fn connect_to_owner(
+        &self,
+        shard_id: &str,
+        addr: &str,
+    ) -> anyhow::Result<InterceptedSiloClient> {
+        if addr.is_empty() {
+            self.topology_stale.store(true, Ordering::Release);
+            return Err(ShardUnownedError {
+                shard_id: shard_id.to_string(),
+            }
+            .into());
+        }
+        self.get_or_connect(addr)
+    }
+
+    /// If a previous lookup found an unowned shard, refresh the topology
+    /// before resolving -- at most once per [`STALE_REFRESH_MIN_INTERVAL`].
+    /// The refresh itself is the coalesced [`refresh_topology`](Self::refresh_topology).
+    async fn refresh_if_stale(&self) {
+        if !self.topology_stale.load(Ordering::Acquire) {
+            return;
+        }
+        let due = {
+            let mut last = self
+                .last_stale_refresh
+                .lock()
+                .expect("stale refresh lock poisoned");
+            let due = last.is_none_or(|at| at.elapsed() >= STALE_REFRESH_MIN_INTERVAL);
+            if due {
+                *last = Some(Instant::now());
+            }
+            due
+        };
+        if !due {
+            return;
+        }
+        self.topology_stale.store(false, Ordering::Release);
+        debug!("topology marked stale by an unowned shard, refreshing");
+        self.refresh_topology().await;
     }
 
     /// Get a client for a random shard (used by workers).
@@ -289,7 +375,12 @@ impl RoutingClient {
     }
 
     /// Get a client for a specific shard (used for report_outcome).
-    pub fn client_for_shard(&self, shard_id: &str) -> anyhow::Result<InterceptedSiloClient> {
+    ///
+    /// Fails with [`ShardUnownedError`] when the shard has no owner address;
+    /// see [`client_for_tenant`](Self::client_for_tenant).
+    pub async fn client_for_shard(&self, shard_id: &str) -> anyhow::Result<InterceptedSiloClient> {
+        self.refresh_if_stale().await;
+
         let addr = {
             let topo = self.topology.read().expect("topology lock poisoned");
             topo.address_for_shard(shard_id)
@@ -297,7 +388,7 @@ impl RoutingClient {
                 .to_string()
         };
 
-        self.get_or_connect(&addr)
+        self.connect_to_owner(shard_id, &addr)
     }
 
     /// Handle a routing error by updating internal state.
@@ -452,6 +543,13 @@ impl RoutingClient {
             .read()
             .expect("topology lock poisoned")
             .clone()
+    }
+
+    /// Number of pooled (lazy) connections. Exposed for tests that assert the
+    /// pool did not grow.
+    #[doc(hidden)]
+    pub fn connection_count(&self) -> usize {
+        self.connections.len()
     }
 
     /// Get or create a lazy connection to the given address.

--- a/src/routing_client.rs
+++ b/src/routing_client.rs
@@ -356,13 +356,22 @@ impl RoutingClient {
 
     /// Get a client for a random shard (used by workers).
     /// Returns (client, shard_id).
-    pub fn client_for_random_shard(&self) -> anyhow::Result<(InterceptedSiloClient, String)> {
+    ///
+    /// Only shards with an owner address are drawn. When the topology has
+    /// shards but none is routable, the topology is marked stale so a later
+    /// call refreshes it; see [`client_for_tenant`](Self::client_for_tenant).
+    pub async fn client_for_random_shard(&self) -> anyhow::Result<(InterceptedSiloClient, String)> {
+        self.refresh_if_stale().await;
+
         let (shard_id, addr) = {
             let topo = self.topology.read().expect("topology lock poisoned");
-            let shard_id = topo
-                .random_shard()
-                .ok_or_else(|| anyhow::anyhow!("no shards available in topology"))?
-                .to_string();
+            let Some(shard_id) = topo.random_shard() else {
+                if !topo.shard_owners.is_empty() {
+                    self.topology_stale.store(true, Ordering::Release);
+                }
+                anyhow::bail!("no shards available in topology");
+            };
+            let shard_id = shard_id.to_string();
             let addr = topo
                 .address_for_shard(&shard_id)
                 .ok_or_else(|| anyhow::anyhow!("no address for shard '{}'", shard_id))?

--- a/tests/routing_client_tests.rs
+++ b/tests/routing_client_tests.rs
@@ -990,3 +990,44 @@ async fn routing_client_stale_refresh_is_rate_limited() -> anyhow::Result<()> {
     .expect("test timed out")?;
     Ok(())
 }
+
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_random_shard_recovers_once_a_shard_gets_an_owner() -> anyhow::Result<()> {
+    tokio::time::timeout(Duration::from_millis(15000), async {
+        let (shutdown_tx, server, addr, request_count, response, client) =
+            discover_stranded().await?;
+        let server_addr = format!("http://{}", addr);
+
+        // Every shard is unowned: nothing to draw from, and no RPC is made.
+        let err = client
+            .client_for_random_shard()
+            .await
+            .expect_err("no routable shard while every shard is unowned");
+        assert!(
+            err.to_string().contains("no shards available"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+
+        // Once a shard has an owner, the next worker lookup re-discovers on
+        // its own (one refresh) and returns a client -- a worker-only client
+        // must not stay wedged on the cached unowned topology.
+        *response.lock().unwrap() = one_shard_response(&server_addr, &server_addr);
+        let (_silo_client, shard) = client
+            .client_for_random_shard()
+            .await
+            .expect("lookup succeeds once the shard has an owner");
+        assert_eq!(shard, "counting-shard");
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            2,
+            "exactly one topology refresh between the failure and the success"
+        );
+
+        shutdown_counting_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}

--- a/tests/routing_client_tests.rs
+++ b/tests/routing_client_tests.rs
@@ -17,7 +17,9 @@ use tonic::{Request, Response, Status};
 
 #[derive(Clone)]
 struct CountingClusterInfoService {
-    grpc_addr: String,
+    /// The response served to every `GetClusterInfo` call. Shared with the
+    /// test so it can swap the topology between calls.
+    response: Arc<std::sync::Mutex<GetClusterInfoResponse>>,
     request_count: Arc<AtomicUsize>,
     response_delay: Duration,
 }
@@ -39,20 +41,7 @@ impl Silo for CountingClusterInfoService {
         self.request_count.fetch_add(1, Ordering::SeqCst);
         tokio::time::sleep(self.response_delay).await;
 
-        Ok(Response::new(GetClusterInfoResponse {
-            num_shards: 1,
-            shard_owners: vec![ShardOwner {
-                shard_id: "counting-shard".to_string(),
-                grpc_addr: self.grpc_addr.clone(),
-                node_id: "counting-node".to_string(),
-                range_start: String::new(),
-                range_end: String::new(),
-                placement_ring: None,
-            }],
-            this_node_id: "counting-node".to_string(),
-            this_grpc_addr: self.grpc_addr.clone(),
-            members: vec![],
-        }))
+        Ok(Response::new(self.response.lock().unwrap().clone()))
     }
 
     async fn get_node_info(
@@ -252,6 +241,29 @@ impl Silo for CountingClusterInfoService {
     }
 }
 
+/// A one-shard topology served by the counting server at `server_addr`, whose
+/// single shard covers the whole keyspace and is owned at `owner_addr` (empty
+/// = no owner).
+fn one_shard_response(server_addr: &str, owner_addr: &str) -> GetClusterInfoResponse {
+    GetClusterInfoResponse {
+        num_shards: 1,
+        shard_owners: vec![ShardOwner {
+            shard_id: "counting-shard".to_string(),
+            grpc_addr: owner_addr.to_string(),
+            node_id: "counting-node".to_string(),
+            range_start: String::new(),
+            range_end: String::new(),
+            placement_ring: None,
+        }],
+        this_node_id: "counting-node".to_string(),
+        this_grpc_addr: server_addr.to_string(),
+        members: vec![],
+    }
+}
+
+/// Start the counting cluster-info server. The returned response handle is
+/// what the server serves; a test can replace its contents between calls.
+/// Initially the single shard is owned by the server itself.
 async fn setup_counting_cluster_info_server(
     response_delay: Duration,
 ) -> anyhow::Result<(
@@ -259,12 +271,18 @@ async fn setup_counting_cluster_info_server(
     tokio::task::JoinHandle<anyhow::Result<()>>,
     SocketAddr,
     Arc<AtomicUsize>,
+    Arc<std::sync::Mutex<GetClusterInfoResponse>>,
 )> {
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
     let addr = listener.local_addr()?;
     let request_count = Arc::new(AtomicUsize::new(0));
+    let server_addr = format!("http://{}", addr);
+    let response = Arc::new(std::sync::Mutex::new(one_shard_response(
+        &server_addr,
+        &server_addr,
+    )));
     let service = CountingClusterInfoService {
-        grpc_addr: format!("http://{}", addr),
+        response: response.clone(),
         request_count: request_count.clone(),
         response_delay,
     };
@@ -292,7 +310,7 @@ async fn setup_counting_cluster_info_server(
             .map_err(anyhow::Error::from)
     });
 
-    Ok((shutdown_tx, server, addr, request_count))
+    Ok((shutdown_tx, server, addr, request_count, response))
 }
 
 async fn shutdown_counting_server(
@@ -420,7 +438,7 @@ async fn routing_client_enqueue_correct_shard() -> anyhow::Result<()> {
 
         // Enqueue to correct shard for each tenant - should all succeed
         for tenant in &["bench-0", "bench-1", "bench-2", "bench-3"] {
-            let (mut silo_client, shard) = client.client_for_tenant(tenant)?;
+            let (mut silo_client, shard) = client.client_for_tenant(tenant).await?;
 
             let result = silo_client
                 .enqueue(EnqueueRequest {
@@ -491,7 +509,7 @@ async fn routing_client_handles_failed_precondition_with_refresh() -> anyhow::Re
         };
 
         // Send to the wrong shard deliberately
-        let (mut silo_client, _correct_shard) = client.client_for_tenant(wrong_tenant)?;
+        let (mut silo_client, _correct_shard) = client.client_for_tenant(wrong_tenant).await?;
 
         let result = silo_client
             .enqueue(EnqueueRequest {
@@ -532,7 +550,7 @@ async fn routing_client_handles_failed_precondition_with_refresh() -> anyhow::Re
         );
 
         // After refresh, routing to the correct shard via client_for_tenant should work
-        let (mut silo_client, shard) = client.client_for_tenant(wrong_tenant)?;
+        let (mut silo_client, shard) = client.client_for_tenant(wrong_tenant).await?;
         let result = silo_client
             .enqueue(EnqueueRequest {
                 shard: shard.clone(),
@@ -699,7 +717,7 @@ async fn routing_client_refreshes_via_redirect_discovery_address() -> anyhow::Re
 #[silo::test(flavor = "multi_thread")]
 async fn routing_client_coalesces_concurrent_refreshes() -> anyhow::Result<()> {
     tokio::time::timeout(std::time::Duration::from_millis(15000), async {
-        let (shutdown_tx, server, addr, request_count) =
+        let (shutdown_tx, server, addr, request_count, _response) =
             setup_counting_cluster_info_server(Duration::from_millis(150)).await?;
 
         let client = RoutingClient::discover(&format!("http://{}", addr)).await?;
@@ -759,7 +777,7 @@ async fn routing_client_connection_pool_reuse() -> anyhow::Result<()> {
 
         // Call client_for_tenant many times - all should succeed and reuse connections
         for _ in 0..20 {
-            let (_silo_client, _shard) = client.client_for_tenant("bench-0")?;
+            let (_silo_client, _shard) = client.client_for_tenant("bench-0").await?;
         }
 
         // The connection pool should have exactly the number of unique addresses
@@ -789,7 +807,7 @@ async fn routing_client_invalidate_connection() -> anyhow::Result<()> {
         let client = RoutingClient::discover(&server_addr).await?;
 
         // Ensure a connection exists by making a request
-        let (mut silo_client, _shard) = client.client_for_tenant("bench-0")?;
+        let (mut silo_client, _shard) = client.client_for_tenant("bench-0").await?;
         let topo = silo_client
             .get_cluster_info(silo::pb::GetClusterInfoRequest {})
             .await;
@@ -799,7 +817,7 @@ async fn routing_client_invalidate_connection() -> anyhow::Result<()> {
         client.invalidate_connection(&server_addr);
 
         // Next request should still work — a fresh lazy connection is created
-        let (mut silo_client, _shard) = client.client_for_tenant("bench-0")?;
+        let (mut silo_client, _shard) = client.client_for_tenant("bench-0").await?;
         let topo = silo_client
             .get_cluster_info(silo::pb::GetClusterInfoRequest {})
             .await;
@@ -810,6 +828,162 @@ async fn routing_client_invalidate_connection() -> anyhow::Result<()> {
         );
 
         shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+// --- unowned shards (empty owner address) ---
+
+/// Start the counting server with its single shard unowned, and discover it.
+async fn discover_stranded() -> anyhow::Result<(
+    tokio::sync::broadcast::Sender<()>,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+    SocketAddr,
+    Arc<AtomicUsize>,
+    Arc<std::sync::Mutex<GetClusterInfoResponse>>,
+    Arc<RoutingClient>,
+)> {
+    let (shutdown_tx, server, addr, request_count, response) =
+        setup_counting_cluster_info_server(Duration::ZERO).await?;
+    let server_addr = format!("http://{}", addr);
+    *response.lock().unwrap() = one_shard_response(&server_addr, "");
+    let client = RoutingClient::discover(&server_addr).await?;
+    assert_eq!(request_count.load(Ordering::SeqCst), 1, "discovery RPC");
+    Ok((shutdown_tx, server, addr, request_count, response, client))
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_tenant_on_unowned_shard_fails_without_connecting() -> anyhow::Result<()> {
+    tokio::time::timeout(Duration::from_millis(15000), async {
+        let (shutdown_tx, server, _addr, _request_count, _response, client) =
+            discover_stranded().await?;
+        let connections_before = client.connection_count();
+
+        let err = client
+            .client_for_tenant("bench-0")
+            .await
+            .expect_err("a tenant on a shard with no owner must not get a client");
+
+        assert_eq!(err.to_string(), "shard `counting-shard` has no owner");
+        assert_eq!(
+            client.connection_count(),
+            connections_before,
+            "no connection may be created for an empty address"
+        );
+
+        shutdown_counting_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_recovers_once_unowned_shard_gets_an_owner() -> anyhow::Result<()> {
+    tokio::time::timeout(Duration::from_millis(15000), async {
+        let (shutdown_tx, server, addr, request_count, response, client) =
+            discover_stranded().await?;
+        let server_addr = format!("http://{}", addr);
+
+        client
+            .client_for_tenant("bench-0")
+            .await
+            .expect_err("shard has no owner yet");
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            1,
+            "the failing lookup itself makes no RPC"
+        );
+
+        // The shard gets an owner; the next lookup refreshes exactly once and
+        // resolves against the fresh topology.
+        *response.lock().unwrap() = one_shard_response(&server_addr, &server_addr);
+        let (_silo_client, shard) = client
+            .client_for_tenant("bench-0")
+            .await
+            .expect("lookup succeeds once the shard has an owner");
+
+        assert_eq!(shard, "counting-shard");
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            2,
+            "exactly one topology refresh between the failure and the success"
+        );
+        assert_eq!(
+            client.topology().address_for_shard("counting-shard"),
+            Some(server_addr.as_str()),
+            "topology now carries the owner address"
+        );
+
+        shutdown_counting_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_shard_lookup_on_unowned_shard_behaves_like_tenant_lookup()
+-> anyhow::Result<()> {
+    tokio::time::timeout(Duration::from_millis(15000), async {
+        let (shutdown_tx, server, addr, request_count, response, client) =
+            discover_stranded().await?;
+        let server_addr = format!("http://{}", addr);
+        let connections_before = client.connection_count();
+
+        let err = client
+            .client_for_shard("counting-shard")
+            .await
+            .expect_err("a shard with no owner must not get a client");
+        assert_eq!(err.to_string(), "shard `counting-shard` has no owner");
+        assert_eq!(client.connection_count(), connections_before);
+
+        *response.lock().unwrap() = one_shard_response(&server_addr, &server_addr);
+        client
+            .client_for_shard("counting-shard")
+            .await
+            .expect("lookup succeeds once the shard has an owner");
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            2,
+            "exactly one topology refresh between the failure and the success"
+        );
+
+        shutdown_counting_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_stale_refresh_is_rate_limited() -> anyhow::Result<()> {
+    tokio::time::timeout(Duration::from_millis(15000), async {
+        let (shutdown_tx, server, _addr, request_count, _response, client) =
+            discover_stranded().await?;
+
+        // First failure marks the topology stale; the second call refreshes
+        // (still unowned, so it fails again); the third is inside the minimum
+        // interval and must not refresh again.
+        for _ in 0..3 {
+            client
+                .client_for_tenant("bench-0")
+                .await
+                .expect_err("shard stays unowned");
+        }
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            2,
+            "one discovery plus at most one stale-triggered refresh inside the interval"
+        );
+
+        shutdown_counting_server(shutdown_tx, server).await?;
         Ok::<(), anyhow::Error>(())
     })
     .await


### PR DESCRIPTION
## Why

`silo-bench` (through the shared `RoutingClient`) hit the same dead end on the enqueue path in the gameday: `client_for_tenant` resolved the stranded shard's owner to an empty address and connected to it. The failure was a client-side error rather than a `tonic::Status`, so `handle_routing_error` never ran and topology was never refreshed; once the shard was recovered, bench kept failing against the cached empty address for the rest of its run.

## What

- `client_for_tenant` and `client_for_shard` are `async`. When the resolved address is empty they return a typed `ShardUnownedError` (stable message: shard `<id>` has no owner) instead of building a connection, and mark the topology stale. At the start of each call, a set flag triggers one awaited, coalesced `refresh_topology` before resolving, at most once per `STALE_REFRESH_MIN_INTERVAL` (first stale call after a failure refreshes immediately), so a recovered shard is picked up on the next attempt without an RPC having to fail.
- `ClusterTopology::all_addresses` drops empty addresses (it feeds pool prepopulation and refresh candidates), and `random_shard` only draws shards whose effective address (redirect override or owner) is non-empty, so `client_for_random_shard` never connects to an empty address either. No code path passes an empty address to `get_or_connect`.
- `client_for_random_shard` (the worker poll path) is async as well: it refreshes a stale topology on entry and marks the topology stale when the topology has shards but none is routable, so a worker-only client re-discovers once a shard regains an owner instead of staying on the cached unowned topology.
- `classify_error` and `handle_routing_error` are unchanged; this error never reaches them because no RPC is made.
- `silo-bench`'s call sites take the async signatures; its enqueue loop already logs and retries on `client_for_tenant` errors, so it recovers without changes. Its `--tenant-prefix` help now says tenants are always named `<prefix>-0` through `<prefix>-N-1`.

## Review notes

- The counting cluster-info test server now serves a shared, swappable response so tests can change the topology between calls; its call counter is what the "exactly one refresh" assertions read.
- The topology `RwLock` is never held across an await; the stale bookkeeping uses a std mutex held only for the due check.
