### PR TITLE
Harden the placement-ring changes after review

### DIFF
--- a/siloctl/src/lib.rs
+++ b/siloctl/src/lib.rs
@@ -77,12 +77,15 @@ pub struct ShardUnownedError {
 
 impl std::fmt::Display for ShardUnownedError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let advertised = if self.advertised_rings.is_empty() {
+            "(none)".to_string()
+        } else {
+            self.advertised_rings.join(", ")
+        };
         write!(
             f,
             "shard `{}` has no owner; its placement ring `{}` has no members (members advertise: `{}`)",
-            self.shard_id,
-            self.ring,
-            self.advertised_rings.join(", ")
+            self.shard_id, self.ring, advertised
         )
     }
 }

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -133,7 +133,7 @@ impl ShardOwnerMap {
     /// This is the desired assignment from current membership, so a shard
     /// appears here only when no member is eligible for its ring -- not while
     /// an eligible owner is still acquiring it.
-    pub fn unassigned_shards(&self) -> BTreeMap<ShardId, String> {
+    pub fn unassigned_shards(&self) -> UnassignedShards {
         self.shard_map
             .shards()
             .iter()
@@ -146,7 +146,16 @@ impl ShardOwnerMap {
     }
 }
 
+/// Unassigned shards keyed by id, each with the ring it is stranded on.
+pub type UnassignedShards = BTreeMap<ShardId, String>;
+
 /// Label under which default-ring shards are reported (metrics, logs).
+///
+/// A shard with no ring set and a shard explicitly pinned to a ring named
+/// `default` both render under this label, although [`member_in_ring`] treats
+/// them differently (members with no rings configured are eligible only for
+/// the former). Pinning a shard to the literal `default` is not a supported
+/// configuration, so the two are not distinguished here.
 pub const DEFAULT_RING_LABEL: &str = "default";
 
 /// Error type for coordination operations

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,8 +208,8 @@ async fn main() -> anyhow::Result<()> {
         ))
     });
 
-    // Periodic placement sample: reports the coordinator's owned shard set so
-    // dashboards and alerts see what this node actually owns.
+    // Periodic placement sample: owned-shard count, per-ring unassigned count,
+    // and a warn/info line when a shard is stranded / recovers.
     let placement_metrics_handle = metrics.as_ref().map(|m| {
         let shutdown = shutdown_tx.subscribe();
         tokio::spawn(silo::placement_metrics::run_sampler(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1869,6 +1869,11 @@ fn register<C: Collector + Clone + 'static>(registry: &Registry, metric: C) -> C
     metric
 }
 
+/// How often the placement sampler (`crate::placement_metrics`) reads the
+/// coordinator. Bounds the staleness of `silo_shards_owned` and
+/// `silo_shards_unassigned`; both HELP texts quote this value.
+pub const PLACEMENT_SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
+
 /// Initialize the metrics system with a Prometheus registry.
 ///
 /// Returns a `Metrics` handle that can be cloned and passed to components.
@@ -2040,7 +2045,7 @@ pub fn init() -> anyhow::Result<Metrics> {
             format!(
                 "Number of shards this node owns (acquired from the coordinator and opened); \
                  sampled every {}s, which bounds staleness",
-                crate::placement_metrics::SAMPLE_INTERVAL.as_secs()
+                PLACEMENT_SAMPLE_INTERVAL.as_secs()
             ),
         )?,
     );
@@ -2056,7 +2061,7 @@ pub fn init() -> anyhow::Result<Metrics> {
                      because no current member is eligible for that ring -- this reflects \
                      desired assignment, not acquisition state; sampled every {}s, which \
                      bounds staleness",
-                    crate::placement_metrics::SAMPLE_INTERVAL.as_secs()
+                    PLACEMENT_SAMPLE_INTERVAL.as_secs()
                 ),
             ),
             &["ring"],

--- a/src/placement_metrics.rs
+++ b/src/placement_metrics.rs
@@ -7,24 +7,22 @@
 //! trait object and feeds them to a single-pass sampler that sets the gauges
 //! and logs strand transitions, so the gauges are scrape-time values that lag
 //! reality by at most one interval.
+//!
+//! The owned set is inserted into after a shard is acquired and opened; the
+//! one exception is a split, which pre-adds both children before opening them
+//! and removes the ones this node does not keep, so `silo_shards_owned` can
+//! transiently include a not-yet-open child while a split is committing.
 
-use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::sync::Arc;
-use std::time::Duration;
 
 use tokio::sync::broadcast;
 use tracing::{debug, info, warn};
 
+pub use crate::coordination::UnassignedShards;
 use crate::coordination::{Coordinator, ShardOwnerMap};
-use crate::metrics::Metrics;
+use crate::metrics::{Metrics, PLACEMENT_SAMPLE_INTERVAL};
 use crate::shard_range::ShardId;
-
-/// How often the driver samples the coordinator. Bounds the staleness of the
-/// placement gauges; the HELP text of each gauge quotes this value.
-pub const SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
-
-/// Unassigned shards keyed by id, each with the ring it is stranded on.
-pub type UnassignedShards = BTreeMap<ShardId, String>;
 
 /// The shards that changed unassigned state between two sampler passes.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -55,30 +53,37 @@ pub fn unassigned_transitions(
 
 /// One sampler pass.
 ///
-/// Sets `silo_shards_owned` from this node's owned shard list and
-/// `silo_shards_unassigned{ring}` from the owner map, clearing ring labels
-/// that no longer have unassigned shards. Logs a `warn` for each shard that
-/// became unassigned since `previous` and an `info` for each that regained an
-/// owner, and returns the current unassigned set for the next pass.
+/// Always sets `silo_shards_owned` from this node's owned shard list. When the
+/// owner map is available, also sets `silo_shards_unassigned{ring}` from it,
+/// clears ring labels that no longer have unassigned shards, logs a `warn` for
+/// each shard that became unassigned since `previous` and an `info` for each
+/// that regained an owner, and returns the current unassigned set for the next
+/// pass. Without an owner map (the driver could not read it) the unassigned
+/// side is left untouched and `previous` is returned unchanged, so the owned
+/// gauge never goes stale because of an owner-map failure.
 pub fn sample(
     metrics: &Metrics,
     owned: &[ShardId],
-    owner_map: &ShardOwnerMap,
+    owner_map: Option<&ShardOwnerMap>,
     previous: &UnassignedShards,
 ) -> UnassignedShards {
     metrics.set_shards_owned(owned.len() as u64);
 
+    let Some(owner_map) = owner_map else {
+        return previous.clone();
+    };
     let current = owner_map.unassigned_shards();
 
-    let mut per_ring: BTreeMap<&str, u64> = BTreeMap::new();
+    let mut per_ring: std::collections::BTreeMap<&str, u64> = std::collections::BTreeMap::new();
     for ring in current.values() {
         *per_ring.entry(ring).or_default() += 1;
     }
     for (ring, count) in &per_ring {
         metrics.set_shards_unassigned(ring, *count);
     }
-    for ring in previous.values() {
-        if !per_ring.contains_key(ring.as_str()) {
+    let previous_rings: BTreeSet<&str> = previous.values().map(String::as_str).collect();
+    for ring in previous_rings {
+        if !per_ring.contains_key(ring) {
             metrics.clear_shards_unassigned(ring);
         }
     }
@@ -102,40 +107,45 @@ pub fn sample(
     current
 }
 
-/// Drive [`sample`] from the coordinator every [`SAMPLE_INTERVAL`] until the
-/// shutdown broadcast fires. Spawned from `main` when metrics are enabled.
+/// Drive [`sample`] from the coordinator every [`PLACEMENT_SAMPLE_INTERVAL`]
+/// until the shutdown broadcast fires. Spawned from `main` when metrics are
+/// enabled. The owner-map read is raced against shutdown so a hung
+/// coordination backend cannot delay process exit.
 pub async fn run_sampler(
     coordinator: Arc<dyn Coordinator>,
     metrics: Metrics,
     mut shutdown: broadcast::Receiver<()>,
 ) {
-    let mut ticker = tokio::time::interval(SAMPLE_INTERVAL);
+    let mut ticker = tokio::time::interval(PLACEMENT_SAMPLE_INTERVAL);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut previous = UnassignedShards::new();
 
     debug!(
-        interval_ms = SAMPLE_INTERVAL.as_millis() as u64,
+        interval_ms = PLACEMENT_SAMPLE_INTERVAL.as_millis() as u64,
         "placement metrics sampler started"
     );
 
     loop {
         tokio::select! {
             biased;
-            _ = shutdown.recv() => {
-                debug!("placement metrics sampler shutting down");
-                break;
-            }
-            _ = ticker.tick() => {
-                let owner_map = match coordinator.get_shard_owner_map().await {
-                    Ok(map) => map,
-                    Err(e) => {
-                        warn!(error = %e, "placement metrics sampler: could not read the shard owner map, skipping this pass");
-                        continue;
-                    }
-                };
-                let owned = coordinator.owned_shards().await;
-                previous = sample(&metrics, &owned, &owner_map, &previous);
-            }
+            _ = shutdown.recv() => break,
+            _ = ticker.tick() => {}
         }
+
+        let owner_map = tokio::select! {
+            biased;
+            _ = shutdown.recv() => break,
+            result = coordinator.get_shard_owner_map() => match result {
+                Ok(map) => Some(map),
+                Err(e) => {
+                    warn!(error = %e, "placement metrics sampler: could not read the shard owner map; unassigned gauge not updated this pass");
+                    None
+                }
+            },
+        };
+        let owned = coordinator.owned_shards().await;
+        previous = sample(&metrics, &owned, owner_map.as_ref(), &previous);
     }
+
+    debug!("placement metrics sampler shutting down");
 }

--- a/src/routing_client.rs
+++ b/src/routing_client.rs
@@ -75,19 +75,18 @@ impl ClusterTopology {
     /// Get a random shard ID among the shards that have an effective address
     /// (redirect override or owner). Unowned shards are never drawn.
     pub fn random_shard(&self) -> Option<&str> {
-        let routable: Vec<&str> = self
-            .shard_owners
+        use rand::seq::IteratorRandom;
+        self.shard_owners
             .iter()
-            .map(|owner| owner.shard_id.as_str())
-            .filter(|shard_id| {
-                self.address_for_shard(shard_id)
-                    .is_some_and(|addr| !addr.is_empty())
+            .filter(|owner| {
+                let effective = self
+                    .shard_addr_overrides
+                    .get(&owner.shard_id)
+                    .unwrap_or(&owner.grpc_addr);
+                !effective.is_empty()
             })
-            .collect();
-        if routable.is_empty() {
-            return None;
-        }
-        Some(routable[rand::random_range(0..routable.len())])
+            .map(|owner| owner.shard_id.as_str())
+            .choose(&mut rand::rng())
     }
 
     /// Get all unique server addresses (including overrides). Shards with no

--- a/tests/placement_metrics_tests.rs
+++ b/tests/placement_metrics_tests.rs
@@ -70,7 +70,7 @@ fn sample_sets_shards_owned_to_owned_count() {
     let owned = vec![ShardId::new(), ShardId::new(), ShardId::new()];
     let owner_map = owner_map_with_rings(&[None], &[]);
 
-    placement_metrics::sample(&metrics, &owned, &owner_map, &UnassignedShards::new());
+    placement_metrics::sample(&metrics, &owned, Some(&owner_map), &UnassignedShards::new());
 
     assert_eq!(
         gauge_value(&metrics, "silo_shards_owned", &[]),
@@ -89,10 +89,10 @@ fn later_pass_replaces_shards_owned() {
     placement_metrics::sample(
         &metrics,
         &[ShardId::new(), ShardId::new(), ShardId::new()],
-        &owner_map,
+        Some(&owner_map),
         &none,
     );
-    placement_metrics::sample(&metrics, &[ShardId::new()], &owner_map, &none);
+    placement_metrics::sample(&metrics, &[ShardId::new()], Some(&owner_map), &none);
 
     assert_eq!(
         gauge_value(&metrics, "silo_shards_owned", &[]),
@@ -107,7 +107,8 @@ fn sample_reports_unassigned_shard_under_its_ring_and_clears_when_assigned() {
     let stranded = owner_map_with_rings(&[Some("heavy"), None], &[0]);
     let recovered = owner_map_with_rings(&[Some("heavy"), None], &[]);
 
-    let unassigned = placement_metrics::sample(&metrics, &[], &stranded, &UnassignedShards::new());
+    let unassigned =
+        placement_metrics::sample(&metrics, &[], Some(&stranded), &UnassignedShards::new());
 
     assert_eq!(
         gauge_value(&metrics, "silo_shards_unassigned", &[("ring", "heavy")]),
@@ -120,7 +121,7 @@ fn sample_reports_unassigned_shard_under_its_ring_and_clears_when_assigned() {
         "the pass returns the unassigned set for the next pass to diff against"
     );
 
-    let unassigned = placement_metrics::sample(&metrics, &[], &recovered, &unassigned);
+    let unassigned = placement_metrics::sample(&metrics, &[], Some(&recovered), &unassigned);
 
     let heavy = gauge_value(&metrics, "silo_shards_unassigned", &[("ring", "heavy")]);
     assert!(
@@ -128,6 +129,66 @@ fn sample_reports_unassigned_shard_under_its_ring_and_clears_when_assigned() {
         "silo_shards_unassigned{{ring=\"heavy\"}} after the shard regains an owner: expected absent or 0, got {heavy:?}"
     );
     assert!(unassigned.is_empty(), "no shard is unassigned any more");
+}
+
+#[silo::test]
+fn sample_clears_only_the_ring_that_recovered() {
+    let metrics = metrics::init().expect("init metrics");
+    let both_stranded = owner_map_with_rings(&[Some("heavy"), None], &[0, 1]);
+    let heavy_recovered = owner_map_with_rings(&[Some("heavy"), None], &[1]);
+
+    let unassigned = placement_metrics::sample(
+        &metrics,
+        &[],
+        Some(&both_stranded),
+        &UnassignedShards::new(),
+    );
+    assert_eq!(
+        gauge_value(&metrics, "silo_shards_unassigned", &[("ring", "heavy")]),
+        Some(1.0)
+    );
+    assert_eq!(
+        gauge_value(&metrics, "silo_shards_unassigned", &[("ring", "default")]),
+        Some(1.0)
+    );
+
+    placement_metrics::sample(&metrics, &[], Some(&heavy_recovered), &unassigned);
+
+    let heavy = gauge_value(&metrics, "silo_shards_unassigned", &[("ring", "heavy")]);
+    assert!(
+        heavy.is_none_or(|v| v == 0.0),
+        "heavy ring clears once its shard has an owner, got {heavy:?}"
+    );
+    assert_eq!(
+        gauge_value(&metrics, "silo_shards_unassigned", &[("ring", "default")]),
+        Some(1.0),
+        "the default ring's series is retained while its shard is still unassigned"
+    );
+}
+
+#[silo::test]
+fn sample_without_owner_map_still_updates_shards_owned() {
+    let metrics = metrics::init().expect("init metrics");
+    let stranded = owner_map_with_rings(&[Some("heavy")], &[0]);
+    let previous =
+        placement_metrics::sample(&metrics, &[], Some(&stranded), &UnassignedShards::new());
+
+    let returned = placement_metrics::sample(&metrics, &[ShardId::new()], None, &previous);
+
+    assert_eq!(
+        gauge_value(&metrics, "silo_shards_owned", &[]),
+        Some(1.0),
+        "the owned gauge is set even when the owner map could not be read"
+    );
+    assert_eq!(
+        gauge_value(&metrics, "silo_shards_unassigned", &[("ring", "heavy")]),
+        Some(1.0),
+        "the unassigned gauge is left as it was"
+    );
+    assert_eq!(
+        returned, previous,
+        "the previous unassigned set carries over to the next pass"
+    );
 }
 
 #[silo::test]

--- a/tests/routing_client_tests.rs
+++ b/tests/routing_client_tests.rs
@@ -9,7 +9,7 @@ use futures::future::join_all;
 use grpc_integration_helpers::{setup_multi_shard_server, shutdown_server};
 use silo::pb::silo_server::{Silo, SiloServer};
 use silo::pb::*;
-use silo::routing_client::{ErrorAction, RoutingClient};
+use silo::routing_client::{ErrorAction, RoutingClient, ShardUnownedError};
 use silo::settings::AppConfig;
 use tokio::net::TcpListener;
 use tonic::transport::Server;
@@ -869,6 +869,13 @@ async fn routing_client_tenant_on_unowned_shard_fails_without_connecting() -> an
 
         assert_eq!(err.to_string(), "shard `counting-shard` has no owner");
         assert_eq!(
+            err.downcast_ref::<ShardUnownedError>(),
+            Some(&ShardUnownedError {
+                shard_id: "counting-shard".to_string()
+            }),
+            "the error is the typed no-owner error, not just its message"
+        );
+        assert_eq!(
             client.connection_count(),
             connections_before,
             "no connection may be created for an empty address"
@@ -970,7 +977,8 @@ async fn routing_client_stale_refresh_is_rate_limited() -> anyhow::Result<()> {
 
         // First failure marks the topology stale; the second call refreshes
         // (still unowned, so it fails again); the third is inside the minimum
-        // interval and must not refresh again.
+        // interval and must not refresh again. This assumes the three calls
+        // (one localhost round trip) complete within STALE_REFRESH_MIN_INTERVAL.
         for _ in 0..3 {
             client
                 .client_for_tenant("bench-0")
@@ -1023,6 +1031,62 @@ async fn routing_client_random_shard_recovers_once_a_shard_gets_an_owner() -> an
             2,
             "exactly one topology refresh between the failure and the success"
         );
+
+        shutdown_counting_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+#[silo::test(flavor = "multi_thread")]
+async fn routing_client_never_routes_to_an_unowned_shard() -> anyhow::Result<()> {
+    tokio::time::timeout(Duration::from_millis(15000), async {
+        let (shutdown_tx, server, addr, _request_count, response, client) =
+            discover_stranded().await?;
+        let server_addr = format!("http://{}", addr);
+
+        // With the only shard unowned there is no server address in the
+        // topology and nothing to draw a random shard from.
+        let topology = client.topology();
+        assert!(
+            topology.all_addresses().is_empty(),
+            "an empty owner address is not a server: {:?}",
+            topology.all_addresses()
+        );
+        assert_eq!(topology.random_shard(), None);
+        let err = client
+            .client_for_random_shard()
+            .await
+            .expect_err("no routable shard");
+        assert!(
+            err.to_string().contains("no shards available"),
+            "unexpected error: {err}"
+        );
+
+        // With one owned and one unowned shard, every draw lands on the owned one.
+        let mut two_shards = one_shard_response(&server_addr, &server_addr);
+        two_shards.shard_owners[0].range_end = "8000000000000000".to_string();
+        two_shards.shard_owners.push(ShardOwner {
+            shard_id: "stranded-shard".to_string(),
+            grpc_addr: String::new(),
+            node_id: String::new(),
+            range_start: "8000000000000000".to_string(),
+            range_end: String::new(),
+            placement_ring: Some("heavy".to_string()),
+        });
+        two_shards.num_shards = 2;
+        *response.lock().unwrap() = two_shards;
+        assert!(client.refresh_topology().await, "refresh succeeds");
+
+        let topology = client.topology();
+        assert_eq!(topology.all_addresses(), vec![server_addr.clone()]);
+        for _ in 0..50 {
+            assert_eq!(topology.random_shard(), Some("counting-shard"));
+            let (_client, shard) = client.client_for_random_shard().await?;
+            assert_eq!(shard, "counting-shard");
+        }
 
         shutdown_counting_server(shutdown_tx, server).await?;
         Ok::<(), anyhow::Error>(())

--- a/tests/siloctl_tests.rs
+++ b/tests/siloctl_tests.rs
@@ -1887,7 +1887,7 @@ mod stranded {
 
     impl StrandedCoordinator {
         /// Two shards; the first is pinned to [`STRANDED_RING`].
-        async fn new(grpc_addr: &str) -> (Self, ShardId) {
+        fn new(grpc_addr: &str) -> (Self, ShardId) {
             let mut shard_map = ShardMap::create_initial(2).expect("create shard map");
             let stranded = shard_map.shard_ids()[0];
             shard_map
@@ -1942,7 +1942,7 @@ mod stranded {
             let mut shard_map = self.base.shard_map.lock().await;
             let shard = shard_map
                 .get_shard_mut(shard_id)
-                .ok_or_else(|| CoordinationError::ShardNotFound(*shard_id))?;
+                .ok_or(CoordinationError::ShardNotFound(*shard_id))?;
             let previous = shard.placement_ring.clone();
             let current = ring.map(|s| s.to_string());
             shard.placement_ring = current.clone();
@@ -2005,7 +2005,7 @@ mod stranded {
         let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
         let addr = listener.local_addr()?;
         let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
-        let (coordinator, stranded) = StrandedCoordinator::new(&format!("http://{}", addr)).await;
+        let (coordinator, stranded) = StrandedCoordinator::new(&format!("http://{}", addr));
         let server = tokio::spawn(run_server(
             listener,
             Arc::new(ShardFactory::new_noop()),
@@ -2131,8 +2131,9 @@ async fn siloctl_configure_unowned_shard_onto_unpopulated_ring_is_still_validate
         .expect_err("moving a stranded shard onto another unpopulated ring must be refused");
         let err_str = err.to_string();
         assert!(
-            err_str.contains("another-empty-ring") && err_str.contains("no members"),
-            "error should carry the server's validation message: {}",
+            err_str.contains("placement ring 'another-empty-ring' has no members")
+                && !err_str.contains("has no owner"),
+            "error should carry the server's validation message, not the client-side no-owner error: {}",
             err_str
         );
 


### PR DESCRIPTION
## Why

A review of the placement-ring stack (#392-#396) found no blocking issues but a handful of robustness gaps that are cheaper to land together than to fold back into each PR.

## What

- Placement sampler: `silo_shards_owned` is set even when the owner-map read fails (the owned set does not depend on it), and the owner-map read is raced against shutdown so a hung coordination backend cannot delay process exit. The sampler clears a ring's series once per ring rather than once per shard.
- `RoutingClient::random_shard` draws in a single pass with a direct override lookup instead of rescanning the owner list per shard under the topology lock.
- `siloctl`'s no-owner error renders `(none)` when the cluster-info response lists no members.
- Housekeeping: the sampling interval constant lives beside the gauge registrations in `metrics`; the `UnassignedShards` alias lives in `coordination` beside its producer; `DEFAULT_RING_LABEL` documents that a shard explicitly pinned to a ring literally named `default` renders under the same label.

## Tests added

Owner-map failure path for the sampler; one ring clearing while another stays unassigned; `all_addresses` dropping empty owners and random draws skipping unowned shards; a downcast assertion that the routing client's error is the typed `ShardUnownedError`; a stronger assertion that `siloctl`'s configure fallback reaches the server's validation rather than the client-side error.
