### PR TITLE
Make concurrency test dequeues robust to broker buffer scan lag

### DIFF
--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2110,14 +2110,7 @@ async fn grant_scanner_handles_backlog_larger_than_status_lookup_concurrency() {
             .await
             .unwrap();
     }
-    let mut holder_tasks = Vec::with_capacity(N);
-    while holder_tasks.len() < N {
-        let tasks = shard.dequeue("w", "tg", N).await.unwrap().tasks;
-        assert!(!tasks.is_empty(), "dequeue should return holders");
-        for t in tasks {
-            holder_tasks.push(t.attempt().task_id().to_string());
-        }
-    }
+    let holder_tasks = dequeue_task_ids_until(&shard, "w", "tg", N).await;
 
     // Enqueue N more — capacity is full, so each becomes a request record.
     for i in 0..N {
@@ -2211,14 +2204,7 @@ async fn grant_scanner_drains_backlog_larger_than_max_per_pass() {
             .await
             .unwrap();
     }
-    let mut holder_tasks = Vec::with_capacity(N);
-    while holder_tasks.len() < N {
-        let tasks = shard.dequeue("w", "tg", N).await.unwrap().tasks;
-        assert!(!tasks.is_empty(), "dequeue should return holders");
-        for t in tasks {
-            holder_tasks.push(t.attempt().task_id().to_string());
-        }
-    }
+    let holder_tasks = dequeue_task_ids_until(&shard, "w", "tg", N).await;
 
     // Enqueue N waiters — each becomes a request (capacity is full).
     for i in 0..N {
@@ -2307,13 +2293,7 @@ async fn grant_scanner_full_queue_cleans_stale_bounded() {
             .await
             .unwrap();
     }
-    let mut holder_tasks = Vec::with_capacity(LIMIT);
-    while holder_tasks.len() < LIMIT {
-        let tasks = shard.dequeue("w", "tg", LIMIT).await.unwrap().tasks;
-        for t in tasks {
-            holder_tasks.push(t.attempt().task_id().to_string());
-        }
-    }
+    let holder_tasks = dequeue_task_ids_until(&shard, "w", "tg", LIMIT).await;
 
     // Inject a large backlog of stale requests (nonexistent jobs).
     for i in 0..BACKLOG {
@@ -2941,13 +2921,7 @@ async fn grant_scanner_caps_grants_at_free_capacity() {
             .await
             .unwrap();
     }
-    let mut holder_tasks = Vec::new();
-    while holder_tasks.len() < LIMIT {
-        let tasks = shard.dequeue("w", "tg", LIMIT).await.unwrap().tasks;
-        for t in tasks {
-            holder_tasks.push(t.attempt().task_id().to_string());
-        }
-    }
+    let holder_tasks = dequeue_task_ids_until(&shard, "w", "tg", LIMIT).await;
 
     // Enqueue WAITERS valid waiters — queue is full, so each becomes a request.
     for i in 0..WAITERS {
@@ -6783,8 +6757,7 @@ async fn grant_scanner_live_headroom_reserves_slots_for_immediate_grants() {
             .expect("enqueue");
     }
     assert_eq!(count_concurrency_holders(shard.db()).await, 10);
-    let tasks = shard.dequeue("w", "tg", 10).await.expect("dequeue").tasks;
-    assert_eq!(tasks.len(), 10);
+    let tasks = dequeue_task_ids_until(&shard, "w", "tg", 10).await;
 
     // Two deferred waiters for the scanner to drain later.
     for i in 0..2 {
@@ -6817,12 +6790,9 @@ async fn grant_scanner_live_headroom_reserves_slots_for_immediate_grants() {
 
     // Free four slots (holders 10 -> 6): the scanner grants only back up to
     // its effective cap of 8.
-    for task in tasks.iter().take(4) {
+    for task_id in tasks.iter().take(4) {
         shard
-            .report_attempt_outcome(
-                &task.attempt().task_id().to_string(),
-                AttemptOutcome::Success { result: vec![] },
-            )
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: vec![] })
             .await
             .expect("release");
     }

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -520,3 +520,35 @@ where
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 }
+
+/// Dequeue from `task_group` until `n` tasks have been collected, returning
+/// their task_ids. The broker buffer is filled asynchronously by a background
+/// DB scan, so a single `dequeue` call can return a partial or empty batch
+/// under CPU load; this accumulates across calls, bounded by a deadline so a
+/// real task loss fails loudly instead of hanging.
+pub async fn dequeue_task_ids_until(
+    shard: &JobStoreShard,
+    worker: &str,
+    task_group: &str,
+    n: usize,
+) -> Vec<String> {
+    let mut task_ids = Vec::with_capacity(n);
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while task_ids.len() < n {
+        let batch = shard
+            .dequeue(worker, task_group, n - task_ids.len())
+            .await
+            .expect("dequeue")
+            .tasks;
+        task_ids.extend(batch.iter().map(|t| t.attempt().task_id().to_string()));
+        if task_ids.len() < n {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for {n} ready tasks; got {}",
+                task_ids.len()
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+    task_ids
+}


### PR DESCRIPTION
The grant-scanner concurrency tests collect their initial holder tasks assuming every `dequeue` call makes visible progress: `grant_scanner_live_headroom_reserves_slots_for_immediate_grants` asserted that a single call returns all 10 granted tasks, `grant_scanner_handles_backlog_larger_than_status_lookup_concurrency` and `grant_scanner_drains_backlog_larger_than_max_per_pass` asserted every iteration of their drain loop returns a non-empty batch, and `grant_scanner_full_queue_cleans_stale_bounded` and `grant_scanner_caps_grants_at_free_capacity` looped with no bound at all. The broker buffer is filled asynchronously by a background DB scan, and `claim_ready_or_nudge` in `src/task_broker.rs` polls for only ~25ms before returning an empty batch -- so under heavy parallel `cargo test` load a dequeue can legitimately come back partial or empty even though the tasks exist in the DB. The headroom test failed intermittently this way when the full suite ran in parallel, and the unbounded loops would spin forever if a task were genuinely lost.

This adds a `dequeue_task_ids_until` helper to the shared test helpers that accumulates task ids across repeated `dequeue` calls until the expected count arrives, bounded by a 30-second deadline that fails loudly with the count collected so far, and routes all five call sites through it.

Verified with the full `job_store_shard_concurrency_tests` suite plus repeated runs of the affected tests under six-way concurrent CPU contention.