### PR TITLE
Harden silo worker against duplicate delivery and lost leases

### DIFF
--- a/typescript_client/src/TaskExecution.ts
+++ b/typescript_client/src/TaskExecution.ts
@@ -7,7 +7,7 @@ export type { ConcurrencyLimit, FloatingConcurrencyLimit, GubernatorRateLimit } 
 /**
  * Reason why a task was cancelled.
  */
-export type CancellationReason = "server" | "client";
+export type CancellationReason = "server" | "client" | "lease-lost";
 
 /**
  * A task received from Silo, with the payload decoded.
@@ -98,6 +98,8 @@ export class TaskExecution<
   private readonly _taskAbortController: AbortController;
   /** Whether the task has been cancelled (by server or client) */
   private _cancelled: boolean = false;
+  /** Whether the worker discovered mid-execution that it no longer holds the lease */
+  private _leaseLost: boolean = false;
   /** The reason for cancellation if cancelled */
   private _cancellationReason: CancellationReason | undefined;
   /** Promise resolving when cancel RPC completes (if initiated by client) */
@@ -135,6 +137,27 @@ export class TaskExecution<
   /** Whether the task was cancelled and should report Cancelled outcome */
   get shouldReportCancelled(): boolean {
     return this._cancelled;
+  }
+
+  /** Whether the lease for this task is known to be gone (no outcome may be reported) */
+  get isLeaseLost(): boolean {
+    return this._leaseLost;
+  }
+
+  /**
+   * Mark the lease as lost and cancel the execution.
+   * One-shot: returns true only for the call that performs the transition,
+   * so concurrent in-flight heartbeat failures surface the event once.
+   */
+  public markLeaseLost(): boolean {
+    if (this._leaseLost) return false;
+    this._leaseLost = true;
+    if (!this._cancelled) {
+      this._cancelled = true;
+      this._cancellationReason = "lease-lost";
+      this._taskAbortController.abort();
+    }
+    return true;
   }
 
   /**

--- a/typescript_client/src/TaskExecution.ts
+++ b/typescript_client/src/TaskExecution.ts
@@ -100,6 +100,8 @@ export class TaskExecution<
   private _cancelled: boolean = false;
   /** Whether the worker discovered mid-execution that it no longer holds the lease */
   private _leaseLost: boolean = false;
+  /** Whether the handler has settled (outcome reporting is underway or done) */
+  private _settled: boolean = false;
   /** The reason for cancellation if cancelled */
   private _cancellationReason: CancellationReason | undefined;
   /** Promise resolving when cancel RPC completes (if initiated by client) */
@@ -142,6 +144,20 @@ export class TaskExecution<
   /** Whether the lease for this task is known to be gone (no outcome may be reported) */
   get isLeaseLost(): boolean {
     return this._leaseLost;
+  }
+
+  /** Whether the handler has settled (outcome reporting is underway or done) */
+  get isSettled(): boolean {
+    return this._settled;
+  }
+
+  /**
+   * Mark the handler as settled. Heartbeat responses that land after this
+   * point are meaningless: outcome reporting releases the lease, so a late
+   * lease-gone rejection is the routine completion race, not a lost lease.
+   */
+  public markSettled(): void {
+    this._settled = true;
   }
 
   /**

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -84,11 +84,40 @@ export class TaskNotFoundError extends Error {
 
   /** The task ID that was not found */
   public readonly taskId: string;
+  /**
+   * The underlying gRPC status message, when mapped from an RPC failure.
+   * Distinguishes NOT_FOUND flavors: a missing lease ("lease not found")
+   * vs exhausted shard routing ("shard not found").
+   */
+  public readonly grpcMessage?: string;
 
-  constructor(taskId: string) {
-    super(`Task "${taskId}" not found`);
+  constructor(taskId: string, grpcMessage?: string) {
+    super(`Task "${taskId}" not found${grpcMessage ? `: ${grpcMessage}` : ""}`);
     this.name = "TaskNotFoundError";
     this.taskId = taskId;
+    this.grpcMessage = grpcMessage;
+  }
+}
+
+/**
+ * Error reported when a worker discovers mid-execution that it no longer
+ * holds a task's lease (the lease record is gone or another worker owns it).
+ * The worker cancels the execution and reports no outcome for the task.
+ */
+export class TaskLeaseLostError extends Error {
+  code = "SILO_TASK_LEASE_LOST";
+
+  /** The task whose lease was lost */
+  public readonly taskId: string;
+  /** The job the task belongs to */
+  public readonly jobId: string;
+
+  constructor(taskId: string, jobId: string, cause: Error) {
+    super(`Lease lost for task "${taskId}" (job "${jobId}"): ${cause.message}`);
+    this.name = "TaskLeaseLostError";
+    this.taskId = taskId;
+    this.jobId = jobId;
+    this.cause = cause;
   }
 }
 
@@ -1081,7 +1110,7 @@ function mapRpcError(error: unknown, context: RpcErrorContext): Error {
   switch (error.code) {
     case "NOT_FOUND":
       if (context.taskId) {
-        return new TaskNotFoundError(context.taskId);
+        return new TaskNotFoundError(context.taskId, error.message);
       }
       if (context.jobId) {
         return new JobNotFoundError(context.jobId, context.tenant);

--- a/typescript_client/src/client.ts
+++ b/typescript_client/src/client.ts
@@ -93,6 +93,27 @@ export class TaskNotFoundError extends Error {
 }
 
 /**
+ * Error reported when a worker receives a task it is already executing.
+ * The duplicate delivery is dropped; the original execution continues.
+ */
+export class DuplicateTaskDeliveryError extends Error {
+  code = "SILO_DUPLICATE_TASK_DELIVERY";
+
+  /** The task ID that was delivered twice */
+  public readonly taskId: string;
+  /** The job ID the task belongs to, if known */
+  public readonly jobId?: string;
+
+  constructor(taskId: string, jobId?: string) {
+    const jobMsg = jobId ? ` for job "${jobId}"` : "";
+    super(`Task "${taskId}"${jobMsg} delivered while already executing on this worker`);
+    this.name = "DuplicateTaskDeliveryError";
+    this.taskId = taskId;
+    this.jobId = jobId;
+  }
+}
+
+/**
  * Base class for errors translated from gRPC status codes.
  */
 export class SiloGrpcError extends Error {

--- a/typescript_client/src/index.ts
+++ b/typescript_client/src/index.ts
@@ -6,6 +6,7 @@ export {
   JobAlreadyExistsError,
   JobNotTerminalError,
   TaskNotFoundError,
+  DuplicateTaskDeliveryError,
   SiloGrpcError,
   SiloNotFoundError,
   SiloAlreadyExistsError,

--- a/typescript_client/src/index.ts
+++ b/typescript_client/src/index.ts
@@ -6,6 +6,7 @@ export {
   JobAlreadyExistsError,
   JobNotTerminalError,
   TaskNotFoundError,
+  TaskLeaseLostError,
   DuplicateTaskDeliveryError,
   SiloGrpcError,
   SiloNotFoundError,

--- a/typescript_client/src/metrics.ts
+++ b/typescript_client/src/metrics.ts
@@ -14,6 +14,8 @@ export class WorkerMetrics {
   readonly emptyPollCounter: Counter<Attributes>;
   /** Counter tracking the total number of tasks returned from polls. */
   readonly pollTasksReturnedCounter: Counter<Attributes>;
+  /** Counter incremented when a delivered task is dropped because it is already executing. */
+  readonly duplicateTaskDeliveriesCounter: Counter<Attributes>;
   /** Gauge reporting the number of available task slots (maxConcurrentTasks - active - queued). */
   readonly availableTaskSlots: ObservableGauge<Attributes>;
   /** Default attributes applied to all metric recordings. */
@@ -33,6 +35,13 @@ export class WorkerMetrics {
     this.pollTasksReturnedCounter = meter.createCounter("silo.worker.polls.tasks_returned", {
       description: "Total number of tasks returned from polls",
     });
+
+    this.duplicateTaskDeliveriesCounter = meter.createCounter(
+      "silo.worker.duplicate_task_deliveries",
+      {
+        description: "Number of delivered tasks dropped because the task was already executing",
+      },
+    );
 
     this.availableTaskSlots = meter.createObservableGauge("silo.worker.available_task_slots", {
       description: "Number of available task slots",

--- a/typescript_client/src/worker.ts
+++ b/typescript_client/src/worker.ts
@@ -15,9 +15,35 @@ import type {
   RefreshOutcome,
   HeartbeatResult,
 } from "./client";
-import { DuplicateTaskDeliveryError } from "./client";
+import {
+  DuplicateTaskDeliveryError,
+  SiloFailedPreconditionError,
+  TaskLeaseLostError,
+  TaskNotFoundError,
+} from "./client";
 import { Task, TaskExecution, transformTask } from "./TaskExecution";
 import { WorkerMetrics, getWorkerMeter } from "./metrics";
+
+/**
+ * Whether a heartbeat failure authoritatively signals the lease is gone.
+ *
+ * Only two signals qualify: the lease-gone flavor of NOT_FOUND (server
+ * message "lease not found") and the lease-owner-mismatch
+ * FAILED_PRECONDITION (another worker re-leased the task). Both are matched
+ * on the underlying message: a wrong-shard NOT_FOUND ("shard not found",
+ * from exhausted routing retries) and the stale-topology FAILED_PRECONDITION
+ * ("is not within shard ... range") are routing conditions, not lease state,
+ * and must not abort a running handler.
+ */
+function isLeaseGoneError(error: unknown): boolean {
+  if (error instanceof TaskNotFoundError) {
+    return error.grpcMessage?.includes("lease not found") ?? false;
+  }
+  if (error instanceof SiloFailedPreconditionError) {
+    return error.message.includes("lease owner mismatch");
+  }
+  return false;
+}
 
 /**
  * Context passed to task handlers with utilities for the current task.
@@ -570,7 +596,7 @@ export class SiloWorker<
     // taskContext — without this every Heartbeat RPC would be its own root
     // trace instead of a child of the lifecycle span.
     const heartbeatFn = otelContext.bind(taskContext, () => {
-      this._sendHeartbeatForTask(execution).catch((error) => {
+      this._sendHeartbeatForTask(execution, stopHeartbeat).catch((error) => {
         this._onError(error instanceof Error ? error : new Error(String(error)), {
           taskId: task.id,
         });
@@ -684,6 +710,11 @@ export class SiloWorker<
     // The handler has settled: no report below may race a heartbeat
     stopHeartbeat();
 
+    // The lease is gone, so any outcome report would fail NOT_FOUND
+    if (execution.isLeaseLost) {
+      return;
+    }
+
     // If the task was cancelled (by server or client), report Cancelled outcome instead
     if (execution.shouldReportCancelled) {
       await this._client.reportOutcome({
@@ -752,23 +783,59 @@ export class SiloWorker<
   /**
    * Send a heartbeat for a task execution and handle cancellation if detected.
    */
-  private async _sendHeartbeatForTask(execution: TaskExecution): Promise<void> {
+  private async _sendHeartbeatForTask(
+    execution: TaskExecution,
+    stopHeartbeat: () => void,
+  ): Promise<void> {
     // Don't send heartbeats for already-cancelled tasks
     if (execution.isCancelled) {
       return;
     }
 
-    const result: HeartbeatResult = await this._client.heartbeat(
-      this._workerId,
-      execution.task.id,
-      execution.task.shard,
-      execution.task.tenantId,
-    );
+    let result: HeartbeatResult;
+    try {
+      result = await this._client.heartbeat(
+        this._workerId,
+        execution.task.id,
+        execution.task.shard,
+        execution.task.tenantId,
+      );
+    } catch (error) {
+      if (isLeaseGoneError(error)) {
+        this._handleLeaseLost(execution, error as Error, stopHeartbeat);
+        return;
+      }
+      // Transient failures (network, UNAVAILABLE, routing) propagate to the
+      // interval's catch, which surfaces them via onError; execution continues
+      throw error;
+    }
 
     // If the server reports cancellation, mark the execution as cancelled
     if (result.cancelled) {
       execution.markCancelledByServer();
     }
+  }
+
+  /**
+   * React to an authoritative lost-lease signal: stop heartbeating, cancel
+   * the execution, free the task id for a re-delivered retry, and surface
+   * the event once.
+   */
+  private _handleLeaseLost(
+    execution: TaskExecution,
+    cause: Error,
+    stopHeartbeat: () => void,
+  ): void {
+    stopHeartbeat();
+    if (!execution.markLeaseLost()) {
+      return;
+    }
+    if (this._activeExecutions.get(execution.task.id) === execution) {
+      this._activeExecutions.delete(execution.task.id);
+    }
+    this._onError(new TaskLeaseLostError(execution.task.id, execution.task.jobId, cause), {
+      taskId: execution.task.id,
+    });
   }
 
   /**

--- a/typescript_client/src/worker.ts
+++ b/typescript_client/src/worker.ts
@@ -717,7 +717,11 @@ export class SiloWorker<
       };
     }
 
-    // The handler has settled: no report below may race a heartbeat
+    // The handler has settled: stop new heartbeat ticks, and mark the
+    // execution settled so heartbeats already on the wire are ignored when
+    // they land -- reporting the outcome releases the lease, so a late
+    // lease-gone rejection is the routine completion race, not a lost lease
+    execution.markSettled();
     stopHeartbeat();
 
     // The lease is gone, so any outcome report would fail NOT_FOUND
@@ -726,33 +730,23 @@ export class SiloWorker<
     }
 
     // If the task was cancelled (by server or client), report Cancelled outcome instead
-    try {
-      if (execution.shouldReportCancelled) {
-        await this._client.reportOutcome({
-          taskId: execution.task.id,
-          shard: execution.task.shard,
-          tenant: execution.task.tenantId,
-          outcome: { type: "cancelled" },
-        });
-        return;
-      }
-
-      // Report the outcome to the correct shard
+    if (execution.shouldReportCancelled) {
       await this._client.reportOutcome({
         taskId: execution.task.id,
         shard: execution.task.shard,
         tenant: execution.task.tenantId,
-        outcome,
+        outcome: { type: "cancelled" },
       });
-    } catch (error) {
-      // A heartbeat in flight when the handler settled can mark the lease
-      // lost while the report is on the wire; the report's failure is then
-      // expected noise -- the lease-lost event already surfaced via onError
-      if (execution.isLeaseLost) {
-        return;
-      }
-      throw error;
+      return;
     }
+
+    // Report the outcome to the correct shard
+    await this._client.reportOutcome({
+      taskId: execution.task.id,
+      shard: execution.task.shard,
+      tenant: execution.task.tenantId,
+      outcome,
+    });
   }
 
   /**
@@ -821,6 +815,13 @@ export class SiloWorker<
         execution.task.tenantId,
       );
     } catch (error) {
+      // The handler settled while this heartbeat was on the wire: outcome
+      // reporting releases the lease, so the late rejection carries no
+      // signal -- notably a lease-gone response here is the routine
+      // completion race, not a lost lease
+      if (execution.isSettled) {
+        return;
+      }
       if (isLeaseGoneError(error)) {
         this._handleLeaseLost(execution, error as Error, stopHeartbeat);
         return;

--- a/typescript_client/src/worker.ts
+++ b/typescript_client/src/worker.ts
@@ -15,6 +15,7 @@ import type {
   RefreshOutcome,
   HeartbeatResult,
 } from "./client";
+import { DuplicateTaskDeliveryError } from "./client";
 import { Task, TaskExecution, transformTask } from "./TaskExecution";
 import { WorkerMetrics, getWorkerMeter } from "./metrics";
 
@@ -531,6 +532,15 @@ export class SiloWorker<
   private _enqueueTask(protoTask: ProtoTask): void {
     const task = transformTask<Payload, Metadata>(protoTask);
 
+    // Drop a delivery of a task that is already executing: the server
+    // double-dispatched (or a lost lease was re-delivered before this worker
+    // noticed). Running it twice would double-execute user code.
+    if (this._activeExecutions.has(task.id)) {
+      this._metrics.duplicateTaskDeliveriesCounter.add(1, this._metrics.defaultAttributes);
+      this._onError(new DuplicateTaskDeliveryError(task.id, task.jobId), { taskId: task.id });
+      return;
+    }
+
     // Open a per-task lifecycle span that covers heartbeats, the user
     // handler, and the eventual reportOutcome. LeaseTasks intentionally sits
     // outside this span — a single batch lease can produce N tasks and they
@@ -607,6 +617,14 @@ export class SiloWorker<
    */
   private _enqueueRefreshTask(task: RefreshTask): void {
     const shard = task.shard;
+
+    // Refresh tasks have no TaskExecution; their heartbeat-interval map entry
+    // doubles as the currently-active marker for dedup.
+    if (this._heartbeatIntervals.has(task.id)) {
+      this._metrics.duplicateTaskDeliveriesCounter.add(1, this._metrics.defaultAttributes);
+      this._onError(new DuplicateTaskDeliveryError(task.id), { taskId: task.id });
+      return;
+    }
 
     // Start heartbeat for this refresh task (no TaskExecution needed, refresh tasks can't be cancelled)
     const heartbeatInterval = setInterval(() => {

--- a/typescript_client/src/worker.ts
+++ b/typescript_client/src/worker.ts
@@ -595,6 +595,13 @@ export class SiloWorker<
     // when setInterval was called, so we explicitly bind the heartbeat fn to
     // taskContext — without this every Heartbeat RPC would be its own root
     // trace instead of a child of the lifecycle span.
+    //
+    // stopHeartbeat is passed into the execute function so the interval stops
+    // the moment the handler settles, before the outcome report goes out — a
+    // heartbeat racing an in-flight report would NOT_FOUND against the
+    // already-deleted lease.
+    let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
+    const stopHeartbeat = (): void => clearInterval(heartbeatInterval);
     const heartbeatFn = otelContext.bind(taskContext, () => {
       this._sendHeartbeatForTask(execution, stopHeartbeat).catch((error) => {
         this._onError(error instanceof Error ? error : new Error(String(error)), {
@@ -602,12 +609,8 @@ export class SiloWorker<
         });
       });
     });
-    const heartbeatInterval = setInterval(heartbeatFn, this._heartbeatIntervalMs);
+    heartbeatInterval = setInterval(heartbeatFn, this._heartbeatIntervalMs);
     this._heartbeatIntervals.set(task.id, heartbeatInterval);
-    // Passed into the execute function so the interval stops the moment the
-    // handler settles, before the outcome report goes out — a heartbeat racing
-    // an in-flight report would NOT_FOUND against the already-deleted lease.
-    const stopHeartbeat = (): void => clearInterval(heartbeatInterval);
 
     // Add task to the queue for execution. Bind the queued callback so the
     // await chain inside (handler invocation + reportOutcome) inherits
@@ -689,6 +692,13 @@ export class SiloWorker<
     execution: TaskExecution<Payload, Metadata>,
     stopHeartbeat: () => void,
   ): Promise<void> {
+    // The lease can be lost while the task is still queued (heartbeats run
+    // from delivery, not execution start) -- never start the handler for a
+    // task this worker no longer owns
+    if (execution.isLeaseLost) {
+      return;
+    }
+
     const context: TaskContext<Payload, Metadata> = {
       task: execution.task,
       cancellationSignal: execution.signal,
@@ -716,23 +726,33 @@ export class SiloWorker<
     }
 
     // If the task was cancelled (by server or client), report Cancelled outcome instead
-    if (execution.shouldReportCancelled) {
+    try {
+      if (execution.shouldReportCancelled) {
+        await this._client.reportOutcome({
+          taskId: execution.task.id,
+          shard: execution.task.shard,
+          tenant: execution.task.tenantId,
+          outcome: { type: "cancelled" },
+        });
+        return;
+      }
+
+      // Report the outcome to the correct shard
       await this._client.reportOutcome({
         taskId: execution.task.id,
         shard: execution.task.shard,
         tenant: execution.task.tenantId,
-        outcome: { type: "cancelled" },
+        outcome,
       });
-      return;
+    } catch (error) {
+      // A heartbeat in flight when the handler settled can mark the lease
+      // lost while the report is on the wire; the report's failure is then
+      // expected noise -- the lease-lost event already surfaced via onError
+      if (execution.isLeaseLost) {
+        return;
+      }
+      throw error;
     }
-
-    // Report the outcome to the correct shard
-    await this._client.reportOutcome({
-      taskId: execution.task.id,
-      shard: execution.task.shard,
-      tenant: execution.task.tenantId,
-      outcome,
-    });
   }
 
   /**

--- a/typescript_client/src/worker.ts
+++ b/typescript_client/src/worker.ts
@@ -500,7 +500,10 @@ export class SiloWorker<
     if (totalTasksReturned === 0) {
       this._metrics.emptyPollCounter.add(1, this._metrics.defaultAttributes);
     } else {
-      this._metrics.pollTasksReturnedCounter.add(totalTasksReturned, this._metrics.defaultAttributes);
+      this._metrics.pollTasksReturnedCounter.add(
+        totalTasksReturned,
+        this._metrics.defaultAttributes,
+      );
     }
 
     // Add regular job tasks to the queue
@@ -565,12 +568,16 @@ export class SiloWorker<
     });
     const heartbeatInterval = setInterval(heartbeatFn, this._heartbeatIntervalMs);
     this._heartbeatIntervals.set(task.id, heartbeatInterval);
+    // Passed into the execute function so the interval stops the moment the
+    // handler settles, before the outcome report goes out — a heartbeat racing
+    // an in-flight report would NOT_FOUND against the already-deleted lease.
+    const stopHeartbeat = (): void => clearInterval(heartbeatInterval);
 
     // Add task to the queue for execution. Bind the queued callback so the
     // await chain inside (handler invocation + reportOutcome) inherits
     // taskContext even though p-queue defers execution to a future microtask.
     const queuedFn = otelContext.bind(taskContext, async () => {
-      await this._executeTaskWithExecution(execution);
+      await this._executeTaskWithExecution(execution, stopHeartbeat);
     });
     this._taskQueue
       .add(queuedFn)
@@ -581,14 +588,16 @@ export class SiloWorker<
         this._onError(e, { taskId: task.id });
       })
       .finally(() => {
-        // Stop heartbeat for this task
-        const interval = this._heartbeatIntervals.get(task.id);
-        if (interval) {
-          clearInterval(interval);
+        // Clear the closure-captured handle, never a map lookup: a concurrent
+        // delivery of the same task id may have replaced the map entry, and
+        // clearing the looked-up handle would orphan this delivery's interval.
+        clearInterval(heartbeatInterval);
+        if (this._heartbeatIntervals.get(task.id) === heartbeatInterval) {
           this._heartbeatIntervals.delete(task.id);
         }
-        // Remove from active executions
-        this._activeExecutions.delete(task.id);
+        if (this._activeExecutions.get(task.id) === execution) {
+          this._activeExecutions.delete(task.id);
+        }
         span.end();
       });
   }
@@ -608,11 +617,12 @@ export class SiloWorker<
       });
     }, this._heartbeatIntervalMs);
     this._heartbeatIntervals.set(task.id, heartbeatInterval);
+    const stopHeartbeat = (): void => clearInterval(heartbeatInterval);
 
     // Add to the queue for execution
     this._taskQueue
       .add(async () => {
-        await this._executeRefreshTask(task, shard);
+        await this._executeRefreshTask(task, shard, stopHeartbeat);
       })
       .catch((error) => {
         this._onError(error instanceof Error ? error : new Error(String(error)), {
@@ -620,10 +630,9 @@ export class SiloWorker<
         });
       })
       .finally(() => {
-        // Stop heartbeat
-        const interval = this._heartbeatIntervals.get(task.id);
-        if (interval) {
-          clearInterval(interval);
+        // Same closure-captured cleanup as _enqueueTask, for the same reason.
+        clearInterval(heartbeatInterval);
+        if (this._heartbeatIntervals.get(task.id) === heartbeatInterval) {
           this._heartbeatIntervals.delete(task.id);
         }
       });
@@ -634,6 +643,7 @@ export class SiloWorker<
    */
   private async _executeTaskWithExecution(
     execution: TaskExecution<Payload, Metadata>,
+    stopHeartbeat: () => void,
   ): Promise<void> {
     const context: TaskContext<Payload, Metadata> = {
       task: execution.task,
@@ -652,6 +662,9 @@ export class SiloWorker<
         data: serializeError(error),
       };
     }
+
+    // The handler has settled: no report below may race a heartbeat
+    stopHeartbeat();
 
     // If the task was cancelled (by server or client), report Cancelled outcome instead
     if (execution.shouldReportCancelled) {
@@ -676,7 +689,11 @@ export class SiloWorker<
   /**
    * Execute a refresh task and report its outcome.
    */
-  private async _executeRefreshTask(task: RefreshTask, shard: string): Promise<void> {
+  private async _executeRefreshTask(
+    task: RefreshTask,
+    shard: string,
+    stopHeartbeat: () => void,
+  ): Promise<void> {
     const context: RefreshTaskContext = {
       task,
       shard,
@@ -701,6 +718,9 @@ export class SiloWorker<
         message: errorObj.message,
       };
     }
+
+    // The handler has settled: stop heartbeats before the report goes out
+    stopHeartbeat();
 
     // Report the refresh outcome
     await this._client.reportRefreshOutcome({

--- a/typescript_client/test/worker-metrics.test.ts
+++ b/typescript_client/test/worker-metrics.test.ts
@@ -300,6 +300,44 @@ describe("SiloWorker metrics", () => {
     await worker.stop();
   });
 
+  it("increments duplicate task deliveries counter when a running task is re-delivered", async () => {
+    const task = createTask("task-dup-metric", "job-dup-metric");
+    const leaseTasks = vi
+      .fn()
+      .mockResolvedValueOnce(tasksResult([task]))
+      .mockResolvedValueOnce(tasksResult([task]))
+      .mockResolvedValue(tasksResult([]));
+    const client = createMockClient({ leaseTasks });
+    const handler: TaskHandler = async () => {
+      await new Promise((r) => setTimeout(r, 100));
+      return { type: "success", result: {} };
+    };
+    const meter = meterProvider.getMeter("test");
+
+    const worker = new SiloWorker({
+      client,
+      workerId: "test-worker",
+      taskGroup: "default",
+      handler,
+      pollIntervalMs: 10,
+      heartbeatIntervalMs: 100000,
+      onError: () => {},
+      meter,
+    });
+
+    worker.start();
+    while (leaseTasks.mock.calls.length < 3) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    await worker.stop();
+
+    const allMetrics = await collectMetrics(metricReader);
+    expect(getMetricValue(allMetrics, "silo.worker.duplicate_task_deliveries")).toBe(1);
+    expect(getMetricAttributes(allMetrics, "silo.worker.duplicate_task_deliveries")).toEqual({
+      task_group: "default",
+    });
+  });
+
   it("includes task_group label on all metrics", async () => {
     let pollCount = 0;
     const leaseTasks = vi.fn().mockImplementation(async () => {

--- a/typescript_client/test/worker.test.ts
+++ b/typescript_client/test/worker.test.ts
@@ -664,6 +664,141 @@ describe("SiloWorker", () => {
       // Heartbeat count should not have increased after task completed
       expect(heartbeat.mock.calls.length).toBe(heartbeatCountAfterComplete);
     });
+
+    it("stops all heartbeats after the same task delivered in two polls settles twice", async () => {
+      const task = createTask("task-dup", "job-dup");
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValue(tasksResult([]));
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      const heartbeat = vi.fn().mockResolvedValue({ cancelled: false });
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+
+      // Long enough that both copies are executing concurrently
+      const handler: TaskHandler = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        heartbeatIntervalMs: 30,
+      });
+
+      worker.start();
+
+      // Wait for both executions to settle
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      const heartbeatCountAfterSettle = heartbeat.mock.calls.length;
+
+      // Wait several heartbeat intervals - no interval may still be live
+      await new Promise((resolve) => setTimeout(resolve, 120));
+
+      await worker.stop();
+
+      expect(heartbeat.mock.calls.length).toBe(heartbeatCountAfterSettle);
+    });
+
+    it("issues no heartbeat after reportOutcome is invoked for a completing task", async () => {
+      const task = createTask("task-hb-order", "job-hb-order");
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValue(tasksResult([]));
+
+      let reportOutcomeInvoked = false;
+      let heartbeatsAfterReport = 0;
+      // Hold the report pending across several heartbeat intervals so any
+      // still-live interval would fire while it is in flight
+      const reportOutcome = vi.fn().mockImplementation(async () => {
+        reportOutcomeInvoked = true;
+        await new Promise((resolve) => setTimeout(resolve, 120));
+      });
+      const heartbeat = vi.fn().mockImplementation(async () => {
+        if (reportOutcomeInvoked) {
+          heartbeatsAfterReport++;
+        }
+        return { cancelled: false };
+      });
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+
+      const handler: TaskHandler = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 80));
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        heartbeatIntervalMs: 30,
+      });
+
+      worker.start();
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await worker.stop();
+
+      // The interval was live during execution...
+      expect(heartbeat).toHaveBeenCalled();
+      // ...but stopped before the outcome report went out
+      expect(reportOutcome).toHaveBeenCalledTimes(1);
+      expect(heartbeatsAfterReport).toBe(0);
+    });
+
+    it("issues no heartbeat after the cancelled outcome report is invoked", async () => {
+      const task = createTask("task-hb-cancel", "job-hb-cancel");
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValue(tasksResult([]));
+
+      let reportOutcomeInvoked = false;
+      let heartbeatsAfterReport = 0;
+      const reportOutcome = vi.fn().mockImplementation(async () => {
+        reportOutcomeInvoked = true;
+        await new Promise((resolve) => setTimeout(resolve, 120));
+      });
+      const heartbeat = vi.fn().mockImplementation(async () => {
+        if (reportOutcomeInvoked) {
+          heartbeatsAfterReport++;
+        }
+        return { cancelled: false };
+      });
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+
+      const handler: TaskHandler = async (ctx) => {
+        await new Promise((resolve) => setTimeout(resolve, 40));
+        await ctx.cancel();
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        heartbeatIntervalMs: 30,
+      });
+
+      worker.start();
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await worker.stop();
+
+      expect(reportOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: { type: "cancelled" } }),
+      );
+      expect(heartbeatsAfterReport).toBe(0);
+    });
   });
 
   describe("error handling", () => {

--- a/typescript_client/test/worker.test.ts
+++ b/typescript_client/test/worker.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { SiloWorker, type TaskHandler } from "../src/worker";
 import type { SiloGRPCClient, LeaseTasksResult } from "../src/client";
-import { encodeBytes } from "../src/client";
+import { encodeBytes, TaskNotFoundError, SiloFailedPreconditionError } from "../src/client";
 import type { Task } from "../src/pb/silo";
 
 // Mock client for unit tests
@@ -897,6 +897,290 @@ describe("SiloWorker", () => {
       expect(err.code).toBe("SILO_DUPLICATE_TASK_DELIVERY");
       expect(err.taskId).toBe("task-1");
       expect(err.jobId).toBe("job-1");
+    });
+  });
+
+  describe("lost lease", () => {
+    it("aborts, stops heartbeating, and reports no outcome when the lease is gone", async () => {
+      const task = createTask("task-ll", "job-ll");
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValue(tasksResult([]));
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      const heartbeat = vi
+        .fn()
+        .mockRejectedValue(new TaskNotFoundError("task-ll", "lease not found"));
+      const onError = vi.fn();
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+
+      let signalAbortedInHandler = false;
+      const handler: TaskHandler = async (ctx) => {
+        // Run until the cancellation signal fires (or a generous timeout)
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, 500);
+          ctx.cancellationSignal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              resolve();
+            },
+            { once: true },
+          );
+        });
+        signalAbortedInHandler = ctx.cancellationSignal.aborted;
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        heartbeatIntervalMs: 30,
+        onError,
+      });
+
+      worker.start();
+      // Enough time for the heartbeat rejection, handler wind-down, and any
+      // further heartbeat intervals that should no longer fire
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      await worker.stop();
+
+      expect(signalAbortedInHandler).toBe(true);
+      expect(reportOutcome).not.toHaveBeenCalled();
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "SILO_TASK_LEASE_LOST" }),
+        expect.objectContaining({ taskId: "task-ll" }),
+      );
+      const err = onError.mock.calls[0][0] as { message: string };
+      expect(err.message).toContain("task-ll");
+      expect(err.message).toContain("job-ll");
+    });
+
+    it("executes a retry re-delivered after the lease was lost", async () => {
+      const task = createTask("task-ll-retry", "job-ll-retry");
+      let leaseLostReported = false;
+      let deliveredRetry = false;
+      const leaseTasks = vi.fn().mockImplementation(async () => {
+        if (leaseTasks.mock.calls.length === 1) {
+          return tasksResult([task]);
+        }
+        // Re-deliver the same task id once the lease-lost event fired
+        if (leaseLostReported && !deliveredRetry) {
+          deliveredRetry = true;
+          return tasksResult([task]);
+        }
+        return tasksResult([]);
+      });
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      // First delivery's heartbeat loses the lease; the retry's heartbeats succeed
+      const heartbeat = vi.fn().mockImplementation(async () => {
+        if (!deliveredRetry) {
+          throw new TaskNotFoundError("task-ll-retry", "lease not found");
+        }
+        return { cancelled: false };
+      });
+      const onError = vi.fn().mockImplementation(() => {
+        leaseLostReported = true;
+      });
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+
+      const handler = vi
+        .fn()
+        .mockImplementation(async (ctx: { cancellationSignal: AbortSignal }) => {
+          await new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, 60);
+            ctx.cancellationSignal.addEventListener(
+              "abort",
+              () => {
+                clearTimeout(timer);
+                resolve();
+              },
+              { once: true },
+            );
+          });
+          return { type: "success", result: {} };
+        });
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        heartbeatIntervalMs: 30,
+        onError,
+      });
+
+      worker.start();
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      await worker.stop();
+
+      // Handler ran for the original delivery and again for the retry
+      expect(handler).toHaveBeenCalledTimes(2);
+      // Only the retry reported an outcome (no duplicate-delivery error either)
+      expect(reportOutcome).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "SILO_TASK_LEASE_LOST" }),
+        expect.anything(),
+      );
+    });
+
+    it("continues executing when a heartbeat fails with a wrong-shard NOT_FOUND", async () => {
+      const task = createTask("task-ws", "job-ws");
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValue(tasksResult([]));
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      const heartbeat = vi
+        .fn()
+        .mockRejectedValue(new TaskNotFoundError("task-ws", "shard not found"));
+      const onError = vi.fn();
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+
+      let signalAbortedInHandler = false;
+      const handler: TaskHandler = async (ctx) => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        signalAbortedInHandler = ctx.cancellationSignal.aborted;
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        heartbeatIntervalMs: 30,
+        onError,
+      });
+
+      worker.start();
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      await worker.stop();
+
+      expect(signalAbortedInHandler).toBe(false);
+      expect(reportOutcome).toHaveBeenCalledTimes(1);
+      expect(reportOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: "task-ws", outcome: { type: "success", result: {} } }),
+      );
+      // The failures surface as plain heartbeat errors, not lease-lost
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "SILO_TASK_NOT_FOUND" }),
+        expect.objectContaining({ taskId: "task-ws" }),
+      );
+    });
+
+    it("continues executing when a heartbeat fails with a stale-topology FAILED_PRECONDITION", async () => {
+      const task = createTask("task-st", "job-st");
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValue(tasksResult([]));
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      const heartbeat = vi
+        .fn()
+        .mockRejectedValue(
+          new SiloFailedPreconditionError(
+            "tenant 'a' is not within shard 00000000-0000-0000-0000-000000000001 range [0, 100); refresh topology and retry",
+          ),
+        );
+      const onError = vi.fn();
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+
+      let signalAbortedInHandler = false;
+      const handler: TaskHandler = async (ctx) => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        signalAbortedInHandler = ctx.cancellationSignal.aborted;
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        heartbeatIntervalMs: 30,
+        onError,
+      });
+
+      worker.start();
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      await worker.stop();
+
+      expect(signalAbortedInHandler).toBe(false);
+      expect(reportOutcome).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "SILO_FAILED_PRECONDITION" }),
+        expect.objectContaining({ taskId: "task-st" }),
+      );
+    });
+
+    it("continues executing when a heartbeat fails with a transient error", async () => {
+      const task = createTask("task-tr", "job-tr");
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValue(tasksResult([]));
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      const heartbeat = vi.fn().mockRejectedValue(new Error("connection reset"));
+      const onError = vi.fn();
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+
+      let signalAbortedInHandler = false;
+      const handler: TaskHandler = async (ctx) => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        signalAbortedInHandler = ctx.cancellationSignal.aborted;
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        heartbeatIntervalMs: 30,
+        onError,
+      });
+
+      worker.start();
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      await worker.stop();
+
+      expect(signalAbortedInHandler).toBe(false);
+      expect(reportOutcome).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "connection reset" }),
+        expect.objectContaining({ taskId: "task-tr" }),
+      );
+    });
+  });
+
+  describe("TaskExecution lease-lost state", () => {
+    it("marks lease-lost once, aborts with the lease-lost reason, and suppresses cancelled reporting", async () => {
+      const { TaskExecution } = await import("../src/TaskExecution");
+      const client = createMockClient();
+      const execution = new TaskExecution(
+        { id: "task-1", jobId: "job-1" } as never,
+        "test-worker",
+        client,
+      );
+
+      expect(execution.markLeaseLost()).toBe(true);
+      expect(execution.signal.aborted).toBe(true);
+      expect(execution.cancellationReason).toBe("lease-lost");
+      expect(execution.isLeaseLost).toBe(true);
+      // A concurrent in-flight heartbeat rejecting with the same signal
+      // does not win the latch a second time
+      expect(execution.markLeaseLost()).toBe(false);
     });
   });
 

--- a/typescript_client/test/worker.test.ts
+++ b/typescript_client/test/worker.test.ts
@@ -665,7 +665,7 @@ describe("SiloWorker", () => {
       expect(heartbeat.mock.calls.length).toBe(heartbeatCountAfterComplete);
     });
 
-    it("stops all heartbeats after the same task delivered in two polls settles twice", async () => {
+    it("stops all heartbeats when two intervals for one task id are concurrently live", async () => {
       const task = createTask("task-dup", "job-dup");
       const leaseTasks = vi
         .fn()
@@ -690,6 +690,13 @@ describe("SiloWorker", () => {
         pollIntervalMs: 10,
         heartbeatIntervalMs: 30,
       });
+
+      // Bypass the duplicate-delivery guard so the second poll registers a
+      // second live interval for the same task id, exercising interval
+      // cleanup under the exact overlap the guard normally prevents
+      const activeExecutions = (worker as unknown as { _activeExecutions: Map<string, unknown> })
+        ._activeExecutions;
+      vi.spyOn(activeExecutions, "has").mockReturnValue(false);
 
       worker.start();
 
@@ -798,6 +805,98 @@ describe("SiloWorker", () => {
         expect.objectContaining({ outcome: { type: "cancelled" } }),
       );
       expect(heartbeatsAfterReport).toBe(0);
+    });
+  });
+
+  describe("duplicate delivery", () => {
+    it("executes a task delivered twice only once and reports the duplicate", async () => {
+      const task = createTask("task-dedup", "job-dedup");
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValue(tasksResult([]));
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      const onError = vi.fn();
+      const client = createMockClient({ leaseTasks, reportOutcome });
+
+      // Long enough that the second delivery arrives while the first executes
+      const handler = vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return { type: "success", result: {} };
+      });
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        onError,
+      });
+
+      worker.start();
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      await worker.stop();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(reportOutcome).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "SILO_DUPLICATE_TASK_DELIVERY" }),
+        expect.objectContaining({ taskId: "task-dedup" }),
+      );
+    });
+
+    it("executes a task re-delivered after its first execution settled", async () => {
+      const task = createTask("task-redeliver", "job-redeliver");
+      let deliveredSecondCopy = false;
+      const leaseTasks = vi.fn().mockImplementation(async () => {
+        // First poll delivers the task; a later poll re-delivers it once the
+        // first execution has fully settled
+        if (leaseTasks.mock.calls.length === 1) {
+          return tasksResult([task]);
+        }
+        if (reportOutcome.mock.calls.length >= 1 && !deliveredSecondCopy) {
+          deliveredSecondCopy = true;
+          return tasksResult([task]);
+        }
+        return tasksResult([]);
+      });
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      const onError = vi.fn();
+      const client = createMockClient({ leaseTasks, reportOutcome });
+
+      const handler = vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return { type: "success", result: {} };
+      });
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        onError,
+      });
+
+      worker.start();
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await worker.stop();
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(reportOutcome).toHaveBeenCalledTimes(2);
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("exports DuplicateTaskDeliveryError from the package barrel", async () => {
+      const barrel = await import("../src/index");
+      expect(barrel.DuplicateTaskDeliveryError).toBeDefined();
+      const err = new barrel.DuplicateTaskDeliveryError("task-1", "job-1");
+      expect(err.code).toBe("SILO_DUPLICATE_TASK_DELIVERY");
+      expect(err.taskId).toBe("task-1");
+      expect(err.jobId).toBe("job-1");
     });
   });
 

--- a/typescript_client/test/worker.test.ts
+++ b/typescript_client/test/worker.test.ts
@@ -713,6 +713,50 @@ describe("SiloWorker", () => {
       expect(heartbeat.mock.calls.length).toBe(heartbeatCountAfterSettle);
     });
 
+    it("ignores an in-flight heartbeat that rejects lease-gone after normal completion", async () => {
+      const task = createTask("task-late-hb", "job-late-hb");
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValue(tasksResult([]));
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      // The heartbeat is on the wire when the handler settles: the server
+      // deletes the lease during reportOutcome, so the late response is a
+      // lease-gone rejection for a task that completed normally
+      const heartbeat = vi.fn().mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            setTimeout(() => reject(new TaskNotFoundError("task-late-hb", "lease not found")), 100);
+          }),
+      );
+      const onError = vi.fn();
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+
+      const handler: TaskHandler = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        heartbeatIntervalMs: 30,
+        onError,
+      });
+
+      worker.start();
+      // Handler settles at ~50ms; the ~30ms heartbeat's rejection lands at
+      // ~130ms, well after the outcome was reported
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await worker.stop();
+
+      expect(reportOutcome).toHaveBeenCalledTimes(1);
+      expect(onError).not.toHaveBeenCalled();
+    });
+
     it("issues no heartbeat after reportOutcome is invoked for a completing task", async () => {
       const task = createTask("task-hb-order", "job-hb-order");
       const leaseTasks = vi

--- a/typescript_client/test/worker.test.ts
+++ b/typescript_client/test/worker.test.ts
@@ -890,13 +890,77 @@ describe("SiloWorker", () => {
       expect(onError).not.toHaveBeenCalled();
     });
 
-    it("exports DuplicateTaskDeliveryError from the package barrel", async () => {
+    it("drops a duplicate delivery of an actively-executing refresh task", async () => {
+      const refreshTask = {
+        id: "refresh-dup",
+        queueKey: "queue-1",
+        currentMaxConcurrency: 5,
+        lastRefreshedAtMs: 0n,
+        metadata: {},
+        leaseMs: 30000n,
+        shard: "00000000-0000-0000-0000-000000000001",
+        taskGroup: "default",
+      };
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce({ tasks: [], refreshTasks: [refreshTask] })
+        .mockResolvedValueOnce({ tasks: [], refreshTasks: [refreshTask] })
+        .mockResolvedValue(tasksResult([]));
+      const reportRefreshOutcome = vi.fn().mockResolvedValue(undefined);
+      const onError = vi.fn();
+      const client = {
+        leaseTasks,
+        reportOutcome: vi.fn().mockResolvedValue(undefined),
+        reportRefreshOutcome,
+        heartbeat: vi.fn().mockResolvedValue({ cancelled: false }),
+        cancelJob: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SiloGRPCClient;
+
+      const refreshHandler = vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return 7;
+      });
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler: async () => ({ type: "success", result: {} }),
+        refreshHandler,
+        pollIntervalMs: 10,
+        onError,
+      });
+
+      worker.start();
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      await worker.stop();
+
+      expect(refreshHandler).toHaveBeenCalledTimes(1);
+      expect(reportRefreshOutcome).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "SILO_DUPLICATE_TASK_DELIVERY" }),
+        expect.objectContaining({ taskId: "refresh-dup" }),
+      );
+    });
+
+    it("exports DuplicateTaskDeliveryError and TaskLeaseLostError from the package barrel", async () => {
       const barrel = await import("../src/index");
       expect(barrel.DuplicateTaskDeliveryError).toBeDefined();
       const err = new barrel.DuplicateTaskDeliveryError("task-1", "job-1");
       expect(err.code).toBe("SILO_DUPLICATE_TASK_DELIVERY");
       expect(err.taskId).toBe("task-1");
       expect(err.jobId).toBe("job-1");
+
+      expect(barrel.TaskLeaseLostError).toBeDefined();
+      const leaseLost = new barrel.TaskLeaseLostError(
+        "task-1",
+        "job-1",
+        new Error("lease not found"),
+      );
+      expect(leaseLost.code).toBe("SILO_TASK_LEASE_LOST");
+      expect(leaseLost.taskId).toBe("task-1");
+      expect(leaseLost.jobId).toBe("job-1");
     });
   });
 
@@ -959,6 +1023,60 @@ describe("SiloWorker", () => {
       const err = onError.mock.calls[0][0] as { message: string };
       expect(err.message).toContain("task-ll");
       expect(err.message).toContain("job-ll");
+    });
+
+    it("treats a lease-owner-mismatch heartbeat rejection as a lost lease", async () => {
+      const task = createTask("task-om", "job-om");
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task]))
+        .mockResolvedValue(tasksResult([]));
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      const heartbeat = vi
+        .fn()
+        .mockRejectedValue(new SiloFailedPreconditionError("lease owner mismatch"));
+      const onError = vi.fn();
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+
+      let signalAbortedInHandler = false;
+      const handler: TaskHandler = async (ctx) => {
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, 500);
+          ctx.cancellationSignal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              resolve();
+            },
+            { once: true },
+          );
+        });
+        signalAbortedInHandler = ctx.cancellationSignal.aborted;
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        pollIntervalMs: 10,
+        heartbeatIntervalMs: 30,
+        onError,
+      });
+
+      worker.start();
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      await worker.stop();
+
+      expect(signalAbortedInHandler).toBe(true);
+      expect(reportOutcome).not.toHaveBeenCalled();
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "SILO_TASK_LEASE_LOST" }),
+        expect.objectContaining({ taskId: "task-om" }),
+      );
     });
 
     it("executes a retry re-delivered after the lease was lost", async () => {
@@ -1028,6 +1146,65 @@ describe("SiloWorker", () => {
       expect(onError).toHaveBeenCalledWith(
         expect.objectContaining({ code: "SILO_TASK_LEASE_LOST" }),
         expect.anything(),
+      );
+    });
+
+    it("never starts the handler for a task whose lease was lost while queued", async () => {
+      const task1 = createTask("task-q1", "job-q1");
+      const task2 = createTask("task-q2", "job-q2");
+      const leaseTasks = vi
+        .fn()
+        .mockResolvedValueOnce(tasksResult([task1, task2]))
+        .mockResolvedValue(tasksResult([]));
+      const reportOutcome = vi.fn().mockResolvedValue(undefined);
+      // task-q2 loses its lease while it waits in the queue behind task-q1
+      const heartbeat = vi.fn().mockImplementation(async (_worker: string, taskId: string) => {
+        if (taskId === "task-q2") {
+          throw new TaskNotFoundError("task-q2", "lease not found");
+        }
+        return { cancelled: false };
+      });
+      const onError = vi.fn();
+      const client = createMockClient({ leaseTasks, reportOutcome, heartbeat });
+
+      let releaseFirstTask: () => void;
+      const firstTaskBlocked = new Promise<void>((resolve) => {
+        releaseFirstTask = resolve;
+      });
+      const handledTaskIds: string[] = [];
+      const handler: TaskHandler = async (ctx) => {
+        handledTaskIds.push(ctx.task.id);
+        if (ctx.task.id === "task-q1") {
+          await firstTaskBlocked;
+        }
+        return { type: "success", result: {} };
+      };
+
+      const worker = new SiloWorker({
+        client,
+        workerId: "test-worker",
+        taskGroup: "default",
+        handler,
+        maxConcurrentTasks: 1,
+        pollIntervalMs: 10,
+        heartbeatIntervalMs: 30,
+        onError,
+      });
+
+      worker.start();
+      // Let task-q2's queued heartbeat reject lease-gone before task-q1 frees the slot
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      releaseFirstTask!();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await worker.stop();
+
+      expect(handledTaskIds).toEqual(["task-q1"]);
+      expect(reportOutcome).toHaveBeenCalledTimes(1);
+      expect(reportOutcome).toHaveBeenCalledWith(expect.objectContaining({ taskId: "task-q1" }));
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "SILO_TASK_LEASE_LOST" }),
+        expect.objectContaining({ taskId: "task-q2" }),
       );
     });
 


### PR DESCRIPTION
## Why

A production incident showed the silo server can dispatch the same RunAttempt task twice to one worker. Both copies executed the customer's action concurrently, and the second delivery overwrote the first heartbeat interval's map entry, orphaning it permanently -- one incident produced 16+ hours of repeating `TaskNotFoundError` heartbeat spam that only a pod restart could stop. A worker whose lease disappears mid-execution also had no reaction: the handler ran to completion unbounded while heartbeats failed every interval. Separately, a benign completion race (a heartbeat tick landing between the server-side lease deletion and `clearInterval`) generated steady one-off NOT_FOUND noise fleet-wide.

## What

Hardens `SiloWorker` so no combination of duplicate delivery, lost lease, or completion timing can leak an interval, double-execute on the same worker, or spam errors:

- **Leak-proof interval lifecycle**: cleanup clears the closure-captured interval handle instead of a map lookup, and map entries are removed only when they still belong to the delivery that is cleaning up. Heartbeats stop the moment the handler settles, before the outcome report goes out, closing the completion-race window.
- **Duplicate-delivery dedup**: a delivery of a task id that is already executing is dropped before any span, interval, or queue entry is created, surfaced via `onError` as `DuplicateTaskDeliveryError` and counted in `silo.worker.duplicate_task_deliveries`. Re-delivery after the first execution settles runs normally.
- **Lost-lease reaction**: a heartbeat rejection that authoritatively signals the lease is gone (NOT_FOUND "lease not found", or FAILED_PRECONDITION "lease owner mismatch") stops the interval, aborts the handler's cancellation signal with a `lease-lost` reason, suppresses all outcome reporting, frees the task id for a re-delivered retry, and surfaces exactly one `TaskLeaseLostError`. Routing conditions (wrong-shard NOT_FOUND, stale-topology FAILED_PRECONDITION) and transient errors deliberately do not trigger this; `TaskNotFoundError` carries the underlying gRPC message so the two NOT_FOUND flavors are distinguishable. A task whose lease is lost while still queued never starts its handler, and heartbeat rejections that land after the handler settles are ignored -- outcome reporting releases the lease, so a late lease-gone response is the completion race, not a lost lease.

## Review notes

Every behavior has a vitest regression test that fails against the prior implementation; the `heartbeats`, `duplicate delivery`, and `lost lease` describe blocks in `worker.test.ts` are the map of the change. The server-side counterpart (dispatch-time lease-overwrite detection) is #400.
