### PR TITLE
Detect lease overwrites at RunAttempt dispatch time

### DIFF
--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -51,6 +51,7 @@ Leases represent tasks actively being processed by workers.
 | `silo_leasable_to_start_latency_ms` | Histogram | `shard`, `task_group` | Time a task spent leasable — eligible for a worker to pick up — before it was leased, excluding waits for concurrency tickets or rate-limit clearance (in milliseconds) |
 | `silo_lease_reaper_duration_seconds` | Histogram | `shard` | Duration of expired lease reaper scan operations |
 | `silo_lease_reaper_scans_total` | Counter | `shard` | Total number of expired lease reaper scan operations |
+| `silo_task_lease_overwrites_total` | Counter | `shard`, `task_group`, `source` | RunAttempt dispatches that wrote a lease over a still-live existing lease (double-dispatch detector); `source` is `stored` for a live lease found by the pre-write read and `batch` for a repeated task id within one dequeue iteration |
 
 **Key insights:**
 - `silo_task_leases_active` shows in-flight work at any given moment
@@ -59,6 +60,7 @@ Leases represent tasks actively being processed by workers.
 - `silo_ready_to_start_latency_ms` measures overall queue time from a task's original scheduled start to its lease. Silo preserves the original scheduled start through tenant concurrency-limit chains, so a task that waited on concurrency tickets or rate limits reports that wait here — high values can mean worker saturation, but can also mean a tenant is self-throttling behind its own limits
 - `silo_leasable_to_start_latency_ms` measures only the time a task was leasable (all grants held, eligible for pickup) before a worker leased it. Waits for concurrency tickets or rate-limit clearance are excluded, so this metric only grows when workers are the bottleneck — it is the worker-capacity signal, while `silo_ready_to_start_latency_ms` is the customer-perceived queue-time signal
 - `silo_lease_reaper_duration_seconds` tracks how long the expired lease reaper takes to scan all leases per shard. High values indicate a large number of active leases or database pressure, and can contribute to increased CPU usage
+- `silo_task_lease_overwrites_total` should stay at zero. Any increment means the dispatch path created a lease over one that was still live — the signature of the same task being dispatched twice — and the `shard`/`task_group`/`source` labels localize where it happened. Dispatch still proceeds; the counter is detection, not prevention
 
 ### Broker Metrics
 

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -1,5 +1,7 @@
 //! Task dequeue and processing operations.
 
+use std::collections::HashSet;
+
 use slatedb::WriteBatch;
 use slatedb::config::WriteOptions;
 
@@ -48,7 +50,7 @@ struct DequeueIterationState {
     /// batch is uncommitted, so a `db.get` cannot see those writes; the
     /// double-dispatch detection guard consults this set to catch a repeat
     /// of the same task id within one dequeue call.
-    leased_task_ids: std::collections::HashSet<String>,
+    leased_task_ids: HashSet<String>,
     processed_internal: bool,
 }
 
@@ -64,7 +66,7 @@ impl DequeueIterationState {
             pending_attempts: Vec::new(),
             holder_releases: Vec::new(),
             converted_requests: Vec::new(),
-            leased_task_ids: std::collections::HashSet::new(),
+            leased_task_ids: HashSet::new(),
             processed_internal: false,
         }
     }
@@ -1204,28 +1206,46 @@ impl JobStoreShard {
                     crate::metrics::LeaseOverwriteSource::Batch,
                 );
             }
-        } else if let Ok(Some(existing_bytes)) = self.db.get(&leased_task_key(task_id)).await
-            && let Ok(existing) = crate::codec::decode_lease(existing_bytes)
-        {
-            let remaining_lease_ms = existing.expiry_ms() - now_ms;
-            if remaining_lease_ms > 0 {
-                tracing::warn!(
-                    tenant = %tenant,
-                    job_id = %job_id,
+        } else {
+            // Detection must never alter dispatch: read and decode failures
+            // are logged at debug so a persistently blind detector remains
+            // observable, then dispatch proceeds regardless.
+            match self.db.get(&leased_task_key(task_id)).await {
+                Ok(Some(existing_bytes)) => match crate::codec::decode_lease(existing_bytes) {
+                    Ok(existing) => {
+                        let remaining_lease_ms = existing.expiry_ms() - now_ms;
+                        if remaining_lease_ms > 0 {
+                            tracing::warn!(
+                                tenant = %tenant,
+                                job_id = %job_id,
+                                task_id = %task_id,
+                                existing_worker_id = %existing.worker_id(),
+                                new_worker_id = %worker_id,
+                                remaining_lease_ms,
+                                "dispatching RunAttempt over a still-live existing lease; \
+                                 possible double dispatch",
+                            );
+                            if let Some(m) = &self.metrics {
+                                m.record_task_lease_overwrite(
+                                    self.name(),
+                                    decoded.task_group(),
+                                    crate::metrics::LeaseOverwriteSource::Stored,
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => tracing::debug!(
+                        task_id = %task_id,
+                        error = %e,
+                        "lease-overwrite guard could not decode existing lease record",
+                    ),
+                },
+                Ok(None) => {}
+                Err(e) => tracing::debug!(
                     task_id = %task_id,
-                    existing_worker_id = %existing.worker_id(),
-                    new_worker_id = %worker_id,
-                    remaining_lease_ms,
-                    "dispatching RunAttempt over a still-live existing lease; \
-                     possible double dispatch",
-                );
-                if let Some(m) = &self.metrics {
-                    m.record_task_lease_overwrite(
-                        self.name(),
-                        decoded.task_group(),
-                        crate::metrics::LeaseOverwriteSource::Stored,
-                    );
-                }
+                    error = %e,
+                    "lease-overwrite guard read failed",
+                ),
             }
         }
         state.leased_task_ids.insert(task_id.to_string());

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -44,6 +44,11 @@ struct DequeueIterationState {
     /// `try_reserve` failing and the batch committing is picked up
     /// immediately instead of waiting for the periodic reconcile.
     converted_requests: Vec<(String, String)>,
+    /// Task ids whose lease was written into this iteration's batch. The
+    /// batch is uncommitted, so a `db.get` cannot see those writes; the
+    /// double-dispatch detection guard consults this set to catch a repeat
+    /// of the same task id within one dequeue call.
+    leased_task_ids: std::collections::HashSet<String>,
     processed_internal: bool,
 }
 
@@ -59,6 +64,7 @@ impl DequeueIterationState {
             pending_attempts: Vec::new(),
             holder_releases: Vec::new(),
             converted_requests: Vec::new(),
+            leased_task_ids: std::collections::HashSet::new(),
             processed_internal: false,
         }
     }
@@ -1177,6 +1183,52 @@ impl JobStoreShard {
         // [SILO-DEQ-CONC] Implicit: If job requires concurrency, task must hold all required queues.
         // This is guaranteed by construction: RunAttempt tasks are only created when concurrency
         // is granted (at enqueue or grant_next), with held_queues populated.
+
+        // Double-dispatch detection: dispatch is about to write this task's
+        // lease record, so a still-live lease there means the same task was
+        // already dispatched. Detection only -- the overwrite proceeds
+        // unchanged and no guard failure may alter the dispatch outcome.
+        if state.leased_task_ids.contains(task_id) {
+            tracing::warn!(
+                tenant = %tenant,
+                job_id = %job_id,
+                task_id = %task_id,
+                worker_id = %worker_id,
+                "RunAttempt task leased twice within one dequeue iteration; \
+                 overwriting the lease still in this iteration's batch",
+            );
+            if let Some(m) = &self.metrics {
+                m.record_task_lease_overwrite(
+                    self.name(),
+                    decoded.task_group(),
+                    crate::metrics::LeaseOverwriteSource::Batch,
+                );
+            }
+        } else if let Ok(Some(existing_bytes)) = self.db.get(&leased_task_key(task_id)).await
+            && let Ok(existing) = crate::codec::decode_lease(existing_bytes)
+        {
+            let remaining_lease_ms = existing.expiry_ms() - now_ms;
+            if remaining_lease_ms > 0 {
+                tracing::warn!(
+                    tenant = %tenant,
+                    job_id = %job_id,
+                    task_id = %task_id,
+                    existing_worker_id = %existing.worker_id(),
+                    new_worker_id = %worker_id,
+                    remaining_lease_ms,
+                    "dispatching RunAttempt over a still-live existing lease; \
+                     possible double dispatch",
+                );
+                if let Some(m) = &self.metrics {
+                    m.record_task_lease_overwrite(
+                        self.name(),
+                        decoded.task_group(),
+                        crate::metrics::LeaseOverwriteSource::Stored,
+                    );
+                }
+            }
+        }
+        state.leased_task_ids.insert(task_id.to_string());
 
         // [SILO-DEQ-3] Delete task from task queue
         state.batch.delete(task_key);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -98,6 +98,26 @@ impl GrantPath {
     }
 }
 
+/// Which detection branch observed a dispatch-time lease overwrite,
+/// recorded as the `source` label on `silo_task_lease_overwrites_total`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LeaseOverwriteSource {
+    /// A still-live lease record was found by the pre-write point read.
+    Stored,
+    /// The task id was already leased earlier within the same dequeue
+    /// iteration (the lease write is still in the uncommitted batch).
+    Batch,
+}
+
+impl LeaseOverwriteSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LeaseOverwriteSource::Stored => "stored",
+            LeaseOverwriteSource::Batch => "batch",
+        }
+    }
+}
+
 // (shard_id, tenant, task_group, queue, queue_kind)
 type BackgroundActionMetricKey = (String, String, String, String, String);
 type BackgroundActionGaugeState = Arc<Mutex<HashMap<BackgroundActionMetricKey, GaugeSeriesState>>>;
@@ -166,6 +186,7 @@ pub struct Metrics {
 
     // Lease metrics
     task_leases_active: GaugeVec,
+    task_lease_overwrites_total: CounterVec,
     ready_to_start_latency_ms: HistogramVec,
     leasable_to_start_latency_ms: HistogramVec,
     lease_reaper_duration: HistogramVec,
@@ -635,6 +656,19 @@ impl Metrics {
         self.lease_reaper_leases_reaped_total
             .with_label_values(&[shard])
             .inc_by(count as f64);
+    }
+
+    /// Record a RunAttempt dispatch that wrote a lease over a still-live
+    /// existing lease.
+    pub fn record_task_lease_overwrite(
+        &self,
+        shard: &str,
+        task_group: &str,
+        source: LeaseOverwriteSource,
+    ) {
+        self.task_lease_overwrites_total
+            .with_label_values(&[shard, task_group, source.as_str()])
+            .inc();
     }
 
     /// Record a lease reaper scan failure.
@@ -2179,6 +2213,17 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let task_lease_overwrites_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_task_lease_overwrites_total",
+                "Number of RunAttempt dispatches that wrote a lease over a still-live existing lease (double-dispatch detector); source is \"stored\" for a lease found in the DB and \"batch\" for a repeat within one dequeue iteration",
+            ),
+            &["shard", "task_group", "source"],
+        )?,
+    );
+
     let ready_to_start_latency_ms = register(
         &registry,
         HistogramVec::new(
@@ -2530,6 +2575,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         polls_total,
         poll_duration,
         task_leases_active,
+        task_lease_overwrites_total,
         ready_to_start_latency_ms,
         leasable_to_start_latency_ms,
         lease_reaper_duration,

--- a/tests/grpc_lease_task_tests.rs
+++ b/tests/grpc_lease_task_tests.rs
@@ -214,3 +214,104 @@ async fn lease_task_grpc_already_running() -> anyhow::Result<()> {
     .expect("test timed out")?;
     Ok(())
 }
+
+/// The TypeScript worker classifies a lost lease by matching these exact
+/// Status messages (isLeaseGoneError in typescript_client/src/worker.ts);
+/// a wording change would silently downgrade lease-lost to a transient
+/// error on every deployed client, so the strings are pinned here.
+#[silo::test(flavor = "multi_thread")]
+async fn heartbeat_grpc_missing_lease_pins_lease_not_found_message() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(5000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let result = client
+            .heartbeat(HeartbeatRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                worker_id: "test-worker".to_string(),
+                task_id: "00000000-0000-0000-0000-00000000dead".to_string(),
+                tenant_id: None,
+            })
+            .await;
+
+        match result {
+            Err(status) => {
+                assert_eq!(status.code(), tonic::Code::NotFound);
+                assert_eq!(status.message(), "lease not found");
+            }
+            Ok(_) => panic!("expected NOT_FOUND error"),
+        }
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}
+
+/// Companion pin to the missing-lease message above: the owner-mismatch
+/// wording is the other authoritative lost-lease signal for clients.
+#[silo::test(flavor = "multi_thread")]
+async fn heartbeat_grpc_wrong_worker_pins_lease_owner_mismatch_message() -> anyhow::Result<()> {
+    let _guard = tokio::time::timeout(std::time::Duration::from_millis(10000), async {
+        let (factory, _tmp) = create_test_factory().await?;
+        let (mut client, shutdown_tx, server, _addr) =
+            setup_test_server(factory.clone(), AppConfig::load(None).unwrap()).await?;
+
+        let enq_resp = client
+            .enqueue(EnqueueRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: "owner-mismatch-pin-job".to_string(),
+                priority: 10,
+                start_at_ms: 0,
+                retry_policy: None,
+                payload: Some(SerializedBytes {
+                    encoding: Some(serialized_bytes::Encoding::Msgpack(
+                        rmp_serde::to_vec(&serde_json::json!({"test": true})).unwrap(),
+                    )),
+                }),
+                limits: vec![],
+                tenant: None,
+                metadata: std::collections::HashMap::new(),
+                task_group: "default".to_string(),
+            })
+            .await?
+            .into_inner();
+
+        let lease_resp = client
+            .lease_task(LeaseTaskRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                id: enq_resp.id,
+                tenant: None,
+                worker_id: "worker-1".to_string(),
+            })
+            .await?
+            .into_inner();
+        let task = lease_resp.task.expect("should have task");
+
+        let result = client
+            .heartbeat(HeartbeatRequest {
+                shard: crate::grpc_integration_helpers::TEST_SHARD_ID.to_string(),
+                worker_id: "worker-2".to_string(),
+                task_id: task.id,
+                tenant_id: None,
+            })
+            .await;
+
+        match result {
+            Err(status) => {
+                assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+                assert_eq!(status.message(), "lease owner mismatch");
+            }
+            Ok(_) => panic!("expected FAILED_PRECONDITION error"),
+        }
+
+        shutdown_server(shutdown_tx, server).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .expect("test timed out")?;
+    Ok(())
+}

--- a/tests/job_store_shard_dequeue_tests.rs
+++ b/tests/job_store_shard_dequeue_tests.rs
@@ -673,3 +673,247 @@ async fn dequeue_ignores_recently_acked_task_keys() {
         );
     });
 }
+
+/// Dispatching a task whose lease key already holds a live lease is the
+/// double-dispatch anomaly: dequeue proceeds (overwrite semantics are
+/// unchanged) but warns and counts the overwrite so the grant-path bug that
+/// materializes duplicate RunAttempt tasks is visible from metrics.
+#[silo::test]
+async fn dequeue_over_live_lease_counts_stored_overwrite_and_still_delivers() {
+    with_timeout!(20000, {
+        let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+        let payload = msgpack_payload(&serde_json::json!({"k": "v"}));
+        let now = now_ms();
+
+        shard
+            .enqueue("-", None, 10, now, None, payload, vec![], None, "default")
+            .await
+            .expect("enqueue");
+
+        // Read the queued task to learn its enqueue-time task id
+        let (_key, task_bytes) = first_task_kv(shard.db()).await.expect("task present");
+        let decoded = silo::codec::decode_task(&task_bytes).expect("decode task");
+        let Task::RunAttempt {
+            id: task_id,
+            job_id,
+            ..
+        } = decoded
+        else {
+            panic!("expected RunAttempt task");
+        };
+
+        // Pre-write a live lease at the task's lease key, as a prior dispatch
+        // of the same task would have left behind
+        let lease = silo::task::LeaseRecord {
+            worker_id: "other-worker".to_string(),
+            task: Task::RunAttempt {
+                id: task_id.clone(),
+                tenant: "-".to_string(),
+                job_id: job_id.clone(),
+                attempt_number: 1,
+                relative_attempt_number: 1,
+                held_queues: vec![],
+                task_group: "default".to_string(),
+            },
+            expiry_ms: now + 60_000,
+            started_at_ms: now,
+        };
+        let mut batch = WriteBatch::new();
+        batch.put(
+            &silo::keys::leased_task_key(&task_id),
+            &silo::codec::encode_lease(&lease),
+        );
+        shard.db().write(batch).await.expect("write lease");
+        shard.db().flush().await.expect("flush lease");
+
+        let result = shard
+            .dequeue("worker-2", "default", 1)
+            .await
+            .expect("dequeue");
+        assert_eq!(result.tasks.len(), 1, "task must still be delivered");
+
+        let body = gather_metrics_text(&metrics);
+        let overwrites = metric_value_or_zero(
+            &body,
+            &[
+                "silo_task_lease_overwrites_total",
+                "task_group=\"default\"",
+                "source=\"stored\"",
+            ],
+        );
+        assert_eq!(overwrites, 1.0, "stored-lease overwrite must be counted");
+
+        // The overwrite proceeded: the lease names the dequeuing worker with
+        // a fresh expiry
+        let lease_bytes = shard
+            .db()
+            .get(&silo::keys::leased_task_key(&task_id))
+            .await
+            .expect("get lease")
+            .expect("lease exists");
+        let lease = decode_lease(lease_bytes).expect("decode lease");
+        assert_eq!(lease.worker_id(), "worker-2");
+        let after = now_ms();
+        assert!(
+            lease.expiry_ms() >= now + silo::task::DEFAULT_LEASE_MS
+                && lease.expiry_ms() <= after + silo::task::DEFAULT_LEASE_MS,
+            "lease expiry {} should be ~now + DEFAULT_LEASE_MS",
+            lease.expiry_ms()
+        );
+    });
+}
+
+fn gather_metrics_text(metrics: &silo::metrics::Metrics) -> String {
+    use prometheus::{Encoder, TextEncoder};
+    let encoder = TextEncoder::new();
+    let metric_families = metrics.registry().gather();
+    let mut buffer = Vec::new();
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+    String::from_utf8(buffer).unwrap()
+}
+
+/// Value of the first metric line matching all substrings, or 0.0 when no
+/// line matches (a counter that never fired is absent from the scrape).
+fn metric_value_or_zero(body: &str, substrings: &[&str]) -> f64 {
+    body.lines()
+        .find(|l| !l.starts_with('#') && substrings.iter().all(|s| l.contains(s)))
+        .and_then(|line| line.rsplit_once(' '))
+        .and_then(|(_, v)| v.parse::<f64>().ok())
+        .unwrap_or(0.0)
+}
+
+/// A repeat of the same task id within a single dequeue iteration cannot be
+/// seen by the pre-write point read (the first lease write is still in the
+/// uncommitted batch), so the guard tracks the iteration's leased task ids
+/// and counts the repeat under source="batch".
+#[silo::test]
+async fn dequeue_counts_batch_overwrite_for_repeated_task_id_in_one_iteration() {
+    with_timeout!(20000, {
+        let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+        let payload = msgpack_payload(&serde_json::json!({"k": "v"}));
+        let now = now_ms();
+
+        let job_id = shard
+            .enqueue("-", None, 10, now, None, payload, vec![], None, "default")
+            .await
+            .expect("enqueue");
+
+        // Learn the enqueue-time task id from the queued record
+        let (_key, task_bytes) = first_task_kv(shard.db()).await.expect("task present");
+        let decoded = silo::codec::decode_task(&task_bytes).expect("decode task");
+        let Task::RunAttempt { id: task_id, .. } = decoded else {
+            panic!("expected RunAttempt task");
+        };
+
+        // Hand-write a second queued RunAttempt sharing the task id (task ids
+        // are fresh UUIDs at enqueue, so this is not constructible through
+        // enqueue). A different attempt number gives it a distinct task key.
+        let duplicate = Task::RunAttempt {
+            id: task_id.clone(),
+            tenant: "-".to_string(),
+            job_id: job_id.clone(),
+            attempt_number: 2,
+            relative_attempt_number: 2,
+            held_queues: vec![],
+            task_group: "default".to_string(),
+        };
+        let dup_key = silo::keys::task_key("default", now, 10, &job_id, 2, now);
+        let mut batch = WriteBatch::new();
+        batch.put(&dup_key, &silo::codec::encode_task(&duplicate));
+        shard.db().write(batch).await.expect("write duplicate task");
+        shard.db().flush().await.expect("flush duplicate task");
+
+        // Both task records dequeue in one call, so the second lease write
+        // repeats a task id already leased in this iteration's batch
+        let result = shard
+            .dequeue("worker-1", "default", 2)
+            .await
+            .expect("dequeue");
+        assert_eq!(result.tasks.len(), 2, "both records must be delivered");
+
+        let body = gather_metrics_text(&metrics);
+        let batch_overwrites = metric_value_or_zero(
+            &body,
+            &[
+                "silo_task_lease_overwrites_total",
+                "task_group=\"default\"",
+                "source=\"batch\"",
+            ],
+        );
+        assert_eq!(batch_overwrites, 1.0, "batch overwrite must be counted");
+        let stored_overwrites = metric_value_or_zero(
+            &body,
+            &[
+                "silo_task_lease_overwrites_total",
+                "task_group=\"default\"",
+                "source=\"stored\"",
+            ],
+        );
+        assert_eq!(
+            stored_overwrites, 0.0,
+            "the repeat is invisible to the point read; only the batch branch fires"
+        );
+    });
+}
+
+/// An expired leftover lease at the task's lease key is routine (reap-and-
+/// retry territory), not a double dispatch -- the guard stays silent.
+#[silo::test]
+async fn dequeue_over_expired_lease_stays_silent() {
+    with_timeout!(20000, {
+        let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+        let payload = msgpack_payload(&serde_json::json!({"k": "v"}));
+        let now = now_ms();
+
+        shard
+            .enqueue("-", None, 10, now, None, payload, vec![], None, "default")
+            .await
+            .expect("enqueue");
+
+        let (_key, task_bytes) = first_task_kv(shard.db()).await.expect("task present");
+        let decoded = silo::codec::decode_task(&task_bytes).expect("decode task");
+        let Task::RunAttempt {
+            id: task_id,
+            job_id,
+            ..
+        } = decoded
+        else {
+            panic!("expected RunAttempt task");
+        };
+
+        let expired_lease = silo::task::LeaseRecord {
+            worker_id: "other-worker".to_string(),
+            task: Task::RunAttempt {
+                id: task_id.clone(),
+                tenant: "-".to_string(),
+                job_id: job_id.clone(),
+                attempt_number: 1,
+                relative_attempt_number: 1,
+                held_queues: vec![],
+                task_group: "default".to_string(),
+            },
+            expiry_ms: now - 60_000,
+            started_at_ms: now - 120_000,
+        };
+        let mut batch = WriteBatch::new();
+        batch.put(
+            &silo::keys::leased_task_key(&task_id),
+            &silo::codec::encode_lease(&expired_lease),
+        );
+        shard.db().write(batch).await.expect("write expired lease");
+        shard.db().flush().await.expect("flush expired lease");
+
+        let result = shard
+            .dequeue("worker-2", "default", 1)
+            .await
+            .expect("dequeue");
+        assert_eq!(result.tasks.len(), 1, "task must still be delivered");
+
+        let body = gather_metrics_text(&metrics);
+        let overwrites = metric_value_or_zero(
+            &body,
+            &["silo_task_lease_overwrites_total", "task_group=\"default\""],
+        );
+        assert_eq!(overwrites, 0.0, "expired leftover lease must not count");
+    });
+}

--- a/tests/job_store_shard_dequeue_tests.rs
+++ b/tests/job_store_shard_dequeue_tests.rs
@@ -763,25 +763,6 @@ async fn dequeue_over_live_lease_counts_stored_overwrite_and_still_delivers() {
     });
 }
 
-fn gather_metrics_text(metrics: &silo::metrics::Metrics) -> String {
-    use prometheus::{Encoder, TextEncoder};
-    let encoder = TextEncoder::new();
-    let metric_families = metrics.registry().gather();
-    let mut buffer = Vec::new();
-    encoder.encode(&metric_families, &mut buffer).unwrap();
-    String::from_utf8(buffer).unwrap()
-}
-
-/// Value of the first metric line matching all substrings, or 0.0 when no
-/// line matches (a counter that never fired is absent from the scrape).
-fn metric_value_or_zero(body: &str, substrings: &[&str]) -> f64 {
-    body.lines()
-        .find(|l| !l.starts_with('#') && substrings.iter().all(|s| l.contains(s)))
-        .and_then(|line| line.rsplit_once(' '))
-        .and_then(|(_, v)| v.parse::<f64>().ok())
-        .unwrap_or(0.0)
-}
-
 /// A repeat of the same task id within a single dequeue iteration cannot be
 /// seen by the pre-write point read (the first lease write is still in the
 /// uncommitted batch), so the guard tracks the iteration's leased task ids
@@ -822,6 +803,28 @@ async fn dequeue_counts_batch_overwrite_for_repeated_task_id_in_one_iteration() 
         batch.put(&dup_key, &silo::codec::encode_task(&duplicate));
         shard.db().write(batch).await.expect("write duplicate task");
         shard.db().flush().await.expect("flush duplicate task");
+
+        // The enqueue already woke the broker, whose scanner may have
+        // buffered the first record before the duplicate was flushed. Wait
+        // until the buffer holds both so the dequeue claims them in ONE
+        // iteration -- split iterations would commit the first lease and
+        // trip the stored branch instead of the batch branch.
+        let buffered = poll_until(
+            || async {
+                let body = gather_metrics_text(&metrics);
+                metric_value_or_zero(
+                    &body,
+                    &["silo_broker_buffer_size", "task_group=\"default\""],
+                )
+            },
+            |v| *v >= 2.0,
+            10_000,
+        )
+        .await;
+        assert!(
+            buffered >= 2.0,
+            "broker never buffered both task records (buffered={buffered})"
+        );
 
         // Both task records dequeue in one call, so the second lease write
         // repeats a task id already leased in this iteration's batch

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -1,5 +1,9 @@
 //! Tests for the Prometheus metrics endpoint.
 
+mod test_helpers;
+
+use test_helpers::{extract_metric_value, gather_metrics_text};
+
 use axum::{
     Router,
     body::Body,
@@ -882,28 +886,4 @@ async fn test_metrics_leasable_to_start_latency() {
         "ready-to-start series should still be emitted, found: {:?}",
         ready_count
     );
-}
-
-/// Gather metrics text from the Prometheus registry.
-fn gather_metrics_text(metrics: &metrics::Metrics) -> String {
-    use prometheus::{Encoder, TextEncoder};
-    let encoder = TextEncoder::new();
-    let metric_families = metrics.registry().gather();
-    let mut buffer = Vec::new();
-    encoder.encode(&metric_families, &mut buffer).unwrap();
-    String::from_utf8(buffer).unwrap()
-}
-
-/// Extract a numeric metric value from Prometheus text output, finding the line
-/// that contains all given substrings.
-fn extract_metric_value(body: &str, substrings: &[&str]) -> f64 {
-    let line = body
-        .lines()
-        .find(|l| !l.starts_with('#') && substrings.iter().all(|s| l.contains(s)))
-        .unwrap_or_else(|| panic!("metric line not found for substrings {:?}", substrings));
-    line.rsplit_once(' ')
-        .unwrap_or_else(|| panic!("no space-separated value in line: {}", line))
-        .1
-        .parse::<f64>()
-        .unwrap_or_else(|_| panic!("failed to parse metric value from line: {}", line))
 }

--- a/tests/task_scanner_saturation_tests.rs
+++ b/tests/task_scanner_saturation_tests.rs
@@ -474,24 +474,3 @@ async fn scanner_buffers_ready_then_breaks_on_future() {
         );
     });
 }
-
-fn gather_metrics_text(metrics: &silo::metrics::Metrics) -> String {
-    use prometheus::{Encoder, TextEncoder};
-    let encoder = TextEncoder::new();
-    let metric_families = metrics.registry().gather();
-    let mut buffer = Vec::new();
-    encoder.encode(&metric_families, &mut buffer).unwrap();
-    String::from_utf8(buffer).unwrap()
-}
-
-fn extract_metric_value(body: &str, substrings: &[&str]) -> f64 {
-    let line = body
-        .lines()
-        .find(|l| !l.starts_with('#') && substrings.iter().all(|s| l.contains(s)))
-        .unwrap_or_else(|| panic!("metric line not found for substrings {:?}", substrings));
-    line.rsplit_once(' ')
-        .unwrap_or_else(|| panic!("no space-separated value in line: {}", line))
-        .1
-        .parse::<f64>()
-        .unwrap_or_else(|_| panic!("could not parse metric value from line: {}", line))
-}

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -552,3 +552,37 @@ pub async fn dequeue_task_ids_until(
     }
     task_ids
 }
+
+/// Render the Prometheus registry as text exposition format.
+pub fn gather_metrics_text(metrics: &silo::metrics::Metrics) -> String {
+    use prometheus::{Encoder, TextEncoder};
+    let encoder = TextEncoder::new();
+    let metric_families = metrics.registry().gather();
+    let mut buffer = Vec::new();
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+    String::from_utf8(buffer).unwrap()
+}
+
+/// Value of the first metric line matching all substrings; panics when no
+/// line matches. Use `metric_value_or_zero` for counters that may never fire.
+pub fn extract_metric_value(body: &str, substrings: &[&str]) -> f64 {
+    let line = body
+        .lines()
+        .find(|l| !l.starts_with('#') && substrings.iter().all(|s| l.contains(s)))
+        .unwrap_or_else(|| panic!("metric line not found for substrings {:?}", substrings));
+    line.rsplit_once(' ')
+        .unwrap_or_else(|| panic!("no space-separated value in line: {}", line))
+        .1
+        .parse::<f64>()
+        .unwrap_or_else(|_| panic!("could not parse metric value from line: {}", line))
+}
+
+/// Value of the first metric line matching all substrings, or 0.0 when no
+/// line matches (a counter that never fired is absent from the scrape).
+pub fn metric_value_or_zero(body: &str, substrings: &[&str]) -> f64 {
+    body.lines()
+        .find(|l| !l.starts_with('#') && substrings.iter().all(|s| l.contains(s)))
+        .and_then(|line| line.rsplit_once(' '))
+        .and_then(|(_, v)| v.parse::<f64>().ok())
+        .unwrap_or(0.0)
+}


### PR DESCRIPTION
## Why

A production incident showed the silo server dispatching the same RunAttempt task twice ~927ms apart. The second dispatch silently overwrote the lease record at the same `leased_task_key`, so nothing observable fired at the moment the anomaly happened -- localizing it took a multi-hour trace investigation. The suspected source is the ticket-grant path that materializes RunAttempt tasks carrying the enqueue-time task id; finding that root cause needs data.

## What

Adds a detection guard to `handle_run_attempt`: before writing the lease, it point-reads the task's lease key, and when a still-live lease is found it emits a warn event (task id, job id, tenant, both worker ids, remaining TTL) and increments `silo_task_lease_overwrites_total{shard,task_group,source="stored"}`. Same-iteration lease writes sit in the uncommitted batch where the read cannot see them, so the iteration also tracks its leased task ids and counts a repeat under `source="batch"`. The two labels localize which path produced the overwrite.

Detection only: dispatch proceeds unchanged, the guard adds no writes and at most one point read to a path that already point-reads job info, and no guard failure (read or decode error) can alter a dispatch outcome. Prevention is deliberately deferred until this counter establishes which paths actually hit it -- refusing dispatch on a false positive would drop work, which is worse than the duplicate execution the client now contains on its side.

Also pins the exact gRPC status messages "lease not found" and "lease owner mismatch" with heartbeat integration tests, since deployed TypeScript clients match those strings to classify a lost lease; a wording change would silently downgrade lease-lost to a transient error.

## Review notes

The three tests in `job_store_shard_dequeue_tests.rs` (stored overwrite, batch overwrite, expired lease stays silent) are the behavioral spec. The metric is documented in the observability guide. The client-side counterpart (worker hardening) is #399.