### PR TITLE
Enforce at most one live terminal task row per job attempt

### DIFF
--- a/docs/src/content/docs/guides/internals.mdx
+++ b/docs/src/content/docs/guides/internals.mdx
@@ -202,6 +202,10 @@ Jobs can specify multiple limits (concurrency, floating concurrency, and rate li
 
 On retry, limit processing restarts from scratch — the job must re-acquire all concurrency tickets.
 
+### Single live terminal row per attempt
+
+A task key ends in a write-time `epoch_ms` that disambiguates a rewritten key from the broker's ack tombstone of its just-deleted predecessor; it is not part of task identity. The invariant that at most one terminal task row (`RunAttempt` or `CheckRateLimit`) is live per `(job_id, attempt)` is enforced by the duplicate-materialization guard at every chain re-entry point — the grant scanner's reserve loop, `handle_request_ticket`, and `handle_check_rate_limit`. Before continuing a chain, each consults `live_terminal_row_exists` (a durable prefix scan at the attempt's candidate start times) plus a per-batch seen-set for rows the current uncommitted batch already wrote, and drops any second grant source for the attempt (a duplicate request row, a replayed ticket, or a replayed rate-limit continuation) instead of materializing a coexisting row at a fresh epoch. Status-driven lookups (`find_task_by_identity` in cancel, expedite, reimport, and lease) rely on this when they act on the single row their prefix scan returns.
+
 ### Floating max concurrency limits
 
 Silo supports concurrency queues who's max concurrency is adjusted continuously over time. This allows queues to be adjusted by operators, as well as by automated controllers trying to achieve some setpoint in some other system, like rate limit usage of a downstream API.

--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -51,7 +51,8 @@ Leases represent tasks actively being processed by workers.
 | `silo_leasable_to_start_latency_ms` | Histogram | `shard`, `task_group` | Time a task spent leasable — eligible for a worker to pick up — before it was leased, excluding waits for concurrency tickets or rate-limit clearance (in milliseconds) |
 | `silo_lease_reaper_duration_seconds` | Histogram | `shard` | Duration of expired lease reaper scan operations |
 | `silo_lease_reaper_scans_total` | Counter | `shard` | Total number of expired lease reaper scan operations |
-| `silo_task_lease_overwrites_total` | Counter | `shard`, `task_group`, `source` | RunAttempt dispatches that wrote a lease over a still-live existing lease (double-dispatch detector); `source` is `stored` for a live lease found by the pre-write read and `batch` for a repeated task id within one dequeue iteration |
+| `silo_task_lease_overwrites_total` | Counter | `shard`, `task_group`, `source` | RunAttempt dispatches that found a still-live existing lease for the task id (double-dispatch detector, counted whether the dispatch overwrote or dropped); `source` is `stored` for a live lease found by the pre-write read and `batch` for a repeated task id within one dequeue iteration |
+| `silo_task_lease_duplicate_drops_total` | Counter | `shard`, `task_group`, `source` | Duplicate RunAttempt rows dropped at dispatch instead of delivered: a durably present row whose task id is live-leased by another worker, or a repeat within one dequeue iteration. Every drop also increments `silo_task_lease_overwrites_total` |
 
 **Key insights:**
 - `silo_task_leases_active` shows in-flight work at any given moment
@@ -60,7 +61,8 @@ Leases represent tasks actively being processed by workers.
 - `silo_ready_to_start_latency_ms` measures overall queue time from a task's original scheduled start to its lease. Silo preserves the original scheduled start through tenant concurrency-limit chains, so a task that waited on concurrency tickets or rate limits reports that wait here — high values can mean worker saturation, but can also mean a tenant is self-throttling behind its own limits
 - `silo_leasable_to_start_latency_ms` measures only the time a task was leasable (all grants held, eligible for pickup) before a worker leased it. Waits for concurrency tickets or rate-limit clearance are excluded, so this metric only grows when workers are the bottleneck — it is the worker-capacity signal, while `silo_ready_to_start_latency_ms` is the customer-perceived queue-time signal
 - `silo_lease_reaper_duration_seconds` tracks how long the expired lease reaper takes to scan all leases per shard. High values indicate a large number of active leases or database pressure, and can contribute to increased CPU usage
-- `silo_task_lease_overwrites_total` should stay at zero. Any increment means the dispatch path created a lease over one that was still live — the signature of the same task being dispatched twice — and the `shard`/`task_group`/`source` labels localize where it happened. Dispatch still proceeds; the counter is detection, not prevention
+- `silo_task_lease_overwrites_total` should stay at zero. Any increment means dispatch found a still-live lease for a task id it was about to dispatch — the signature of the same task being dispatched twice — and the `shard`/`task_group`/`source` labels localize where it happened. The warn event's `action` field says how each detection resolved: `dropped` (a provable duplicate row, deleted instead of delivered) or `overwritten` (a legitimate re-lease: a lost-response redispatch whose durable row is already gone, or a same-worker requeue recovery)
+- `silo_task_lease_duplicate_drops_total` counts only the dropped detections, so a drop can never masquerade as a healthy overwrite: `overwrites - drops` is the re-lease recovery rate, and any `drops` increment is a duplicate materialization that prevention contained to a single execution
 
 ### Broker Metrics
 

--- a/silo-macros/src/lib.rs
+++ b/silo-macros/src/lib.rs
@@ -14,6 +14,7 @@ use syn::{ItemFn, parse_macro_input};
 pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args_ts = proc_macro2::TokenStream::from(attr);
     let input = parse_macro_input!(item as ItemFn);
+    let attrs = &input.attrs;
     let vis = &input.vis;
     let sig = &input.sig;
     let block = &input.block;
@@ -30,6 +31,7 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let output = if is_async {
         quote! {
             #[tokio::test #paren_args]
+            #(#attrs)*
             #vis #sig {
                 silo::trace::with_test_tracing(stringify!(#name), || async move { #block }).await
             }
@@ -37,6 +39,7 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
     } else {
         quote! {
             #[test]
+            #(#attrs)*
             #vis #sig {
                 silo::trace::with_test_tracing_sync(stringify!(#name), || { #block })
             }

--- a/silo-macros/src/lib.rs
+++ b/silo-macros/src/lib.rs
@@ -30,16 +30,16 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let output = if is_async {
         quote! {
-            #[tokio::test #paren_args]
             #(#attrs)*
+            #[tokio::test #paren_args]
             #vis #sig {
                 silo::trace::with_test_tracing(stringify!(#name), || async move { #block }).await
             }
         }
     } else {
         quote! {
-            #[test]
             #(#attrs)*
+            #[test]
             #vis #sig {
                 silo::trace::with_test_tracing_sync(stringify!(#name), || { #block })
             }

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -2845,7 +2845,7 @@ impl ConcurrencyManager {
                         &req.job_id,
                         req.attempt_number,
                         &starts,
-                        None,
+                        &[],
                     )
                     .await
                     {

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -51,7 +51,7 @@ use slatedb::config::WriteOptions;
 use crate::instrumented_db::InstrumentedDb;
 
 use crate::job_store_shard::counters::{decode_counter, encode_counter};
-use crate::job_store_shard::helpers::WriteBatcher;
+use crate::job_store_shard::helpers::{WriteBatcher, live_terminal_row_exists};
 
 use crate::codec::{
     decode_concurrency_action, decode_floating_limit_state, encode_concurrency_action,
@@ -2314,6 +2314,12 @@ impl ConcurrencyManager {
             /// JobInfo fetch when computing max_concurrency and resuming the
             /// chain.
             limits: Vec<Limit>,
+            /// The job status's `next_attempt_starts_after_ms`, captured at
+            /// validation. When a resumed chain wrote its terminal row at a
+            /// retargeted start time, this is where that row lives — the
+            /// duplicate-materialization guard checks it alongside the
+            /// request's own start.
+            status_start_ms: Option<i64>,
         }
 
         let mut max_concurrency: Option<(usize, ConcurrencyLimitType)> = None;
@@ -2341,6 +2347,12 @@ impl ConcurrencyManager {
         let mut total_stale_deleted: usize = 0;
         let mut budget_exhausted = false;
         let chain_resumer = self.chain_resumer();
+        // Duplicate-materialization guard, same-batch half: (job_id, attempt)
+        // pairs whose chain this invocation has already resumed into a chunk
+        // batch that is not yet committed — invisible to the durable check.
+        // Cleared at every `commit_grant_chunk`, after which the durable check
+        // sees the committed rows.
+        let mut chunk_materialized: HashSet<(String, u32)> = HashSet::new();
 
         // Scan→validate→grant loop: keeps pulling from the iterator until we've
         // granted `count` requests, or hit the end / capacity limit. Each pass
@@ -2546,6 +2558,7 @@ impl ConcurrencyManager {
                     limit_index,
                     held_queues,
                     limits,
+                    status_start_ms: None,
                 });
             }
 
@@ -2651,7 +2664,7 @@ impl ConcurrencyManager {
             .await;
 
             let mut valid_requests: Vec<ScannedRequest> = Vec::new();
-            for (req, status_result) in scanned.into_iter().zip(status_results.into_iter()) {
+            for (mut req, status_result) in scanned.into_iter().zip(status_results.into_iter()) {
                 let is_valid = match status_result {
                     Ok(Some(status_raw)) => match decode_job_status_owned(&status_raw) {
                         // [SILO-GRANT-5] Request records are only valid for the currently
@@ -2671,7 +2684,10 @@ impl ConcurrencyManager {
                             );
                             false
                         }
-                        Ok(_) => true,
+                        Ok(status) => {
+                            req.status_start_ms = status.next_attempt_starts_after_ms;
+                            true
+                        }
                         Err(_) => {
                             tracing::warn!(
                                 job_id = %req.job_id,
@@ -2806,6 +2822,58 @@ impl ConcurrencyManager {
                     break;
                 }
 
+                // Duplicate-materialization guard: at most one live terminal
+                // task row per (job_id, attempt). A request row whose attempt
+                // already has a live RunAttempt / CheckRateLimit — either
+                // durably (an earlier grant, a replayed conversion) or in this
+                // chunk's uncommitted batch — is a second grant source for the
+                // same chain; granting it would materialize a duplicate row at
+                // a fresh epoch and dispatch the attempt twice. Delete it like
+                // any other stale request.
+                let attempt_key = (req.job_id.clone(), req.attempt_number);
+                let already_materialized = if chunk_materialized.contains(&attempt_key) {
+                    true
+                } else {
+                    let mut starts = vec![req.start_time_ms];
+                    if let Some(s) = req.status_start_ms {
+                        starts.push(s);
+                    }
+                    match live_terminal_row_exists(
+                        db,
+                        &req.task_group,
+                        req.priority,
+                        &req.job_id,
+                        req.attempt_number,
+                        &starts,
+                        None,
+                    )
+                    .await
+                    {
+                        Ok(exists) => exists,
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                job_id = %req.job_id,
+                                queue = %queue,
+                                "grant scanner: duplicate-materialization check failed; skipping request this pass"
+                            );
+                            continue;
+                        }
+                    }
+                };
+                if already_materialized {
+                    tracing::warn!(
+                        job_id = %req.job_id,
+                        queue = %queue,
+                        attempt = req.attempt_number,
+                        task_id = %req.task_id,
+                        "grant scanner: dropping duplicate request; a live terminal task row already exists for this attempt"
+                    );
+                    batch.delete(&req.request_key);
+                    chunk_stale += 1;
+                    continue;
+                }
+
                 // [SILO-GRANT-1] Pre: Queue has capacity — try to atomically reserve a slot
                 if !self.counts.try_reserve_internal(
                     tenant,
@@ -2893,6 +2961,7 @@ impl ConcurrencyManager {
                     }
                 }
 
+                chunk_materialized.insert(attempt_key);
                 chunk_grants.push((req.task_id.clone(), req.task_group.clone()));
 
                 if chunk_grants.len() >= self.grant_scanner_commit_chunk_size {
@@ -2920,6 +2989,7 @@ impl ConcurrencyManager {
                     total_stale_deleted += stale_deletes;
                     all_granted_groups.extend(chunk_grants.drain(..).map(|(_, tg)| tg));
                     chunk_reservations.clear();
+                    chunk_materialized.clear();
                     chunk_now = crate::job_store_shard::now_epoch_ms();
                 }
             }
@@ -2954,6 +3024,7 @@ impl ConcurrencyManager {
             total_granted += chunk_grants.len();
             total_stale_deleted += stale_deletes;
             all_granted_groups.extend(chunk_grants.into_iter().map(|(_, tg)| tg));
+            chunk_materialized.clear();
         }
 
         // No silent cap: surface invocations that yielded on the scan budget so

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -589,6 +589,47 @@ impl JobStoreShard {
         Ok((attempt_val, background_action_transition))
     }
 
+    /// Whether `attempt_key`'s chain already has a live terminal
+    /// materialization, making any further grant source for it a duplicate:
+    /// the job is `Running` at that attempt (materialized AND dispatched),
+    /// this iteration's batch already continued the chain
+    /// (`materialized_attempts` — invisible to a durable read), or a live
+    /// `RunAttempt` / `CheckRateLimit` row exists at the parent's start time
+    /// or the status-pointed start (`live_terminal_row_exists`, ignoring
+    /// `exclude_key`, the row the caller is itself consuming).
+    #[allow(clippy::too_many_arguments)]
+    async fn attempt_already_materialized(
+        &self,
+        state: &DequeueIterationState,
+        status: &JobStatus,
+        attempt_key: &(String, String, u32),
+        task_group: &str,
+        priority: u8,
+        parent_start_time_ms: i64,
+        exclude_key: Option<&[u8]>,
+    ) -> Result<bool, JobStoreShardError> {
+        if status.kind == JobStatusKind::Running
+            || state.materialized_attempts.contains(attempt_key)
+        {
+            return Ok(true);
+        }
+        let mut starts = vec![parent_start_time_ms];
+        if let Some(s) = status.next_attempt_starts_after_ms {
+            starts.push(s);
+        }
+        let (_, job_id, attempt_number) = attempt_key;
+        Ok(live_terminal_row_exists(
+            &self.db,
+            task_group,
+            priority,
+            job_id,
+            *attempt_number,
+            &starts,
+            exclude_key,
+        )
+        .await?)
+    }
+
     /// Process a RequestTicket task.
     ///
     /// The ticket carries the chain's task_id, the persisted limits list,
@@ -698,14 +739,9 @@ impl JobStoreShard {
             return Ok(());
         }
 
-        // Duplicate-materialization guard: at most one live terminal task row
-        // per (job_id, attempt). A Running status at this attempt means the
-        // chain already materialized AND dispatched; a live RunAttempt /
-        // CheckRateLimit row — durable, or written by this iteration's batch
-        // (`materialized_attempts`) — means it materialized and awaits
-        // dispatch. Either way this ticket is a second grant source for the
-        // same chain: drop it WITHOUT releasing holders, which the live chain
-        // owns under the same task id.
+        // Duplicate-materialization guard: this ticket is a second grant
+        // source for a chain that already materialized. Drop it WITHOUT
+        // releasing holders, which the live chain owns under the same task id.
         let parent = parse_task_key(task_key);
         let parent_start_time_ms = parent
             .as_ref()
@@ -713,27 +749,18 @@ impl JobStoreShard {
             .unwrap_or(now_ms);
         let parent_epoch_ms = parent.as_ref().map(|p| p.epoch_ms as i64).unwrap_or(0);
         let attempt_key = (tenant.clone(), job_id.clone(), attempt_number);
-        let already_materialized = if status.kind == JobStatusKind::Running
-            || state.materialized_attempts.contains(&attempt_key)
-        {
-            true
-        } else {
-            let mut starts = vec![parent_start_time_ms];
-            if let Some(s) = status.next_attempt_starts_after_ms {
-                starts.push(s);
-            }
-            live_terminal_row_exists(
-                &self.db,
+        if self
+            .attempt_already_materialized(
+                state,
+                &status,
+                &attempt_key,
                 &req_task_group,
                 rt.priority(),
-                &job_id,
-                attempt_number,
-                &starts,
+                parent_start_time_ms,
                 None,
             )
             .await?
-        };
-        if already_materialized {
+        {
             tracing::warn!(
                 tenant = %tenant,
                 job_id = %job_id,
@@ -1011,27 +1038,18 @@ impl JobStoreShard {
         // WITHOUT releasing holders — the live chain owns them under the same
         // task id.
         let attempt_key = (tenant.to_string(), job_id.to_string(), attempt_number);
-        let already_materialized = if status.kind == JobStatusKind::Running
-            || state.materialized_attempts.contains(&attempt_key)
-        {
-            true
-        } else {
-            let mut starts = vec![parent_start_time_ms];
-            if let Some(s) = status.next_attempt_starts_after_ms {
-                starts.push(s);
-            }
-            live_terminal_row_exists(
-                &self.db,
+        if self
+            .attempt_already_materialized(
+                state,
+                &status,
+                &attempt_key,
                 check_task_group,
                 priority,
-                job_id,
-                attempt_number,
-                &starts,
+                parent_start_time_ms,
                 Some(task_key),
             )
             .await?
-        };
-        if already_materialized {
+        {
             tracing::warn!(
                 tenant = %tenant,
                 job_id = %job_id,
@@ -1166,6 +1184,21 @@ impl JobStoreShard {
                     parent_epoch_ms,
                     check_task_group,
                 )?;
+                // Point the job status at the retry row's start time so
+                // status-driven lookups (cancel, expedite, reimport, and this
+                // handler's own duplicate guard) can find the parked row.
+                if let Some(transition) = self
+                    .retarget_scheduled_task_key(
+                        &mut DbWriteBatcher::new(&self.db, &mut state.batch),
+                        tenant,
+                        job_id,
+                        attempt_number,
+                        retry_backoff,
+                    )
+                    .await?
+                {
+                    state.background_action_transitions.push(transition);
+                }
             }
             Err(e) => {
                 tracing::warn!(job_id = %job_id, error = %e, "gubernator rate limit check failed, will retry");
@@ -1187,11 +1220,23 @@ impl JobStoreShard {
                     parent_epoch_ms,
                     check_task_group,
                 )?;
+                if let Some(transition) = self
+                    .retarget_scheduled_task_key(
+                        &mut DbWriteBatcher::new(&self.db, &mut state.batch),
+                        tenant,
+                        job_id,
+                        attempt_number,
+                        retry_backoff,
+                    )
+                    .await?
+                {
+                    state.background_action_transitions.push(transition);
+                }
             }
         }
 
-        // Every branch above wrote this attempt's next terminal-variant row
-        // (the chain continuation or a rate-limit retry) into the batch.
+        // Every branch above continued this attempt's chain into the batch --
+        // a chain continuation, a parked deferral, or a rate-limit retry.
         state.materialized_attempts.insert(attempt_key);
 
         Ok(())

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -12,7 +12,9 @@ use crate::fb::silo::fb;
 use crate::job::{JobStatus, JobStatusKind, JobView, Limit};
 use crate::job_attempt::{AttemptStatus, JobAttempt, JobAttemptView};
 use crate::job_store_shard::counters::BackgroundActionMetricTransition;
-use crate::job_store_shard::helpers::{DbWriteBatcher, decode_job_status_owned, now_epoch_ms};
+use crate::job_store_shard::helpers::{
+    DbWriteBatcher, decode_job_status_owned, live_terminal_row_exists, now_epoch_ms,
+};
 use crate::job_store_shard::holder_release_guard::PendingHolderReleaseGuard;
 use crate::job_store_shard::{DequeueResult, JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
@@ -51,6 +53,12 @@ struct DequeueIterationState {
     /// double-dispatch detection guard consults this set to catch a repeat
     /// of the same task id within one dequeue call.
     leased_task_ids: HashSet<String>,
+    /// `(tenant, job_id, attempt)` tuples whose chain this iteration has
+    /// already continued into the uncommitted batch. The same-batch half of
+    /// the duplicate-materialization guard: a durable read cannot see this
+    /// batch's terminal-row writes, so a second RequestTicket / CheckRateLimit
+    /// for the same attempt within one iteration is caught here.
+    materialized_attempts: HashSet<(String, String, u32)>,
     processed_internal: bool,
 }
 
@@ -67,6 +75,7 @@ impl DequeueIterationState {
             holder_releases: Vec::new(),
             converted_requests: Vec::new(),
             leased_task_ids: HashSet::new(),
+            materialized_attempts: HashSet::new(),
             processed_internal: false,
         }
     }
@@ -655,7 +664,7 @@ impl JobStoreShard {
                     .push((tenant.clone(), q.clone(), task_id.clone()));
             }
         };
-        match self.db.get(&job_status_key(&tenant, &job_id)).await? {
+        let status = match self.db.get(&job_status_key(&tenant, &job_id)).await? {
             Some(raw) => match decode_job_status_owned(&raw) {
                 Ok(status)
                     if matches!(
@@ -667,7 +676,7 @@ impl JobStoreShard {
                     drop_ticket_and_release(state);
                     return Ok(());
                 }
-                Ok(_) => {}
+                Ok(status) => status,
                 Err(_) => {
                     // Unreadable status — treat as missing.
                     drop_ticket_and_release(state);
@@ -678,6 +687,63 @@ impl JobStoreShard {
                 drop_ticket_and_release(state);
                 return Ok(());
             }
+        };
+
+        // A ticket is only current for the attempt the job status schedules.
+        // A ticket for another attempt is a remnant of an earlier chain (its
+        // attempt could only advance after that chain materialized and
+        // dispatched), so drop it and release its holders.
+        if status.current_attempt != Some(attempt_number) {
+            drop_ticket_and_release(state);
+            return Ok(());
+        }
+
+        // Duplicate-materialization guard: at most one live terminal task row
+        // per (job_id, attempt). A Running status at this attempt means the
+        // chain already materialized AND dispatched; a live RunAttempt /
+        // CheckRateLimit row — durable, or written by this iteration's batch
+        // (`materialized_attempts`) — means it materialized and awaits
+        // dispatch. Either way this ticket is a second grant source for the
+        // same chain: drop it WITHOUT releasing holders, which the live chain
+        // owns under the same task id.
+        let parent = parse_task_key(task_key);
+        let parent_start_time_ms = parent
+            .as_ref()
+            .map(|p| p.start_time_ms as i64)
+            .unwrap_or(now_ms);
+        let parent_epoch_ms = parent.as_ref().map(|p| p.epoch_ms as i64).unwrap_or(0);
+        let attempt_key = (tenant.clone(), job_id.clone(), attempt_number);
+        let already_materialized = if status.kind == JobStatusKind::Running
+            || state.materialized_attempts.contains(&attempt_key)
+        {
+            true
+        } else {
+            let mut starts = vec![parent_start_time_ms];
+            if let Some(s) = status.next_attempt_starts_after_ms {
+                starts.push(s);
+            }
+            live_terminal_row_exists(
+                &self.db,
+                &req_task_group,
+                rt.priority(),
+                &job_id,
+                attempt_number,
+                &starts,
+                None,
+            )
+            .await?
+        };
+        if already_materialized {
+            tracing::warn!(
+                tenant = %tenant,
+                job_id = %job_id,
+                task_id = %task_id,
+                attempt = attempt_number,
+                "dropping duplicate RequestTicket; the attempt's chain already has a live terminal row or is running"
+            );
+            state.batch.delete(task_key);
+            state.ack_deleted(task_key);
+            return Ok(());
         }
 
         // Capacity comes from the persisted limits (no JobInfo round-trip).
@@ -781,12 +847,6 @@ impl JobStoreShard {
         // (task_group, priority, job_id, attempt_number) are constant within a
         // chain, so a fresh `epoch_ms` strictly past the parent's makes the
         // follow-up key unique even when it reuses the parent's start_time.
-        let parent = parse_task_key(task_key);
-        let parent_start_time_ms = parent
-            .as_ref()
-            .map(|p| p.start_time_ms as i64)
-            .unwrap_or(now_ms);
-        let parent_epoch_ms = parent.as_ref().map(|p| p.epoch_ms as i64).unwrap_or(0);
         let task_key_epoch_ms = now_ms.max(parent_epoch_ms + 1);
 
         let mut writer = DbWriteBatcher::new(&self.db, &mut state.batch);
@@ -813,6 +873,8 @@ impl JobStoreShard {
                 },
             )
             .await?;
+
+        state.materialized_attempts.insert(attempt_key);
 
         // Each (queue, task_id) the chain reserved also needs rollback if the
         // batch write fails.
@@ -909,7 +971,7 @@ impl JobStoreShard {
                     .push((tenant.to_string(), queue, check_task_id.to_string()));
             }
         };
-        match self.db.get(&job_status_key(tenant, job_id)).await? {
+        let status = match self.db.get(&job_status_key(tenant, job_id)).await? {
             Some(raw) => match decode_job_status_owned(&raw) {
                 Ok(status)
                     if matches!(
@@ -920,7 +982,7 @@ impl JobStoreShard {
                     drop_and_release(state);
                     return Ok(());
                 }
-                Ok(_) => {}
+                Ok(status) => status,
                 Err(_) => {
                     drop_and_release(state);
                     return Ok(());
@@ -930,6 +992,54 @@ impl JobStoreShard {
                 drop_and_release(state);
                 return Ok(());
             }
+        };
+
+        // A CheckRateLimit is only current for the attempt the job status
+        // schedules; one for another attempt is a remnant of an earlier chain.
+        // Drop it and release its holders.
+        if status.current_attempt != Some(attempt_number) {
+            drop_and_release(state);
+            return Ok(());
+        }
+
+        // Duplicate-materialization guard, mirroring handle_request_ticket: a
+        // Running status at this attempt, an attempt already continued by this
+        // iteration's batch, or a live terminal row elsewhere in the keyspace
+        // (this row's own key is excluded — its batch delete is uncommitted,
+        // so a durable read still sees it) all mean the chain already
+        // materialized through another copy of this continuation. Drop
+        // WITHOUT releasing holders — the live chain owns them under the same
+        // task id.
+        let attempt_key = (tenant.to_string(), job_id.to_string(), attempt_number);
+        let already_materialized = if status.kind == JobStatusKind::Running
+            || state.materialized_attempts.contains(&attempt_key)
+        {
+            true
+        } else {
+            let mut starts = vec![parent_start_time_ms];
+            if let Some(s) = status.next_attempt_starts_after_ms {
+                starts.push(s);
+            }
+            live_terminal_row_exists(
+                &self.db,
+                check_task_group,
+                priority,
+                job_id,
+                attempt_number,
+                &starts,
+                Some(task_key),
+            )
+            .await?
+        };
+        if already_materialized {
+            tracing::warn!(
+                tenant = %tenant,
+                job_id = %job_id,
+                task_id = %check_task_id,
+                attempt = attempt_number,
+                "dropping duplicate CheckRateLimit; the attempt's chain already has a live terminal row or is running"
+            );
+            return Ok(());
         }
 
         // Load job info to get the full limits list
@@ -1079,6 +1189,10 @@ impl JobStoreShard {
                 )?;
             }
         }
+
+        // Every branch above wrote this attempt's next terminal-variant row
+        // (the chain continuation or a rate-limit retry) into the batch.
+        state.materialized_attempts.insert(attempt_key);
 
         Ok(())
     }

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -596,8 +596,12 @@ impl JobStoreShard {
     /// (`materialized_attempts` — invisible to a durable read), or a live
     /// `RunAttempt` / `CheckRateLimit` row exists at the parent's start time
     /// or the status-pointed start (`live_terminal_row_exists`, ignoring
-    /// `exclude_key`, the row the caller is itself consuming).
-    #[allow(clippy::too_many_arguments)]
+    /// every row this iteration's batch has already deleted —
+    /// `tombstone_keys` — since those deletes are uncommitted and a durable
+    /// read still sees them). Skipping all batch-deleted rows, not just the
+    /// caller's own, keeps same-start peers claimed into one batch from
+    /// mutually deferring: the last peer scanned sees only tombstoned
+    /// evidence and continues the chain.
     async fn attempt_already_materialized(
         &self,
         state: &DequeueIterationState,
@@ -606,7 +610,6 @@ impl JobStoreShard {
         task_group: &str,
         priority: u8,
         parent_start_time_ms: i64,
-        exclude_key: Option<&[u8]>,
     ) -> Result<bool, JobStoreShardError> {
         if status.kind == JobStatusKind::Running
             || state.materialized_attempts.contains(attempt_key)
@@ -625,7 +628,7 @@ impl JobStoreShard {
             job_id,
             *attempt_number,
             &starts,
-            exclude_key,
+            &state.tombstone_keys,
         )
         .await?)
     }
@@ -757,7 +760,6 @@ impl JobStoreShard {
                 &req_task_group,
                 rt.priority(),
                 parent_start_time_ms,
-                None,
             )
             .await?
         {
@@ -1032,11 +1034,14 @@ impl JobStoreShard {
         // Duplicate-materialization guard, mirroring handle_request_ticket: a
         // Running status at this attempt, an attempt already continued by this
         // iteration's batch, or a live terminal row elsewhere in the keyspace
-        // (this row's own key is excluded — its batch delete is uncommitted,
-        // so a durable read still sees it) all mean the chain already
-        // materialized through another copy of this continuation. Drop
-        // WITHOUT releasing holders — the live chain owns them under the same
-        // task id.
+        // (rows this batch already consumed are excluded — their deletes are
+        // uncommitted, so a durable read still sees them) all mean the chain
+        // already materialized through another copy of this continuation. The
+        // batch-wide exclusion is what lets exactly one of N same-start peers
+        // claimed into this batch proceed: earlier peers defer to the
+        // still-live later ones, and the last sees only tombstoned evidence.
+        // Drop WITHOUT releasing holders — the live chain owns them under the
+        // same task id.
         let attempt_key = (tenant.to_string(), job_id.to_string(), attempt_number);
         if self
             .attempt_already_materialized(
@@ -1046,7 +1051,6 @@ impl JobStoreShard {
                 check_task_group,
                 priority,
                 parent_start_time_ms,
-                Some(task_key),
             )
             .await?
         {

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -1300,35 +1300,68 @@ impl JobStoreShard {
         // This is guaranteed by construction: RunAttempt tasks are only created when concurrency
         // is granted (at enqueue or grant_next), with held_queues populated.
 
-        // Double-dispatch detection: dispatch is about to write this task's
-        // lease record, so a still-live lease there means the same task was
-        // already dispatched. Detection only -- the overwrite proceeds
-        // unchanged and no guard failure may alter the dispatch outcome.
+        // Double-dispatch guard: dispatch is about to write this task's lease
+        // record, so a still-live lease there means the task id was already
+        // dispatched. Repeats that can only be a duplicate materialization are
+        // DROPPED -- deleted in the batch and acknowledged to the broker like
+        // a delivered row, never delivered:
+        //
+        // - An in-batch repeat: one LeaseTasks call carries one worker for
+        //   its whole iteration and the broker never yields a key twice in
+        //   one claim, so a repeated task id is always a second row.
+        // - A stored live lease held by a DIFFERENT worker while this row is
+        //   still durably present: the leased dispatch deleted its own row in
+        //   its commit, so a surviving row is a second materialization. When
+        //   the row is durably ABSENT (only a stale broker-buffer entry
+        //   survives, the redispatch shape a dequeue future dropped
+        //   mid-commit produces), the dispatch is the lost-response recovery
+        //   and delivers via overwrite.
+        //
+        // A stored live lease held by the SAME worker keeps overwrite
+        // semantics: that is the requeue-after-ambiguous-commit recovery,
+        // re-delivering the task to its rightful owner, and the client's
+        // duplicate-delivery dedup contains the case where the first copy did
+        // arrive. Guard read/decode failures never turn into drops -- on any
+        // uncertainty the dispatch delivers.
+        let mut drop_source: Option<crate::metrics::LeaseOverwriteSource> = None;
         if state.leased_task_ids.contains(task_id) {
             tracing::warn!(
                 tenant = %tenant,
                 job_id = %job_id,
                 task_id = %task_id,
                 worker_id = %worker_id,
+                action = "dropped",
                 "RunAttempt task leased twice within one dequeue iteration; \
-                 overwriting the lease still in this iteration's batch",
+                 dropping the duplicate row",
             );
-            if let Some(m) = &self.metrics {
-                m.record_task_lease_overwrite(
-                    self.name(),
-                    decoded.task_group(),
-                    crate::metrics::LeaseOverwriteSource::Batch,
-                );
-            }
+            drop_source = Some(crate::metrics::LeaseOverwriteSource::Batch);
         } else {
-            // Detection must never alter dispatch: read and decode failures
-            // are logged at debug so a persistently blind detector remains
-            // observable, then dispatch proceeds regardless.
             match self.db.get(&leased_task_key(task_id)).await {
                 Ok(Some(existing_bytes)) => match crate::codec::decode_lease(existing_bytes) {
                     Ok(existing) => {
                         let remaining_lease_ms = existing.expiry_ms() - now_ms;
                         if remaining_lease_ms > 0 {
+                            let row_durably_present = if existing.worker_id() == worker_id {
+                                false
+                            } else {
+                                match self.db.get(&task_key).await {
+                                    Ok(present) => present.is_some(),
+                                    Err(e) => {
+                                        tracing::debug!(
+                                            task_id = %task_id,
+                                            error = %e,
+                                            "lease guard row-presence read failed; delivering via overwrite",
+                                        );
+                                        false
+                                    }
+                                }
+                            };
+                            let action = if row_durably_present {
+                                drop_source = Some(crate::metrics::LeaseOverwriteSource::Stored);
+                                "dropped"
+                            } else {
+                                "overwritten"
+                            };
                             tracing::warn!(
                                 tenant = %tenant,
                                 job_id = %job_id,
@@ -1336,6 +1369,7 @@ impl JobStoreShard {
                                 existing_worker_id = %existing.worker_id(),
                                 new_worker_id = %worker_id,
                                 remaining_lease_ms,
+                                action,
                                 "dispatching RunAttempt over a still-live existing lease; \
                                  possible double dispatch",
                             );
@@ -1361,6 +1395,17 @@ impl JobStoreShard {
                     "lease-overwrite guard read failed",
                 ),
             }
+        }
+        if let Some(source) = drop_source {
+            if let Some(m) = &self.metrics {
+                if source == crate::metrics::LeaseOverwriteSource::Batch {
+                    m.record_task_lease_overwrite(self.name(), decoded.task_group(), source);
+                }
+                m.record_task_lease_duplicate_drop(self.name(), decoded.task_group(), source);
+            }
+            state.batch.delete(task_key);
+            state.ack_deleted(task_key);
+            return Ok(());
         }
         state.leased_task_ids.insert(task_id.to_string());
 

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -54,10 +54,12 @@ struct DequeueIterationState {
     /// of the same task id within one dequeue call.
     leased_task_ids: HashSet<String>,
     /// `(tenant, job_id, attempt)` tuples whose chain this iteration has
-    /// already continued into the uncommitted batch. The same-batch half of
-    /// the duplicate-materialization guard: a durable read cannot see this
-    /// batch's terminal-row writes, so a second RequestTicket / CheckRateLimit
-    /// for the same attempt within one iteration is caught here.
+    /// already continued into the uncommitted batch — including delivering
+    /// its RunAttempt. The same-batch half of the duplicate-materialization
+    /// guard: a durable read cannot see this batch's terminal-row, lease, or
+    /// status writes (and the guard's scan skips rows the batch has deleted),
+    /// so a second RequestTicket / CheckRateLimit for the same attempt within
+    /// one iteration is caught here.
     materialized_attempts: HashSet<(String, String, u32)>,
     processed_internal: bool,
 }
@@ -1457,6 +1459,17 @@ impl JobStoreShard {
             return Ok(());
         }
         state.leased_task_ids.insert(task_id.to_string());
+        // Delivery is this batch materializing (and dispatching) the attempt.
+        // Recording it in the seen-set is what keeps a co-claimed duplicate
+        // grant source from re-continuing the chain: this row is about to be
+        // tombstoned (excluded from the guard's durable scan) and the
+        // status/lease writes below are uncommitted, so a durable read alone
+        // would conclude the attempt was never materialized.
+        state.materialized_attempts.insert((
+            tenant.to_string(),
+            job_id.to_string(),
+            attempt_number,
+        ));
 
         // [SILO-DEQ-3] Delete task from task queue
         state.batch.delete(task_key);

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -330,8 +330,11 @@ pub(crate) async fn find_task_by_identity(
 
 /// Whether a live terminal task row (`RunAttempt` or `CheckRateLimit`) exists
 /// for `(job_id, attempt)` at any of the candidate `start_times`, ignoring
-/// `exclude_key` (the row a chain continuation is consuming in its own
-/// uncommitted batch, which a durable read still sees).
+/// `exclude_keys` (rows the caller's own uncommitted batch has deleted, which
+/// a durable read still sees). Excluding every batch-deleted row — not just
+/// the caller's own — is what breaks the tie between same-start peer rows
+/// claimed into one batch: each peer defers to the still-live later ones, and
+/// the last peer scanned finds no remaining evidence and continues the chain.
 ///
 /// This is the durable half of the duplicate-materialization guard: the chain
 /// re-entry points (grant scanner, RequestTicket grant, CheckRateLimit
@@ -346,7 +349,7 @@ pub(crate) async fn live_terminal_row_exists(
     job_id: &str,
     attempt: u32,
     start_times: &[i64],
-    exclude_key: Option<&[u8]>,
+    exclude_keys: &[Vec<u8>],
 ) -> Result<bool, slatedb::Error> {
     use crate::fb::silo::fb::TaskVariant;
 
@@ -362,7 +365,7 @@ pub(crate) async fn live_terminal_row_exists(
             .scan_with_options::<Vec<u8>, _>(prefix..end, &crate::scan_options())
             .await?;
         while let Some(kv) = iter.next().await? {
-            if exclude_key == Some(kv.key.as_ref()) {
+            if exclude_keys.iter().any(|k| k.as_slice() == kv.key.as_ref()) {
                 continue;
             }
             if let Ok(decoded) = crate::codec::decode_task_validated(kv.value.clone())

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -301,8 +301,13 @@ pub(crate) fn put_task<W: WriteBatcher>(
 /// Status-driven point lookups (lease, cancel, expedite, reimport) know a task's
 /// identity from `JobStatus` but not its `epoch_ms`, which is a write-only
 /// disambiguator (see [`crate::keys::task_key`]). Only one chain task is ever
-/// live per `(job_id, attempt)` — a rewrite deletes the old key and writes the
-/// new one in the same batch — so this prefix scan returns at most one row.
+/// live per `(job_id, attempt)`: a rewrite deletes the old key and writes the
+/// new one in the same batch, and the duplicate-materialization guard —
+/// [`live_terminal_row_exists`] plus the per-batch seen-sets consulted at the
+/// chain re-entry points (the grant scanner's reserve loop,
+/// `handle_request_ticket`, `handle_check_rate_limit`) — drops any second
+/// grant source for an attempt instead of letting it write a coexisting row.
+/// So this prefix scan returns at most one row.
 pub(crate) async fn find_task_by_identity(
     txn: &InstrumentedDbTransaction,
     task_group: &str,
@@ -318,6 +323,56 @@ pub(crate) async fn find_task_by_identity(
         Some(kv) => Ok(Some((kv.key.to_vec(), kv.value))),
         None => Ok(None),
     }
+}
+
+/// Whether a live terminal task row (`RunAttempt` or `CheckRateLimit`) exists
+/// for `(job_id, attempt)` at any of the candidate `start_times`, ignoring
+/// `exclude_key` (the row a chain continuation is consuming in its own
+/// uncommitted batch, which a durable read still sees).
+///
+/// This is the durable half of the duplicate-materialization guard: the chain
+/// re-entry points (grant scanner, RequestTicket grant, CheckRateLimit
+/// continuation) consult it before materializing a terminal row, so a second
+/// grant source for one attempt is dropped instead of coexisting at a fresh
+/// `epoch_ms`. Same-batch repeats are invisible to durable reads and are
+/// caught by the callers' seen-sets instead.
+pub(crate) async fn live_terminal_row_exists(
+    db: &InstrumentedDb,
+    task_group: &str,
+    priority: u8,
+    job_id: &str,
+    attempt: u32,
+    start_times: &[i64],
+    exclude_key: Option<&[u8]>,
+) -> Result<bool, slatedb::Error> {
+    use crate::fb::silo::fb::TaskVariant;
+
+    let mut checked: Vec<i64> = Vec::with_capacity(start_times.len());
+    for &start in start_times {
+        if checked.contains(&start) {
+            continue;
+        }
+        checked.push(start);
+        let prefix = task_key_lookup_prefix(task_group, start, priority, job_id, attempt);
+        let end = end_bound(&prefix);
+        let mut iter = db
+            .scan_with_options::<Vec<u8>, _>(prefix..end, &crate::scan_options())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            if exclude_key == Some(kv.key.as_ref()) {
+                continue;
+            }
+            if let Ok(decoded) = crate::codec::decode_task_validated(kv.value.clone())
+                && matches!(
+                    decoded.variant_type(),
+                    TaskVariant::RunAttempt | TaskVariant::CheckRateLimit
+                )
+            {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
 }
 
 /// Retry an operation that may fail with a SlateDB transaction conflict.

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -300,14 +300,17 @@ pub(crate) fn put_task<W: WriteBatcher>(
 ///
 /// Status-driven point lookups (lease, cancel, expedite, reimport) know a task's
 /// identity from `JobStatus` but not its `epoch_ms`, which is a write-only
-/// disambiguator (see [`crate::keys::task_key`]). Only one chain task is ever
-/// live per `(job_id, attempt)`: a rewrite deletes the old key and writes the
-/// new one in the same batch, and the duplicate-materialization guard —
+/// disambiguator (see [`crate::keys::task_key`]). Only one chain task survives
+/// to dispatch per `(job_id, attempt)`: a rewrite deletes the old key and
+/// writes the new one in the same batch, the duplicate-materialization guard —
 /// [`live_terminal_row_exists`] plus the per-batch seen-sets consulted at the
 /// chain re-entry points (the grant scanner's reserve loop,
 /// `handle_request_ticket`, `handle_check_rate_limit`) — drops any second
-/// grant source for an attempt instead of letting it write a coexisting row.
-/// So this prefix scan returns at most one row.
+/// grant source for an attempt instead of letting it write a coexisting row,
+/// and dispatch drops a provably duplicate row it is handed. The guard
+/// resolves uncertainty toward delivery, so a duplicate can exist transiently
+/// between two concurrent writers' commits; this prefix scan takes the first
+/// row in that window.
 pub(crate) async fn find_task_by_identity(
     txn: &InstrumentedDbTransaction,
     task_group: &str,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -187,6 +187,7 @@ pub struct Metrics {
     // Lease metrics
     task_leases_active: GaugeVec,
     task_lease_overwrites_total: CounterVec,
+    task_lease_duplicate_drops_total: CounterVec,
     ready_to_start_latency_ms: HistogramVec,
     leasable_to_start_latency_ms: HistogramVec,
     lease_reaper_duration: HistogramVec,
@@ -667,6 +668,20 @@ impl Metrics {
         source: LeaseOverwriteSource,
     ) {
         self.task_lease_overwrites_total
+            .with_label_values(&[shard, task_group, source.as_str()])
+            .inc();
+    }
+
+    /// Record a duplicate RunAttempt row dropped at dispatch instead of
+    /// delivered. Every drop is also a detection, so the overwrite counter is
+    /// incremented alongside this one.
+    pub fn record_task_lease_duplicate_drop(
+        &self,
+        shard: &str,
+        task_group: &str,
+        source: LeaseOverwriteSource,
+    ) {
+        self.task_lease_duplicate_drops_total
             .with_label_values(&[shard, task_group, source.as_str()])
             .inc();
     }
@@ -2218,7 +2233,18 @@ pub fn init() -> anyhow::Result<Metrics> {
         CounterVec::new(
             Opts::new(
                 "silo_task_lease_overwrites_total",
-                "Number of RunAttempt dispatches that wrote a lease over a still-live existing lease (double-dispatch detector); source is \"stored\" for a lease found in the DB and \"batch\" for a repeat within one dequeue iteration",
+                "Number of RunAttempt dispatches that found a still-live existing lease for the task id (double-dispatch detector, counted whether the dispatch overwrote or dropped); source is \"stored\" for a lease found in the DB and \"batch\" for a repeat within one dequeue iteration",
+            ),
+            &["shard", "task_group", "source"],
+        )?,
+    );
+
+    let task_lease_duplicate_drops_total = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_task_lease_duplicate_drops_total",
+                "Number of duplicate RunAttempt rows dropped at dispatch instead of delivered (a durably present row whose task id is live-leased by another worker, or a repeat within one dequeue iteration); every drop also increments silo_task_lease_overwrites_total",
             ),
             &["shard", "task_group", "source"],
         )?,
@@ -2576,6 +2602,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         poll_duration,
         task_leases_active,
         task_lease_overwrites_total,
+        task_lease_duplicate_drops_total,
         ready_to_start_latency_ms,
         leasable_to_start_latency_ms,
         lease_reaper_duration,

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -196,13 +196,31 @@ async fn periodic_reconcile_grants_pending_request_without_signal() {
     let manual_task_id = parsed.task_id;
     drop(iter);
 
+    // Clear the enqueue's grant entirely -- holder AND the terminal RunAttempt
+    // row it wrote -- so the injected request models a genuinely parked chain.
+    // A request row coexisting with a live terminal row for the same attempt
+    // is the duplicate-materialization state the grant scanner's guard drops
+    // rather than grants.
     let mut clear_batch = WriteBatch::new();
     clear_batch.delete(&holder_key);
+    let tasks_prefix = silo::keys::task_group_prefix("default");
+    let mut task_iter = shard
+        .db()
+        .scan_with_options::<Vec<u8>, _>(
+            tasks_prefix.clone()..silo::keys::end_bound(&tasks_prefix),
+            &silo::scan_options(),
+        )
+        .await
+        .expect("scan tasks");
+    while let Some(kv) = task_iter.next().await.expect("iterate tasks") {
+        clear_batch.delete(&kv.key);
+    }
+    drop(task_iter);
     shard
         .db()
         .write(clear_batch)
         .await
-        .expect("clear pre-existing holder");
+        .expect("clear pre-existing grant state");
     shard.rollback_concurrency_grant_for_test(tenant, &queue, &manual_task_id);
 
     assert_eq!(

--- a/tests/duplicate_materialization_tests.rs
+++ b/tests/duplicate_materialization_tests.rs
@@ -149,13 +149,10 @@ async fn invariant_helper_reports_hand_planted_duplicate_terminal_rows() {
 }
 
 /// R1 — two request rows for one `(job_id, attempt)` (the state the random
-/// request-key suffix permits) granted by two separate scanner invocations.
-/// Each invocation stamps its own epoch on the resumed chain's terminal write,
-/// so the second grant materializes a second live RunAttempt row.
+/// request-key suffix permits) reaching the scanner in separate invocations:
+/// the first grants; the second is dropped by the duplicate-materialization
+/// guard's durable check, which finds the attempt's live terminal row.
 #[silo::test]
-#[ignore = "red reproduction: duplicate request rows granted across scanner invocations \
-            materialize two terminal rows for one attempt (random request-key suffix + \
-            blind terminal write + per-chunk epoch stamping)"]
 async fn duplicate_request_rows_granted_across_invocations_keep_single_terminal_row() {
     let (_tmp, shard) = open_temp_shard().await;
     shard.stop_grant_scanner();
@@ -187,22 +184,26 @@ async fn duplicate_request_rows_granted_across_invocations_keep_single_terminal_
 
     let first = shard.process_concurrency_grants(tenant, QUEUE, 1).await;
     assert_eq!(first.len(), 1, "first invocation must grant one request");
-    // A later invocation stamps a fresh chunk epoch.
     tokio::time::sleep(std::time::Duration::from_millis(3)).await;
     let second = shard.process_concurrency_grants(tenant, QUEUE, 1).await;
     assert_eq!(
         second.len(),
-        1,
-        "second invocation must grant the duplicate"
+        0,
+        "the duplicate row must be dropped, not granted"
     );
 
     assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+    assert_eq!(count_live_run_attempt_rows(&shard, &job_id).await, 1);
+    assert_eq!(
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "the dropped duplicate row must be deleted"
+    );
 }
 
-/// R2 — the same duplicate request rows granted within ONE scanner commit
-/// chunk share the chunk's epoch, so both terminal writes land at the same
-/// task key and collapse to a single live row. Pins the same-chunk collision
-/// as regression coverage.
+/// R2 — the same duplicate request rows reaching the scanner within ONE
+/// commit chunk: the durable check cannot see the chunk's uncommitted batch,
+/// so the guard's per-chunk seen-set is what drops the second row.
 #[silo::test]
 async fn duplicate_request_rows_granted_in_one_chunk_keep_single_terminal_row() {
     let (_tmp, shard) = open_temp_shard().await;
@@ -236,15 +237,16 @@ async fn duplicate_request_rows_granted_in_one_chunk_keep_single_terminal_row() 
     let granted = shard.process_concurrency_grants(tenant, QUEUE, 2).await;
     assert_eq!(
         granted.len(),
-        2,
-        "both duplicate rows must be granted in one pass (one commit chunk)"
+        1,
+        "one row grants; its same-chunk duplicate must be dropped by the seen-set"
     );
 
     assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+    assert_eq!(count_live_run_attempt_rows(&shard, &job_id).await, 1);
     assert_eq!(
-        count_live_run_attempt_rows(&shard, &job_id).await,
-        1,
-        "same-chunk grants share one epoch, so the terminal writes collide at one key"
+        count_concurrency_requests(shard.db()).await,
+        0,
+        "the dropped duplicate row must be deleted"
     );
 }
 
@@ -255,9 +257,6 @@ async fn duplicate_request_rows_granted_in_one_chunk_keep_single_terminal_row() 
 /// rows dispatch to the worker — one attempt delivered twice, the second over
 /// the first's live lease.
 #[silo::test]
-#[ignore = "red reproduction: a replayed at-capacity RequestTicket conversion leaves both a \
-            request row and a re-processable ticket for one attempt; the scanner and the \
-            ticket each materialize a terminal row and both dispatch (source=stored)"]
 async fn request_ticket_replayed_after_landed_conversion_delivers_attempt_once() {
     let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
     shard.stop_grant_scanner();
@@ -356,14 +355,17 @@ async fn request_ticket_replayed_after_landed_conversion_delivers_attempt_once()
     assert_eq!(overwrites, 0.0, "no lease overwrite may fire");
 }
 
-/// R4 — two chain resumes for one attempt in two separate write batches (the
-/// shape a scanner grant racing a dequeue-driven resume produces): each
-/// writer's durable read cannot see the other's uncommitted batch, and each
-/// stamps its own `now_ms` epoch, so both terminal writes survive commit.
+/// R4 — the cross-writer race: two chain resumes for one attempt run against
+/// separate write batches BEFORE either batch commits (a scanner chunk and a
+/// concurrent dequeue iteration's batch). Each writer's durable read cannot
+/// see the other's uncommitted edits and their per-batch seen-sets are
+/// disjoint, so both terminal writes survive at distinct epochs.
 #[silo::test]
-#[ignore = "red reproduction: two chain resumes for one attempt against separate write \
-            batches each pass their own durable read and stamp distinct epochs — both \
-            terminal rows commit"]
+#[ignore = "residual: the cross-writer interleaving defeats any per-writer durable read \
+            plus seen-set; closing it needs a transactional write path or deterministic \
+            request-row identity. Containment: dispatch-time prevention backstops the \
+            different-worker and in-batch delivery shapes, and the hardened client's \
+            duplicate-delivery dedup contains the same-worker shape"]
 async fn concurrent_chain_resumes_in_two_batches_keep_single_terminal_row() {
     let (_tmp, shard) = open_temp_shard().await;
     shard.stop_grant_scanner();
@@ -393,7 +395,10 @@ async fn concurrent_chain_resumes_in_two_batches_keep_single_terminal_row() {
         read_cache: None,
     };
 
+    // Both writers resume with neither batch committed — the interleaving a
+    // concurrent scanner chunk and dequeue iteration produce.
     let epoch_base = now_ms();
+    let mut batches = Vec::new();
     for offset in [0, 1] {
         let mut batch = WriteBatch::new();
         let grants = resumer
@@ -404,6 +409,9 @@ async fn concurrent_chain_resumes_in_two_batches_keep_single_terminal_row() {
             grants.is_empty(),
             "terminal resume makes no further reservations"
         );
+        batches.push(batch);
+    }
+    for batch in batches {
         shard.db().write(batch).await.expect("commit resume batch");
     }
 
@@ -416,9 +424,6 @@ async fn concurrent_chain_resumes_in_two_batches_keep_single_terminal_row() {
 /// same worker — the second over the first's still-live lease — so one
 /// attempt is delivered twice.
 #[silo::test]
-#[ignore = "red reproduction: a replayed CheckRateLimit continuation re-enters the chain \
-            with the same task id and materializes a second RunAttempt; both dispatch, \
-            the second over the first's live lease (source=stored)"]
 async fn replayed_check_rate_limit_continuation_delivers_attempt_once() {
     let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
     shard.stop_grant_scanner();
@@ -492,6 +497,51 @@ async fn replayed_check_rate_limit_continuation_delivers_attempt_once() {
         &["silo_task_lease_overwrites_total", "task_group=\"default\""],
     );
     assert_eq!(overwrites, 0.0, "no lease overwrite may fire");
+}
+
+/// A legitimate chain re-materialization must keep dodging the broker's ack
+/// tombstone: processing a CheckRateLimit through a real dequeue ack-deletes
+/// its row (tombstoning that exact key in the broker), and the continuation
+/// RunAttempt reuses every key component except a strictly fresher epoch. An
+/// epoch reuse would be suppressed by the tombstone and never deliver.
+#[silo::test]
+async fn rate_limit_chain_delivers_once_after_its_check_row_is_tombstoned() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let tenant = "rl-tombstone-dodge";
+    let limits = vec![Limit::RateLimit(GubernatorRateLimit::new(
+        "rl-dodge",
+        "rl-dodge-key",
+        100,
+        60_000,
+    ))];
+
+    shard
+        .enqueue(
+            tenant,
+            None,
+            10,
+            now_ms(),
+            None,
+            msgpack_payload(&serde_json::json!({})),
+            limits,
+            None,
+            TASK_GROUP,
+        )
+        .await
+        .expect("enqueue rate-limited job");
+
+    // The dequeue loop claims the CheckRateLimit through the broker (ack
+    // tombstone installed at its key), writes the continuation, and delivers
+    // it — exactly once.
+    let task_ids = dequeue_task_ids_until(&shard, "worker-rl", TASK_GROUP, 1).await;
+    assert_eq!(task_ids.len(), 1, "the chain's RunAttempt must deliver");
+
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+    assert_eq!(
+        count_task_keys(shard.db()).await,
+        0,
+        "no task row may remain after delivery"
+    );
 }
 
 /// R6 — redispatch over another worker's still-live lease (the

--- a/tests/duplicate_materialization_tests.rs
+++ b/tests/duplicate_materialization_tests.rs
@@ -589,6 +589,87 @@ async fn replayed_check_rate_limit_continuation_delivers_attempt_once() {
     assert_eq!(overwrites, 0.0, "no lease overwrite may fire");
 }
 
+/// Two live CheckRateLimit peers for one attempt at the same start time
+/// (differing only in `epoch_ms`), claimed in one dequeue iteration. Each
+/// peer's durable guard scan sees the other, so the guard must ignore rows
+/// this iteration's batch already consumed — otherwise both peers defer to
+/// each other, both deletes commit, and the attempt stalls `Scheduled` with
+/// no live row.
+#[silo::test]
+async fn peer_check_rate_limit_rows_at_same_start_deliver_attempt_once() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let tenant = "dup-crl-peer";
+    let limits = vec![Limit::RateLimit(GubernatorRateLimit::new(
+        "dup-peer-rl",
+        "dup-peer-rl-key",
+        100,
+        60_000,
+    ))];
+
+    // Enqueue with a past start so the chain writes a ready CheckRateLimit row.
+    let start_a = now_ms() - 2_000;
+    let job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10,
+            start_a,
+            None,
+            msgpack_payload(&serde_json::json!({})),
+            limits,
+            None,
+            TASK_GROUP,
+        )
+        .await
+        .expect("enqueue rate-limited job");
+
+    let (crl_key, crl_bytes) = first_task_kv(shard.db()).await.expect("check row present");
+    let Ok(Task::CheckRateLimit { .. }) = silo::codec::decode_task(&crl_bytes) else {
+        panic!("expected the job's CheckRateLimit row");
+    };
+
+    // The replay's durable state: a peer CheckRateLimit row at the SAME start,
+    // distinguished only by `epoch_ms` — the shape a replay that reuses the
+    // parent's start time produces. Both rows share a key prefix, so each
+    // peer's guard scan sees the other.
+    let peer_key = silo::keys::task_key(TASK_GROUP, start_a, 10, &job_id, 1, now_ms() + 50_000);
+    assert_ne!(peer_key, crl_key, "peer must be a distinct key");
+    let mut batch = WriteBatch::new();
+    batch.put(&peer_key, &crl_bytes);
+    shard.db().write(batch).await.expect("write peer row");
+    shard.db().flush().await.expect("flush peer row");
+
+    // Force both peers into one claimed batch so a single dequeue iteration
+    // processes them back to back.
+    shard
+        .force_buffer_tasks_for_test(vec![crl_key.clone(), peer_key.clone()])
+        .await
+        .expect("buffer both peers");
+
+    let mut deliveries = Vec::new();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        let out = shard
+            .dequeue("worker-crl-peer", TASK_GROUP, 4)
+            .await
+            .expect("dequeue")
+            .tasks;
+        deliveries.extend(out.iter().map(|t| t.attempt().task_id().to_string()));
+        if count_task_keys(shard.db()).await == 0 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+    assert_eq!(
+        deliveries.len(),
+        1,
+        "one peer must continue the chain and deliver exactly once, got deliveries {deliveries:?}"
+    );
+}
+
 /// A replayed CheckRateLimit for an attempt whose live chain is parked in a
 /// rate-limit retry backoff must be dropped, not re-entered: the retry branch
 /// retargets the job status to the retry row's start time, so the guard's

--- a/tests/duplicate_materialization_tests.rs
+++ b/tests/duplicate_materialization_tests.rs
@@ -1,0 +1,588 @@
+//! Reproductions for double materialization of terminal task rows.
+//!
+//! A job's limit chain must keep at most one live terminal task row
+//! (`RunAttempt` or `CheckRateLimit`) per `(job_id, attempt)`. The task key's
+//! trailing `epoch_ms` is a write-time disambiguator, not identity, so any two
+//! writers that stamp different epochs coexist and the same attempt dispatches
+//! twice. Each test here arranges one candidate mechanism directly and asserts
+//! the invariant via `assert_single_live_terminal_task_row_per_attempt`;
+//! `#[ignore]`d tests are red reproductions of mechanisms the grant /
+//! chain-resume / request-row path does not yet prevent.
+
+mod test_helpers;
+
+use silo::codec::encode_task;
+use silo::concurrency::ResumeChainParams;
+use silo::job::{ConcurrencyLimit, GubernatorRateLimit, Limit};
+use silo::job_attempt::AttemptOutcome;
+use silo::task::{ConcurrencyAction, Task};
+use slatedb::WriteBatch;
+
+use test_helpers::*;
+
+const QUEUE: &str = "dup-q";
+const TASK_GROUP: &str = "default";
+
+fn one_concurrency_limit(max_concurrency: u32) -> Vec<Limit> {
+    vec![Limit::Concurrency(ConcurrencyLimit {
+        key: QUEUE.to_string(),
+        max_concurrency,
+    })]
+}
+
+/// Enqueue a job whose chain parks without a live terminal row: the start time
+/// is far in the future, so the walk writes a future `RequestTicket` and the
+/// job sits in `Scheduled` at attempt 1. Returns the job id.
+async fn enqueue_parked_job(
+    shard: &silo::job_store_shard::JobStoreShard,
+    tenant: &str,
+    limits: Vec<Limit>,
+) -> String {
+    shard
+        .enqueue(
+            tenant,
+            None,
+            10,
+            now_ms() + 3_600_000,
+            None,
+            msgpack_payload(&serde_json::json!({})),
+            limits,
+            None,
+            TASK_GROUP,
+        )
+        .await
+        .expect("enqueue parked job")
+}
+
+/// Hand-write a deferred concurrency request row for `job_id`'s attempt 1,
+/// carrying `task_id` as the chain task id — the durable state
+/// `append_request_edits` produces. `suffix` stands in for the random key
+/// suffix, so repeated calls create additional rows for the same attempt
+/// instead of colliding.
+async fn write_request_row(
+    shard: &silo::job_store_shard::JobStoreShard,
+    tenant: &str,
+    job_id: &str,
+    task_id: &str,
+    start_time_ms: i64,
+    suffix: &str,
+    limits: &[Limit],
+) {
+    let action = ConcurrencyAction::EnqueueTask {
+        start_time_ms,
+        priority: 10,
+        job_id: job_id.to_string(),
+        attempt_number: 1,
+        relative_attempt_number: 1,
+        task_group: TASK_GROUP.to_string(),
+        limit_index: 0,
+        held_queues: Vec::new(),
+        task_id: task_id.to_string(),
+        limits: limits.to_vec(),
+    };
+    let key =
+        silo::keys::concurrency_request_key(tenant, QUEUE, start_time_ms, 10, job_id, 1, suffix);
+    let mut batch = WriteBatch::new();
+    batch.put(&key, &silo::codec::encode_concurrency_action(&action));
+    shard.db().write(batch).await.expect("write request row");
+    shard.db().flush().await.expect("flush request row");
+}
+
+/// Count live RunAttempt task rows for a job across the task keyspace.
+async fn count_live_run_attempt_rows(
+    shard: &silo::job_store_shard::JobStoreShard,
+    job_id: &str,
+) -> usize {
+    let prefix = silo::keys::task_group_prefix(TASK_GROUP);
+    let end = silo::keys::end_bound(&prefix);
+    let mut iter = shard
+        .db()
+        .scan::<Vec<u8>, _>(prefix..end)
+        .await
+        .expect("scan tasks");
+    let mut count = 0;
+    while let Some(kv) = iter.next().await.expect("iterate tasks") {
+        if let Ok(Task::RunAttempt { job_id: jid, .. }) = silo::codec::decode_task(&kv.value)
+            && jid == job_id
+        {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// The invariant helper itself must detect a hand-planted duplicate: two live
+/// RunAttempt rows for one `(job_id, attempt)` at different epochs.
+#[silo::test]
+async fn invariant_helper_reports_hand_planted_duplicate_terminal_rows() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let start = now_ms() - 1_000;
+
+    let task = Task::RunAttempt {
+        id: "planted-task".to_string(),
+        tenant: "-".to_string(),
+        job_id: "planted-job".to_string(),
+        attempt_number: 1,
+        relative_attempt_number: 1,
+        held_queues: vec![],
+        task_group: TASK_GROUP.to_string(),
+    };
+    let mut batch = WriteBatch::new();
+    for epoch in [start, start + 1] {
+        batch.put(
+            &silo::keys::task_key(TASK_GROUP, start, 10, "planted-job", 1, epoch),
+            &encode_task(&task),
+        );
+    }
+    shard.db().write(batch).await.expect("write duplicates");
+
+    let violations = duplicate_live_terminal_task_rows(shard.db()).await;
+    assert_eq!(
+        violations.len(),
+        1,
+        "expected exactly one violation group, got {violations:?}"
+    );
+    assert!(
+        violations[0].contains("planted-job") && violations[0].contains("2 live terminal"),
+        "violation should name the job and the row count: {violations:?}"
+    );
+}
+
+/// R1 — two request rows for one `(job_id, attempt)` (the state the random
+/// request-key suffix permits) granted by two separate scanner invocations.
+/// Each invocation stamps its own epoch on the resumed chain's terminal write,
+/// so the second grant materializes a second live RunAttempt row.
+#[silo::test]
+#[ignore = "red reproduction: duplicate request rows granted across scanner invocations \
+            materialize two terminal rows for one attempt (random request-key suffix + \
+            blind terminal write + per-chunk epoch stamping)"]
+async fn duplicate_request_rows_granted_across_invocations_keep_single_terminal_row() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let tenant = "dup-cross-invocation";
+    let limits = one_concurrency_limit(2);
+
+    let job_id = enqueue_parked_job(&shard, tenant, limits.clone()).await;
+    let ready_at = now_ms() - 1_000;
+    write_request_row(
+        &shard,
+        tenant,
+        &job_id,
+        "dup-chain-task",
+        ready_at,
+        "aaaa0001",
+        &limits,
+    )
+    .await;
+    write_request_row(
+        &shard,
+        tenant,
+        &job_id,
+        "dup-chain-task",
+        ready_at,
+        "bbbb0002",
+        &limits,
+    )
+    .await;
+
+    let first = shard.process_concurrency_grants(tenant, QUEUE, 1).await;
+    assert_eq!(first.len(), 1, "first invocation must grant one request");
+    // A later invocation stamps a fresh chunk epoch.
+    tokio::time::sleep(std::time::Duration::from_millis(3)).await;
+    let second = shard.process_concurrency_grants(tenant, QUEUE, 1).await;
+    assert_eq!(
+        second.len(),
+        1,
+        "second invocation must grant the duplicate"
+    );
+
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+}
+
+/// R2 — the same duplicate request rows granted within ONE scanner commit
+/// chunk share the chunk's epoch, so both terminal writes land at the same
+/// task key and collapse to a single live row. Pins the same-chunk collision
+/// as regression coverage.
+#[silo::test]
+async fn duplicate_request_rows_granted_in_one_chunk_keep_single_terminal_row() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let tenant = "dup-same-chunk";
+    let limits = one_concurrency_limit(2);
+
+    let job_id = enqueue_parked_job(&shard, tenant, limits.clone()).await;
+    let ready_at = now_ms() - 1_000;
+    write_request_row(
+        &shard,
+        tenant,
+        &job_id,
+        "dup-chain-task",
+        ready_at,
+        "aaaa0001",
+        &limits,
+    )
+    .await;
+    write_request_row(
+        &shard,
+        tenant,
+        &job_id,
+        "dup-chain-task",
+        ready_at,
+        "bbbb0002",
+        &limits,
+    )
+    .await;
+
+    let granted = shard.process_concurrency_grants(tenant, QUEUE, 2).await;
+    assert_eq!(
+        granted.len(),
+        2,
+        "both duplicate rows must be granted in one pass (one commit chunk)"
+    );
+
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+    assert_eq!(
+        count_live_run_attempt_rows(&shard, &job_id).await,
+        1,
+        "same-chunk grants share one epoch, so the terminal writes collide at one key"
+    );
+}
+
+/// R3 — a RequestTicket replayed after its at-capacity conversion committed:
+/// the durable request row from the conversion AND the replayed ticket both
+/// continue the same chain. The scanner grants the row while the job is still
+/// `Scheduled`; the replayed ticket grants again at dequeue; both terminal
+/// rows dispatch to the worker — one attempt delivered twice, the second over
+/// the first's live lease.
+#[silo::test]
+#[ignore = "red reproduction: a replayed at-capacity RequestTicket conversion leaves both a \
+            request row and a re-processable ticket for one attempt; the scanner and the \
+            ticket each materialize a terminal row and both dispatch (source=stored)"]
+async fn request_ticket_replayed_after_landed_conversion_delivers_attempt_once() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    shard.stop_grant_scanner();
+    let tenant = "dup-ticket-replay";
+    let limits = one_concurrency_limit(2);
+
+    let job_id = enqueue_parked_job(&shard, tenant, limits.clone()).await;
+
+    // The chain's ticket sits future-dated; read its task id — the conversion
+    // and the replay both carry it.
+    let (ticket_key, ticket_bytes) = first_task_kv(shard.db()).await.expect("ticket present");
+    let Ok(Task::RequestTicket {
+        task_id, priority, ..
+    }) = silo::codec::decode_task(&ticket_bytes)
+    else {
+        panic!("expected the parked job's RequestTicket");
+    };
+
+    // Durable state of the landed conversion: a request row for the attempt,
+    // with the future ticket replaced by the replayed ready-dated copy (the
+    // broker re-buffered the ticket whose conversion commit landed).
+    let ready_at = now_ms() - 1_000;
+    write_request_row(
+        &shard, tenant, &job_id, &task_id, ready_at, "aaaa0001", &limits,
+    )
+    .await;
+    let replayed = Task::RequestTicket {
+        queue: QUEUE.to_string(),
+        start_time_ms: ready_at,
+        priority,
+        tenant: tenant.to_string(),
+        job_id: job_id.clone(),
+        attempt_number: 1,
+        relative_attempt_number: 1,
+        task_id: task_id.clone(),
+        task_group: TASK_GROUP.to_string(),
+        limit_index: 0,
+        held_queues: vec![],
+        limits: limits.clone(),
+    };
+    let replayed_key = silo::keys::task_key(TASK_GROUP, ready_at, priority, &job_id, 1, ready_at);
+    let mut batch = WriteBatch::new();
+    batch.put(&replayed_key, &encode_task(&replayed));
+    batch.delete(&ticket_key);
+    shard
+        .db()
+        .write(batch)
+        .await
+        .expect("write replayed ticket");
+    shard.db().flush().await.expect("flush replayed ticket");
+
+    // The scanner grants the conversion's request row: the chain's terminal
+    // RunAttempt row exists, undispatched, and the job is still Scheduled.
+    let granted = shard.process_concurrency_grants(tenant, QUEUE, 1).await;
+    assert_eq!(
+        granted.len(),
+        1,
+        "the landed conversion's request row must validate and grant"
+    );
+    assert_eq!(count_live_run_attempt_rows(&shard, &job_id).await, 1);
+
+    // A worker polls: the replayed ticket grants the chain AGAIN and writes a
+    // second terminal row; both rows dispatch. A single execution total means
+    // exactly one delivery and no lease overwrite.
+    tokio::time::sleep(std::time::Duration::from_millis(3)).await;
+    shard
+        .force_buffer_tasks_for_test(vec![replayed_key])
+        .await
+        .expect("buffer replayed ticket");
+    let mut deliveries = Vec::new();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        let out = shard
+            .dequeue("worker-replay", TASK_GROUP, 4)
+            .await
+            .expect("dequeue")
+            .tasks;
+        deliveries.extend(out.iter().map(|t| t.attempt().task_id().to_string()));
+        if count_live_run_attempt_rows(&shard, &job_id).await == 0 && !deliveries.is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+    assert_eq!(
+        deliveries.len(),
+        1,
+        "one attempt must be delivered exactly once, got deliveries {deliveries:?}"
+    );
+    let body = gather_metrics_text(&metrics);
+    let overwrites = metric_value_or_zero(
+        &body,
+        &["silo_task_lease_overwrites_total", "task_group=\"default\""],
+    );
+    assert_eq!(overwrites, 0.0, "no lease overwrite may fire");
+}
+
+/// R4 — two chain resumes for one attempt in two separate write batches (the
+/// shape a scanner grant racing a dequeue-driven resume produces): each
+/// writer's durable read cannot see the other's uncommitted batch, and each
+/// stamps its own `now_ms` epoch, so both terminal writes survive commit.
+#[silo::test]
+#[ignore = "red reproduction: two chain resumes for one attempt against separate write \
+            batches each pass their own durable read and stamp distinct epochs — both \
+            terminal rows commit"]
+async fn concurrent_chain_resumes_in_two_batches_keep_single_terminal_row() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let tenant = "dup-two-batch";
+    let limits = one_concurrency_limit(2);
+
+    let job_id = enqueue_parked_job(&shard, tenant, limits.clone()).await;
+    let resumer = shard
+        .take_chain_resumer_for_test()
+        .expect("chain resumer installed at shard open");
+
+    let start_at = now_ms() - 1_000;
+    let resume_params = |epoch_now: i64| ResumeChainParams {
+        tenant: tenant.to_string(),
+        task_id: "dup-chain-task".to_string(),
+        job_id: job_id.clone(),
+        attempt_number: 1,
+        relative_attempt_number: 1,
+        // Past the final limit: the resumer writes the terminal RunAttempt.
+        limit_index: 1,
+        priority: 10,
+        start_at_ms: start_at,
+        held_queues: vec![QUEUE.to_string()],
+        task_group: TASK_GROUP.to_string(),
+        limits: limits.clone(),
+        now_ms: epoch_now,
+        read_cache: None,
+    };
+
+    let epoch_base = now_ms();
+    for offset in [0, 1] {
+        let mut batch = WriteBatch::new();
+        let grants = resumer
+            .resume_chain(&mut batch, resume_params(epoch_base + offset))
+            .await
+            .expect("resume chain");
+        assert!(
+            grants.is_empty(),
+            "terminal resume makes no further reservations"
+        );
+        shard.db().write(batch).await.expect("commit resume batch");
+    }
+
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+}
+
+/// R5 — a replayed CheckRateLimit continuation: two live CheckRateLimit rows
+/// for one attempt (the durable state a replay produces) each re-enter the
+/// chain and each writes a RunAttempt at its own key. Both dispatch to the
+/// same worker — the second over the first's still-live lease — so one
+/// attempt is delivered twice.
+#[silo::test]
+#[ignore = "red reproduction: a replayed CheckRateLimit continuation re-enters the chain \
+            with the same task id and materializes a second RunAttempt; both dispatch, \
+            the second over the first's live lease (source=stored)"]
+async fn replayed_check_rate_limit_continuation_delivers_attempt_once() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    shard.stop_grant_scanner();
+    let tenant = "dup-crl-replay";
+    let limits = vec![Limit::RateLimit(GubernatorRateLimit::new(
+        "dup-rl",
+        "dup-rl-key",
+        100,
+        60_000,
+    ))];
+
+    // Enqueue with a past start so the chain writes a ready CheckRateLimit row.
+    let start_a = now_ms() - 2_000;
+    let job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10,
+            start_a,
+            None,
+            msgpack_payload(&serde_json::json!({})),
+            limits,
+            None,
+            TASK_GROUP,
+        )
+        .await
+        .expect("enqueue rate-limited job");
+
+    let (_crl_key, crl_bytes) = first_task_kv(shard.db()).await.expect("check row present");
+    let Ok(Task::CheckRateLimit { .. }) = silo::codec::decode_task(&crl_bytes) else {
+        panic!("expected the job's CheckRateLimit row");
+    };
+
+    // The replay's durable state: a second live CheckRateLimit row for the
+    // same attempt at a different key (later start keeps the two rows' chain
+    // continuations at distinct task keys regardless of epoch collisions).
+    let start_b = start_a + 1_000;
+    let replay_key = silo::keys::task_key(TASK_GROUP, start_b, 10, &job_id, 1, start_b);
+    let mut batch = WriteBatch::new();
+    batch.put(&replay_key, &crl_bytes);
+    shard.db().write(batch).await.expect("write replayed row");
+    shard.db().flush().await.expect("flush replayed row");
+
+    // One dequeue loop processes both continuations and the RunAttempts they
+    // write. A single execution total means one delivery and no lease
+    // overwrite.
+    let mut deliveries = Vec::new();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        let out = shard
+            .dequeue("worker-crl", TASK_GROUP, 4)
+            .await
+            .expect("dequeue")
+            .tasks;
+        deliveries.extend(out.iter().map(|t| t.attempt().task_id().to_string()));
+        if count_task_keys(shard.db()).await == 0 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+    assert_eq!(
+        deliveries.len(),
+        1,
+        "one attempt must be delivered exactly once, got deliveries {deliveries:?}"
+    );
+    let body = gather_metrics_text(&metrics);
+    let overwrites = metric_value_or_zero(
+        &body,
+        &["silo_task_lease_overwrites_total", "task_group=\"default\""],
+    );
+    assert_eq!(overwrites, 0.0, "no lease overwrite may fire");
+}
+
+/// R6 — redispatch over another worker's still-live lease (the
+/// production-confirmed cancelled-dequeue shape): the row is the SAME
+/// materialization delivered again, so it must deliver (lost-response
+/// recovery), count a stored overwrite, and leave no duplicate terminal row.
+#[silo::test]
+async fn redispatch_over_other_workers_live_lease_delivers_without_duplicate_row() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let tenant = "dup-redispatch";
+    let now = now_ms();
+
+    shard
+        .enqueue(
+            tenant,
+            None,
+            10,
+            now,
+            None,
+            msgpack_payload(&serde_json::json!({})),
+            vec![],
+            None,
+            TASK_GROUP,
+        )
+        .await
+        .expect("enqueue");
+
+    let (_key, task_bytes) = first_task_kv(shard.db()).await.expect("task present");
+    let Ok(Task::RunAttempt {
+        id: task_id,
+        job_id,
+        ..
+    }) = silo::codec::decode_task(&task_bytes)
+    else {
+        panic!("expected RunAttempt task");
+    };
+
+    // The still-live lease a dropped-mid-commit dispatch to worker A leaves
+    // behind (its response never reached A).
+    let lease = silo::task::LeaseRecord {
+        worker_id: "worker-a".to_string(),
+        task: Task::RunAttempt {
+            id: task_id.clone(),
+            tenant: tenant.to_string(),
+            job_id: job_id.clone(),
+            attempt_number: 1,
+            relative_attempt_number: 1,
+            held_queues: vec![],
+            task_group: TASK_GROUP.to_string(),
+        },
+        expiry_ms: now + silo::task::DEFAULT_LEASE_MS,
+        started_at_ms: now,
+    };
+    let mut batch = WriteBatch::new();
+    batch.put(
+        &silo::keys::leased_task_key(&task_id),
+        &silo::codec::encode_lease(&lease),
+    );
+    shard.db().write(batch).await.expect("write lease");
+    shard.db().flush().await.expect("flush lease");
+
+    let result = shard
+        .dequeue("worker-b", TASK_GROUP, 1)
+        .await
+        .expect("dequeue");
+    assert_eq!(result.tasks.len(), 1, "the redispatch must deliver");
+
+    let body = gather_metrics_text(&metrics);
+    let stored = metric_value_or_zero(
+        &body,
+        &[
+            "silo_task_lease_overwrites_total",
+            "task_group=\"default\"",
+            "source=\"stored\"",
+        ],
+    );
+    assert_eq!(stored, 1.0, "the redispatch counts one stored overwrite");
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+    assert_eq!(
+        count_live_run_attempt_rows(&shard, &job_id).await,
+        0,
+        "the redispatch consumed the single materialization; no duplicate row exists"
+    );
+
+    // Reporting the outcome as worker-b completes the attempt normally.
+    let delivered_task_id = result.tasks[0].attempt().task_id().to_string();
+    shard
+        .report_attempt_outcome(
+            &delivered_task_id,
+            AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("report outcome");
+}

--- a/tests/duplicate_materialization_tests.rs
+++ b/tests/duplicate_materialization_tests.rs
@@ -184,6 +184,10 @@ async fn duplicate_request_rows_granted_across_invocations_keep_single_terminal_
 
     let first = shard.process_concurrency_grants(tenant, QUEUE, 1).await;
     assert_eq!(first.len(), 1, "first invocation must grant one request");
+    // Advance the millisecond clock so a regressed guard would write the
+    // duplicate at a distinct epoch instead of silently coalescing onto the
+    // first grant's key, which would let the invariant assertion pass
+    // vacuously.
     tokio::time::sleep(std::time::Duration::from_millis(3)).await;
     let second = shard.process_concurrency_grants(tenant, QUEUE, 1).await;
     assert_eq!(
@@ -199,6 +203,90 @@ async fn duplicate_request_rows_granted_across_invocations_keep_single_terminal_
         0,
         "the dropped duplicate row must be deleted"
     );
+}
+
+/// A job routed through TWO concurrency queues whose first grant is
+/// processed twice (the incident's routing shape): the first grant resumes
+/// the chain through the second queue to the terminal RunAttempt; the
+/// duplicate is dropped, leaving exactly one live row, one delivery carrying
+/// both held queues, and one holder per queue.
+#[silo::test]
+async fn two_limit_chain_with_first_grant_processed_twice_delivers_once() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let tenant = "dup-two-queues";
+    let queue_b = "dup-q-b";
+    let limits = vec![
+        Limit::Concurrency(ConcurrencyLimit {
+            key: QUEUE.to_string(),
+            max_concurrency: 2,
+        }),
+        Limit::Concurrency(ConcurrencyLimit {
+            key: queue_b.to_string(),
+            max_concurrency: 2,
+        }),
+    ];
+
+    let job_id = enqueue_parked_job(&shard, tenant, limits.clone()).await;
+    let ready_at = now_ms() - 1_000;
+    write_request_row(
+        &shard,
+        tenant,
+        &job_id,
+        "dup-two-queue-task",
+        ready_at,
+        "aaaa0001",
+        &limits,
+    )
+    .await;
+    write_request_row(
+        &shard,
+        tenant,
+        &job_id,
+        "dup-two-queue-task",
+        ready_at,
+        "bbbb0002",
+        &limits,
+    )
+    .await;
+
+    let first = shard.process_concurrency_grants(tenant, QUEUE, 1).await;
+    assert_eq!(first.len(), 1, "first invocation must grant and resume");
+    // Advance the millisecond clock so a regressed guard would write the
+    // duplicate at a distinct epoch instead of coalescing onto the first
+    // grant's key.
+    tokio::time::sleep(std::time::Duration::from_millis(3)).await;
+    let second = shard.process_concurrency_grants(tenant, QUEUE, 1).await;
+    assert_eq!(
+        second.len(),
+        0,
+        "the duplicate must be dropped, not granted"
+    );
+
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+    assert_eq!(count_live_run_attempt_rows(&shard, &job_id).await, 1);
+
+    let task_ids = dequeue_task_ids_until(&shard, "worker-two-q", TASK_GROUP, 1).await;
+    let lease_bytes = shard
+        .db()
+        .get(&silo::keys::leased_task_key(&task_ids[0]))
+        .await
+        .expect("read lease")
+        .expect("lease present");
+    let lease = silo::codec::decode_lease(lease_bytes).expect("decode lease");
+    let held = lease.held_queues();
+    assert_eq!(
+        held,
+        vec![QUEUE.to_string(), queue_b.to_string()],
+        "the delivered chain must hold both queues in order"
+    );
+    let followup = shard
+        .dequeue("worker-two-q", TASK_GROUP, 1)
+        .await
+        .expect("follow-up poll");
+    assert!(followup.tasks.is_empty(), "exactly one delivery total");
+    assert_eq!(shard.concurrency_holder_count(tenant, QUEUE), 1);
+    assert_eq!(shard.concurrency_holder_count(tenant, queue_b), 1);
 }
 
 /// R2 — the same duplicate request rows reaching the scanner within ONE
@@ -320,7 +408,9 @@ async fn request_ticket_replayed_after_landed_conversion_delivers_attempt_once()
 
     // A worker polls: the replayed ticket grants the chain AGAIN and writes a
     // second terminal row; both rows dispatch. A single execution total means
-    // exactly one delivery and no lease overwrite.
+    // exactly one delivery and no lease overwrite. The sleep advances the
+    // millisecond clock so a regressed guard would write the duplicate at a
+    // distinct epoch instead of silently coalescing onto the first row's key.
     tokio::time::sleep(std::time::Duration::from_millis(3)).await;
     shard
         .force_buffer_tasks_for_test(vec![replayed_key])
@@ -499,6 +589,81 @@ async fn replayed_check_rate_limit_continuation_delivers_attempt_once() {
     assert_eq!(overwrites, 0.0, "no lease overwrite may fire");
 }
 
+/// A replayed CheckRateLimit for an attempt whose live chain is parked in a
+/// rate-limit retry backoff must be dropped, not re-entered: the retry branch
+/// retargets the job status to the retry row's start time, so the guard's
+/// status-derived candidate start finds the parked row.
+#[silo::test]
+async fn replayed_check_rate_limit_during_retry_backoff_is_dropped() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let tenant = "dup-crl-backoff";
+    // limit 0: every check is over limit, so the chain parks in retry backoff.
+    let limits = vec![Limit::RateLimit(GubernatorRateLimit::new(
+        "dup-backoff",
+        "dup-backoff-key",
+        0,
+        60_000,
+    ))];
+
+    let start_a = now_ms() - 2_000;
+    let job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10,
+            start_a,
+            None,
+            msgpack_payload(&serde_json::json!({})),
+            limits,
+            None,
+            TASK_GROUP,
+        )
+        .await
+        .expect("enqueue rate-limited job");
+
+    let (_crl_key, crl_bytes) = first_task_kv(shard.db()).await.expect("check row present");
+
+    // Processing the check parks the chain: the over-limit result schedules a
+    // future-dated retry row.
+    let out = shard
+        .dequeue("worker-backoff", TASK_GROUP, 1)
+        .await
+        .expect("dequeue check");
+    assert!(out.tasks.is_empty(), "an over-limit check delivers nothing");
+    assert_eq!(
+        count_task_keys(shard.db()).await,
+        1,
+        "the chain must be parked on one retry row"
+    );
+
+    // The replay's durable state: a second copy of the original check row,
+    // ready-dated so the broker claims it while the retry row waits out its
+    // backoff.
+    let replay_key = silo::keys::task_key(TASK_GROUP, start_a + 500, 10, &job_id, 1, start_a + 500);
+    let mut batch = WriteBatch::new();
+    batch.put(&replay_key, &crl_bytes);
+    shard.db().write(batch).await.expect("write replayed row");
+    shard.db().flush().await.expect("flush replayed row");
+    shard
+        .force_buffer_tasks_for_test(vec![replay_key])
+        .await
+        .expect("buffer replayed row");
+
+    let out = shard
+        .dequeue("worker-backoff", TASK_GROUP, 1)
+        .await
+        .expect("dequeue replay");
+    assert!(out.tasks.is_empty(), "the replay delivers nothing");
+
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+    assert_eq!(
+        count_task_keys(shard.db()).await,
+        1,
+        "the replay must be dropped, leaving only the parked retry row"
+    );
+}
+
 /// A legitimate chain re-materialization must keep dodging the broker's ack
 /// tombstone: processing a CheckRateLimit through a real dequeue ack-deletes
 /// its row (tombstoning that exact key in the broker), and the continuation
@@ -532,15 +697,23 @@ async fn rate_limit_chain_delivers_once_after_its_check_row_is_tombstoned() {
 
     // The dequeue loop claims the CheckRateLimit through the broker (ack
     // tombstone installed at its key), writes the continuation, and delivers
-    // it — exactly once.
-    let task_ids = dequeue_task_ids_until(&shard, "worker-rl", TASK_GROUP, 1).await;
-    assert_eq!(task_ids.len(), 1, "the chain's RunAttempt must deliver");
+    // it — exactly once (dequeue_task_ids_until panics on its deadline if the
+    // continuation never delivers).
+    dequeue_task_ids_until(&shard, "worker-rl", TASK_GROUP, 1).await;
 
     assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
     assert_eq!(
         count_task_keys(shard.db()).await,
         0,
         "no task row may remain after delivery"
+    );
+    let followup = shard
+        .dequeue("worker-rl", TASK_GROUP, 1)
+        .await
+        .expect("follow-up poll");
+    assert!(
+        followup.tasks.is_empty(),
+        "no second delivery may exist for the chain"
     );
 }
 
@@ -591,28 +764,25 @@ async fn redispatch_over_other_workers_live_lease_delivers_without_duplicate_row
         .force_buffer_tasks_for_test(vec![row_key.clone()])
         .await
         .expect("buffer the row");
-    let lease = silo::task::LeaseRecord {
-        worker_id: "worker-a".to_string(),
-        task: Task::RunAttempt {
-            id: task_id.clone(),
-            tenant: tenant.to_string(),
-            job_id: job_id.clone(),
-            attempt_number: 1,
-            relative_attempt_number: 1,
-            held_queues: vec![],
-            task_group: TASK_GROUP.to_string(),
-        },
-        expiry_ms: now + silo::task::DEFAULT_LEASE_MS,
-        started_at_ms: now,
-    };
+    write_run_attempt_lease(
+        &shard,
+        "worker-a",
+        &task_id,
+        tenant,
+        &job_id,
+        TASK_GROUP,
+        now + 60_000,
+        now,
+    )
+    .await;
     let mut batch = WriteBatch::new();
-    batch.put(
-        &silo::keys::leased_task_key(&task_id),
-        &silo::codec::encode_lease(&lease),
-    );
     batch.delete(&row_key);
-    shard.db().write(batch).await.expect("write lease");
-    shard.db().flush().await.expect("flush lease");
+    shard
+        .db()
+        .write(batch)
+        .await
+        .expect("delete the durable row");
+    shard.db().flush().await.expect("flush the row delete");
 
     let result = shard
         .dequeue("worker-b", TASK_GROUP, 1)

--- a/tests/duplicate_materialization_tests.rs
+++ b/tests/duplicate_materialization_tests.rs
@@ -546,8 +546,12 @@ async fn rate_limit_chain_delivers_once_after_its_check_row_is_tombstoned() {
 
 /// R6 — redispatch over another worker's still-live lease (the
 /// production-confirmed cancelled-dequeue shape): the row is the SAME
-/// materialization delivered again, so it must deliver (lost-response
-/// recovery), count a stored overwrite, and leave no duplicate terminal row.
+/// materialization delivered again — its durable row was already deleted by
+/// the landed commit, only a stale broker-buffer entry survives — so it must
+/// deliver (lost-response recovery), count a stored overwrite, and leave no
+/// duplicate terminal row. The durable-absence of the row is what
+/// distinguishes this legitimate redispatch from a duplicate row, which
+/// dispatch drops.
 #[silo::test]
 async fn redispatch_over_other_workers_live_lease_delivers_without_duplicate_row() {
     let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
@@ -569,7 +573,7 @@ async fn redispatch_over_other_workers_live_lease_delivers_without_duplicate_row
         .await
         .expect("enqueue");
 
-    let (_key, task_bytes) = first_task_kv(shard.db()).await.expect("task present");
+    let (row_key, task_bytes) = first_task_kv(shard.db()).await.expect("task present");
     let Ok(Task::RunAttempt {
         id: task_id,
         job_id,
@@ -579,8 +583,14 @@ async fn redispatch_over_other_workers_live_lease_delivers_without_duplicate_row
         panic!("expected RunAttempt task");
     };
 
-    // The still-live lease a dropped-mid-commit dispatch to worker A leaves
-    // behind (its response never reached A).
+    // The state a dispatch dropped mid-commit leaves behind: worker A's lease
+    // landed and the row's durable delete landed with it (its response never
+    // reached A), while the broker's buffer still holds the row from a scan
+    // snapshot that predates the delete.
+    shard
+        .force_buffer_tasks_for_test(vec![row_key.clone()])
+        .await
+        .expect("buffer the row");
     let lease = silo::task::LeaseRecord {
         worker_id: "worker-a".to_string(),
         task: Task::RunAttempt {
@@ -600,6 +610,7 @@ async fn redispatch_over_other_workers_live_lease_delivers_without_duplicate_row
         &silo::keys::leased_task_key(&task_id),
         &silo::codec::encode_lease(&lease),
     );
+    batch.delete(&row_key);
     shard.db().write(batch).await.expect("write lease");
     shard.db().flush().await.expect("flush lease");
 

--- a/tests/duplicate_materialization_tests.rs
+++ b/tests/duplicate_materialization_tests.rs
@@ -670,6 +670,107 @@ async fn peer_check_rate_limit_rows_at_same_start_deliver_attempt_once() {
     );
 }
 
+/// A RunAttempt delivered earlier in the same dequeue iteration must still
+/// count as materialization evidence for a co-claimed duplicate grant source.
+/// Delivery tombstones the RunAttempt's row (excluded from the guard's
+/// durable scan) and its status/lease writes are uncommitted (invisible to
+/// durable reads), so the guard's batch seen-set is the only thing standing
+/// between a same-batch replayed CheckRateLimit and a second chain
+/// continuation.
+#[silo::test]
+async fn replayed_check_rate_limit_after_same_batch_delivery_is_dropped() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    shard.stop_grant_scanner();
+    let tenant = "dup-crl-post-delivery";
+
+    // A plain job whose chain materializes a ready RunAttempt row directly.
+    let start_a = now_ms() - 2_000;
+    let job_id = shard
+        .enqueue(
+            tenant,
+            None,
+            10,
+            start_a,
+            None,
+            msgpack_payload(&serde_json::json!({})),
+            vec![],
+            None,
+            TASK_GROUP,
+        )
+        .await
+        .expect("enqueue plain job");
+
+    let (ra_key, ra_bytes) = first_task_kv(shard.db())
+        .await
+        .expect("run attempt present");
+    let Ok(Task::RunAttempt { id: task_id, .. }) = silo::codec::decode_task(&ra_bytes) else {
+        panic!("expected the job's RunAttempt row");
+    };
+
+    // The replay's durable state: a duplicate CheckRateLimit for the same
+    // attempt at the same start, with a larger epoch so the RunAttempt is
+    // scanned (and delivered) first within the shared batch.
+    let rate_limit =
+        GubernatorRateLimit::new("dup-post-delivery", "dup-post-delivery-key", 100, 60_000);
+    let crl = Task::CheckRateLimit {
+        task_id: task_id.clone(),
+        tenant: tenant.to_string(),
+        job_id: job_id.clone(),
+        attempt_number: 1,
+        relative_attempt_number: 1,
+        limit_index: 0,
+        rate_limit: (&rate_limit).into(),
+        retry_count: 0,
+        started_at_ms: start_a,
+        priority: 10,
+        held_queues: vec![],
+        task_group: TASK_GROUP.to_string(),
+    };
+    let crl_key = silo::keys::task_key(TASK_GROUP, start_a, 10, &job_id, 1, now_ms() + 60_000);
+    let mut batch = WriteBatch::new();
+    batch.put(&crl_key, &encode_task(&crl));
+    shard
+        .db()
+        .write(batch)
+        .await
+        .expect("write replayed check row");
+    shard.db().flush().await.expect("flush replayed check row");
+
+    // Force both rows into one claimed batch, RunAttempt first.
+    shard
+        .force_buffer_tasks_for_test(vec![ra_key.clone(), crl_key.clone()])
+        .await
+        .expect("buffer both rows");
+
+    let mut deliveries = Vec::new();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        let out = shard
+            .dequeue("worker-post-delivery", TASK_GROUP, 4)
+            .await
+            .expect("dequeue")
+            .tasks;
+        deliveries.extend(out.iter().map(|t| t.attempt().task_id().to_string()));
+        if count_task_keys(shard.db()).await == 0 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+    assert_eq!(
+        deliveries.len(),
+        1,
+        "the replayed check must be dropped, not re-continue the chain; got deliveries {deliveries:?}"
+    );
+    let body = gather_metrics_text(&metrics);
+    let overwrites = metric_value_or_zero(
+        &body,
+        &["silo_task_lease_overwrites_total", "task_group=\"default\""],
+    );
+    assert_eq!(overwrites, 0.0, "no lease overwrite may fire");
+}
+
 /// A replayed CheckRateLimit for an attempt whose live chain is parked in a
 /// rate-limit retry backoff must be dropped, not re-entered: the retry branch
 /// retargets the job status to the retry row's start time, so the guard's

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -3421,6 +3421,10 @@ async fn two_concurrency_limits_chain_resumes_correctly() {
     );
     let job2_task_id = job2_tasks[0].attempt().task_id().to_string();
 
+    // The multi-hop resume must not have materialized a second terminal task
+    // row for either job's attempt.
+    assert_single_live_terminal_task_row_per_attempt(shard.db()).await;
+
     // Inspect the lease: held_queues must include BOTH A and B. Pre-fix this
     // would have been only [A] (the queue just granted by the scanner), and B
     // would be silently bypassed.

--- a/tests/job_store_shard_dequeue_tests.rs
+++ b/tests/job_store_shard_dequeue_tests.rs
@@ -706,27 +706,17 @@ async fn dequeue_drops_duplicate_row_when_other_worker_holds_live_lease() {
 
         // The other worker's live lease from dispatching the attempt's other
         // materialization.
-        let lease = silo::task::LeaseRecord {
-            worker_id: "other-worker".to_string(),
-            task: Task::RunAttempt {
-                id: task_id.clone(),
-                tenant: "-".to_string(),
-                job_id: job_id.clone(),
-                attempt_number: 1,
-                relative_attempt_number: 1,
-                held_queues: vec![],
-                task_group: "default".to_string(),
-            },
-            expiry_ms: now + 60_000,
-            started_at_ms: now,
-        };
-        let mut batch = WriteBatch::new();
-        batch.put(
-            &silo::keys::leased_task_key(&task_id),
-            &silo::codec::encode_lease(&lease),
-        );
-        shard.db().write(batch).await.expect("write lease");
-        shard.db().flush().await.expect("flush lease");
+        write_run_attempt_lease(
+            &shard,
+            "other-worker",
+            &task_id,
+            "-",
+            &job_id,
+            "default",
+            now + 60_000,
+            now,
+        )
+        .await;
 
         let result = shard
             .dequeue("worker-2", "default", 1)
@@ -932,28 +922,20 @@ async fn dequeue_over_same_workers_live_lease_delivers_via_overwrite() {
             panic!("expected RunAttempt task");
         };
 
-        // Worker W's own live lease with the row still present.
-        let lease = silo::task::LeaseRecord {
-            worker_id: "worker-w".to_string(),
-            task: Task::RunAttempt {
-                id: task_id.clone(),
-                tenant: "-".to_string(),
-                job_id: job_id.clone(),
-                attempt_number: 1,
-                relative_attempt_number: 1,
-                held_queues: vec![],
-                task_group: "default".to_string(),
-            },
-            expiry_ms: now + 60_000,
-            started_at_ms: now,
-        };
-        let mut batch = WriteBatch::new();
-        batch.put(
-            &silo::keys::leased_task_key(&task_id),
-            &silo::codec::encode_lease(&lease),
-        );
-        shard.db().write(batch).await.expect("write lease");
-        shard.db().flush().await.expect("flush lease");
+        // Worker W's own live lease with the row still present. The stale
+        // started_at_ms lets the post-dequeue assertion prove the lease was
+        // actually rewritten, not merely left in place.
+        write_run_attempt_lease(
+            &shard,
+            "worker-w",
+            &task_id,
+            "-",
+            &job_id,
+            "default",
+            now + 60_000,
+            now - 100_000,
+        )
+        .await;
 
         let result = shard
             .dequeue("worker-w", "default", 1)
@@ -973,11 +955,18 @@ async fn dequeue_over_same_workers_live_lease_delivers_via_overwrite() {
         assert_eq!(overwrites, 1.0, "the detection is counted");
         let drops = metric_value_or_zero(
             &body,
-            &["silo_task_lease_duplicate_drops_total", "task_group=\"default\""],
+            &[
+                "silo_task_lease_duplicate_drops_total",
+                "task_group=\"default\"",
+            ],
         );
-        assert_eq!(drops, 0.0, "a same-worker re-lease must not count as a drop");
+        assert_eq!(
+            drops, 0.0,
+            "a same-worker re-lease must not count as a drop"
+        );
 
-        // The overwrite proceeded: fresh expiry, same worker.
+        // The overwrite actually rewrote the lease: same worker, but a fresh
+        // started_at_ms that only the new dispatch can have stamped.
         let lease_bytes = shard
             .db()
             .get(&silo::keys::leased_task_key(&task_id))
@@ -986,7 +975,12 @@ async fn dequeue_over_same_workers_live_lease_delivers_via_overwrite() {
             .expect("lease exists");
         let lease = decode_lease(lease_bytes).expect("decode lease");
         assert_eq!(lease.worker_id(), "worker-w");
-        assert!(lease.expiry_ms() >= now + silo::task::DEFAULT_LEASE_MS);
+        assert!(
+            lease.started_at_ms() >= now,
+            "started_at_ms {} must be re-stamped by the overwrite (pre-written lease had {})",
+            lease.started_at_ms(),
+            now - 100_000
+        );
     });
 }
 
@@ -1011,27 +1005,17 @@ async fn dropped_duplicate_row_is_never_delivered_and_owner_completes() {
             panic!("expected RunAttempt task");
         };
 
-        let lease = silo::task::LeaseRecord {
-            worker_id: "other-worker".to_string(),
-            task: Task::RunAttempt {
-                id: task_id.clone(),
-                tenant: "-".to_string(),
-                job_id: job_id.clone(),
-                attempt_number: 1,
-                relative_attempt_number: 1,
-                held_queues: vec![],
-                task_group: "default".to_string(),
-            },
-            expiry_ms: now + 60_000,
-            started_at_ms: now,
-        };
-        let mut batch = WriteBatch::new();
-        batch.put(
-            &silo::keys::leased_task_key(&task_id),
-            &silo::codec::encode_lease(&lease),
-        );
-        shard.db().write(batch).await.expect("write lease");
-        shard.db().flush().await.expect("flush lease");
+        write_run_attempt_lease(
+            &shard,
+            "other-worker",
+            &task_id,
+            "-",
+            &job_id,
+            "default",
+            now + 60_000,
+            now,
+        )
+        .await;
 
         // The duplicate row is dropped on the first poll and never surfaces
         // again on later polls.
@@ -1095,27 +1079,17 @@ async fn dequeue_over_expired_lease_stays_silent() {
             panic!("expected RunAttempt task");
         };
 
-        let expired_lease = silo::task::LeaseRecord {
-            worker_id: "other-worker".to_string(),
-            task: Task::RunAttempt {
-                id: task_id.clone(),
-                tenant: "-".to_string(),
-                job_id: job_id.clone(),
-                attempt_number: 1,
-                relative_attempt_number: 1,
-                held_queues: vec![],
-                task_group: "default".to_string(),
-            },
-            expiry_ms: now - 60_000,
-            started_at_ms: now - 120_000,
-        };
-        let mut batch = WriteBatch::new();
-        batch.put(
-            &silo::keys::leased_task_key(&task_id),
-            &silo::codec::encode_lease(&expired_lease),
-        );
-        shard.db().write(batch).await.expect("write expired lease");
-        shard.db().flush().await.expect("flush expired lease");
+        write_run_attempt_lease(
+            &shard,
+            "other-worker",
+            &task_id,
+            "-",
+            &job_id,
+            "default",
+            now - 60_000,
+            now - 120_000,
+        )
+        .await;
 
         let result = shard
             .dequeue("worker-2", "default", 1)
@@ -1131,7 +1105,10 @@ async fn dequeue_over_expired_lease_stays_silent() {
         assert_eq!(overwrites, 0.0, "expired leftover lease must not count");
         let drops = metric_value_or_zero(
             &body,
-            &["silo_task_lease_duplicate_drops_total", "task_group=\"default\""],
+            &[
+                "silo_task_lease_duplicate_drops_total",
+                "task_group=\"default\"",
+            ],
         );
         assert_eq!(drops, 0.0, "expired leftover lease must not be dropped");
     });

--- a/tests/job_store_shard_dequeue_tests.rs
+++ b/tests/job_store_shard_dequeue_tests.rs
@@ -674,12 +674,14 @@ async fn dequeue_ignores_recently_acked_task_keys() {
     });
 }
 
-/// Dispatching a task whose lease key already holds a live lease is the
-/// double-dispatch anomaly: dequeue proceeds (overwrite semantics are
-/// unchanged) but warns and counts the overwrite so the grant-path bug that
-/// materializes duplicate RunAttempt tasks is visible from metrics.
+/// A durably present RunAttempt row whose task id is live-leased by ANOTHER
+/// worker can only be a duplicate materialization: the leased dispatch
+/// consumed its own row, so this one is a second grant source's write.
+/// Dispatch drops it -- deleted and acknowledged like a delivered row, never
+/// delivered -- counted in the drops counter beside the detection counter,
+/// and the live lease is left untouched.
 #[silo::test]
-async fn dequeue_over_live_lease_counts_stored_overwrite_and_still_delivers() {
+async fn dequeue_drops_duplicate_row_when_other_worker_holds_live_lease() {
     with_timeout!(20000, {
         let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
         let payload = msgpack_payload(&serde_json::json!({"k": "v"}));
@@ -702,8 +704,8 @@ async fn dequeue_over_live_lease_counts_stored_overwrite_and_still_delivers() {
             panic!("expected RunAttempt task");
         };
 
-        // Pre-write a live lease at the task's lease key, as a prior dispatch
-        // of the same task would have left behind
+        // The other worker's live lease from dispatching the attempt's other
+        // materialization.
         let lease = silo::task::LeaseRecord {
             worker_id: "other-worker".to_string(),
             task: Task::RunAttempt {
@@ -730,7 +732,20 @@ async fn dequeue_over_live_lease_counts_stored_overwrite_and_still_delivers() {
             .dequeue("worker-2", "default", 1)
             .await
             .expect("dequeue");
-        assert_eq!(result.tasks.len(), 1, "task must still be delivered");
+        assert!(
+            result.tasks.is_empty(),
+            "the duplicate row must be dropped, not delivered"
+        );
+        assert_eq!(
+            count_task_keys(shard.db()).await,
+            0,
+            "the dropped row must be deleted"
+        );
+        assert_eq!(
+            shard.broker_inflight_len("default"),
+            0,
+            "the dropped row must be acknowledged out of the broker's in-flight set"
+        );
 
         let body = gather_metrics_text(&metrics);
         let overwrites = metric_value_or_zero(
@@ -741,10 +756,19 @@ async fn dequeue_over_live_lease_counts_stored_overwrite_and_still_delivers() {
                 "source=\"stored\"",
             ],
         );
-        assert_eq!(overwrites, 1.0, "stored-lease overwrite must be counted");
+        assert_eq!(overwrites, 1.0, "the detection is still counted");
+        let drops = metric_value_or_zero(
+            &body,
+            &[
+                "silo_task_lease_duplicate_drops_total",
+                "task_group=\"default\"",
+                "source=\"stored\"",
+            ],
+        );
+        assert_eq!(drops, 1.0, "the drop must be counted");
 
-        // The overwrite proceeded: the lease names the dequeuing worker with
-        // a fresh expiry
+        // The live lease is untouched: still the other worker's, original
+        // expiry.
         let lease_bytes = shard
             .db()
             .get(&silo::keys::leased_task_key(&task_id))
@@ -752,23 +776,20 @@ async fn dequeue_over_live_lease_counts_stored_overwrite_and_still_delivers() {
             .expect("get lease")
             .expect("lease exists");
         let lease = decode_lease(lease_bytes).expect("decode lease");
-        assert_eq!(lease.worker_id(), "worker-2");
-        let after = now_ms();
-        assert!(
-            lease.expiry_ms() >= now + silo::task::DEFAULT_LEASE_MS
-                && lease.expiry_ms() <= after + silo::task::DEFAULT_LEASE_MS,
-            "lease expiry {} should be ~now + DEFAULT_LEASE_MS",
-            lease.expiry_ms()
-        );
+        assert_eq!(lease.worker_id(), "other-worker");
+        assert_eq!(lease.expiry_ms(), now + 60_000);
     });
 }
 
 /// A repeat of the same task id within a single dequeue iteration cannot be
 /// seen by the pre-write point read (the first lease write is still in the
-/// uncommitted batch), so the guard tracks the iteration's leased task ids
-/// and counts the repeat under source="batch".
+/// uncommitted batch), so the guard tracks the iteration's leased task ids.
+/// One LeaseTasks call carries one worker and the broker never yields a key
+/// twice in one claim, so the repeat is always a second row: it is dropped --
+/// deleted, acknowledged, never delivered -- and counted under
+/// source="batch" in both the detection and drop counters.
 #[silo::test]
-async fn dequeue_counts_batch_overwrite_for_repeated_task_id_in_one_iteration() {
+async fn dequeue_drops_in_batch_repeat_of_a_task_id() {
     with_timeout!(20000, {
         let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
         let payload = msgpack_payload(&serde_json::json!({"k": "v"}));
@@ -826,13 +847,27 @@ async fn dequeue_counts_batch_overwrite_for_repeated_task_id_in_one_iteration() 
             "broker never buffered both task records (buffered={buffered})"
         );
 
-        // Both task records dequeue in one call, so the second lease write
-        // repeats a task id already leased in this iteration's batch
+        // Both task records dequeue in one call, so the second row repeats a
+        // task id already leased in this iteration's batch and is dropped.
         let result = shard
             .dequeue("worker-1", "default", 2)
             .await
             .expect("dequeue");
-        assert_eq!(result.tasks.len(), 2, "both records must be delivered");
+        assert_eq!(
+            result.tasks.len(),
+            1,
+            "exactly one record delivers; the in-batch repeat is dropped"
+        );
+        assert_eq!(
+            count_task_keys(shard.db()).await,
+            0,
+            "no row may be left behind"
+        );
+        assert_eq!(
+            shard.broker_inflight_len("default"),
+            0,
+            "the dropped row must be acknowledged out of the broker's in-flight set"
+        );
 
         let body = gather_metrics_text(&metrics);
         let batch_overwrites = metric_value_or_zero(
@@ -843,7 +878,16 @@ async fn dequeue_counts_batch_overwrite_for_repeated_task_id_in_one_iteration() 
                 "source=\"batch\"",
             ],
         );
-        assert_eq!(batch_overwrites, 1.0, "batch overwrite must be counted");
+        assert_eq!(batch_overwrites, 1.0, "the detection must be counted");
+        let batch_drops = metric_value_or_zero(
+            &body,
+            &[
+                "silo_task_lease_duplicate_drops_total",
+                "task_group=\"default\"",
+                "source=\"batch\"",
+            ],
+        );
+        assert_eq!(batch_drops, 1.0, "the drop must be counted");
         let stored_overwrites = metric_value_or_zero(
             &body,
             &[
@@ -856,6 +900,173 @@ async fn dequeue_counts_batch_overwrite_for_repeated_task_id_in_one_iteration() 
             stored_overwrites, 0.0,
             "the repeat is invisible to the point read; only the batch branch fires"
         );
+    });
+}
+
+/// A still-live stored lease held by the SAME worker keeps overwrite
+/// semantics: this is the shape of the requeue-after-ambiguous-commit
+/// recovery, where the commit landed but the worker never received the
+/// response -- the overwrite re-delivers the task to its rightful owner, and
+/// the client's duplicate-delivery dedup contains the case where the first
+/// copy did arrive.
+#[silo::test]
+async fn dequeue_over_same_workers_live_lease_delivers_via_overwrite() {
+    with_timeout!(20000, {
+        let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+        let payload = msgpack_payload(&serde_json::json!({"k": "v"}));
+        let now = now_ms();
+
+        shard
+            .enqueue("-", None, 10, now, None, payload, vec![], None, "default")
+            .await
+            .expect("enqueue");
+
+        let (_key, task_bytes) = first_task_kv(shard.db()).await.expect("task present");
+        let decoded = silo::codec::decode_task(&task_bytes).expect("decode task");
+        let Task::RunAttempt {
+            id: task_id,
+            job_id,
+            ..
+        } = decoded
+        else {
+            panic!("expected RunAttempt task");
+        };
+
+        // Worker W's own live lease with the row still present.
+        let lease = silo::task::LeaseRecord {
+            worker_id: "worker-w".to_string(),
+            task: Task::RunAttempt {
+                id: task_id.clone(),
+                tenant: "-".to_string(),
+                job_id: job_id.clone(),
+                attempt_number: 1,
+                relative_attempt_number: 1,
+                held_queues: vec![],
+                task_group: "default".to_string(),
+            },
+            expiry_ms: now + 60_000,
+            started_at_ms: now,
+        };
+        let mut batch = WriteBatch::new();
+        batch.put(
+            &silo::keys::leased_task_key(&task_id),
+            &silo::codec::encode_lease(&lease),
+        );
+        shard.db().write(batch).await.expect("write lease");
+        shard.db().flush().await.expect("flush lease");
+
+        let result = shard
+            .dequeue("worker-w", "default", 1)
+            .await
+            .expect("dequeue");
+        assert_eq!(result.tasks.len(), 1, "the task must be re-delivered");
+
+        let body = gather_metrics_text(&metrics);
+        let overwrites = metric_value_or_zero(
+            &body,
+            &[
+                "silo_task_lease_overwrites_total",
+                "task_group=\"default\"",
+                "source=\"stored\"",
+            ],
+        );
+        assert_eq!(overwrites, 1.0, "the detection is counted");
+        let drops = metric_value_or_zero(
+            &body,
+            &["silo_task_lease_duplicate_drops_total", "task_group=\"default\""],
+        );
+        assert_eq!(drops, 0.0, "a same-worker re-lease must not count as a drop");
+
+        // The overwrite proceeded: fresh expiry, same worker.
+        let lease_bytes = shard
+            .db()
+            .get(&silo::keys::leased_task_key(&task_id))
+            .await
+            .expect("get lease")
+            .expect("lease exists");
+        let lease = decode_lease(lease_bytes).expect("decode lease");
+        assert_eq!(lease.worker_id(), "worker-w");
+        assert!(lease.expiry_ms() >= now + silo::task::DEFAULT_LEASE_MS);
+    });
+}
+
+/// A dropped duplicate row stays dropped: it is never delivered on later
+/// polls (deleted and tombstoned like a delivered row), and the attempt's
+/// rightful execution -- owned by the live lease -- completes normally.
+#[silo::test]
+async fn dropped_duplicate_row_is_never_delivered_and_owner_completes() {
+    with_timeout!(20000, {
+        let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+        let payload = msgpack_payload(&serde_json::json!({"k": "v"}));
+        let now = now_ms();
+
+        let job_id = shard
+            .enqueue("-", None, 10, now, None, payload, vec![], None, "default")
+            .await
+            .expect("enqueue");
+
+        let (_key, task_bytes) = first_task_kv(shard.db()).await.expect("task present");
+        let decoded = silo::codec::decode_task(&task_bytes).expect("decode task");
+        let Task::RunAttempt { id: task_id, .. } = decoded else {
+            panic!("expected RunAttempt task");
+        };
+
+        let lease = silo::task::LeaseRecord {
+            worker_id: "other-worker".to_string(),
+            task: Task::RunAttempt {
+                id: task_id.clone(),
+                tenant: "-".to_string(),
+                job_id: job_id.clone(),
+                attempt_number: 1,
+                relative_attempt_number: 1,
+                held_queues: vec![],
+                task_group: "default".to_string(),
+            },
+            expiry_ms: now + 60_000,
+            started_at_ms: now,
+        };
+        let mut batch = WriteBatch::new();
+        batch.put(
+            &silo::keys::leased_task_key(&task_id),
+            &silo::codec::encode_lease(&lease),
+        );
+        shard.db().write(batch).await.expect("write lease");
+        shard.db().flush().await.expect("flush lease");
+
+        // The duplicate row is dropped on the first poll and never surfaces
+        // again on later polls.
+        for poll in 0..5 {
+            let result = shard
+                .dequeue("worker-2", "default", 1)
+                .await
+                .expect("dequeue");
+            assert!(
+                result.tasks.is_empty(),
+                "poll {poll} must not deliver the dropped duplicate"
+            );
+        }
+        let body = gather_metrics_text(&metrics);
+        let drops = metric_value_or_zero(
+            &body,
+            &[
+                "silo_task_lease_duplicate_drops_total",
+                "task_group=\"default\"",
+                "source=\"stored\"",
+            ],
+        );
+        assert_eq!(drops, 1.0, "exactly one drop across all polls");
+
+        // The live lease's owner completes the attempt normally.
+        shard
+            .report_attempt_outcome(&task_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .expect("owner reports outcome");
+        let status = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("get status")
+            .expect("status present");
+        assert_eq!(status.kind, silo::job::JobStatusKind::Succeeded);
     });
 }
 
@@ -918,5 +1129,10 @@ async fn dequeue_over_expired_lease_stays_silent() {
             &["silo_task_lease_overwrites_total", "task_group=\"default\""],
         );
         assert_eq!(overwrites, 0.0, "expired leftover lease must not count");
+        let drops = metric_value_or_zero(
+            &body,
+            &["silo_task_lease_duplicate_drops_total", "task_group=\"default\""],
+        );
+        assert_eq!(drops, 0.0, "expired leftover lease must not be dropped");
     });
 }

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -500,6 +500,74 @@ pub fn msgpack_payload(value: &serde_json::Value) -> Vec<u8> {
     rmp_serde::to_vec(value).expect("failed to encode payload as messagepack")
 }
 
+/// Scan the whole task keyspace and report every `(tenant, job_id, attempt)`
+/// with MORE than one live terminal task row (`RunAttempt` or
+/// `CheckRateLimit`), one human-readable violation string per group.
+///
+/// A job's limit chain must keep at most one live terminal row per
+/// `(job_id, attempt)` — the trailing `epoch_ms` in the task key is a
+/// write-time disambiguator, not identity, so a second row at a different
+/// epoch is a double materialization that dispatches the same attempt twice.
+/// Non-terminal variants (`RequestTicket`, `RefreshFloatingLimit`) are not
+/// counted: tickets park a chain rather than dispatch it, and refresh tasks
+/// use synthetic per-queue job ids.
+pub async fn duplicate_live_terminal_task_rows(db: &InstrumentedDb) -> Vec<String> {
+    use silo::task::Task;
+    use std::collections::HashMap;
+
+    let start = silo::keys::tasks_prefix();
+    let end = silo::keys::end_bound(&start);
+    let mut iter = db
+        .scan::<Vec<u8>, _>(start..end)
+        .await
+        .expect("scan task keyspace");
+
+    let mut rows: HashMap<(String, String, u32), Vec<String>> = HashMap::new();
+    loop {
+        let maybe = iter.next().await.expect("iterate task keyspace");
+        let Some(kv) = maybe else { break };
+        let Some(parsed) = silo::keys::parse_task_key(&kv.key) else {
+            continue;
+        };
+        let (variant, tenant) = match silo::codec::decode_task(&kv.value) {
+            Ok(Task::RunAttempt { tenant, .. }) => ("RunAttempt", tenant),
+            Ok(Task::CheckRateLimit { tenant, .. }) => ("CheckRateLimit", tenant),
+            _ => continue,
+        };
+        rows.entry((tenant, parsed.job_id.clone(), parsed.attempt))
+            .or_default()
+            .push(format!(
+                "{variant}@start={},epoch={}",
+                parsed.start_time_ms, parsed.epoch_ms
+            ));
+    }
+
+    let mut violations: Vec<String> = rows
+        .into_iter()
+        .filter(|(_, group)| group.len() > 1)
+        .map(|((tenant, job_id, attempt), group)| {
+            format!(
+                "tenant={tenant} job={job_id} attempt={attempt}: {} live terminal task rows [{}]",
+                group.len(),
+                group.join(", ")
+            )
+        })
+        .collect();
+    violations.sort();
+    violations
+}
+
+/// Assert the "at most one live terminal task row per `(job_id, attempt)`"
+/// invariant across the shard's whole task keyspace.
+pub async fn assert_single_live_terminal_task_row_per_attempt(db: &InstrumentedDb) {
+    let violations = duplicate_live_terminal_task_rows(db).await;
+    assert!(
+        violations.is_empty(),
+        "single-live-terminal-row invariant violated:\n  {}",
+        violations.join("\n  ")
+    );
+}
+
 /// Poll an async function until the predicate returns true, or timeout.
 /// Returns the last value produced by `f`.
 pub async fn poll_until<F, Fut, T, P>(mut f: F, predicate: P, timeout_ms: u64) -> T

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -532,7 +532,12 @@ pub async fn duplicate_live_terminal_task_rows(db: &InstrumentedDb) -> Vec<Strin
         let (variant, tenant) = match silo::codec::decode_task(&kv.value) {
             Ok(Task::RunAttempt { tenant, .. }) => ("RunAttempt", tenant),
             Ok(Task::CheckRateLimit { tenant, .. }) => ("CheckRateLimit", tenant),
-            _ => continue,
+            Ok(_) => continue,
+            Err(e) => panic!(
+                "undecodable task row at key {:?}: {e} -- a corrupt terminal row would \
+                 silently escape the invariant check",
+                parsed
+            ),
         };
         rows.entry((tenant, parsed.job_id.clone(), parsed.attempt))
             .or_default()
@@ -566,6 +571,43 @@ pub async fn assert_single_live_terminal_task_row_per_attempt(db: &InstrumentedD
         "single-live-terminal-row invariant violated:\n  {}",
         violations.join("\n  ")
     );
+}
+
+/// Durably write a live RunAttempt lease at `task_id`'s lease key, naming
+/// `worker_id` as the owner -- the state a prior dispatch of the same task id
+/// leaves behind. Flushes so a subsequent dequeue's point read sees it.
+#[allow(clippy::too_many_arguments)]
+pub async fn write_run_attempt_lease(
+    shard: &JobStoreShard,
+    worker_id: &str,
+    task_id: &str,
+    tenant: &str,
+    job_id: &str,
+    task_group: &str,
+    expiry_ms: i64,
+    started_at_ms: i64,
+) {
+    let lease = silo::task::LeaseRecord {
+        worker_id: worker_id.to_string(),
+        task: silo::task::Task::RunAttempt {
+            id: task_id.to_string(),
+            tenant: tenant.to_string(),
+            job_id: job_id.to_string(),
+            attempt_number: 1,
+            relative_attempt_number: 1,
+            held_queues: vec![],
+            task_group: task_group.to_string(),
+        },
+        expiry_ms,
+        started_at_ms,
+    };
+    let mut batch = slatedb::WriteBatch::new();
+    batch.put(
+        &silo::keys::leased_task_key(task_id),
+        &silo::codec::encode_lease(&lease),
+    );
+    shard.db().write(batch).await.expect("write lease");
+    shard.db().flush().await.expect("flush lease");
 }
 
 /// Poll an async function until the predicate returns true, or timeout.

--- a/tests/turmoil_runner/helpers.rs
+++ b/tests/turmoil_runner/helpers.rs
@@ -300,6 +300,17 @@ pub fn dst_turmoilfs_database_template(
 
 /// Helper to create a standard server host for tests
 pub async fn setup_server(port: u16) -> turmoil::Result<()> {
+    setup_server_with_seeder(port, |_shard| async { Ok(()) }).await
+}
+
+/// Like [`setup_server`], but hands the opened shard to `seed` before the
+/// gRPC server starts serving, so a scenario can plant durable state (e.g.
+/// hand-written task rows) that clients then observe through the API.
+pub async fn setup_server_with_seeder<F, Fut>(port: u16, seed: F) -> turmoil::Result<()>
+where
+    F: FnOnce(Arc<silo::job_store_shard::JobStoreShard>) -> Fut,
+    Fut: Future<Output = turmoil::Result<()>>,
+{
     tracing::trace!(port = port, "setup_server: starting");
     let cfg = AppConfig {
         server: silo::settings::ServerConfig {
@@ -338,10 +349,11 @@ pub async fn setup_server(port: u16) -> turmoil::Result<()> {
     // For DST tests, use a fixed shard ID (zero UUID) for simplicity
     let test_shard_id = ShardId::parse("00000000-0000-0000-0000-000000000000").unwrap();
     tracing::trace!("setup_server: opening shard");
-    let _ = factory
+    let shard = factory
         .open(&test_shard_id, &ShardRange::full())
         .await
         .map_err(|e| e.to_string())?;
+    seed(shard).await?;
     let factory = Arc::new(factory);
     tracing::trace!("setup_server: shard opened");
 
@@ -1717,7 +1729,51 @@ pub async fn verify_server_invariants(
         }
     }
 
-    // Query 4: Check for terminal jobs with holders (noHoldersForTerminal violation)
+    // Query 4: At most one live terminal task row (RunAttempt / CheckRateLimit)
+    // per (tenant, job_id, attempt). The task key's trailing epoch_ms is a
+    // write-time disambiguator, not identity, so a second row at a different
+    // epoch is a double materialization that dispatches the same attempt
+    // twice. The variant filter also keeps floating-refresh rows (synthetic
+    // per-queue job ids) out of the count.
+    let duplicate_terminal_rows_query = r#"
+        SELECT tenant, job_id, attempt, COUNT(*) as cnt
+        FROM tasks
+        WHERE variant_type IN ('RunAttempt', 'CheckRateLimit')
+        GROUP BY tenant, job_id, attempt
+        HAVING COUNT(*) > 1
+    "#;
+    match client
+        .query(tonic::Request::new(QueryRequest {
+            shard: shard.to_string(),
+            sql: duplicate_terminal_rows_query.to_string(),
+            tenant: None,
+            parameters: vec![],
+        }))
+        .await
+    {
+        Ok(resp) => {
+            let response = resp.into_inner();
+            for row_bytes in &response.rows {
+                if let Some(serialized_bytes::Encoding::Msgpack(data)) = &row_bytes.encoding
+                    && let Ok(row) = parse_msgpack_row(data)
+                {
+                    let tenant = row.get("tenant").and_then(|v| v.as_str()).unwrap_or("");
+                    let job_id = row.get("job_id").and_then(|v| v.as_str()).unwrap_or("");
+                    let attempt = row.get("attempt").and_then(|v| v.as_u64()).unwrap_or(0);
+                    let count = row.get("cnt").and_then(|v| v.as_u64()).unwrap_or(0);
+                    result.violations.push(format!(
+                        "singleLiveTerminalRow violation: tenant '{}' job '{}' attempt {} has {} live terminal task rows",
+                        tenant, job_id, attempt, count
+                    ));
+                }
+            }
+        }
+        Err(e) => {
+            tracing::trace!(error = %e, "duplicate terminal task rows query failed");
+        }
+    }
+
+    // Query 5: Check for terminal jobs with holders (noHoldersForTerminal violation)
     // This joins jobs and queues to find any terminal jobs that still have holders
     let terminal_with_holders_query = r#"
         SELECT j.id, j.status_kind, q.queue_name, q.task_id

--- a/tests/turmoil_runner/helpers.rs
+++ b/tests/turmoil_runner/helpers.rs
@@ -1736,7 +1736,9 @@ pub async fn verify_server_invariants(
     // twice. The variant filter also keeps floating-refresh rows (synthetic
     // per-queue job ids) out of the count.
     let duplicate_terminal_rows_query = r#"
-        SELECT tenant, job_id, attempt, COUNT(*) as cnt
+        SELECT tenant, job_id, attempt, COUNT(*) as cnt,
+               array_agg(variant_type) as variants,
+               array_agg(start_time_ms) as starts
         FROM tasks
         WHERE variant_type IN ('RunAttempt', 'CheckRateLimit')
         GROUP BY tenant, job_id, attempt
@@ -1761,9 +1763,14 @@ pub async fn verify_server_invariants(
                     let job_id = row.get("job_id").and_then(|v| v.as_str()).unwrap_or("");
                     let attempt = row.get("attempt").and_then(|v| v.as_u64()).unwrap_or(0);
                     let count = row.get("cnt").and_then(|v| v.as_u64()).unwrap_or(0);
+                    let variants = row
+                        .get("variants")
+                        .map(|v| v.to_string())
+                        .unwrap_or_default();
+                    let starts = row.get("starts").map(|v| v.to_string()).unwrap_or_default();
                     result.violations.push(format!(
-                        "singleLiveTerminalRow violation: tenant '{}' job '{}' attempt {} has {} live terminal task rows",
-                        tenant, job_id, attempt, count
+                        "singleLiveTerminalRow violation: tenant '{}' job '{}' attempt {} has {} live terminal task rows (variants {} at starts {})",
+                        tenant, job_id, attempt, count, variants, starts
                     ));
                 }
             }

--- a/tests/turmoil_runner/main.rs
+++ b/tests/turmoil_runner/main.rs
@@ -40,6 +40,15 @@ fn grpc_end_to_end() {
 }
 
 #[test]
+fn duplicate_terminal_rows() {
+    if is_subprocess() || is_fuzz_mode() {
+        scenarios::duplicate_terminal_rows::run();
+    } else {
+        verify_determinism("duplicate_terminal_rows", get_seed());
+    }
+}
+
+#[test]
 fn fault_injection_partition() {
     if is_subprocess() || is_fuzz_mode() {
         scenarios::fault_injection_partition::run();

--- a/tests/turmoil_runner/scenarios/duplicate_terminal_rows.rs
+++ b/tests/turmoil_runner/scenarios/duplicate_terminal_rows.rs
@@ -1,0 +1,79 @@
+//! Duplicate terminal task rows scenario: the server-side invariant check must
+//! report a shard holding two live terminal task rows for one
+//! `(job_id, attempt)`.
+//!
+//! `verify_server_invariants` swallows per-query errors, so a scenario seeded
+//! with a hand-planted duplicate is what proves the singleLiveTerminalRow
+//! query actually runs: an unreported duplicate here means the query silently
+//! broke, not that the shard is healthy.
+
+use crate::helpers::{
+    TEST_SHARD_ID, connect_to_server, get_seed, run_scenario_impl, setup_server_with_seeder,
+    verify_server_invariants,
+};
+
+pub fn run() {
+    let seed = get_seed();
+    run_scenario_impl("duplicate_terminal_rows", seed, 30, |sim| {
+        sim.host("server", || async move {
+            setup_server_with_seeder(9930, |shard| async move {
+                // Two live RunAttempt rows for one (job_id, attempt): the same
+                // task at two write-time epochs, exactly what a double
+                // materialization in the grant path produces. Start time is in
+                // the past relative to simulated time zero, so both rows are
+                // live; no worker polls in this scenario, so they stay live.
+                let task = silo::task::Task::RunAttempt {
+                    id: "seeded-duplicate-task".to_string(),
+                    tenant: "-".to_string(),
+                    job_id: "seeded-duplicate-job".to_string(),
+                    attempt_number: 1,
+                    relative_attempt_number: 1,
+                    held_queues: vec![],
+                    task_group: "default".to_string(),
+                };
+                let mut batch = slatedb::WriteBatch::new();
+                for epoch in [1_000, 1_001] {
+                    batch.put(
+                        &silo::keys::task_key(
+                            "default",
+                            1_000,
+                            10,
+                            "seeded-duplicate-job",
+                            1,
+                            epoch,
+                        ),
+                        &silo::codec::encode_task(&task),
+                    );
+                }
+                shard.db().write(batch).await.map_err(|e| e.to_string())?;
+                shard.db().flush().await.map_err(|e| e.to_string())?;
+                Ok(())
+            })
+            .await
+        });
+
+        sim.client("client", async move {
+            let mut client = connect_to_server("http://server:9930").await?;
+            tracing::trace!("client_start");
+
+            let state = verify_server_invariants(&mut client, TEST_SHARD_ID)
+                .await
+                .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+            tracing::trace!(violations = ?state.violations, "server_state");
+
+            let reported = state
+                .violations
+                .iter()
+                .any(|v| v.contains("singleLiveTerminalRow") && v.contains("seeded-duplicate-job"));
+            assert!(
+                reported,
+                "the seeded duplicate terminal rows must be reported as a \
+                 singleLiveTerminalRow violation; got violations: {:?}",
+                state.violations
+            );
+
+            tracing::trace!("client_done");
+            Ok(())
+        });
+    });
+}

--- a/tests/turmoil_runner/scenarios/duplicate_terminal_rows.rs
+++ b/tests/turmoil_runner/scenarios/duplicate_terminal_rows.rs
@@ -61,14 +61,16 @@ pub fn run() {
                 .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
             tracing::trace!(violations = ?state.violations, "server_state");
 
-            let reported = state
-                .violations
-                .iter()
-                .any(|v| v.contains("singleLiveTerminalRow") && v.contains("seeded-duplicate-job"));
+            let reported = state.violations.iter().any(|v| {
+                v.contains("singleLiveTerminalRow")
+                    && v.contains("seeded-duplicate-job")
+                    && v.contains("has 2 live terminal task rows")
+            });
             assert!(
                 reported,
                 "the seeded duplicate terminal rows must be reported as a \
-                 singleLiveTerminalRow violation; got violations: {:?}",
+                 singleLiveTerminalRow violation counting exactly 2 rows; got \
+                 violations: {:?}",
                 state.violations
             );
 

--- a/tests/turmoil_runner/scenarios/mod.rs
+++ b/tests/turmoil_runner/scenarios/mod.rs
@@ -6,6 +6,7 @@ pub mod cancel_releases_ticket;
 pub mod chaos;
 pub mod concurrency_limits;
 pub mod concurrent_grant_race;
+pub mod duplicate_terminal_rows;
 pub mod expedite_concurrency;
 pub mod fault_injection_partition;
 pub mod floating_concurrency;


### PR DESCRIPTION
The 2026-08-19 double-dispatch incident delivered one RunAttempt to the same worker twice, ~927 ms apart, through two LeaseTasks polls. The root cause is that a task key's trailing `epoch_ms` is a write-time disambiguator, not identity: any two writers stamping different epochs can each keep a live terminal task row (`RunAttempt` or `CheckRateLimit`) for one `(job_id, attempt)`, and the attempt then dispatches once per row. Every chain re-entry point wrote its continuation blindly, so a duplicate deferred request row (request keys end in a random suffix), a replayed at-capacity ticket conversion, or a replayed rate-limit continuation each materialized a coexisting second row.

The branch is six commits -- invariant plus reproductions, the chain re-entry guard, the dispatch-time drop, review hardening, and two same-batch guard refinements from PR review -- and reads best in that order.

**Make the invariant checkable, then reproduce the violations.** A test helper scans the task keyspace for any attempt with more than one live terminal row, the multi-hop chain test asserts it, and the turmoil DST checks the same invariant through the `tasks` table in `verify_server_invariants` (whose `violations` list was previously never populated), with a seeded-duplicate scenario proving the query actually runs. Each candidate double-grant mechanism got one deterministic reproduction test; the reproduced ones landed as ignored red tests that the fix commits un-ignore.

**Enforce the invariant at every chain re-entry point.** Before continuing a chain, the grant scanner's reserve loop, `handle_request_ticket`, and `handle_check_rate_limit` consult `live_terminal_row_exists` -- a durable prefix scan at the attempt's candidate start times -- plus a per-batch seen-set for rows the current uncommitted batch already wrote (per commit chunk in the scanner, per iteration in dequeue). The durable scan ignores every row the writer's own uncommitted batch has already consumed, so when several same-start copies of one continuation are claimed into a single dequeue batch, earlier copies defer to the still-live later ones and exactly one continues the chain -- rather than every copy deferring to every other and stalling the attempt with no live row. The seen-set also records RunAttempt deliveries, since a delivered row is tombstoned in its batch and the lease and Running-status writes are invisible to a durable read until commit; without that entry a co-claimed duplicate continuation behind the delivery would see no evidence at all. Duplicate grant sources are dropped: the scanner deletes the request row like any stale entry, and the handlers drop the task row without releasing holders, which the live chain owns under the same task id. Rate-limit retries now also retarget the job status to the retry row's start time, so a chain parked in backoff is visible to the guard and to cancel/expedite/reimport.

**Drop provably duplicate rows at dispatch.** `handle_run_attempt` previously detected a still-live lease for the task id (warn plus `silo_task_lease_overwrites_total`) but always overwrote and delivered. It now drops the row -- deleted in the iteration's batch and acknowledged to the broker like a delivered row -- exactly when the repeat is provable: a repeated task id within one dequeue iteration, or a stored live lease held by a different worker while the row is still durably present. Durable row presence is what separates a duplicate from the legitimate cross-worker redispatch observed in production guard data (a dequeue future dropped mid-commit lands its leases and row deletes while a stale broker scan re-inserts the rows; that redispatch is the lost-response recovery, its row is durably absent, and it keeps delivering via overwrite). Same-worker live leases and expired leases keep delivering, and any guard read or decode failure resolves to delivery, never a drop. Drops are counted in the new `silo_task_lease_duplicate_drops_total` beside the detection counter, the warn events carry an `action` field saying which happened, and the internals and observability guides document the invariant and the counters.

One known residual, deliberately out of scope: the cross-writer interleaving where a scanner chunk and a concurrent dequeue iteration resume the same attempt before either batch commits defeats any per-writer durable read. Its reproduction stays `#[ignore]`d with the containment named in the ignore reason (the dispatch backstop covers the different-worker and in-batch delivery shapes; the hardened client's duplicate-delivery dedup covers same-worker). Closing it needs deterministic request-row identity or a transactional write path.

Ancillary: `#[silo::test]` now forwards item attributes so the red reproductions can carry `#[ignore]`.
