### PR TITLE
Serve enqueue_time_ms from the status index for large-tenant listings

### DIFF
--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -48,6 +48,11 @@ pub const DEEP_QUEUE_WAITERS: usize = 20_000;
 
 const METADATA_FILE: &str = "golden-metadata.json";
 
+/// On-disk format of the golden shard. Bump whenever the rows a generated
+/// shard contains change shape (a schema field, an index value encoding);
+/// a cached shard with a different version is removed and regenerated.
+pub const GOLDEN_FORMAT_VERSION: u32 = 2;
+
 // ---------------------------------------------------------------------------
 // Metadata
 // ---------------------------------------------------------------------------
@@ -55,6 +60,8 @@ const METADATA_FILE: &str = "golden-metadata.json";
 /// Persisted metadata about the golden shard, written as JSON.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GoldenShardMetadata {
+    /// Must equal [`GOLDEN_FORMAT_VERSION`] for the cached shard to be reused.
+    pub format_version: u32,
     pub total_jobs: usize,
     pub checkpoint_id: Uuid,
 
@@ -231,18 +238,30 @@ pub async fn ensure_golden_shard() -> GoldenShardMetadata {
         return meta;
     }
 
+    // A cache with missing or mismatched metadata is replaced wholesale so a
+    // stale shard is never appended to.
+    if Path::new(GOLDEN_DATA_DIR).exists() {
+        println!(
+            "Removing golden shard at {} (missing or mismatched format version)",
+            GOLDEN_DATA_DIR
+        );
+        std::fs::remove_dir_all(GOLDEN_DATA_DIR).expect("remove stale golden data dir");
+    }
     std::fs::create_dir_all(GOLDEN_DATA_DIR).expect("create golden data dir");
     let tenant_sizes = compute_tenant_sizes();
     generate_golden_dataset(&tenant_sizes).await
 }
 
+/// The cached metadata, or `None` when it is absent, unreadable, or written
+/// for a different [`GOLDEN_FORMAT_VERSION`].
 fn load_cached_metadata() -> Option<GoldenShardMetadata> {
     let path = metadata_path();
     if !path.exists() {
         return None;
     }
     let data = std::fs::read_to_string(&path).ok()?;
-    serde_json::from_str(&data).ok()
+    let meta: GoldenShardMetadata = serde_json::from_str(&data).ok()?;
+    (meta.format_version == GOLDEN_FORMAT_VERSION).then_some(meta)
 }
 
 async fn generate_golden_dataset(tenant_sizes: &[(String, usize)]) -> GoldenShardMetadata {
@@ -311,6 +330,7 @@ async fn generate_golden_dataset(tenant_sizes: &[(String, usize)]) -> GoldenShar
     let known = collect_known_job_ids(tenant_sizes);
 
     let metadata = GoldenShardMetadata {
+        format_version: GOLDEN_FORMAT_VERSION,
         total_jobs,
         checkpoint_id: checkpoint.id,
         waiting_jobs: known.waiting,
@@ -631,6 +651,37 @@ pub async fn clone_golden_shard(
     let guard = CloneGuard { path: clone_path };
 
     (guard, shard)
+}
+
+/// Rewrite every status/time index entry of `tenant` with an empty value, the
+/// shape of entries written without `enqueue_time_ms`, so the index path has to
+/// hydrate each row from `JOB_INFO`. Returns the number of entries rewritten.
+pub async fn strip_tenant_index_values(shard: &JobStoreShard, tenant: &str) -> usize {
+    use silo::keys::{end_bound, idx_status_time_tenant_prefix};
+
+    let start = idx_status_time_tenant_prefix(tenant);
+    let end = end_bound(&start);
+    let mut iter = shard
+        .db()
+        .scan_with_options::<Vec<u8>, _>(start..end, &silo::scan_options_uncached())
+        .await
+        .expect("scan index entries");
+    let mut keys = Vec::new();
+    while let Some(kv) = iter.next().await.expect("next index entry") {
+        keys.push(kv.key.to_vec());
+    }
+    for chunk in keys.chunks(BATCH_SIZE) {
+        let mut batch = slatedb::WriteBatch::new();
+        for key in chunk {
+            batch.put(key, []);
+        }
+        shard
+            .db()
+            .write(batch)
+            .await
+            .expect("write stripped entries");
+    }
+    keys.len()
 }
 
 /// Open the golden shard read-only (large flush interval, no cloning).

--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -242,7 +242,7 @@ pub async fn ensure_golden_shard() -> GoldenShardMetadata {
     // stale shard is never appended to.
     if Path::new(GOLDEN_DATA_DIR).exists() {
         println!(
-            "Removing golden shard at {} (missing or mismatched format version)",
+            "Removing golden shard at {} (metadata absent, unreadable, or written for a different format version)",
             GOLDEN_DATA_DIR
         );
         std::fs::remove_dir_all(GOLDEN_DATA_DIR).expect("remove stale golden data dir");

--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -617,6 +617,7 @@ pub async fn clone_golden_shard(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            enqueue_time_backfill: silo::settings::EnqueueTimeBackfillConfig::default(),
             grant_scanner: silo::concurrency::GrantScannerConfig::default(),
             concurrency_reconcile_scan_slice:
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,

--- a/benches/grant_latency.rs
+++ b/benches/grant_latency.rs
@@ -271,6 +271,7 @@ async fn open_shard(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            enqueue_time_backfill: silo::settings::EnqueueTimeBackfillConfig::default(),
             grant_scanner: silo::concurrency::GrantScannerConfig::default(),
             concurrency_reconcile_scan_slice:
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,

--- a/benches/query_performance.rs
+++ b/benches/query_performance.rs
@@ -69,6 +69,15 @@ async fn main() {
         "Dataset: {} jobs across {} tenants (expected ~{}, actual {})",
         total_jobs, NUM_TENANTS, total_jobs, actual_count
     );
+    // The generator writes the Zipf jobs plus the expedite and deep-queue jobs.
+    let generated_jobs = total_jobs
+        + metadata.expedite_job_ids.len()
+        + metadata.deep_queue_waiter_ids.len()
+        + metadata.deep_queue_holder_task_ids.len();
+    assert_eq!(
+        actual_count as usize, generated_jobs,
+        "golden shard job count must equal the generator's total"
+    );
 
     let large_tenant = &tenant_sizes[0].0; // tenant_001, ~796k
     let large_count = tenant_sizes[0].1;
@@ -261,7 +270,80 @@ async fn main() {
     println!();
 
     shard.close().await.expect("close shard");
+
+    run_listing_benchmarks(&metadata, large_tenant).await;
+    println!();
+
     println!("Done.");
+}
+
+/// The editor's listing shape: a bounded sample of one tenant, optionally
+/// pinned to a status, ordered newest-first by enqueue time.
+fn listing_query(tenant: &str, status_filter: Option<&str>) -> String {
+    let status = status_filter
+        .map(|s| format!(" AND status_kind = '{s}'"))
+        .unwrap_or_default();
+    format!(
+        "SELECT id FROM (SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '{tenant}'{status} LIMIT 50000) ORDER BY enqueue_time_ms DESC, id DESC LIMIT 101"
+    )
+}
+
+/// Measure the listing shape on a clone of the golden shard in three states:
+/// the completion marker set with every index entry carrying its value (the
+/// index path), the marker cleared (the job-record path for the unfiltered
+/// shape), and the marker set with the tenant's index values stripped (every
+/// row hydrated through the fallback).
+async fn run_listing_benchmarks(metadata: &GoldenShardMetadata, tenant: &str) {
+    let (_guard, shard) = clone_golden_shard("listing", metadata).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("query engine");
+    let shapes = [("unfiltered", None), ("succeeded", Some("Succeeded"))];
+
+    println!("--- Editor Listing Query ({}) ---", tenant);
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .expect("set marker");
+    for (name, filter) in shapes {
+        let r = bench_query(
+            &engine,
+            &format!("listing_{name}_index"),
+            &listing_query(tenant, filter),
+        )
+        .await;
+        r.print();
+    }
+
+    shard
+        .set_enqueue_time_backfill_complete(false)
+        .await
+        .expect("clear marker");
+    for (name, filter) in shapes {
+        let r = bench_query(
+            &engine,
+            &format!("listing_{name}_marker_cleared"),
+            &listing_query(tenant, filter),
+        )
+        .await;
+        r.print();
+    }
+
+    let stripped = strip_tenant_index_values(&shard, tenant).await;
+    println!("  (stripped {} index values)", stripped);
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .expect("set marker");
+    for (name, filter) in shapes {
+        let r = bench_query(
+            &engine,
+            &format!("listing_{name}_fallback"),
+            &listing_query(tenant, filter),
+        )
+        .await;
+        r.print();
+    }
+
+    shard.close().await.expect("close listing clone");
 }
 
 async fn run_tenant_queries(engine: &ShardQueryEngine, tenant: &str) {

--- a/benches/query_performance.rs
+++ b/benches/query_performance.rs
@@ -65,15 +65,15 @@ async fn main() {
     println!("\n========================================");
     println!("Query Performance Benchmark");
     println!("========================================\n");
-    println!(
-        "Dataset: {} jobs across {} tenants (expected ~{}, actual {})",
-        total_jobs, NUM_TENANTS, total_jobs, actual_count
-    );
     // The generator writes the Zipf jobs plus the expedite and deep-queue jobs.
     let generated_jobs = total_jobs
         + metadata.expedite_job_ids.len()
         + metadata.deep_queue_waiter_ids.len()
         + metadata.deep_queue_holder_task_ids.len();
+    println!(
+        "Dataset: {} Zipf jobs across {} tenants (generated {}, actual {})",
+        total_jobs, NUM_TENANTS, generated_jobs, actual_count
+    );
     assert_eq!(
         actual_count as usize, generated_jobs,
         "golden shard job count must equal the generator's total"
@@ -313,6 +313,8 @@ async fn run_listing_benchmarks(metadata: &GoldenShardMetadata, tenant: &str) {
         r.print();
     }
 
+    // The marker gates only the unfiltered shape; the filtered shape is a
+    // control here and should match its `_index` row within noise.
     shard
         .set_enqueue_time_backfill_complete(false)
         .await
@@ -329,6 +331,15 @@ async fn run_listing_benchmarks(metadata: &GoldenShardMetadata, tenant: &str) {
 
     let stripped = strip_tenant_index_values(&shard, tenant).await;
     println!("  (stripped {} index values)", stripped);
+    // Flush so the stripped entries are read from SSTs like the other states
+    // rather than from whatever mix of memtable and L0 the writes landed in.
+    shard
+        .db()
+        .flush_with_options(slatedb::config::FlushOptions {
+            flush_type: slatedb::config::FlushType::MemTable,
+        })
+        .await
+        .expect("flush stripped entries");
     shard
         .set_enqueue_time_backfill_complete(true)
         .await

--- a/docs/src/content/docs/guides/querying.mdx
+++ b/docs/src/content/docs/guides/querying.mdx
@@ -408,16 +408,16 @@ SELECT * FROM jobs WHERE tenant = 'customer-123' AND status_kind = 'Failed'
 
 ### Index-served columns
 
-On large tenants, which columns you project matters as much as which filters you use. The status/time index carries `tenant`, `id`, `status_kind`, `status_changed_at_ms` and `enqueue_time_ms` for every job, so a query that projects only those columns is answered from the index alone, without reading a job record per row:
+On large tenants, which columns you project matters as much as which filters you use. The status/time index carries `tenant`, `id`, `status_kind` and `status_changed_at_ms` for every job, and `enqueue_time_ms` for every job written since the value was added to the index (the `enqueue_time_backfill` sweep fills it in for the rest), so a query that projects only those columns is answered from the index alone, without reading a job record per row:
 
 - `enqueue_time_ms` is index-served on tenant-filtered `status_kind = ...` and `status_kind IN (...)` queries, and on tenant-filtered queries with no status filter once the shard has finished backfilling its index entries (see the `enqueue_time_backfill` setting in the server configuration reference).
 - `status_changed_at_ms` on a single `status_kind = ...` filter reads the status record instead, so that shape stays on the per-row path.
 - Every other column (`priority`, `payload`, `task_group`, `metadata`, `limits`, `current_attempt`, `next_attempt_starts_after_ms`) needs a per-row record read.
 
-`EXPLAIN` names the path taken as `path=status-counters`, `path=status-index`, `path=fullscan-join` or `path=pairs`; the first two never read job records. The editor's listing shape is index-served on a backfilled shard:
+`EXPLAIN` names the path taken as `path=status-counters`, `path=status-index`, `path=fullscan-join` or `path=pairs`. `status-counters` never reads job records; `status-index` reads one only for index entries that lack `enqueue_time_ms`, which the `silo_enqueue_time_fallback_hydrations_total` metric counts. The editor's listing shape is index-served on a backfilled shard:
 
 ```sql
--- path=status-index: no job record reads, even with hundreds of thousands of jobs
+-- path=status-index: no job record reads on a backfilled shard, whatever the tenant's size
 SELECT id FROM (
   SELECT id, enqueue_time_ms FROM jobs WHERE tenant = 'customer-123' LIMIT 50000
 ) ORDER BY enqueue_time_ms DESC, id DESC LIMIT 101

--- a/docs/src/content/docs/guides/querying.mdx
+++ b/docs/src/content/docs/guides/querying.mdx
@@ -406,6 +406,23 @@ SELECT * FROM jobs WHERE tenant = 'customer-123' AND array_contains(element_at(m
 SELECT * FROM jobs WHERE tenant = 'customer-123' AND status_kind = 'Failed'
 ```
 
+### Index-served columns
+
+On large tenants, which columns you project matters as much as which filters you use. The status/time index carries `tenant`, `id`, `status_kind`, `status_changed_at_ms` and `enqueue_time_ms` for every job, so a query that projects only those columns is answered from the index alone, without reading a job record per row:
+
+- `enqueue_time_ms` is index-served on tenant-filtered `status_kind = ...` and `status_kind IN (...)` queries, and on tenant-filtered queries with no status filter once the shard has finished backfilling its index entries (see the `enqueue_time_backfill` setting in the server configuration reference).
+- `status_changed_at_ms` on a single `status_kind = ...` filter reads the status record instead, so that shape stays on the per-row path.
+- Every other column (`priority`, `payload`, `task_group`, `metadata`, `limits`, `current_attempt`, `next_attempt_starts_after_ms`) needs a per-row record read.
+
+`EXPLAIN` names the path taken as `path=status-counters`, `path=status-index`, `path=fullscan-join` or `path=pairs`; the first two never read job records. The editor's listing shape is index-served on a backfilled shard:
+
+```sql
+-- path=status-index: no job record reads, even with hundreds of thousands of jobs
+SELECT id FROM (
+  SELECT id, enqueue_time_ms FROM jobs WHERE tenant = 'customer-123' LIMIT 50000
+) ORDER BY enqueue_time_ms DESC, id DESC LIMIT 101
+```
+
 ### Tasks table: always filter by task_group
 
 The `tasks` table performs best when filtered by `task_group`, which uses a key prefix scan matching the task broker's internal access pattern. Adding a `start_time_ms` range narrows the scan further with early termination.

--- a/docs/src/content/docs/reference/server-configuration.mdx
+++ b/docs/src/content/docs/reference/server-configuration.mdx
@@ -96,6 +96,13 @@ apply_wal_on_close = true
 [database.wal]
 backend = "fs"
 path = "/var/lib/silo/wal/%shard%"
+
+# Optional: one-shot sweep that fills enqueue_time_ms into status rows
+# written without it (off by default)
+[database.enqueue_time_backfill]
+enabled = false
+batch_size = 1000
+pause_ms = 50
 ```
 
 ### Database Options
@@ -106,6 +113,9 @@ path = "/var/lib/silo/wal/%shard%"
 | `path` | string | `"/tmp/silo/%shard%"` | Path or URL for data storage. Use `%shard%` as a placeholder for the shard number. |
 | `apply_wal_on_close` | bool | `true` | Flush WAL to object storage before closing shards (recommended for durability) |
 | `concurrency_reconcile_interval_ms` | number | `5000` | Optional interval for periodic pending-request reconciliation in the concurrency manager |
+| `enqueue_time_backfill.enabled` | bool | `false` | Run the one-shot sweep that fills `enqueue_time_ms` into status rows written without it (see below) |
+| `enqueue_time_backfill.batch_size` | number | `1000` | Status records the sweep examines per batch before pausing |
+| `enqueue_time_backfill.pause_ms` | number | `50` | Pause between sweep batches, in milliseconds; also bounds the per-shard jitter before the first batch |
 
 <Aside type="caution">
 The `%shard%` placeholder must be an independent directory segment—it cannot have a prefix or suffix within the same path component.
@@ -167,6 +177,14 @@ Note that `apply_wal_on_close` only applies during **graceful** shutdowns. If a 
 Silo runs a background reconciliation loop while each shard is open. This loop periodically scans pending concurrency request records and re-signals grant processing. It is a self-healing mechanism for cases where durable requests exist but in-memory notifications were missed (for example, due to a crash between separate write/notify phases).
 
 This option is **optional**. If omitted, Silo uses the default value of `5000` milliseconds.
+
+#### `enqueue_time_backfill`
+
+Each job's status record and status/time index entry carry the job's `enqueue_time_ms`, which lets the query engine serve that column from the index instead of decoding every job record. Rows written by a Silo build that stored the value only in the job record lack it; queries still return the right answer for those rows by reading the job record, only slower.
+
+The `[database.enqueue_time_backfill]` sweep fills the value into every such row once per shard. It starts shortly after the shard opens, walks the shard's status records in batches of `batch_size` with a `pause_ms` pause between batches, rewrites only rows that lack the value (keeping each row's expiry exactly as it is), and records a completion marker so it never runs again on that shard. Progress is checkpointed after every batch, so a restart mid-sweep resumes where it left off. A row that a live status transition rewrites while the sweep is running is skipped, because the transition wrote the value itself.
+
+The sweep is **off by default**. Enable it in a deploy once every node runs a build that writes the value; the `silo_enqueue_time_repair_reads_total` metric counts the job-record reads it issues and stops growing once the sweep has converged.
 
 ### SlateDB Configuration
 

--- a/schema/internal_storage.fbs
+++ b/schema/internal_storage.fbs
@@ -232,6 +232,9 @@ table JobStatus {
   changed_at_ms: int64;
   next_attempt_starts_after_ms: int64 = null;
   current_attempt: uint32 = null;
+  /// The job's enqueue_time_ms as stored in JobInfo, copied forward on every
+  /// status transition. Absent on records written without it.
+  enqueue_time_ms: int64 = null;
 }
 
 // ============================================================

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -530,6 +530,7 @@ pub fn encode_job_status(status: &JobStatus) -> Vec<u8> {
             changed_at_ms: status.changed_at_ms,
             next_attempt_starts_after_ms: status.next_attempt_starts_after_ms,
             current_attempt: status.current_attempt,
+            enqueue_time_ms: status.enqueue_time_ms,
         },
     );
     builder.finish(root, None);
@@ -1074,6 +1075,7 @@ pub fn decode_job_status_owned(bytes: &[u8]) -> Result<JobStatus, CodecError> {
         changed_at_ms: s.changed_at_ms(),
         next_attempt_starts_after_ms: s.next_attempt_starts_after_ms(),
         current_attempt: s.current_attempt(),
+        enqueue_time_ms: s.enqueue_time_ms(),
     })
 }
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -304,6 +304,7 @@ impl ShardFactory {
                         completed_job_expire_s: template.completed_job_expire_s,
                         terminal_job_expire_s: template.terminal_job_expire_s,
                         count_from_status_counters: template.count_from_status_counters,
+                        enqueue_time_backfill: template.enqueue_time_backfill.clone(),
                     },
                     range.clone(),
                 )
@@ -1127,6 +1128,7 @@ impl ShardFactory {
                 completed_job_expire_s: self.template.completed_job_expire_s,
                 terminal_job_expire_s: self.template.terminal_job_expire_s,
                 count_from_status_counters: self.template.count_from_status_counters,
+                enqueue_time_backfill: self.template.enqueue_time_backfill.clone(),
             },
             ShardRange::full(),
         )

--- a/src/job.rs
+++ b/src/job.rs
@@ -192,6 +192,11 @@ pub struct JobStatus {
     /// Present when a task exists in the task queue (Scheduled status), absent when the job is running (task became a lease) or terminal.
     /// Used for O(1) task key reconstruction in expedite operations.
     pub current_attempt: Option<u32>,
+    /// The job's `enqueue_time_ms` as stored in `JobInfo`. Immutable for the
+    /// job's whole life and copied forward on every status transition so the
+    /// status/time index can serve it without reading `JobInfo`. `None` on
+    /// records written without it; the next transition fills it in.
+    pub enqueue_time_ms: Option<i64>,
 }
 
 impl JobStatus {
@@ -206,7 +211,14 @@ impl JobStatus {
             changed_at_ms,
             next_attempt_starts_after_ms,
             current_attempt,
+            enqueue_time_ms: None,
         }
+    }
+
+    /// Attach the job's `enqueue_time_ms` (the value stored in `JobInfo`).
+    pub fn with_enqueue_time_ms(mut self, enqueue_time_ms: i64) -> Self {
+        self.enqueue_time_ms = Some(enqueue_time_ms);
+        self
     }
 
     /// Create a Scheduled status with the next attempt start time and attempt number.

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -17,11 +17,11 @@ use crate::job_store_shard::counters::{
 };
 use crate::job_store_shard::helpers::{
     DbWriteBatcher, TxnWriter, WriteBatcher, decode_job_status_owned, now_epoch_ms, put_task,
-    retry_on_txn_conflict,
+    retry_on_txn_conflict, try_load_job_view,
 };
 use crate::keys::{
-    idx_metadata_key, idx_status_time_key, job_info_key, job_status_key, status_index_timestamp,
-    tenant_status_counter_key,
+    encode_status_index_value, idx_metadata_key, idx_status_time_key, job_info_key, job_status_key,
+    status_index_timestamp, tenant_status_counter_key,
 };
 use crate::retry::RetryPolicy;
 use crate::task::{GubernatorRateLimitData, Task};
@@ -431,8 +431,11 @@ impl JobStoreShard {
             start_at_ms
         };
 
-        // [SILO-ENQ-2] Create job with status Scheduled, with next attempt time
-        let job_status = JobStatus::scheduled(now_ms, effective_start_at_ms, 1);
+        // [SILO-ENQ-2] Create job with status Scheduled, with next attempt time.
+        // The status carries the raw start_at_ms stored in JobInfo, not the
+        // clamped effective start used for the first task.
+        let job_status = JobStatus::scheduled(now_ms, effective_start_at_ms, 1)
+            .with_enqueue_time_ms(start_at_ms);
         let job_status_kind = job_status.kind;
 
         writer.put(job_info_key(tenant, job_id), &job_value)?;
@@ -851,7 +854,7 @@ impl JobStoreShard {
         writer: &mut W,
         tenant: &str,
         job_id: &str,
-        new_status: JobStatus,
+        mut new_status: JobStatus,
         expire_ts: Option<i64>,
         job_metric_info: Option<&JobView>,
     ) -> Result<Option<BackgroundActionMetricTransition>, JobStoreShardError> {
@@ -875,23 +878,44 @@ impl JobStoreShard {
         let new_kind = new_status.kind;
         let needs_background_action_counters =
             background_action_queue_counter_transition_is_relevant(old_kind, new_kind);
+
+        // Resolve the enqueue time to copy forward, cheapest source first. A
+        // JOB_INFO read is issued only when the old status record lacks the
+        // value, and at most once per transition: when the gauge path below
+        // reads JOB_INFO anyway, that read is reused, and a miss there ends
+        // resolution without a second read.
+        let mut enqueue_time_ms = new_status
+            .enqueue_time_ms
+            .or_else(|| old_status.as_ref().and_then(|old| old.enqueue_time_ms))
+            .or_else(|| job_metric_info.map(JobView::enqueue_time_ms));
+        let mut repair_read_issued = false;
+
         let derived_metric_info: Option<(String, Vec<(String, String)>)> =
             if needs_background_action_counters {
                 match job_metric_info {
                     Some(view) => Some((view.task_group().to_string(), view.metadata())),
-                    None => writer
-                        .get(&job_info_key(tenant, job_id))
-                        .await?
-                        .map(|raw| {
-                            JobView::new(raw)
-                                .map(|view| (view.task_group().to_string(), view.metadata()))
-                                .map_err(|e| JobStoreShardError::Codec(e.to_string()))
-                        })
-                        .transpose()?,
+                    None => {
+                        let view = try_load_job_view(writer, tenant, job_id).await?;
+                        if enqueue_time_ms.is_none() {
+                            repair_read_issued = true;
+                            enqueue_time_ms = view.as_ref().map(JobView::enqueue_time_ms);
+                        }
+                        view.map(|view| (view.task_group().to_string(), view.metadata()))
+                    }
                 }
             } else {
                 None
             };
+        if enqueue_time_ms.is_none() && !repair_read_issued {
+            repair_read_issued = true;
+            enqueue_time_ms = try_load_job_view(writer, tenant, job_id)
+                .await?
+                .map(|view| view.enqueue_time_ms());
+        }
+        if repair_read_issued && let Some(m) = &self.metrics {
+            m.record_enqueue_time_repair_reads(&self.name, 1);
+        }
+        new_status.enqueue_time_ms = enqueue_time_ms;
         let background_action_transition =
             derived_metric_info.as_ref().map(|(task_group, metadata)| {
                 BackgroundActionMetricTransition {
@@ -933,6 +957,7 @@ impl JobStoreShard {
         )
     }
 
+    /// Write the status row and merge the +1 tenant status counter for its kind.
     pub(crate) fn write_job_status_with_index_opts_and_metadata<W: WriteBatcher>(
         writer: &mut W,
         tenant: &str,
@@ -940,31 +965,46 @@ impl JobStoreShard {
         new_status: JobStatus,
         expire_ts: Option<i64>,
     ) -> Result<(), JobStoreShardError> {
-        // Write new status value
-        let job_status_value = encode_job_status(&new_status);
-        let status_key = job_status_key(tenant, job_id);
-        match expire_ts {
-            Some(ts) => writer.put_with_expire(&status_key, &job_status_value, ts)?,
-            None => writer.put(&status_key, &job_status_value)?,
-        }
-
-        // Insert new index entries
-        // For Scheduled statuses, use next_attempt_starts_after_ms as the timestamp
-        // to enable efficient waiting/future-scheduled range scans.
-        let new_kind = new_status.kind;
-        let ts = status_index_timestamp(&new_status);
-        let timek = idx_status_time_key(tenant, new_kind.as_str(), ts, job_id);
-        match expire_ts {
-            Some(ets) => writer.put_with_expire(&timek, [], ets)?,
-            None => writer.put(&timek, [])?,
-        }
-
-        // Increment tenant status counter for the new status
+        Self::write_job_status_row(writer, tenant, job_id, &new_status, expire_ts)?;
         writer.merge(
-            tenant_status_counter_key(tenant, new_kind.as_str()),
+            tenant_status_counter_key(tenant, new_status.kind.as_str()),
             encode_counter(1),
         )?;
+        Ok(())
+    }
 
+    /// Write a job's status record and its status/time index entry, both with
+    /// the optional row TTL. Moves no counters. This is the only producer of
+    /// index entry values: the entry carries the status record's
+    /// `enqueue_time_ms`, so the two can never disagree.
+    pub(crate) fn write_job_status_row<W: WriteBatcher>(
+        writer: &mut W,
+        tenant: &str,
+        job_id: &str,
+        status: &JobStatus,
+        expire_ts: Option<i64>,
+    ) -> Result<(), JobStoreShardError> {
+        let status_value = encode_job_status(status);
+        let status_key = job_status_key(tenant, job_id);
+        // For Scheduled statuses the index is keyed by next_attempt_starts_after_ms
+        // so waiting/future-scheduled range scans stay cheap.
+        let index_key = idx_status_time_key(
+            tenant,
+            status.kind.as_str(),
+            status_index_timestamp(status),
+            job_id,
+        );
+        let index_value = encode_status_index_value(status.enqueue_time_ms);
+        match expire_ts {
+            Some(ts) => {
+                writer.put_with_expire(&status_key, &status_value, ts)?;
+                writer.put_with_expire(&index_key, &index_value, ts)?;
+            }
+            None => {
+                writer.put(&status_key, &status_value)?;
+                writer.put(&index_key, &index_value)?;
+            }
+        }
         Ok(())
     }
 

--- a/src/job_store_shard/enqueue_time_backfill.rs
+++ b/src/job_store_shard/enqueue_time_backfill.rs
@@ -1,0 +1,293 @@
+//! One-shot per-shard sweep that fills `enqueue_time_ms` into status records
+//! and status/time index entries that lack it.
+//!
+//! The sweep walks the `JOB_STATUS` keyspace inside the shard's tenant range
+//! in batches, reads `JOB_INFO` for each status record without the value, and
+//! rewrites that record and its index entry in a conflict-detecting
+//! transaction. It moves no counters: it never changes a status kind or adds
+//! or removes rows, and every rewritten row keeps the `expire_ts` it already
+//! carries. Progress is persisted after every batch so a restart resumes
+//! where it left off; reaching the end of the keyspace sets the shard's
+//! completion marker and flag, after which the sweep never runs again.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use slatedb::IsolationLevel;
+use slatedb::bytes::Bytes;
+use tracing::{debug, info, warn};
+
+use crate::job::JobView;
+use crate::job_store_shard::helpers::{TxnWriter, decode_job_status_owned};
+use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
+use crate::keys::{
+    end_bound, enqueue_time_backfill_progress_key, job_info_key, parse_job_status_key, prefix,
+};
+use crate::shard_range::ShardRange;
+
+/// Persisted sweep state: the resume point and running counts. Stays on the
+/// shard after completion so the final counts remain readable.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnqueueTimeBackfillProgress {
+    /// Last `JOB_STATUS` key a completed batch ended on, hex encoded. The
+    /// next batch starts just after it.
+    pub last_key: Option<String>,
+    /// Status records inside the shard range examined so far.
+    pub scanned: u64,
+    /// Rows rewritten with the value.
+    pub repaired: u64,
+    /// Rows skipped because a concurrent transition rewrote them first.
+    pub skipped_conflict: u64,
+    /// Rows skipped because their `JOB_INFO` no longer exists.
+    pub skipped_missing_job_info: u64,
+}
+
+/// Outcome of one [`JobStoreShard::run_enqueue_time_backfill`] call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnqueueTimeBackfillOutcome {
+    pub progress: EnqueueTimeBackfillProgress,
+    /// True when the walk reached the end of the keyspace and the completion
+    /// marker is set; false when the shard's cancellation stopped it early.
+    pub complete: bool,
+}
+
+/// FNV-1a hash of the shard name, for shard-deterministic jitter.
+fn shard_name_hash(name: &str) -> u64 {
+    let mut h: u64 = 1469598103934665603;
+    for b in name.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(1099511628211);
+    }
+    h
+}
+
+impl JobStoreShard {
+    /// Start the sweep in the background unless it is disabled or the shard
+    /// already holds the completion marker.
+    pub(crate) fn spawn_enqueue_time_backfill(self: &Arc<Self>, range: ShardRange) {
+        let config = self.enqueue_time_backfill.clone();
+        if !config.enabled || self.enqueue_time_backfill_complete() {
+            return;
+        }
+        let shard = Arc::clone(self);
+        let cancellation = self.cancellation.clone();
+        tokio::spawn(async move {
+            // Shard-deterministic jitter inside the inter-batch pause so shards
+            // opening together do not start scanning at the same instant.
+            let jitter_ms = shard_name_hash(&shard.name) % config.pause_ms.max(1);
+            tokio::select! {
+                biased;
+                _ = tokio::time::sleep(Duration::from_millis(jitter_ms)) => {}
+                _ = cancellation.cancelled() => return,
+            }
+            match shard.run_enqueue_time_backfill(&range).await {
+                Ok(outcome) if outcome.complete => info!(
+                    shard = %shard.name,
+                    scanned = outcome.progress.scanned,
+                    repaired = outcome.progress.repaired,
+                    skipped_conflict = outcome.progress.skipped_conflict,
+                    skipped_missing_job_info = outcome.progress.skipped_missing_job_info,
+                    "enqueue-time backfill complete"
+                ),
+                Ok(outcome) => debug!(
+                    shard = %shard.name,
+                    scanned = outcome.progress.scanned,
+                    repaired = outcome.progress.repaired,
+                    "enqueue-time backfill paused (shard closing); resumes on next open"
+                ),
+                Err(e) => warn!(
+                    shard = %shard.name,
+                    error = %e,
+                    "enqueue-time backfill failed; resumes from the persisted key on next open"
+                ),
+            }
+        });
+    }
+
+    /// Run the sweep until the keyspace is exhausted or the shard's
+    /// cancellation token fires, resuming from any persisted progress.
+    /// Completion writes the marker and sets the in-memory flag.
+    pub async fn run_enqueue_time_backfill(
+        &self,
+        range: &ShardRange,
+    ) -> Result<EnqueueTimeBackfillOutcome, JobStoreShardError> {
+        let batch_size = self.enqueue_time_backfill.batch_size.max(1);
+        let pause = Duration::from_millis(self.enqueue_time_backfill.pause_ms);
+        let keyspace_end = end_bound(&[prefix::JOB_STATUS]);
+        let mut progress = self
+            .enqueue_time_backfill_progress()
+            .await?
+            .unwrap_or_default();
+
+        loop {
+            let start = match &progress.last_key {
+                Some(last_key) => {
+                    let mut key = hex::decode(last_key).map_err(|e| {
+                        JobStoreShardError::Codec(format!("backfill progress key: {e}"))
+                    })?;
+                    key.push(0);
+                    key
+                }
+                None => vec![prefix::JOB_STATUS],
+            };
+            let batch_end = self
+                .enqueue_time_backfill_batch(
+                    range,
+                    start,
+                    keyspace_end.clone(),
+                    batch_size,
+                    &mut progress,
+                )
+                .await?;
+            let Some(last_key) = batch_end else {
+                self.save_enqueue_time_backfill_progress(&progress).await?;
+                self.set_enqueue_time_backfill_complete(true).await?;
+                return Ok(EnqueueTimeBackfillOutcome {
+                    progress,
+                    complete: true,
+                });
+            };
+            progress.last_key = Some(hex::encode(&last_key));
+            self.save_enqueue_time_backfill_progress(&progress).await?;
+            debug!(
+                shard = %self.name,
+                scanned = progress.scanned,
+                repaired = progress.repaired,
+                "enqueue-time backfill batch checkpoint"
+            );
+            tokio::select! {
+                biased;
+                _ = self.cancellation.cancelled() => {
+                    return Ok(EnqueueTimeBackfillOutcome { progress, complete: false });
+                }
+                _ = tokio::time::sleep(pause) => {}
+            }
+        }
+    }
+
+    /// The persisted sweep progress, or `None` if the sweep has not run on
+    /// this shard.
+    pub async fn enqueue_time_backfill_progress(
+        &self,
+    ) -> Result<Option<EnqueueTimeBackfillProgress>, JobStoreShardError> {
+        match self.db.get(&enqueue_time_backfill_progress_key()).await? {
+            Some(raw) => Ok(Some(serde_json::from_slice(&raw)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn save_enqueue_time_backfill_progress(
+        &self,
+        progress: &EnqueueTimeBackfillProgress,
+    ) -> Result<(), JobStoreShardError> {
+        let data = serde_json::to_vec(progress)?;
+        self.db
+            .put(&enqueue_time_backfill_progress_key(), &data)
+            .await?;
+        Ok(())
+    }
+
+    /// Examine up to `batch_size` status records from `start`. Returns the
+    /// last key examined, or `None` when the keyspace ended before the batch
+    /// filled. Iterates the database directly with uncached scan options so
+    /// the sweep's reads never register as query scanned keys.
+    async fn enqueue_time_backfill_batch(
+        &self,
+        range: &ShardRange,
+        start: Vec<u8>,
+        end: Vec<u8>,
+        batch_size: usize,
+        progress: &mut EnqueueTimeBackfillProgress,
+    ) -> Result<Option<Vec<u8>>, JobStoreShardError> {
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options_uncached())
+            .await?;
+        let mut last_key = None;
+        for _ in 0..batch_size {
+            let Some(kv) = iter.next().await? else {
+                return Ok(None);
+            };
+            last_key = Some(kv.key.to_vec());
+            let Some(parsed) = parse_job_status_key(&kv.key) else {
+                continue;
+            };
+            if !range.contains_tenant(&parsed.tenant) {
+                continue;
+            }
+            progress.scanned += 1;
+            self.backfill_status_row(
+                &parsed.tenant,
+                &parsed.job_id,
+                &kv.key,
+                &kv.value,
+                kv.expire_ts,
+                progress,
+            )
+            .await?;
+        }
+        Ok(last_key)
+    }
+
+    /// Rewrite one status record and its index entry with `enqueue_time_ms`
+    /// when the record lacks it. The row keeps `expire_ts` exactly. A row that
+    /// changed since the scan, or whose rewrite conflicts with a concurrent
+    /// transition, is skipped: that transition wrote the value itself.
+    async fn backfill_status_row(
+        &self,
+        tenant: &str,
+        job_id: &str,
+        status_key: &Bytes,
+        status_raw: &Bytes,
+        expire_ts: Option<i64>,
+        progress: &mut EnqueueTimeBackfillProgress,
+    ) -> Result<(), JobStoreShardError> {
+        let status = match decode_job_status_owned(status_raw) {
+            Ok(status) => status,
+            Err(e) => {
+                warn!(
+                    shard = %self.name,
+                    tenant = %tenant,
+                    job_id = %job_id,
+                    error = %e,
+                    "enqueue-time backfill: failed to decode job status, skipping row"
+                );
+                return Ok(());
+            }
+        };
+        if status.enqueue_time_ms.is_some() {
+            return Ok(());
+        }
+
+        if let Some(m) = &self.metrics {
+            m.record_enqueue_time_repair_reads(&self.name, 1);
+        }
+        let Some(job_raw) = self.db.get(&job_info_key(tenant, job_id)).await? else {
+            progress.skipped_missing_job_info += 1;
+            return Ok(());
+        };
+        let enqueue_time_ms = JobView::new(job_raw)?.enqueue_time_ms();
+
+        let txn = self.db.begin(IsolationLevel::SerializableSnapshot).await?;
+        if txn.get(status_key).await?.as_ref() != Some(status_raw) {
+            progress.skipped_conflict += 1;
+            return Ok(());
+        }
+        Self::write_job_status_row(
+            &mut TxnWriter(&txn),
+            tenant,
+            job_id,
+            &status.with_enqueue_time_ms(enqueue_time_ms),
+            expire_ts,
+        )?;
+        match txn.commit().await {
+            Ok(_) => progress.repaired += 1,
+            Err(e) if e.kind() == slatedb::ErrorKind::Transaction => {
+                progress.skipped_conflict += 1;
+            }
+            Err(e) => return Err(e.into()),
+        }
+        Ok(())
+    }
+}

--- a/src/job_store_shard/enqueue_time_backfill.rs
+++ b/src/job_store_shard/enqueue_time_backfill.rs
@@ -11,6 +11,7 @@
 //! completion marker and flag, after which the sweep never runs again.
 
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -19,10 +20,11 @@ use slatedb::bytes::Bytes;
 use tracing::{debug, info, warn};
 
 use crate::job::JobView;
-use crate::job_store_shard::helpers::{TxnWriter, decode_job_status_owned};
+use crate::job_store_shard::helpers::{TxnWriter, decode_job_status_owned, now_epoch_ms};
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
-    end_bound, enqueue_time_backfill_progress_key, job_info_key, parse_job_status_key, prefix,
+    end_bound, enqueue_time_backfill_complete_key, enqueue_time_backfill_progress_key,
+    job_info_key, parse_job_status_key, prefix,
 };
 use crate::shard_range::ShardRange;
 
@@ -39,8 +41,21 @@ pub struct EnqueueTimeBackfillProgress {
     pub repaired: u64,
     /// Rows skipped because a concurrent transition rewrote them first.
     pub skipped_conflict: u64,
-    /// Rows skipped because their `JOB_INFO` no longer exists.
+    /// Rows skipped because `JOB_INFO` is absent.
     pub skipped_missing_job_info: u64,
+    /// Rows skipped because the status record or `JOB_INFO` failed to decode.
+    #[serde(default)]
+    pub skipped_undecodable: u64,
+}
+
+/// How a batch ended.
+enum BatchEnd {
+    /// The iterator ran out before the batch filled: the keyspace is done.
+    Exhausted,
+    /// The batch filled; resume after this key.
+    Checkpoint(Vec<u8>),
+    /// The shard is closing; resume after this key, if any row was examined.
+    Cancelled(Option<Vec<u8>>),
 }
 
 /// Outcome of one [`JobStoreShard::run_enqueue_time_backfill`] call.
@@ -88,6 +103,7 @@ impl JobStoreShard {
                     repaired = outcome.progress.repaired,
                     skipped_conflict = outcome.progress.skipped_conflict,
                     skipped_missing_job_info = outcome.progress.skipped_missing_job_info,
+                    skipped_undecodable = outcome.progress.skipped_undecodable,
                     "enqueue-time backfill complete"
                 ),
                 Ok(outcome) => debug!(
@@ -95,6 +111,11 @@ impl JobStoreShard {
                     scanned = outcome.progress.scanned,
                     repaired = outcome.progress.repaired,
                     "enqueue-time backfill paused (shard closing); resumes on next open"
+                ),
+                Err(e) if cancellation.is_cancelled() => debug!(
+                    shard = %shard.name,
+                    error = %e,
+                    "enqueue-time backfill interrupted by shard close; resumes on next open"
                 ),
                 Err(e) => warn!(
                     shard = %shard.name,
@@ -107,8 +128,10 @@ impl JobStoreShard {
 
     /// Run the sweep until the keyspace is exhausted or the shard's
     /// cancellation token fires, resuming from any persisted progress.
-    /// Completion writes the marker and sets the in-memory flag.
-    pub async fn run_enqueue_time_backfill(
+    /// Completion writes the final progress and the marker together and sets
+    /// the in-memory flag. The sweep is idempotent, so unreadable progress
+    /// restarts it from the beginning rather than stopping it.
+    pub(crate) async fn run_enqueue_time_backfill(
         &self,
         range: &ShardRange,
     ) -> Result<EnqueueTimeBackfillOutcome, JobStoreShardError> {
@@ -121,13 +144,18 @@ impl JobStoreShard {
             .unwrap_or_default();
 
         loop {
-            let start = match &progress.last_key {
-                Some(last_key) => {
-                    let mut key = hex::decode(last_key).map_err(|e| {
-                        JobStoreShardError::Codec(format!("backfill progress key: {e}"))
-                    })?;
+            let start = match progress.last_key.as_deref().map(hex::decode) {
+                Some(Ok(mut key)) if key.first() == Some(&prefix::JOB_STATUS) => {
                     key.push(0);
                     key
+                }
+                Some(_) => {
+                    warn!(
+                        shard = %self.name,
+                        "enqueue-time backfill: persisted resume key is not a JOB_STATUS key; restarting from the beginning"
+                    );
+                    progress.last_key = None;
+                    vec![prefix::JOB_STATUS]
                 }
                 None => vec![prefix::JOB_STATUS],
             };
@@ -140,16 +168,30 @@ impl JobStoreShard {
                     &mut progress,
                 )
                 .await?;
-            let Some(last_key) = batch_end else {
-                self.save_enqueue_time_backfill_progress(&progress).await?;
-                self.set_enqueue_time_backfill_complete(true).await?;
-                return Ok(EnqueueTimeBackfillOutcome {
-                    progress,
-                    complete: true,
-                });
-            };
-            progress.last_key = Some(hex::encode(&last_key));
-            self.save_enqueue_time_backfill_progress(&progress).await?;
+            match batch_end {
+                BatchEnd::Exhausted => {
+                    self.record_enqueue_time_backfill_complete(&progress)
+                        .await?;
+                    return Ok(EnqueueTimeBackfillOutcome {
+                        progress,
+                        complete: true,
+                    });
+                }
+                BatchEnd::Cancelled(last_key) => {
+                    if let Some(last_key) = last_key {
+                        progress.last_key = Some(hex::encode(&last_key));
+                        self.save_enqueue_time_backfill_progress(&progress).await?;
+                    }
+                    return Ok(EnqueueTimeBackfillOutcome {
+                        progress,
+                        complete: false,
+                    });
+                }
+                BatchEnd::Checkpoint(last_key) => {
+                    progress.last_key = Some(hex::encode(&last_key));
+                    self.save_enqueue_time_backfill_progress(&progress).await?;
+                }
+            }
             debug!(
                 shard = %self.name,
                 scanned = progress.scanned,
@@ -167,14 +209,46 @@ impl JobStoreShard {
     }
 
     /// The persisted sweep progress, or `None` if the sweep has not run on
-    /// this shard.
+    /// this shard or its record is unreadable.
     pub async fn enqueue_time_backfill_progress(
         &self,
     ) -> Result<Option<EnqueueTimeBackfillProgress>, JobStoreShardError> {
-        match self.db.get(&enqueue_time_backfill_progress_key()).await? {
-            Some(raw) => Ok(Some(serde_json::from_slice(&raw)?)),
-            None => Ok(None),
+        let Some(raw) = self.db.get(&enqueue_time_backfill_progress_key()).await? else {
+            return Ok(None);
+        };
+        match serde_json::from_slice(&raw) {
+            Ok(progress) => Ok(Some(progress)),
+            Err(e) => {
+                warn!(
+                    shard = %self.name,
+                    error = %e,
+                    "enqueue-time backfill: persisted progress is unreadable; treating as absent"
+                );
+                Ok(None)
+            }
         }
+    }
+
+    /// Write the final progress and the completion marker in one batch, then
+    /// set the flag, so a crash cannot leave the counts and the marker
+    /// disagreeing.
+    async fn record_enqueue_time_backfill_complete(
+        &self,
+        progress: &EnqueueTimeBackfillProgress,
+    ) -> Result<(), JobStoreShardError> {
+        let mut batch = slatedb::WriteBatch::new();
+        batch.put(
+            enqueue_time_backfill_progress_key(),
+            serde_json::to_vec(progress)?,
+        );
+        batch.put(
+            enqueue_time_backfill_complete_key(),
+            now_epoch_ms().to_be_bytes(),
+        );
+        self.db.write(batch).await?;
+        self.enqueue_time_backfill_complete
+            .store(true, Ordering::Release);
+        Ok(())
     }
 
     async fn save_enqueue_time_backfill_progress(
@@ -188,10 +262,10 @@ impl JobStoreShard {
         Ok(())
     }
 
-    /// Examine up to `batch_size` status records from `start`. Returns the
-    /// last key examined, or `None` when the keyspace ended before the batch
-    /// filled. Iterates the database directly with uncached scan options so
-    /// the sweep's reads never register as query scanned keys.
+    /// Examine up to `batch_size` status records from `start`, stopping early
+    /// when the shard starts closing. Iterates the database directly with
+    /// uncached scan options so the sweep's reads never register as query
+    /// scanned keys.
     async fn enqueue_time_backfill_batch(
         &self,
         range: &ShardRange,
@@ -199,15 +273,18 @@ impl JobStoreShard {
         end: Vec<u8>,
         batch_size: usize,
         progress: &mut EnqueueTimeBackfillProgress,
-    ) -> Result<Option<Vec<u8>>, JobStoreShardError> {
+    ) -> Result<BatchEnd, JobStoreShardError> {
         let mut iter = self
             .db
             .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options_uncached())
             .await?;
         let mut last_key = None;
         for _ in 0..batch_size {
+            if self.cancellation.is_cancelled() {
+                return Ok(BatchEnd::Cancelled(last_key));
+            }
             let Some(kv) = iter.next().await? else {
-                return Ok(None);
+                return Ok(BatchEnd::Exhausted);
             };
             last_key = Some(kv.key.to_vec());
             let Some(parsed) = parse_job_status_key(&kv.key) else {
@@ -227,7 +304,9 @@ impl JobStoreShard {
             )
             .await?;
         }
-        Ok(last_key)
+        Ok(BatchEnd::Checkpoint(
+            last_key.expect("a full batch examined at least one key"),
+        ))
     }
 
     /// Rewrite one status record and its index entry with `enqueue_time_ms`
@@ -246,6 +325,7 @@ impl JobStoreShard {
         let status = match decode_job_status_owned(status_raw) {
             Ok(status) => status,
             Err(e) => {
+                progress.skipped_undecodable += 1;
                 warn!(
                     shard = %self.name,
                     tenant = %tenant,
@@ -267,7 +347,20 @@ impl JobStoreShard {
             progress.skipped_missing_job_info += 1;
             return Ok(());
         };
-        let enqueue_time_ms = JobView::new(job_raw)?.enqueue_time_ms();
+        let enqueue_time_ms = match JobView::new(job_raw) {
+            Ok(view) => view.enqueue_time_ms(),
+            Err(e) => {
+                progress.skipped_undecodable += 1;
+                warn!(
+                    shard = %self.name,
+                    tenant = %tenant,
+                    job_id = %job_id,
+                    error = %e,
+                    "enqueue-time backfill: failed to decode job info, skipping row"
+                );
+                return Ok(());
+            }
+        };
 
         let txn = self.db.begin(IsolationLevel::SerializableSnapshot).await?;
         if txn.get(status_key).await?.as_ref() != Some(status_raw) {

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -443,12 +443,9 @@ pub(crate) async fn load_job_view(
     tenant: &str,
     id: &str,
 ) -> Result<crate::job::JobView, JobStoreShardError> {
-    let job_info_key = crate::keys::job_info_key(tenant, id);
-    let maybe_job_raw = reader.get(&job_info_key).await?;
-    let Some(job_raw) = maybe_job_raw else {
-        return Err(JobStoreShardError::JobNotFound(id.to_string()));
-    };
-    crate::job::JobView::new(job_raw)
+    try_load_job_view(reader, tenant, id)
+        .await?
+        .ok_or_else(|| JobStoreShardError::JobNotFound(id.to_string()))
 }
 
 /// Load a `JobView` for the given tenant/job, or `None` when the job info

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -451,6 +451,21 @@ pub(crate) async fn load_job_view(
     crate::job::JobView::new(job_raw)
 }
 
+/// Load a `JobView` for the given tenant/job, or `None` when the job info
+/// key does not exist.
+pub(crate) async fn try_load_job_view(
+    reader: &impl WriteBatcher,
+    tenant: &str,
+    id: &str,
+) -> Result<Option<crate::job::JobView>, JobStoreShardError> {
+    let job_info_key = crate::keys::job_info_key(tenant, id);
+    reader
+        .get(&job_info_key)
+        .await?
+        .map(crate::job::JobView::new)
+        .transpose()
+}
+
 /// Decode a `JobStatus` from raw bytes into an owned value.
 pub(crate) fn decode_job_status_owned(raw: &[u8]) -> Result<JobStatus, JobStoreShardError> {
     Ok(crate::codec::decode_job_status_owned(raw)?)

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -192,6 +192,7 @@ impl JobStoreShard {
         let num_attempts = params.attempts.len() as u32;
         let (job_status, status_kind, is_terminal) =
             determine_import_status(params, num_attempts, now_ms, effective_start_at_ms);
+        let job_status = job_status.with_enqueue_time_ms(effective_enqueue_time_ms);
         let terminal_expire_ts: Option<i64> = if is_terminal {
             self.terminal_expire_ts(status_kind, now_ms)
         } else {
@@ -512,6 +513,8 @@ impl JobStoreShard {
         let total_attempts = params.attempts.len() as u32;
         let (new_job_status, status_kind, is_terminal) =
             determine_import_status(params, total_attempts, now_ms, effective_start_at_ms);
+        // JOB_INFO keeps the job's original enqueue time across a reimport.
+        let new_job_status = new_job_status.with_enqueue_time_ms(existing_job.enqueue_time_ms());
         let terminal_expire_ts: Option<i64> = if is_terminal {
             self.terminal_expire_ts(status_kind, now_ms)
         } else {

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod counters;
 mod dequeue;
 mod drop_tenant_holders;
 mod enqueue;
+pub mod enqueue_time_backfill;
 mod expedite;
 mod floating;
 pub(crate) mod helpers;
@@ -109,6 +110,9 @@ pub struct OpenShardOptions {
     /// next-hop skip threshold, live headroom). Populated from the
     /// `grant_scanner_*` knobs in the database config.
     pub grant_scanner: GrantScannerConfig,
+    /// One-shot sweep that fills `enqueue_time_ms` into status rows lacking
+    /// it. Off by default; see `EnqueueTimeBackfillConfig`.
+    pub enqueue_time_backfill: crate::settings::EnqueueTimeBackfillConfig,
     /// Max requester-counter keys the periodic concurrency reconcile sweep
     /// walks per tick. Populated from `concurrency_reconcile_scan_slice` in
     /// the database config.
@@ -239,6 +243,9 @@ pub struct JobStoreShard {
     /// it at open, written together with it by
     /// [`set_enqueue_time_backfill_complete`](Self::set_enqueue_time_backfill_complete).
     enqueue_time_backfill_complete: AtomicBool,
+    /// Settings for the sweep that fills `enqueue_time_ms` into status rows
+    /// lacking it.
+    pub(crate) enqueue_time_backfill: crate::settings::EnqueueTimeBackfillConfig,
 }
 
 #[derive(Debug, Error)]
@@ -432,6 +439,7 @@ impl JobStoreShard {
                 completed_job_expire_s: cfg.completed_job_expire_s,
                 terminal_job_expire_s: cfg.terminal_job_expire_s,
                 count_from_status_counters: cfg.count_from_status_counters,
+                enqueue_time_backfill: cfg.enqueue_time_backfill.clone(),
             },
             range,
         )
@@ -476,6 +484,7 @@ impl JobStoreShard {
             completed_job_expire_s,
             terminal_job_expire_s,
             count_from_status_counters,
+            enqueue_time_backfill,
         } = options;
 
         // Wall-clock timer for the whole open, used to emit per-phase debug
@@ -599,6 +608,7 @@ impl JobStoreShard {
             terminal_job_expire_s,
             count_from_status_counters,
             enqueue_time_backfill_complete: AtomicBool::new(enqueue_time_backfill_complete),
+            enqueue_time_backfill,
         });
 
         // Install the chain resumer before starting the grant scanner so the
@@ -646,6 +656,10 @@ impl JobStoreShard {
         // change (durable_seq advances, manifest revisions). No-op when
         // metrics are disabled.
         shard.spawn_db_status_watcher();
+
+        // Fill enqueue_time_ms into status rows written without it, once per
+        // shard. No-op unless enabled and the completion marker is absent.
+        shard.spawn_enqueue_time_backfill(range.clone());
 
         // Periodically reconcile job counters from JOB_INFO/JOB_STATUS truth.
         // Only enabled when the deployment runs the standalone compactor, which

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -38,6 +38,7 @@ use slatedb_common::metrics::DefaultMetricsRecorder;
 use std::sync::Arc;
 #[cfg(feature = "server")]
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
@@ -233,6 +234,11 @@ pub struct JobStoreShard {
     /// When true, the query engine answers unfiltered per-tenant `COUNT(*)`
     /// from per-status counters instead of a full status-index scan.
     pub(crate) count_from_status_counters: bool,
+    /// Whether every status record and status/time index entry on this shard
+    /// carries `enqueue_time_ms`. Mirrors the completion marker key: read from
+    /// it at open, written together with it by
+    /// [`set_enqueue_time_backfill_complete`](Self::set_enqueue_time_backfill_complete).
+    enqueue_time_backfill_complete: AtomicBool,
 }
 
 #[derive(Debug, Error)]
@@ -565,6 +571,11 @@ impl JobStoreShard {
             range.clone(),
         );
 
+        let enqueue_time_backfill_complete = db
+            .get(&crate::keys::enqueue_time_backfill_complete_key())
+            .await?
+            .is_some();
+
         let shard = Arc::new(Self {
             name,
             db,
@@ -587,6 +598,7 @@ impl JobStoreShard {
             completed_job_expire_s,
             terminal_job_expire_s,
             count_from_status_counters,
+            enqueue_time_backfill_complete: AtomicBool::new(enqueue_time_backfill_complete),
         });
 
         // Install the chain resumer before starting the grant scanner so the
@@ -659,6 +671,34 @@ impl JobStoreShard {
         );
 
         Ok(shard)
+    }
+
+    /// Whether every status record and status/time index entry on this shard
+    /// carries `enqueue_time_ms`. While false, index entries written without
+    /// the value may still exist, so unfiltered scans that project
+    /// `enqueue_time_ms` must read it from `JOB_INFO`.
+    pub fn enqueue_time_backfill_complete(&self) -> bool {
+        self.enqueue_time_backfill_complete.load(Ordering::Acquire)
+    }
+
+    /// Record or clear backfill completion: writes (or deletes) the marker key
+    /// and updates the in-memory flag together, so the flag never disagrees
+    /// with what a reopen would read.
+    pub async fn set_enqueue_time_backfill_complete(
+        &self,
+        complete: bool,
+    ) -> Result<(), JobStoreShardError> {
+        let key = crate::keys::enqueue_time_backfill_complete_key();
+        if complete {
+            self.db
+                .put(&key, helpers::now_epoch_ms().to_be_bytes())
+                .await?;
+        } else {
+            self.db.delete(&key).await?;
+        }
+        self.enqueue_time_backfill_complete
+            .store(complete, Ordering::Release);
+        Ok(())
     }
 
     /// Get the query engine for this shard, lazily initializing it on first access.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -33,6 +33,7 @@ pub mod prefix {
     pub const CLEANUP_COMPLETED_AT: u8 = 0xF6;
     pub const COUNTER_CONCURRENCY_REQUESTERS: u8 = 0xF7;
     pub const COUNTER_TENANT_STATUS: u8 = 0xF8;
+    pub const ENQUEUE_TIME_BACKFILL_COMPLETE: u8 = 0xF9;
 }
 
 /// Encode a key with its namespace prefix.
@@ -187,6 +188,26 @@ pub fn status_index_timestamp(status: &JobStatus) -> i64 {
     } else {
         status.changed_at_ms
     }
+}
+
+/// Byte length of a status/time index entry value that carries an enqueue time.
+pub const STATUS_INDEX_VALUE_LEN: usize = 8;
+
+/// Encode the value stored under a status/time index key: the job's
+/// `enqueue_time_ms` as a big-endian i64, or empty when it is unknown.
+pub fn encode_status_index_value(enqueue_time_ms: Option<i64>) -> Vec<u8> {
+    match enqueue_time_ms {
+        Some(ms) => ms.to_be_bytes().to_vec(),
+        None => Vec::new(),
+    }
+}
+
+/// Decode a status/time index entry value into the job's `enqueue_time_ms`.
+/// An empty value means the entry was written without one; any other length
+/// is treated the same way (unknown), never as an error.
+pub fn decode_status_index_value(value: &[u8]) -> Option<i64> {
+    let bytes: [u8; STATUS_INDEX_VALUE_LEN] = value.try_into().ok()?;
+    Some(i64::from_be_bytes(bytes))
 }
 
 /// Index: jobs by metadata key/value (unsorted within key/value).
@@ -597,6 +618,12 @@ pub fn cleanup_complete_key() -> Vec<u8> {
 /// This is the source of truth for whether the shard needs cleanup work.
 pub fn cleanup_status_key() -> Vec<u8> {
     vec![prefix::CLEANUP_STATUS]
+}
+
+/// Key for the marker recording that every status record and status/time
+/// index entry on this shard carries `enqueue_time_ms`.
+pub fn enqueue_time_backfill_complete_key() -> Vec<u8> {
+    vec![prefix::ENQUEUE_TIME_BACKFILL_COMPLETE]
 }
 
 /// Key for storing the timestamp (ms) when the shard was first created/initialized.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -34,6 +34,7 @@ pub mod prefix {
     pub const COUNTER_CONCURRENCY_REQUESTERS: u8 = 0xF7;
     pub const COUNTER_TENANT_STATUS: u8 = 0xF8;
     pub const ENQUEUE_TIME_BACKFILL_COMPLETE: u8 = 0xF9;
+    pub const ENQUEUE_TIME_BACKFILL_PROGRESS: u8 = 0xFA;
 }
 
 /// Encode a key with its namespace prefix.
@@ -624,6 +625,12 @@ pub fn cleanup_status_key() -> Vec<u8> {
 /// index entry on this shard carries `enqueue_time_ms`.
 pub fn enqueue_time_backfill_complete_key() -> Vec<u8> {
     vec![prefix::ENQUEUE_TIME_BACKFILL_COMPLETE]
+}
+
+/// Key for the enqueue-time backfill sweep's persisted progress (resume
+/// point and counts).
+pub fn enqueue_time_backfill_progress_key() -> Vec<u8> {
+    vec![prefix::ENQUEUE_TIME_BACKFILL_PROGRESS]
 }
 
 /// Key for storing the timestamp (ms) when the shard was first created/initialized.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -166,10 +166,11 @@ pub struct Metrics {
     /// shard. Stays flat for index-only scans — the signal that an aggregate
     /// shape rode the index-only path instead of per-row hydration.
     query_point_lookups: CounterVec,
-    /// `JOB_INFO` reads issued to resolve `enqueue_time_ms` for a status
-    /// record that lacks it, per shard — on the write path (once per such
-    /// record, at its next transition) and in the backfill sweep. Converges
-    /// to zero once every status record carries the value.
+    /// Status records that lacked `enqueue_time_ms` and had it resolved from a
+    /// `JOB_INFO` read, per shard — on the write path (once per such record,
+    /// at its next transition, counting a read the gauge path issued anyway)
+    /// and in the backfill sweep. Converges to zero once every status record
+    /// carries the value.
     enqueue_time_repair_reads: CounterVec,
     /// Rows the status-index query path had to hydrate from `JOB_INFO`
     /// because their index entry carried no `enqueue_time_ms`, per shard.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -171,6 +171,10 @@ pub struct Metrics {
     /// record, at its next transition) and in the backfill sweep. Converges
     /// to zero once every status record carries the value.
     enqueue_time_repair_reads: CounterVec,
+    /// Rows the status-index query path had to hydrate from `JOB_INFO`
+    /// because their index entry carried no `enqueue_time_ms`, per shard.
+    /// Converges to zero once every index entry carries the value.
+    enqueue_time_fallback_hydrations: CounterVec,
 
     // Shard/broker metrics
     shards_owned: Gauge,
@@ -495,6 +499,24 @@ impl Metrics {
     /// touch `JOB_INFO`.
     pub fn enqueue_time_repair_reads_value(&self, shard: &str) -> f64 {
         self.enqueue_time_repair_reads
+            .with_label_values(&[shard])
+            .get()
+    }
+
+    /// Add `n` to the per-shard fallback-hydration counter: rows on the
+    /// status-index query path whose index entry lacked `enqueue_time_ms` and
+    /// were read from `JOB_INFO` instead.
+    pub fn record_enqueue_time_fallback_hydrations(&self, shard: &str, n: u64) {
+        self.enqueue_time_fallback_hydrations
+            .with_label_values(&[shard])
+            .inc_by(n as f64);
+    }
+
+    /// Read the current fallback-hydration counter for a shard. Exposed for
+    /// tests and operational assertions that an index-served query stayed
+    /// index-only.
+    pub fn enqueue_time_fallback_hydrations_value(&self, shard: &str) -> f64 {
+        self.enqueue_time_fallback_hydrations
             .with_label_values(&[shard])
             .get()
     }
@@ -2117,6 +2139,16 @@ pub fn init() -> anyhow::Result<Metrics> {
             &["shard"],
         )?,
     );
+    let enqueue_time_fallback_hydrations = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_enqueue_time_fallback_hydrations_total",
+                "Rows hydrated from JOB_INFO on the status-index query path because their index entry lacked enqueue_time_ms, per shard",
+            ),
+            &["shard"],
+        )?,
+    );
 
     // Shard/broker metrics
     let shards_owned = register(
@@ -2622,6 +2654,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         query_scanned_keys,
         query_point_lookups,
         enqueue_time_repair_reads,
+        enqueue_time_fallback_hydrations,
         shards_owned,
         shards_unassigned,
         coordination_shards_open,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -166,6 +166,11 @@ pub struct Metrics {
     /// shard. Stays flat for index-only scans — the signal that an aggregate
     /// shape rode the index-only path instead of per-row hydration.
     query_point_lookups: CounterVec,
+    /// `JOB_INFO` reads issued to resolve `enqueue_time_ms` for a status
+    /// record that lacks it, per shard — on the write path (once per such
+    /// record, at its next transition) and in the backfill sweep. Converges
+    /// to zero once every status record carries the value.
+    enqueue_time_repair_reads: CounterVec,
 
     // Shard/broker metrics
     shards_owned: Gauge,
@@ -475,6 +480,23 @@ impl Metrics {
     /// tests and operational assertions that a scan stayed on the index-only path.
     pub fn query_point_lookups_value(&self, shard: &str) -> f64 {
         self.query_point_lookups.with_label_values(&[shard]).get()
+    }
+
+    /// Add `n` to the per-shard enqueue-time repair-read counter: `JOB_INFO`
+    /// reads issued to fill in `enqueue_time_ms` on a status record lacking it.
+    pub fn record_enqueue_time_repair_reads(&self, shard: &str, n: u64) {
+        self.enqueue_time_repair_reads
+            .with_label_values(&[shard])
+            .inc_by(n as f64);
+    }
+
+    /// Read the current enqueue-time repair-read counter for a shard. Exposed
+    /// for tests and operational assertions that a transition or sweep did not
+    /// touch `JOB_INFO`.
+    pub fn enqueue_time_repair_reads_value(&self, shard: &str) -> f64 {
+        self.enqueue_time_repair_reads
+            .with_label_values(&[shard])
+            .get()
     }
 
     /// Update the number of shards owned by this node (from coordinator).
@@ -2085,6 +2107,16 @@ pub fn init() -> anyhow::Result<Metrics> {
             &["shard"],
         )?,
     );
+    let enqueue_time_repair_reads = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_enqueue_time_repair_reads_total",
+                "JOB_INFO reads issued to resolve enqueue_time_ms for status records lacking it, per shard",
+            ),
+            &["shard"],
+        )?,
+    );
 
     // Shard/broker metrics
     let shards_owned = register(
@@ -2589,6 +2621,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         query_cancelled,
         query_scanned_keys,
         query_point_lookups,
+        enqueue_time_repair_reads,
         shards_owned,
         shards_unassigned,
         coordination_shards_open,

--- a/src/query.rs
+++ b/src/query.rs
@@ -266,8 +266,14 @@ pub trait Scan: std::fmt::Debug + Send + Sync + 'static {
     ) -> SendableRecordBatchStream;
 
     /// Describe the scan strategy for EXPLAIN output. Returns a human-readable
-    /// description of what index/scan path will be used for the given filters.
-    fn describe(&self, _filters: &[Expr], _limit: Option<usize>) -> String {
+    /// description of what index/scan path will be used for the given
+    /// projection and filters.
+    fn describe(
+        &self,
+        _projection: &SchemaRef,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> String {
         "CustomScan".to_string()
     }
 
@@ -429,7 +435,9 @@ impl DisplayAs for SiloExecutionPlan {
             DisplayFormatType::Default
             | DisplayFormatType::Verbose
             | DisplayFormatType::TreeRender => {
-                let desc = self.scanner.describe(&self.filters, self.limit);
+                let desc = self
+                    .scanner
+                    .describe(&self.projected_schema, &self.filters, self.limit);
                 write!(f, "SiloExecutionPlan: {}", desc)
             }
         }
@@ -891,7 +899,8 @@ impl JobsScanner {
 /// Captures what columns the DataFusion projection requires, so we can pick
 /// the most efficient scan path and skip fetches we don't need.
 struct ProjectionNeeds {
-    /// Needs fields only in job_info: priority, enqueue_time_ms, payload, task_group, metadata
+    /// Needs a job_info read per row: priority, payload, task_group, metadata,
+    /// limits, or enqueue_time_ms when the status index cannot serve it.
     need_job_info: bool,
     /// Needs fields available from the status/time index key: status_kind, status_changed_at_ms
     need_status_index_fields: bool,
@@ -899,6 +908,9 @@ struct ProjectionNeeds {
     need_status_point_lookup: bool,
     /// Fast path: scan status/time index directly, no point-lookups required
     use_status_index_path: bool,
+    /// On the fast path, enqueue_time_ms is projected and read from each index
+    /// entry's value, with a job_info read for just the entries lacking it.
+    enqueue_time_from_index: bool,
     /// ExactId with a tenant: must verify existence even without job_info columns
     needs_existence_check: bool,
 }
@@ -909,11 +921,17 @@ impl ProjectionNeeds {
     }
 }
 
-fn analyze_projection(projection: &SchemaRef, strategy: &JobsScanStrategy) -> ProjectionNeeds {
-    let need_job_info = projection.fields().iter().any(|f| {
+fn analyze_projection(
+    projection: &SchemaRef,
+    strategy: &JobsScanStrategy,
+    backfill_complete: bool,
+) -> ProjectionNeeds {
+    let projects = |name: &str| projection.fields().iter().any(|f| f.name() == name);
+    let need_enqueue_time = projects("enqueue_time_ms");
+    let need_other_job_info = projection.fields().iter().any(|f| {
         matches!(
             f.name().as_str(),
-            "priority" | "enqueue_time_ms" | "payload" | "task_group" | "metadata" | "limits"
+            "priority" | "payload" | "task_group" | "metadata" | "limits"
         )
     });
     // status_kind and status_changed_at_ms are encoded in the status/time index key, so
@@ -928,17 +946,41 @@ fn analyze_projection(projection: &SchemaRef, strategy: &JobsScanStrategy) -> Pr
             "current_attempt" | "next_attempt_starts_after_ms"
         )
     });
+    // For Scheduled rows the index key carries the scheduled start time while
+    // the status record carries the transition time; the Status strategy's
+    // pairs path returns the record's value, so it keeps that column.
+    let need_status_changed_at = projects("status_changed_at_ms");
+    let index_path_strategy = match strategy {
+        JobsScanStrategy::FullScan { .. } | JobsScanStrategy::StatusUnion { .. } => true,
+        JobsScanStrategy::Status {
+            tenant: Some(_), ..
+        } => !need_status_changed_at,
+        _ => false,
+    };
     // When no job_info fields or status point-lookup fields are needed (including the
     // empty-projection case for COUNT(*)), scan the status/time index directly and skip
     // all get_jobs_batch / get_jobs_status_batch point-lookups.
-    // Valid for FullScan (whole index prefix) and StatusUnion (per-status ranges of the
-    // same index) — other strategies already have a bounded pair list.
-    let use_status_index_path = !need_job_info
-        && !need_status_point_lookup
-        && matches!(
-            strategy,
-            JobsScanStrategy::FullScan { .. } | JobsScanStrategy::StatusUnion { .. }
-        );
+    // Valid for FullScan (whole index prefix), StatusUnion and tenant-scoped Status
+    // (per-status ranges of the same index) — other strategies already have a
+    // bounded pair list.
+    let base_fast_path = !need_other_job_info && !need_status_point_lookup && index_path_strategy;
+    // enqueue_time_ms is index-served only where the scanned ranges are
+    // expected to carry it in every entry: tenant-scoped Status and StatusUnion
+    // always, FullScan once the shard's backfill has completed. Entries that
+    // lack it are hydrated from job_info individually. Whenever the fast path
+    // is not taken, the column stays a job_info column.
+    let enqueue_time_from_index = need_enqueue_time
+        && base_fast_path
+        && match strategy {
+            JobsScanStrategy::Status {
+                tenant: Some(_), ..
+            }
+            | JobsScanStrategy::StatusUnion { .. } => true,
+            JobsScanStrategy::FullScan { tenant: Some(_) } => backfill_complete,
+            _ => false,
+        };
+    let use_status_index_path = base_fast_path && (!need_enqueue_time || enqueue_time_from_index);
+    let need_job_info = need_other_job_info || (need_enqueue_time && !use_status_index_path);
     // ExactId with a tenant synthesises the pair without scanning the DB, so we must
     // verify existence via get_jobs_batch even when job_info columns aren't projected.
     let needs_existence_check = matches!(
@@ -953,14 +995,74 @@ fn analyze_projection(projection: &SchemaRef, strategy: &JobsScanStrategy) -> Pr
         need_status_index_fields,
         need_status_point_lookup,
         use_status_index_path,
+        enqueue_time_from_index,
         needs_existence_check,
     }
 }
 
+/// The scan path the jobs scanner takes for a projection, strategy and limit.
+/// Named in EXPLAIN output so an index-served query is recognisable without
+/// profiling it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JobsScanPath {
+    /// Row tally from the per-status counters; no scan at all.
+    StatusCounters,
+    /// Status/time index entries only, with a per-row job_info read for
+    /// entries lacking a projected enqueue_time_ms.
+    StatusIndex,
+    /// Streaming job_info / job_status merge join over a FullScan.
+    FullscanJoin,
+    /// Index-resolved (tenant, job_id) pairs hydrated by batched point-lookups.
+    Pairs,
+}
+
+impl std::fmt::Display for JobsScanPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            JobsScanPath::StatusCounters => "status-counters",
+            JobsScanPath::StatusIndex => "status-index",
+            JobsScanPath::FullscanJoin => "fullscan-join",
+            JobsScanPath::Pairs => "pairs",
+        })
+    }
+}
+
+/// The one dispatch decision shared by `scan` and `describe`, so EXPLAIN
+/// reports exactly the path the scan takes. The counters guard comes first.
+fn choose_jobs_scan_path(
+    shard: &JobStoreShard,
+    projection: &SchemaRef,
+    strategy: &JobsScanStrategy,
+    limit: Option<usize>,
+) -> (JobsScanPath, ProjectionNeeds) {
+    let needs = analyze_projection(projection, strategy, shard.enqueue_time_backfill_complete());
+    let path = if projection.fields().is_empty()
+        && limit.is_none()
+        && shard.count_from_status_counters
+        && matches!(strategy, JobsScanStrategy::FullScan { tenant: Some(_) })
+    {
+        // Empty-projection full-tenant scan with no LIMIT — the shape of
+        // `SELECT COUNT(*) FROM jobs WHERE tenant = ...`. Answer the row
+        // tally from the per-status counters (O(#statuses)) rather than
+        // walking the index. The `limit.is_none()` guard excludes shapes
+        // like `EXISTS`/`SELECT 1 ... LIMIT n` that push a scan limit and
+        // want actual rows, not a (reconciler-lagged) counter tally.
+        JobsScanPath::StatusCounters
+    } else if needs.use_status_index_path {
+        JobsScanPath::StatusIndex
+    } else if needs.need_job_info && matches!(strategy, JobsScanStrategy::FullScan { .. }) {
+        JobsScanPath::FullscanJoin
+    } else {
+        JobsScanPath::Pairs
+    };
+    (path, needs)
+}
+
 impl Scan for JobsScanner {
-    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+    fn describe(&self, projection: &SchemaRef, filters: &[Expr], limit: Option<usize>) -> String {
         let strategy = parse_jobs_scan_strategy(filters);
-        format!("jobs[{}], limit={:?}", strategy, limit)
+        let (path, _) = choose_jobs_scan_path(&self.shard, projection, &strategy, limit);
+        format!("jobs[{strategy}], path={path}, limit={limit:?}")
     }
 
     fn classify_filters(&self, filters: &[&Expr]) -> Vec<TableProviderFilterPushDown> {
@@ -976,56 +1078,43 @@ impl Scan for JobsScanner {
     ) -> SendableRecordBatchStream {
         let strategy = parse_jobs_scan_strategy(filters);
         let shard = Arc::clone(&self.shard);
-        let needs = analyze_projection(&projection, &strategy);
+        let (path, needs) = choose_jobs_scan_path(&shard, &projection, &strategy, limit);
 
         // Each branch produces its own lazy `async_stream` generator that owns
         // the underlying scan cursor(s). Because nothing is spawned, dropping the
         // returned stream (statement timeout, client disconnect, LIMIT satisfied)
         // drops the cursor and stops the scan at its next `.await` — no zombies.
-        let inner: Pin<Box<dyn Stream<Item = DfResult<RecordBatch>> + Send>> =
-            if projection.fields().is_empty()
-                && limit.is_none()
-                && shard.count_from_status_counters
-                && matches!(&strategy, JobsScanStrategy::FullScan { tenant: Some(_) })
-            {
-                // Empty-projection full-tenant scan with no LIMIT — the shape of
-                // `SELECT COUNT(*) FROM jobs WHERE tenant = ...`. Answer the row
-                // tally from the per-status counters (O(#statuses)) rather than
-                // walking the index. The `limit.is_none()` guard excludes shapes
-                // like `EXISTS`/`SELECT 1 ... LIMIT n` that push a scan limit and
-                // want actual rows, not a (reconciler-lagged) counter tally.
-                Box::pin(count_from_counters_stream(
-                    shard,
-                    projection.clone(),
-                    strategy,
-                ))
-            } else if needs.use_status_index_path {
-                Box::pin(status_index_stream(
-                    shard,
-                    projection.clone(),
-                    strategy,
-                    batch_size,
-                    limit,
-                ))
-            } else if needs.need_job_info && matches!(strategy, JobsScanStrategy::FullScan { .. }) {
-                Box::pin(fullscan_join_stream(
-                    shard,
-                    projection.clone(),
-                    needs,
-                    strategy,
-                    batch_size,
-                    limit,
-                ))
-            } else {
-                Box::pin(job_pairs_stream(
-                    shard,
-                    projection.clone(),
-                    needs,
-                    strategy,
-                    batch_size,
-                    limit,
-                ))
-            };
+        let inner: Pin<Box<dyn Stream<Item = DfResult<RecordBatch>> + Send>> = match path {
+            JobsScanPath::StatusCounters => Box::pin(count_from_counters_stream(
+                shard,
+                projection.clone(),
+                strategy,
+            )),
+            JobsScanPath::StatusIndex => Box::pin(status_index_stream(
+                shard,
+                projection.clone(),
+                strategy,
+                needs.enqueue_time_from_index,
+                batch_size,
+                limit,
+            )),
+            JobsScanPath::FullscanJoin => Box::pin(fullscan_join_stream(
+                shard,
+                projection.clone(),
+                needs,
+                strategy,
+                batch_size,
+                limit,
+            )),
+            JobsScanPath::Pairs => Box::pin(job_pairs_stream(
+                shard,
+                projection.clone(),
+                needs,
+                strategy,
+                batch_size,
+                limit,
+            )),
+        };
 
         Box::pin(RecordBatchStreamAdapter::new(projection, inner))
     }
@@ -1051,22 +1140,36 @@ fn count_from_counters_stream(
     }
 }
 
+/// One status/time index entry as the fast path reads it: the key's fields
+/// plus the value's `enqueue_time_ms`, `None` when the entry lacks it.
+struct IndexRow {
+    tenant: String,
+    job_id: String,
+    status: String,
+    changed_at_ms: i64,
+    enqueue_time_ms: Option<i64>,
+}
+
 /// Streams the status/time index in bounded chunks, emitting RecordBatches with
 /// no point-lookups. Used when the projection only needs tenant, id,
-/// status_kind, or status_changed_at_ms (including the COUNT(*) fallback when
-/// counter-based counting is disabled). Serves FullScan (one whole-prefix range)
-/// and StatusUnion (one range per status arm, all planned from a single clock
-/// snapshot that also fixes the emitted virtual-status labels).
+/// status_kind, status_changed_at_ms or an index-served enqueue_time_ms
+/// (including the COUNT(*) fallback when counter-based counting is disabled).
+/// Serves FullScan (one whole-prefix range), tenant-scoped Status (one range)
+/// and StatusUnion (one range per status arm); the status arms are planned
+/// from a single clock snapshot that also fixes the emitted virtual-status
+/// labels. With `enqueue_time_from_index`, entries whose value lacks the
+/// column are hydrated from job_info individually.
 fn status_index_stream(
     shard: Arc<JobStoreShard>,
     projection: SchemaRef,
     strategy: JobsScanStrategy,
+    enqueue_time_from_index: bool,
     batch_size: usize,
     limit: Option<usize>,
 ) -> impl Stream<Item = DfResult<RecordBatch>> {
     async_stream::try_stream! {
-        // FullScan keeps its per-batch label clock (`None`); a union plans every
-        // arm's range from one snapshot and labels rows with that same snapshot,
+        // FullScan keeps its per-batch label clock (`None`); a status arm plans
+        // its range from one snapshot and labels rows with that same snapshot,
         // so a job crossing its scheduled-start time mid-scan cannot appear in
         // two arms or carry a label inconsistent with the arm that produced it.
         let (ranges, label_now): (Vec<KeyRange>, Option<i64>) = match &strategy {
@@ -1077,6 +1180,16 @@ fn status_index_stream(
                         .iter()
                         .map(|status| status_index_range(tenant, *status, scan_now))
                         .collect(),
+                    Some(scan_now),
+                )
+            }
+            JobsScanStrategy::Status {
+                tenant: Some(tenant),
+                status,
+            } => {
+                let scan_now = crate::job_store_shard::helpers::now_epoch_ms();
+                (
+                    vec![status_index_range(tenant, *status, scan_now)],
                     Some(scan_now),
                 )
             }
@@ -1109,15 +1222,20 @@ fn status_index_stream(
                 if chunk.is_empty() {
                     break;
                 }
-                let mut rows: Vec<(String, String, String, i64)> = Vec::with_capacity(chunk.len());
+                let mut rows: Vec<IndexRow> = Vec::with_capacity(chunk.len());
                 for kv in &chunk {
                     let Some(p) = crate::keys::parse_status_time_index_key(&kv.key)
                         .filter(|p| !p.job_id.is_empty())
                     else {
                         continue;
                     };
-                    let changed = p.changed_at_ms();
-                    rows.push((p.tenant, p.job_id, p.status, changed));
+                    rows.push(IndexRow {
+                        changed_at_ms: p.changed_at_ms(),
+                        tenant: p.tenant,
+                        job_id: p.job_id,
+                        status: p.status,
+                        enqueue_time_ms: crate::keys::decode_status_index_value(&kv.value),
+                    });
                 }
                 if rows.is_empty() {
                     continue;
@@ -1128,6 +1246,12 @@ fn status_index_stream(
                         rows.truncate(remaining);
                     }
                 }
+                if enqueue_time_from_index {
+                    hydrate_missing_enqueue_times(&shard, &mut rows).await?;
+                    if rows.is_empty() {
+                        continue;
+                    }
+                }
                 let batch_now =
                     label_now.unwrap_or_else(crate::job_store_shard::helpers::now_epoch_ms);
                 let batch = build_status_index_batch(&projection, &shard_id, &rows, batch_now)?;
@@ -1136,6 +1260,52 @@ fn status_index_stream(
             }
         }
     }
+}
+
+/// Fill `enqueue_time_ms` for the rows whose index entry lacks it by reading
+/// job_info for just those rows. A row whose job_info is gone is dropped,
+/// matching the pairs path. Every row looked up counts on both the
+/// point-lookup and the fallback-hydration metrics.
+async fn hydrate_missing_enqueue_times(
+    shard: &JobStoreShard,
+    rows: &mut Vec<IndexRow>,
+) -> DfResult<()> {
+    let mut by_tenant: HashMap<String, Vec<String>> = HashMap::new();
+    for row in rows.iter().filter(|row| row.enqueue_time_ms.is_none()) {
+        by_tenant
+            .entry(row.tenant.clone())
+            .or_default()
+            .push(row.job_id.clone());
+    }
+    if by_tenant.is_empty() {
+        return Ok(());
+    }
+    let mut found: HashMap<(String, String), i64> = HashMap::new();
+    for (tenant, ids) in &by_tenant {
+        if let Some(metrics) = &shard.metrics {
+            metrics.record_query_point_lookups(shard.name(), ids.len() as u64);
+            metrics.record_enqueue_time_fallback_hydrations(shard.name(), ids.len() as u64);
+        }
+        let views = shard.get_jobs_batch(tenant, ids).await.map_err(exec_err)?;
+        found.extend(
+            views
+                .into_iter()
+                .map(|(id, view)| ((tenant.clone(), id), view.enqueue_time_ms())),
+        );
+    }
+    rows.retain_mut(|row| {
+        if row.enqueue_time_ms.is_some() {
+            return true;
+        }
+        match found.get(&(row.tenant.clone(), row.job_id.clone())) {
+            Some(enqueue_time_ms) => {
+                row.enqueue_time_ms = Some(*enqueue_time_ms);
+                true
+            }
+            None => false,
+        }
+    });
+    Ok(())
 }
 
 /// Tenant-scoped status/time index range for one status filter arm. `now_ms`
@@ -1169,7 +1339,7 @@ fn status_index_range(tenant: &str, status: QueryStatusFilter, now_ms: i64) -> K
 fn build_status_index_batch(
     projection: &SchemaRef,
     shard_id: &str,
-    chunk: &[(String, String, String, i64)],
+    chunk: &[IndexRow],
     now_ms: i64,
 ) -> DfResult<RecordBatch> {
     let n = chunk.len();
@@ -1183,13 +1353,13 @@ fn build_status_index_batch(
             "tenant" => Arc::new(StringArray::from(
                 chunk
                     .iter()
-                    .map(|(t, _, _, _)| t.as_str())
+                    .map(|row| row.tenant.as_str())
                     .collect::<Vec<_>>(),
             )),
             "id" => Arc::new(StringArray::from(
                 chunk
                     .iter()
-                    .map(|(_, id, _, _)| id.as_str())
+                    .map(|row| row.job_id.as_str())
                     .collect::<Vec<_>>(),
             )),
             "status_kind" => {
@@ -1199,11 +1369,11 @@ fn build_status_index_batch(
                 Arc::new(StringArray::from(
                     chunk
                         .iter()
-                        .map(|(_, _, sk, ts)| {
-                            if sk == "Scheduled" && *ts <= now_ms {
+                        .map(|row| {
+                            if row.status == "Scheduled" && row.changed_at_ms <= now_ms {
                                 Some("Waiting")
                             } else {
-                                Some(sk.as_str())
+                                Some(row.status.as_str())
                             }
                         })
                         .collect::<Vec<_>>(),
@@ -1212,8 +1382,16 @@ fn build_status_index_batch(
             "status_changed_at_ms" => Arc::new(Int64Array::from(
                 chunk
                     .iter()
-                    .map(|(_, _, _, ts)| Some(*ts))
+                    .map(|row| Some(row.changed_at_ms))
                     .collect::<Vec<_>>(),
+            )),
+            // Present only when the scan chose to serve it from the index; by
+            // then every row has been decoded or hydrated.
+            "enqueue_time_ms" => Arc::new(Int64Array::from(
+                chunk
+                    .iter()
+                    .map(|row| row.enqueue_time_ms.unwrap_or(0))
+                    .collect::<Vec<i64>>(),
             )),
             _ => new_null_array(f.data_type(), n),
         };
@@ -2077,7 +2255,7 @@ impl QueuesScanner {
 }
 
 impl Scan for QueuesScanner {
-    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+    fn describe(&self, _projection: &SchemaRef, filters: &[Expr], limit: Option<usize>) -> String {
         let mut tenant = None;
         let mut queue = None;
         let mut entry_type = None;
@@ -2411,7 +2589,7 @@ impl std::fmt::Debug for TenantCountsScanner {
 }
 
 impl Scan for TenantCountsScanner {
-    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+    fn describe(&self, _projection: &SchemaRef, filters: &[Expr], limit: Option<usize>) -> String {
         let tenant_range = parse_tenant_counts_scan_range(filters)
             .map(|range| describe_tenant_status_counter_scan_range(&range))
             .unwrap_or_else(|| "all".to_string());
@@ -2498,7 +2676,7 @@ impl std::fmt::Debug for QueueCountsScanner {
 }
 
 impl Scan for QueueCountsScanner {
-    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+    fn describe(&self, _projection: &SchemaRef, filters: &[Expr], limit: Option<usize>) -> String {
         let mut tenant = None;
         for f in filters {
             if let Some((col, val)) = parse_eq_filter(f)
@@ -2810,7 +2988,7 @@ fn variant_type_name(vt: crate::fb::silo::fb::TaskVariant) -> &'static str {
 }
 
 impl Scan for TasksScanner {
-    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+    fn describe(&self, _projection: &SchemaRef, filters: &[Expr], limit: Option<usize>) -> String {
         let strategy = parse_tasks_scan_strategy(filters);
         format!("tasks[{}], limit={:?}", strategy, limit)
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -906,7 +906,8 @@ struct ProjectionNeeds {
     need_status_index_fields: bool,
     /// Needs fields only in the status record: current_attempt, next_attempt_starts_after_ms
     need_status_point_lookup: bool,
-    /// Fast path: scan status/time index directly, no point-lookups required
+    /// Fast path: scan status/time index directly, with point-lookups only for
+    /// entries lacking an index-served enqueue_time_ms
     use_status_index_path: bool,
     /// On the fast path, enqueue_time_ms is projected and read from each index
     /// entry's value, with a job_info read for just the entries lacking it.
@@ -964,11 +965,12 @@ fn analyze_projection(
     // (per-status ranges of the same index) — other strategies already have a
     // bounded pair list.
     let base_fast_path = !need_other_job_info && !need_status_point_lookup && index_path_strategy;
-    // enqueue_time_ms is index-served only where the scanned ranges are
-    // expected to carry it in every entry: tenant-scoped Status and StatusUnion
-    // always, FullScan once the shard's backfill has completed. Entries that
-    // lack it are hydrated from job_info individually. Whenever the fast path
-    // is not taken, the column stays a job_info column.
+    // enqueue_time_ms is index-served where per-row hydration of entries that
+    // lack it can never cost more than the alternative: tenant-scoped Status
+    // and StatusUnion always (their pairs path already reads job_info per
+    // row), FullScan only once the shard's backfill has completed (its merge
+    // join is cheaper than per-row hydration). Whenever the fast path is not
+    // taken, the column stays a job_info column.
     let enqueue_time_from_index = need_enqueue_time
         && base_fast_path
         && match strategy {
@@ -1151,7 +1153,8 @@ struct IndexRow {
 }
 
 /// Streams the status/time index in bounded chunks, emitting RecordBatches with
-/// no point-lookups. Used when the projection only needs tenant, id,
+/// no point-lookups beyond the per-row `enqueue_time_ms` hydration described
+/// below. Used when the projection only needs tenant, id,
 /// status_kind, status_changed_at_ms or an index-served enqueue_time_ms
 /// (including the COUNT(*) fallback when counter-based counting is disabled).
 /// Serves FullScan (one whole-prefix range), tenant-scoped Status (one range)
@@ -1280,24 +1283,29 @@ async fn hydrate_missing_enqueue_times(
     if by_tenant.is_empty() {
         return Ok(());
     }
-    let mut found: HashMap<(String, String), i64> = HashMap::new();
+    let mut found: HashMap<&str, HashMap<String, i64>> = HashMap::new();
     for (tenant, ids) in &by_tenant {
         if let Some(metrics) = &shard.metrics {
             metrics.record_query_point_lookups(shard.name(), ids.len() as u64);
             metrics.record_enqueue_time_fallback_hydrations(shard.name(), ids.len() as u64);
         }
         let views = shard.get_jobs_batch(tenant, ids).await.map_err(exec_err)?;
-        found.extend(
+        found.insert(
+            tenant.as_str(),
             views
                 .into_iter()
-                .map(|(id, view)| ((tenant.clone(), id), view.enqueue_time_ms())),
+                .map(|(id, view)| (id, view.enqueue_time_ms()))
+                .collect(),
         );
     }
     rows.retain_mut(|row| {
         if row.enqueue_time_ms.is_some() {
             return true;
         }
-        match found.get(&(row.tenant.clone(), row.job_id.clone())) {
+        match found
+            .get(row.tenant.as_str())
+            .and_then(|by_id| by_id.get(&row.job_id))
+        {
             Some(enqueue_time_ms) => {
                 row.enqueue_time_ms = Some(*enqueue_time_ms);
                 true
@@ -1390,7 +1398,13 @@ fn build_status_index_batch(
             "enqueue_time_ms" => Arc::new(Int64Array::from(
                 chunk
                     .iter()
-                    .map(|row| row.enqueue_time_ms.unwrap_or(0))
+                    .map(|row| {
+                        debug_assert!(
+                            row.enqueue_time_ms.is_some(),
+                            "enqueue_time_ms projected on the index path without hydration"
+                        );
+                        row.enqueue_time_ms.unwrap_or(0)
+                    })
                     .collect::<Vec<i64>>(),
             )),
             _ => new_null_array(f.data_type(), n),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -415,6 +415,53 @@ pub struct DatabaseTemplate {
     /// (512 MB for block cache, 128 MB for meta cache).
     #[serde(default)]
     pub memory_cache: Option<MemoryCacheConfig>,
+    /// One-shot background sweep that fills `enqueue_time_ms` into status
+    /// records and status/time index entries that lack it. See
+    /// [`EnqueueTimeBackfillConfig`]. Off by default.
+    #[serde(default)]
+    pub enqueue_time_backfill: EnqueueTimeBackfillConfig,
+}
+
+/// Default for `enqueue_time_backfill.batch_size`.
+fn default_enqueue_time_backfill_batch_size() -> usize {
+    1000
+}
+
+/// Default for `enqueue_time_backfill.pause_ms`.
+fn default_enqueue_time_backfill_pause_ms() -> u64 {
+    50
+}
+
+/// Settings for the one-shot background sweep that fills `enqueue_time_ms`
+/// into status records and status/time index entries that lack it. The sweep
+/// runs once per shard after open, persists its progress so a restart
+/// resumes, and records a completion marker so it never runs again. Enabling
+/// it is the rollout step for serving `enqueue_time_ms` from the status index
+/// on unfiltered scans.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct EnqueueTimeBackfillConfig {
+    /// Run the sweep on shards that do not hold the completion marker.
+    /// Defaults to false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Status records examined per batch before pausing. Defaults to 1000.
+    /// Values below 1 are treated as 1.
+    #[serde(default = "default_enqueue_time_backfill_batch_size")]
+    pub batch_size: usize,
+    /// Pause between batches in milliseconds. Also bounds the per-shard
+    /// jitter before the first batch. Defaults to 50.
+    #[serde(default = "default_enqueue_time_backfill_pause_ms")]
+    pub pause_ms: u64,
+}
+
+impl Default for EnqueueTimeBackfillConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            batch_size: default_enqueue_time_backfill_batch_size(),
+            pause_ms: default_enqueue_time_backfill_pause_ms(),
+        }
+    }
 }
 
 impl Default for DatabaseTemplate {
@@ -443,6 +490,7 @@ impl Default for DatabaseTemplate {
             count_from_status_counters: default_count_from_status_counters(),
             slatedb: None,
             memory_cache: None,
+            enqueue_time_backfill: EnqueueTimeBackfillConfig::default(),
         }
     }
 }
@@ -826,6 +874,11 @@ pub struct DatabaseConfig {
     /// (512 MB for block cache, 128 MB for meta cache).
     #[serde(default)]
     pub memory_cache: Option<MemoryCacheConfig>,
+    /// One-shot background sweep that fills `enqueue_time_ms` into status
+    /// records and status/time index entries that lack it. See
+    /// [`EnqueueTimeBackfillConfig`]. Off by default.
+    #[serde(default)]
+    pub enqueue_time_backfill: EnqueueTimeBackfillConfig,
 }
 
 impl Default for DatabaseConfig {
@@ -853,6 +906,7 @@ impl Default for DatabaseConfig {
             count_from_status_counters: default_count_from_status_counters(),
             slatedb: None,
             memory_cache: None,
+            enqueue_time_backfill: EnqueueTimeBackfillConfig::default(),
         }
     }
 }

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -607,3 +607,14 @@ fn test_decoded_task_invalid_data() {
     let result = decode_task_validated(vec![0xFF, 0xFF]);
     assert!(result.is_err());
 }
+
+#[silo::test]
+fn test_job_status_enqueue_time_roundtrip() {
+    let without = JobStatus::running(5000);
+    let decoded = decode_job_status_owned(&encode_job_status(&without)).unwrap();
+    assert_eq!(decoded.enqueue_time_ms, None);
+
+    let with = JobStatus::running(5000).with_enqueue_time_ms(1_700_000_000_000);
+    let decoded = decode_job_status_owned(&encode_job_status(&with)).unwrap();
+    assert_eq!(decoded.enqueue_time_ms, Some(1_700_000_000_000));
+}

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -1029,3 +1029,93 @@ async fn factory_passes_slatedb_settings_to_shards() {
     let result = shard.db().get(b"key").await.expect("get");
     assert_eq!(result.unwrap().as_ref(), b"value");
 }
+
+#[silo::test]
+fn parse_toml_enqueue_time_backfill_defaults_off() {
+    use silo::settings::{DatabaseConfig, EnqueueTimeBackfillConfig};
+
+    let cfg: AppConfig = toml::from_str(
+        r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+"#,
+    )
+    .expect("parse TOML");
+    let defaults = EnqueueTimeBackfillConfig::default();
+    assert!(!defaults.enabled, "sweep is off by default");
+    assert_eq!(defaults.batch_size, 1000);
+    assert_eq!(defaults.pause_ms, 50);
+    assert_eq!(cfg.database.enqueue_time_backfill, defaults, "template");
+
+    let db: DatabaseConfig = toml::from_str(
+        r#"
+name = "shard-0"
+backend = "fs"
+path = "/tmp/silo-0"
+"#,
+    )
+    .expect("parse DatabaseConfig");
+    assert_eq!(db.enqueue_time_backfill, defaults, "database config");
+    assert_eq!(
+        DatabaseConfig::default().enqueue_time_backfill,
+        defaults,
+        "database config Default"
+    );
+}
+
+#[silo::test]
+fn parse_toml_enqueue_time_backfill_round_trip() {
+    use silo::settings::{DatabaseConfig, DatabaseTemplate, EnqueueTimeBackfillConfig};
+
+    let expected = EnqueueTimeBackfillConfig {
+        enabled: true,
+        batch_size: 250,
+        pause_ms: 10,
+    };
+
+    let cfg: AppConfig = toml::from_str(
+        r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+
+[database.enqueue_time_backfill]
+enabled = true
+batch_size = 250
+pause_ms = 10
+"#,
+    )
+    .expect("parse TOML");
+    assert_eq!(
+        cfg.database.enqueue_time_backfill, expected,
+        "template parse"
+    );
+    let serialized = toml::to_string(&cfg.database).expect("serialize template");
+    let template: DatabaseTemplate = toml::from_str(&serialized).expect("reparse template");
+    assert_eq!(
+        template.enqueue_time_backfill, expected,
+        "template round trip"
+    );
+
+    let db: DatabaseConfig = toml::from_str(
+        r#"
+name = "shard-0"
+backend = "fs"
+path = "/tmp/silo-0"
+
+[enqueue_time_backfill]
+enabled = true
+batch_size = 250
+pause_ms = 10
+"#,
+    )
+    .expect("parse DatabaseConfig");
+    assert_eq!(db.enqueue_time_backfill, expected, "database config parse");
+    let serialized = toml::to_string(&db).expect("serialize database config");
+    let db: DatabaseConfig = toml::from_str(&serialized).expect("reparse database config");
+    assert_eq!(
+        db.enqueue_time_backfill, expected,
+        "database config round trip"
+    );
+}

--- a/tests/enqueue_time_backfill_tests.rs
+++ b/tests/enqueue_time_backfill_tests.rs
@@ -121,15 +121,6 @@ async fn sweep_fills_missing_values_and_sets_completion_marker() {
     for (tenant, job_id) in &jobs {
         assert_rows_carry_job_info_enqueue_time(&shard, tenant, job_id, "after sweep").await;
     }
-    assert!(
-        shard
-            .db()
-            .get(&enqueue_time_backfill_complete_key())
-            .await
-            .unwrap()
-            .is_some(),
-        "completion marker written"
-    );
 }
 
 fn repair_reads(metrics: &silo::metrics::Metrics, shard: &JobStoreShard) -> f64 {
@@ -235,9 +226,11 @@ async fn interrupted_sweep_resumes_from_persisted_key() {
         .await
         .unwrap()
         .expect("progress");
-    assert_eq!(
-        progress.scanned, n as u64,
-        "each row scanned once: {progress:?}"
+    // A close that lands inside a batch re-scans that batch's rows, so the
+    // exactly-once guarantees are on repairs and reads, not on scans.
+    assert!(
+        progress.scanned >= n as u64,
+        "every row scanned: {progress:?}"
     );
     assert_eq!(
         progress.repaired, n as u64,
@@ -489,15 +482,6 @@ async fn missing_job_info_is_skipped_and_the_sweep_completes() {
     assert_eq!(progress.repaired, 1, "{progress:?}");
     assert_rows_lack_enqueue_time(&shard, "-", &jobs[0]).await;
     assert_rows_carry_job_info_enqueue_time(&shard, "-", &jobs[1], "intact job").await;
-    assert!(
-        shard
-            .db()
-            .get(&enqueue_time_backfill_complete_key())
-            .await
-            .unwrap()
-            .is_some(),
-        "completion marker written"
-    );
 }
 
 #[silo::test]
@@ -568,4 +552,66 @@ async fn sweep_only_rewrites_rows_inside_the_shard_range() {
         .unwrap()
         .unwrap();
     assert_eq!(progress.scanned, inside.len() as u64, "{progress:?}");
+}
+
+/// Once the sweep has completed, index-served queries never fall back to
+/// `JOB_INFO`, whichever rows lacked the value before it ran.
+#[silo::test]
+async fn queries_after_the_sweep_need_no_fallback() {
+    use datafusion::arrow::array::{Array, Int64Array};
+    use silo::query::ShardQueryEngine;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let metrics = silo::metrics::init().expect("init metrics");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |_| {}).await;
+    let stripped = seed_stripped_scheduled(&shard, "-", 20).await;
+    shard.close().await.expect("close");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |cfg| {
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(4);
+    })
+    .await;
+    wait_for_completion(&shard).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    for query in [
+        "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-'",
+        "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' AND status_kind = 'Scheduled'",
+    ] {
+        let fallback_before = metrics.enqueue_time_fallback_hydrations_value(shard.name());
+        let lookups_before = metrics.query_point_lookups_value(shard.name());
+        let batches = sql
+            .sql(query)
+            .await
+            .expect("sql")
+            .collect()
+            .await
+            .expect("collect");
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, stripped.len(), "{query}: row count");
+        for batch in &batches {
+            let times = batch
+                .column_by_name("enqueue_time_ms")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            assert!(
+                (0..times.len()).all(|i| times.value(i) > 0),
+                "{query}: values"
+            );
+        }
+        assert_eq!(
+            metrics.enqueue_time_fallback_hydrations_value(shard.name()),
+            fallback_before,
+            "{query}: no fallback hydrations after the sweep"
+        );
+        assert_eq!(
+            metrics.query_point_lookups_value(shard.name()),
+            lookups_before,
+            "{query}: no point lookups after the sweep"
+        );
+    }
 }

--- a/tests/enqueue_time_backfill_tests.rs
+++ b/tests/enqueue_time_backfill_tests.rs
@@ -1,0 +1,571 @@
+//! The one-shot per-shard sweep that fills `enqueue_time_ms` into status
+//! records and status/time index entries that lack it.
+
+mod test_helpers;
+
+use std::sync::Arc;
+
+use silo::job::JobStatusKind;
+use silo::job_attempt::AttemptOutcome;
+use silo::job_store_shard::JobStoreShard;
+use silo::keys::enqueue_time_backfill_complete_key;
+use silo::shard_range::ShardRange;
+use test_helpers::*;
+
+async fn enqueue_at(shard: &JobStoreShard, tenant: &str, start_at_ms: i64) -> String {
+    shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            start_at_ms,
+            None,
+            msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue")
+}
+
+async fn dequeue_one(shard: &JobStoreShard) -> String {
+    let ids = dequeue_task_ids_until(shard, "w", "default", 1).await;
+    ids.into_iter().next().expect("one task")
+}
+
+/// Seed one job per status kind for each tenant, strip every job's rows, and
+/// return the `(tenant, job_id)` pairs.
+async fn seed_stripped_jobs(shard: &JobStoreShard, tenants: &[&str]) -> Vec<(String, String)> {
+    let mut jobs = Vec::new();
+    for tenant in tenants {
+        let far_future = now_ms() + 3_600_000;
+
+        let scheduled = enqueue_at(shard, tenant, far_future).await;
+
+        let running = enqueue_at(shard, tenant, 0).await;
+        dequeue_one(shard).await;
+
+        let succeeded = enqueue_at(shard, tenant, 0).await;
+        let task = dequeue_one(shard).await;
+        shard
+            .report_attempt_outcome(&task, AttemptOutcome::Success { result: vec![] })
+            .await
+            .expect("success");
+
+        let failed = enqueue_at(shard, tenant, 0).await;
+        let task = dequeue_one(shard).await;
+        shard
+            .report_attempt_outcome(
+                &task,
+                AttemptOutcome::Error {
+                    error_code: "E".into(),
+                    error: vec![],
+                },
+            )
+            .await
+            .expect("failure");
+
+        let cancelled = enqueue_at(shard, tenant, far_future).await;
+        shard.cancel_job(tenant, &cancelled).await.expect("cancel");
+
+        for (job_id, kind) in [
+            (scheduled, JobStatusKind::Scheduled),
+            (running, JobStatusKind::Running),
+            (succeeded, JobStatusKind::Succeeded),
+            (failed, JobStatusKind::Failed),
+            (cancelled, JobStatusKind::Cancelled),
+        ] {
+            let status = shard
+                .get_job_status(tenant, &job_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(status.kind, kind, "seed {tenant}/{job_id}");
+            strip_enqueue_time_from_job_rows(shard, tenant, &job_id).await;
+            jobs.push((tenant.to_string(), job_id));
+        }
+    }
+    jobs
+}
+
+async fn wait_for_completion(shard: &Arc<JobStoreShard>) {
+    let complete = poll_until(
+        || async { shard.enqueue_time_backfill_complete() },
+        |complete| *complete,
+        20_000,
+    )
+    .await;
+    assert!(complete, "sweep did not complete in time");
+}
+
+#[silo::test]
+async fn sweep_fills_missing_values_and_sets_completion_marker() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let metrics = silo::metrics::init().expect("init metrics");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |_| {}).await;
+    let jobs = seed_stripped_jobs(&shard, &["-", "tenant-a", "tenant-b"]).await;
+    for (tenant, job_id) in &jobs {
+        assert_rows_lack_enqueue_time(&shard, tenant, job_id).await;
+    }
+    shard.close().await.expect("close");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics, |cfg| {
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(4);
+    })
+    .await;
+    wait_for_completion(&shard).await;
+
+    for (tenant, job_id) in &jobs {
+        assert_rows_carry_job_info_enqueue_time(&shard, tenant, job_id, "after sweep").await;
+    }
+    assert!(
+        shard
+            .db()
+            .get(&enqueue_time_backfill_complete_key())
+            .await
+            .unwrap()
+            .is_some(),
+        "completion marker written"
+    );
+}
+
+fn repair_reads(metrics: &silo::metrics::Metrics, shard: &JobStoreShard) -> f64 {
+    metrics.enqueue_time_repair_reads_value(shard.name())
+}
+
+/// Seed `n` future-scheduled jobs for `tenant` and strip their rows.
+async fn seed_stripped_scheduled(shard: &JobStoreShard, tenant: &str, n: usize) -> Vec<String> {
+    let mut ids = Vec::with_capacity(n);
+    for _ in 0..n {
+        let job_id = enqueue_at(shard, tenant, now_ms() + 3_600_000).await;
+        strip_enqueue_time_from_job_rows(shard, tenant, &job_id).await;
+        ids.push(job_id);
+    }
+    ids
+}
+
+#[silo::test]
+async fn completed_shard_does_not_run_the_sweep_again() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let metrics = silo::metrics::init().expect("init metrics");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |_| {}).await;
+    let jobs = seed_stripped_scheduled(&shard, "-", 2).await;
+    shard.close().await.expect("close");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |cfg| {
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(1);
+    })
+    .await;
+    wait_for_completion(&shard).await;
+    let reads_after_sweep = repair_reads(&metrics, &shard);
+    let progress_after_sweep = shard.enqueue_time_backfill_progress().await.unwrap();
+    strip_enqueue_time_from_job_rows(&shard, "-", &jobs[0]).await;
+    shard.close().await.expect("close");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |cfg| {
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(1);
+    })
+    .await;
+    assert!(
+        shard.enqueue_time_backfill_complete(),
+        "flag read from marker"
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    assert_eq!(
+        repair_reads(&metrics, &shard),
+        reads_after_sweep,
+        "no JOB_INFO reads on a completed shard"
+    );
+    assert_eq!(
+        shard.enqueue_time_backfill_progress().await.unwrap(),
+        progress_after_sweep,
+        "progress untouched on a completed shard"
+    );
+    assert_rows_lack_enqueue_time(&shard, "-", &jobs[0]).await;
+}
+
+#[silo::test]
+async fn interrupted_sweep_resumes_from_persisted_key() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let metrics = silo::metrics::init().expect("init metrics");
+    let n = 8;
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |_| {}).await;
+    let jobs = seed_stripped_scheduled(&shard, "-", n).await;
+    shard.close().await.expect("close");
+
+    // One row per batch with a long pause: the first checkpoint lands within
+    // the jitter plus one row, and the close lands inside the pause.
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |cfg| {
+        cfg.enqueue_time_backfill = silo::settings::EnqueueTimeBackfillConfig {
+            enabled: true,
+            batch_size: 1,
+            pause_ms: 2_000,
+        };
+    })
+    .await;
+    let progress = poll_until(
+        || async { shard.enqueue_time_backfill_progress().await.unwrap() },
+        |p| p.as_ref().is_some_and(|p| p.scanned >= 1),
+        10_000,
+    )
+    .await
+    .expect("progress persisted after the first batch");
+    shard.close().await.expect("close mid-sweep");
+    assert!(progress.last_key.is_some(), "resume key persisted");
+    assert!(
+        progress.scanned < n as u64,
+        "sweep must be interrupted before finishing: {progress:?}"
+    );
+    assert!(!shard.enqueue_time_backfill_complete());
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |cfg| {
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(1);
+    })
+    .await;
+    wait_for_completion(&shard).await;
+    let progress = shard
+        .enqueue_time_backfill_progress()
+        .await
+        .unwrap()
+        .expect("progress");
+    assert_eq!(
+        progress.scanned, n as u64,
+        "each row scanned once: {progress:?}"
+    );
+    assert_eq!(
+        progress.repaired, n as u64,
+        "each row repaired once: {progress:?}"
+    );
+    assert_eq!(repair_reads(&metrics, &shard), n as f64, "one read per row");
+    for job_id in &jobs {
+        assert_rows_carry_job_info_enqueue_time(&shard, "-", job_id, "after resume").await;
+    }
+}
+
+/// `(status row expire_ts, index row expire_ts)` for the job's current status.
+async fn row_expiries(
+    shard: &JobStoreShard,
+    tenant: &str,
+    job_id: &str,
+) -> (Option<i64>, Option<i64>) {
+    use silo::keys::{idx_status_time_key, job_status_key, status_index_timestamp};
+
+    let status = shard.get_job_status(tenant, job_id).await.unwrap().unwrap();
+    let status_kv = shard
+        .db()
+        .get_key_value(&job_status_key(tenant, job_id))
+        .await
+        .unwrap()
+        .expect("status row");
+    let index_kv = shard
+        .db()
+        .get_key_value(&idx_status_time_key(
+            tenant,
+            status.kind.as_str(),
+            status_index_timestamp(&status),
+            job_id,
+        ))
+        .await
+        .unwrap()
+        .expect("index row");
+    (status_kv.expire_ts, index_kv.expire_ts)
+}
+
+#[silo::test]
+async fn sweep_keeps_each_rows_expiry_exactly() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let metrics = silo::metrics::init().expect("init metrics");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |cfg| {
+        cfg.completed_job_expire_s = Some(60);
+        cfg.terminal_job_expire_s = Some(60);
+    })
+    .await;
+    let terminal = enqueue_at(&shard, "-", 0).await;
+    let task = dequeue_one(&shard).await;
+    shard
+        .report_attempt_outcome(&task, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("success");
+    let scheduled = enqueue_at(&shard, "-", now_ms() + 3_600_000).await;
+    strip_enqueue_time_from_job_rows(&shard, "-", &terminal).await;
+    strip_enqueue_time_from_job_rows(&shard, "-", &scheduled).await;
+    let terminal_before = row_expiries(&shard, "-", &terminal).await;
+    assert!(terminal_before.0.is_some() && terminal_before.1.is_some());
+    assert_eq!(row_expiries(&shard, "-", &scheduled).await, (None, None));
+    shard.close().await.expect("close");
+
+    // Different expiry settings from the ones the rows were written under.
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics, |cfg| {
+        cfg.completed_job_expire_s = Some(3_600);
+        cfg.terminal_job_expire_s = None;
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(1);
+    })
+    .await;
+    wait_for_completion(&shard).await;
+
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &terminal, "terminal").await;
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &scheduled, "scheduled").await;
+    assert_eq!(
+        row_expiries(&shard, "-", &terminal).await,
+        terminal_before,
+        "terminal rows keep their expiry"
+    );
+    assert_eq!(
+        row_expiries(&shard, "-", &scheduled).await,
+        (None, None),
+        "rows without an expiry stay without one"
+    );
+}
+
+#[silo::test]
+async fn sweep_leaves_counters_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let metrics = silo::metrics::init().expect("init metrics");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |_| {}).await;
+    seed_stripped_jobs(&shard, &["-", "tenant-a"]).await;
+    let tenant_counters_before = shard.scan_tenant_status_counters(None).await.unwrap();
+    let shard_counters_before = shard.get_counters().await.unwrap();
+    shard.close().await.expect("close");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics, |cfg| {
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(3);
+    })
+    .await;
+    wait_for_completion(&shard).await;
+
+    assert_eq!(
+        shard.scan_tenant_status_counters(None).await.unwrap(),
+        tenant_counters_before,
+        "per-tenant status counters"
+    );
+    let shard_counters_after = shard.get_counters().await.unwrap();
+    assert_eq!(
+        shard_counters_after.total_jobs,
+        shard_counters_before.total_jobs
+    );
+    assert_eq!(
+        shard_counters_after.completed_jobs,
+        shard_counters_before.completed_jobs
+    );
+}
+
+#[silo::test]
+async fn transitions_racing_the_sweep_leave_one_index_entry_per_job() {
+    use silo::keys::{end_bound, idx_status_time_tenant_prefix, parse_status_time_index_key};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let metrics = silo::metrics::init().expect("init metrics");
+    let n = 150;
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |_| {}).await;
+    let jobs = seed_stripped_scheduled(&shard, "-", n).await;
+    shard.close().await.expect("close");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics, |cfg| {
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(1);
+    })
+    .await;
+    for job_id in &jobs {
+        shard.cancel_job("-", job_id).await.expect("cancel");
+    }
+    wait_for_completion(&shard).await;
+
+    let mut seen = std::collections::HashMap::<String, usize>::new();
+    let start = idx_status_time_tenant_prefix("-");
+    let end = end_bound(&start);
+    let mut iter = shard
+        .db()
+        .scan_with_options::<Vec<u8>, _>(start..end, &silo::scan_options())
+        .await
+        .expect("scan index");
+    while let Some(kv) = iter.next().await.expect("next") {
+        let parsed = parse_status_time_index_key(&kv.key).expect("index key");
+        assert_eq!(
+            parsed.status, "Cancelled",
+            "{}: stale index entry",
+            parsed.job_id
+        );
+        *seen.entry(parsed.job_id).or_default() += 1;
+    }
+    assert_eq!(seen.len(), n, "one entry per job");
+    for job_id in &jobs {
+        assert_eq!(
+            seen.get(job_id),
+            Some(&1),
+            "{job_id}: exactly one index entry"
+        );
+        let status = shard.get_job_status("-", job_id).await.unwrap().unwrap();
+        assert_eq!(status.kind, JobStatusKind::Cancelled);
+        assert_rows_carry_job_info_enqueue_time(&shard, "-", job_id, "raced").await;
+    }
+}
+
+#[silo::test]
+async fn rows_carrying_the_value_are_skipped_without_reads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let metrics = silo::metrics::init().expect("init metrics");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |_| {}).await;
+    let stripped = seed_stripped_scheduled(&shard, "-", 3).await;
+    let mut intact = Vec::new();
+    for _ in 0..3 {
+        intact.push(enqueue_at(&shard, "-", now_ms() + 3_600_000).await);
+    }
+    shard.close().await.expect("close");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |cfg| {
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(2);
+    })
+    .await;
+    let scanned_keys_before = metrics.query_scanned_keys_value(shard.name());
+    let point_lookups_before = metrics.query_point_lookups_value(shard.name());
+    wait_for_completion(&shard).await;
+
+    assert_eq!(repair_reads(&metrics, &shard), stripped.len() as f64);
+    let progress = shard
+        .enqueue_time_backfill_progress()
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(progress.scanned, 6);
+    assert_eq!(progress.repaired, 3);
+    for job_id in stripped.iter().chain(&intact) {
+        assert_rows_carry_job_info_enqueue_time(&shard, "-", job_id, "after sweep").await;
+    }
+    assert_eq!(
+        metrics.query_scanned_keys_value(shard.name()),
+        scanned_keys_before,
+        "sweep I/O is not query scanned keys"
+    );
+    assert_eq!(
+        metrics.query_point_lookups_value(shard.name()),
+        point_lookups_before,
+        "sweep reads are not query point lookups"
+    );
+}
+
+#[silo::test]
+async fn missing_job_info_is_skipped_and_the_sweep_completes() {
+    use silo::keys::job_info_key;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let metrics = silo::metrics::init().expect("init metrics");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |_| {}).await;
+    let jobs = seed_stripped_scheduled(&shard, "-", 2).await;
+    shard
+        .db()
+        .delete(&job_info_key("-", &jobs[0]))
+        .await
+        .expect("delete JOB_INFO");
+    shard.close().await.expect("close");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics, |cfg| {
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(1);
+    })
+    .await;
+    wait_for_completion(&shard).await;
+
+    let progress = shard
+        .enqueue_time_backfill_progress()
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(progress.skipped_missing_job_info, 1, "{progress:?}");
+    assert_eq!(progress.repaired, 1, "{progress:?}");
+    assert_rows_lack_enqueue_time(&shard, "-", &jobs[0]).await;
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &jobs[1], "intact job").await;
+    assert!(
+        shard
+            .db()
+            .get(&enqueue_time_backfill_complete_key())
+            .await
+            .unwrap()
+            .is_some(),
+        "completion marker written"
+    );
+}
+
+#[silo::test]
+async fn disabled_sweep_never_runs() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let job_id = enqueue_at(&shard, "-", now_ms() + 3_600_000).await;
+    strip_enqueue_time_from_job_rows(&shard, "-", &job_id).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    assert!(!shard.enqueue_time_backfill_complete());
+    assert!(
+        shard
+            .db()
+            .get(&enqueue_time_backfill_complete_key())
+            .await
+            .unwrap()
+            .is_none(),
+        "no marker"
+    );
+    assert_eq!(shard.enqueue_time_backfill_progress().await.unwrap(), None);
+    assert_eq!(repair_reads(&metrics, &shard), 0.0);
+    assert_rows_lack_enqueue_time(&shard, "-", &job_id).await;
+}
+
+#[silo::test]
+async fn sweep_only_rewrites_rows_inside_the_shard_range() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let metrics = silo::metrics::init().expect("init metrics");
+    let range = ShardRange::new("", "8000000000000000");
+
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |_| {}).await;
+    let mut inside = Vec::new();
+    let mut outside = Vec::new();
+    for i in 0..12 {
+        let tenant = format!("tenant-{i}");
+        let job_id = enqueue_at(&shard, &tenant, now_ms() + 3_600_000).await;
+        strip_enqueue_time_from_job_rows(&shard, &tenant, &job_id).await;
+        if range.contains_tenant(&tenant) {
+            inside.push((tenant, job_id));
+        } else {
+            outside.push((tenant, job_id));
+        }
+    }
+    assert!(
+        !inside.is_empty() && !outside.is_empty(),
+        "tenants on both sides"
+    );
+    shard.close().await.expect("close");
+
+    let shard = open_shard_at_path(&path, range, metrics.clone(), |cfg| {
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(2);
+    })
+    .await;
+    wait_for_completion(&shard).await;
+
+    for (tenant, job_id) in &inside {
+        assert_rows_carry_job_info_enqueue_time(&shard, tenant, job_id, "inside range").await;
+    }
+    for (tenant, job_id) in &outside {
+        assert_rows_lack_enqueue_time(&shard, tenant, job_id).await;
+    }
+    assert_eq!(repair_reads(&metrics, &shard), inside.len() as f64);
+    let progress = shard
+        .enqueue_time_backfill_progress()
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(progress.scanned, inside.len() as u64, "{progress:?}");
+}

--- a/tests/keys_tests.rs
+++ b/tests/keys_tests.rs
@@ -457,3 +457,54 @@ fn test_task_key_lookup_prefix_matches_any_epoch() {
     let other = task_key("group1", 1000, 10, "job124", 1, 0);
     assert!(!other.starts_with(&prefix));
 }
+
+#[test]
+fn status_index_value_roundtrips_enqueue_time() {
+    use silo::keys::{decode_status_index_value, encode_status_index_value};
+
+    let cases: [i64; 4] = [0, 1, -1, 1_700_000_000_000];
+    for enqueue_time_ms in cases {
+        let value = encode_status_index_value(Some(enqueue_time_ms));
+        assert_eq!(
+            value.len(),
+            8,
+            "value for {enqueue_time_ms} must be 8 bytes"
+        );
+        assert_eq!(
+            decode_status_index_value(&value),
+            Some(enqueue_time_ms),
+            "roundtrip of {enqueue_time_ms}"
+        );
+    }
+}
+
+#[test]
+fn status_index_value_unknown_encodes_empty() {
+    use silo::keys::{decode_status_index_value, encode_status_index_value};
+
+    let value = encode_status_index_value(None);
+    assert!(
+        value.is_empty(),
+        "unknown enqueue time must encode as empty"
+    );
+    assert_eq!(decode_status_index_value(&value), None);
+}
+
+#[test]
+fn status_index_value_decode_tolerates_malformed_values() {
+    use silo::keys::decode_status_index_value;
+
+    let cases: [(&str, &[u8]); 4] = [
+        ("empty", &[]),
+        ("short", &[1, 2, 3]),
+        ("seven bytes", &[0; 7]),
+        ("nine bytes", &[0; 9]),
+    ];
+    for (name, value) in cases {
+        assert_eq!(
+            decode_status_index_value(value),
+            None,
+            "{name} value must decode as unknown"
+        );
+    }
+}

--- a/tests/keys_tests.rs
+++ b/tests/keys_tests.rs
@@ -460,14 +460,16 @@ fn test_task_key_lookup_prefix_matches_any_epoch() {
 
 #[test]
 fn status_index_value_roundtrips_enqueue_time() {
-    use silo::keys::{decode_status_index_value, encode_status_index_value};
+    use silo::keys::{
+        STATUS_INDEX_VALUE_LEN, decode_status_index_value, encode_status_index_value,
+    };
 
     let cases: [i64; 4] = [0, 1, -1, 1_700_000_000_000];
     for enqueue_time_ms in cases {
         let value = encode_status_index_value(Some(enqueue_time_ms));
         assert_eq!(
             value.len(),
-            8,
+            STATUS_INDEX_VALUE_LEN,
             "value for {enqueue_time_ms} must be 8 bytes"
         );
         assert_eq!(

--- a/tests/query_index_enqueue_time_tests.rs
+++ b/tests/query_index_enqueue_time_tests.rs
@@ -324,6 +324,9 @@ async fn other_job_info_columns_keep_the_job_record_path() {
     }
 }
 
+/// Every index-served shape hydrates exactly the rows in its range whose
+/// entry lacks the value. The status shapes run without the marker, since
+/// they are index-served regardless of it.
 #[silo::test]
 async fn rows_lacking_the_value_are_hydrated_individually() {
     let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
@@ -331,29 +334,46 @@ async fn rows_lacking_the_value_are_hydrated_individually() {
     for i in 0..10 {
         strip_enqueue_time_from_job_rows(&shard, "-", &format!("future{i:03}")).await;
     }
-    shard
-        .set_enqueue_time_backfill_complete(true)
-        .await
-        .unwrap();
+    strip_enqueue_time_from_job_rows(&shard, "-", "done").await;
+    strip_enqueue_time_from_job_rows(&shard, "-", "waiting").await;
     let sql = engine(&shard);
-    let query = "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-'";
 
-    let before = snapshot(&metrics, &shard);
-    let rows = id_enqueue_rows(&run(&sql, query).await);
-    let after = snapshot(&metrics, &shard);
+    // (shape name, marker set, stripped rows inside the shape's ranges)
+    let cases = [
+        ("FullScan", true, 12.0),
+        ("Status stored", false, 1.0),
+        ("Status virtual", false, 1.0),
+        ("StatusUnion", false, 2.0),
+    ];
+    for (name, marker, stripped_in_range) in cases {
+        let query = INDEX_SERVED_SHAPES
+            .iter()
+            .find(|(shape, _)| *shape == name)
+            .map(|(_, query)| *query)
+            .expect("known shape");
+        shard
+            .set_enqueue_time_backfill_complete(marker)
+            .await
+            .unwrap();
+        assert_eq!(explain_path(&sql, query).await, "status-index", "{name}");
 
-    assert_eq!(rows.len(), expected.len());
-    assert_rows_match(&rows, &expected, "mixed chunk");
-    assert_eq!(
-        after.fallback - before.fallback,
-        10.0,
-        "one hydration per stripped row"
-    );
-    assert_eq!(
-        after.point_lookups - before.point_lookups,
-        10.0,
-        "rows carrying the value are not looked up"
-    );
+        let before = snapshot(&metrics, &shard);
+        let rows = id_enqueue_rows(&run(&sql, query).await);
+        let after = snapshot(&metrics, &shard);
+
+        assert!(!rows.is_empty(), "{name}: rows");
+        assert_rows_match(&rows, &expected, name);
+        assert_eq!(
+            after.fallback - before.fallback,
+            stripped_in_range,
+            "{name}: one hydration per stripped row in range"
+        );
+        assert_eq!(
+            after.point_lookups - before.point_lookups,
+            stripped_in_range,
+            "{name}: rows carrying the value are not looked up"
+        );
+    }
 }
 
 #[silo::test]
@@ -388,6 +408,19 @@ async fn row_whose_job_info_is_gone_is_dropped_without_error() {
     );
     assert_eq!(rows.len(), expected.len());
     assert_rows_match(&rows, &expected, "after drop");
+
+    // A dropped row does not count toward the LIMIT: the scan pulls the next
+    // entry in its place.
+    let limit = expected.len();
+    let limited = id_enqueue_rows(
+        &run(
+            &sql,
+            &format!("SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' LIMIT {limit}"),
+        )
+        .await,
+    );
+    assert_eq!(limited.len(), limit, "LIMIT filled past the dropped row");
+    assert_rows_match(&limited, &expected, "limited after drop");
 }
 
 #[silo::test]
@@ -497,4 +530,82 @@ async fn waiting_status_query_returns_the_transition_time() {
             .value(0);
         assert_eq!(changed, status.changed_at_ms, "complete={complete}");
     }
+}
+
+/// The editor's listing shape on a tenant larger than production's problem
+/// threshold. Imports 120k jobs, so it runs only on request:
+/// `cargo test --test query_index_enqueue_time_tests -- --ignored`.
+#[silo::test]
+#[ignore]
+async fn listing_query_on_a_100k_job_tenant_is_index_only() {
+    use silo::job_store_shard::import::{ImportJobParams, ImportedAttempt, ImportedAttemptStatus};
+
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let total = 120_000usize;
+    let now = now_ms();
+    for chunk_start in (0..total).step_by(500) {
+        let params: Vec<ImportJobParams> = (chunk_start..(chunk_start + 500).min(total))
+            .map(|i| {
+                let enqueue_time_ms = now - total as i64 + i as i64;
+                let attempts = if i % 2 == 0 {
+                    vec![ImportedAttempt {
+                        status: ImportedAttemptStatus::Succeeded { result: vec![] },
+                        started_at_ms: enqueue_time_ms + 10,
+                        finished_at_ms: enqueue_time_ms + 20,
+                    }]
+                } else {
+                    vec![]
+                };
+                ImportJobParams {
+                    id: format!("job-{i:07}"),
+                    priority: 50,
+                    enqueue_time_ms,
+                    start_at_ms: now + 3_600_000,
+                    retry_policy: None,
+                    payload: msgpack_payload(&serde_json::json!({"i": i})),
+                    limits: vec![],
+                    metadata: None,
+                    task_group: "default".to_string(),
+                    attempts,
+                }
+            })
+            .collect();
+        let results = shard.import_jobs("-", params).await.expect("import");
+        assert!(
+            results.iter().all(|r| r.success),
+            "import batch at {chunk_start}"
+        );
+    }
+    let sql = engine(&shard);
+
+    // Both paths see every row when the sample bound exceeds the tenant, so
+    // their results must agree exactly.
+    let whole_tenant = "SELECT id FROM (SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' LIMIT 200000) ORDER BY enqueue_time_ms DESC, id DESC LIMIT 101";
+    assert_eq!(explain_path(&sql, whole_tenant).await, "fullscan-join");
+    let job_record_order = string_column(&run(&sql, whole_tenant).await, "id");
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .unwrap();
+    assert_eq!(explain_path(&sql, whole_tenant).await, "status-index");
+    let before = snapshot(&metrics, &shard);
+    let index_order = string_column(&run(&sql, whole_tenant).await, "id");
+    let after = snapshot(&metrics, &shard);
+    assert_eq!(index_order.len(), 101);
+    assert_eq!(index_order, job_record_order, "same rows in the same order");
+    assert_eq!(
+        after.point_lookups, before.point_lookups,
+        "zero JOB_INFO point lookups"
+    );
+    assert_eq!(after.fallback, before.fallback, "zero fallback hydrations");
+
+    // The production shape (50k sample) is index-only as well.
+    let production = "SELECT id FROM (SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' LIMIT 50000) ORDER BY enqueue_time_ms DESC, id DESC LIMIT 101";
+    assert_eq!(explain_path(&sql, production).await, "status-index");
+    let before = snapshot(&metrics, &shard);
+    let rows = string_column(&run(&sql, production).await, "id");
+    let after = snapshot(&metrics, &shard);
+    assert_eq!(rows.len(), 101);
+    assert_eq!(after.point_lookups, before.point_lookups);
+    assert_eq!(after.fallback, before.fallback);
 }

--- a/tests/query_index_enqueue_time_tests.rs
+++ b/tests/query_index_enqueue_time_tests.rs
@@ -1,0 +1,500 @@
+//! `enqueue_time_ms` served from the status/time index value by the jobs
+//! scanner: path selection (EXPLAIN), correctness, the fallback for rows whose
+//! index value is unknown, and the metrics that observe each.
+
+mod test_helpers;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, Int64Array, StringArray};
+use datafusion::arrow::record_batch::RecordBatch;
+use silo::job_attempt::AttemptOutcome;
+use silo::job_store_shard::JobStoreShard;
+use silo::query::ShardQueryEngine;
+use test_helpers::*;
+
+async fn enqueue_job(shard: &JobStoreShard, tenant: &str, id: &str, start_at_ms: i64) {
+    shard
+        .enqueue(
+            tenant,
+            Some(id.to_string()),
+            10u8,
+            start_at_ms,
+            None,
+            msgpack_payload(&serde_json::json!({"id": id})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+}
+
+async fn dequeue_one(shard: &JobStoreShard) -> String {
+    let ids = dequeue_task_ids_until(shard, "w", "default", 1).await;
+    ids.into_iter().next().expect("one task")
+}
+
+/// Seed jobs in `tenant` with distinct enqueue times: `count` far-future
+/// scheduled jobs, one waiting job, and one succeeded job. Returns
+/// `job_id -> enqueue_time_ms` as `JOB_INFO` reports it.
+async fn seed_jobs(shard: &JobStoreShard, tenant: &str, count: usize) -> HashMap<String, i64> {
+    let now = now_ms();
+    for i in 0..count {
+        enqueue_job(
+            shard,
+            tenant,
+            &format!("future{i:03}"),
+            now + 3_600_000 + i as i64,
+        )
+        .await;
+    }
+    enqueue_job(shard, tenant, "done", now).await;
+    let task = dequeue_one(shard).await;
+    shard
+        .report_attempt_outcome(&task, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("success");
+    enqueue_job(shard, tenant, "waiting", now - 60_000).await;
+    expected_enqueue_times(shard, tenant).await
+}
+
+async fn expected_enqueue_times(shard: &JobStoreShard, tenant: &str) -> HashMap<String, i64> {
+    let pairs = shard.scan_all_jobs(None).await.expect("scan jobs");
+    let mut out = HashMap::new();
+    for (t, id) in pairs {
+        if t != tenant {
+            continue;
+        }
+        let view = shard.get_job(tenant, &id).await.unwrap().unwrap();
+        out.insert(id, view.enqueue_time_ms());
+    }
+    out
+}
+
+fn engine(shard: &Arc<JobStoreShard>) -> ShardQueryEngine {
+    ShardQueryEngine::new(Arc::clone(shard), "jobs").expect("engine")
+}
+
+async fn run(sql: &ShardQueryEngine, query: &str) -> Vec<RecordBatch> {
+    sql.sql(query)
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect")
+}
+
+/// `(id, enqueue_time_ms)` rows from batches projecting both columns.
+fn id_enqueue_rows(batches: &[RecordBatch]) -> Vec<(String, i64)> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        let ids = batch
+            .column_by_name("id")
+            .expect("id column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string");
+        let times = batch
+            .column_by_name("enqueue_time_ms")
+            .expect("enqueue_time_ms column")
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64");
+        for i in 0..batch.num_rows() {
+            rows.push((ids.value(i).to_string(), times.value(i)));
+        }
+    }
+    rows
+}
+
+fn string_column(batches: &[RecordBatch], name: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for batch in batches {
+        let col = batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("{name} column"))
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string");
+        for i in 0..batch.num_rows() {
+            out.push(col.value(i).to_string());
+        }
+    }
+    out
+}
+
+/// The `path=` label from the SiloExecutionPlan line of EXPLAIN.
+async fn explain_path(sql: &ShardQueryEngine, query: &str) -> String {
+    let explain = sql.explain(query).await.expect("explain");
+    let line = explain
+        .lines()
+        .find(|l| l.contains("SiloExecutionPlan:"))
+        .unwrap_or_else(|| panic!("no SiloExecutionPlan line in EXPLAIN:\n{explain}"));
+    line.split("path=")
+        .nth(1)
+        .unwrap_or_else(|| panic!("no path= in plan line: {line}"))
+        .split(',')
+        .next()
+        .unwrap()
+        .trim()
+        .to_string()
+}
+
+fn assert_rows_match(rows: &[(String, i64)], expected: &HashMap<String, i64>, context: &str) {
+    assert!(!rows.is_empty(), "{context}: no rows");
+    for (id, enqueue_time_ms) in rows {
+        assert_eq!(
+            expected.get(id),
+            Some(enqueue_time_ms),
+            "{context}: enqueue_time_ms for {id}"
+        );
+    }
+}
+
+struct MetricSnapshot {
+    point_lookups: f64,
+    fallback: f64,
+    scanned_keys: f64,
+}
+
+fn snapshot(metrics: &silo::metrics::Metrics, shard: &JobStoreShard) -> MetricSnapshot {
+    MetricSnapshot {
+        point_lookups: metrics.query_point_lookups_value(shard.name()),
+        fallback: metrics.enqueue_time_fallback_hydrations_value(shard.name()),
+        scanned_keys: metrics.query_scanned_keys_value(shard.name()),
+    }
+}
+
+const INDEX_SERVED_SHAPES: [(&str, &str); 4] = [
+    (
+        "FullScan",
+        "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-'",
+    ),
+    (
+        "Status stored",
+        "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' AND status_kind = 'Succeeded'",
+    ),
+    (
+        "Status virtual",
+        "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting'",
+    ),
+    (
+        "StatusUnion",
+        "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' AND status_kind IN ('Waiting', 'Succeeded')",
+    ),
+];
+
+#[silo::test]
+async fn backfilled_shard_serves_enqueue_time_from_the_index() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let expected = seed_jobs(&shard, "-", 20).await;
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .unwrap();
+    let sql = engine(&shard);
+
+    for (name, query) in INDEX_SERVED_SHAPES {
+        assert_eq!(explain_path(&sql, query).await, "status-index", "{name}");
+        let before = snapshot(&metrics, &shard);
+        let rows = id_enqueue_rows(&run(&sql, query).await);
+        let after = snapshot(&metrics, &shard);
+        assert_rows_match(&rows, &expected, name);
+        assert_eq!(
+            after.point_lookups, before.point_lookups,
+            "{name}: point lookups"
+        );
+        assert_eq!(
+            after.fallback, before.fallback,
+            "{name}: fallback hydrations"
+        );
+    }
+}
+
+#[silo::test]
+async fn shard_without_marker_keeps_fullscan_on_the_job_record_path() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let expected = seed_jobs(&shard, "-", 5).await;
+    assert!(!shard.enqueue_time_backfill_complete());
+    let sql = engine(&shard);
+
+    for (name, query) in INDEX_SERVED_SHAPES {
+        let path = if name == "FullScan" {
+            "fullscan-join"
+        } else {
+            "status-index"
+        };
+        assert_eq!(explain_path(&sql, query).await, path, "{name}");
+        let rows = id_enqueue_rows(&run(&sql, query).await);
+        assert_rows_match(&rows, &expected, name);
+    }
+
+    // Index-only shapes that do not project enqueue_time_ms are unaffected by
+    // the marker: same path and zero point lookups.
+    for query in [
+        "SELECT COUNT(*) FROM jobs",
+        "SELECT id, status_kind FROM jobs WHERE tenant = '-'",
+    ] {
+        assert_eq!(explain_path(&sql, query).await, "status-index", "{query}");
+        let before = snapshot(&metrics, &shard);
+        run(&sql, query).await;
+        let after = snapshot(&metrics, &shard);
+        assert_eq!(
+            after.point_lookups, before.point_lookups,
+            "{query}: point lookups"
+        );
+    }
+}
+
+#[silo::test]
+async fn counters_path_only_for_unfiltered_count() {
+    let (_tmp, shard, _metrics) = open_temp_shard_with_metrics().await;
+    seed_jobs(&shard, "-", 3).await;
+    let sql = engine(&shard);
+
+    assert_eq!(
+        explain_path(&sql, "SELECT COUNT(*) FROM jobs WHERE tenant = '-'").await,
+        "status-counters"
+    );
+    assert_eq!(
+        explain_path(&sql, "SELECT id FROM jobs WHERE tenant = '-' LIMIT 5").await,
+        "status-index"
+    );
+}
+
+#[silo::test]
+async fn tenant_less_status_query_stays_on_the_pairs_path() {
+    let (_tmp, shard, _metrics) = open_temp_shard_with_metrics().await;
+    let expected = seed_jobs(&shard, "-", 3).await;
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .unwrap();
+    let sql = engine(&shard);
+    let query = "SELECT id, enqueue_time_ms FROM jobs WHERE status_kind = 'Succeeded'";
+
+    assert_eq!(explain_path(&sql, query).await, "pairs");
+    let rows = id_enqueue_rows(&run(&sql, query).await);
+    assert_eq!(rows.len(), 1);
+    assert_rows_match(&rows, &expected, "tenant-less Status");
+}
+
+#[silo::test]
+async fn other_job_info_columns_keep_the_job_record_path() {
+    let (_tmp, shard, _metrics) = open_temp_shard_with_metrics().await;
+    let expected = seed_jobs(&shard, "-", 5).await;
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .unwrap();
+    let sql = engine(&shard);
+
+    let cases = [
+        (
+            "SELECT id, enqueue_time_ms, priority FROM jobs WHERE tenant = '-'",
+            "fullscan-join",
+        ),
+        (
+            "SELECT id, enqueue_time_ms, priority FROM jobs WHERE tenant = '-' AND status_kind = 'Succeeded'",
+            "pairs",
+        ),
+        (
+            "SELECT id, enqueue_time_ms, current_attempt FROM jobs WHERE tenant = '-'",
+            "fullscan-join",
+        ),
+        (
+            "SELECT id, enqueue_time_ms, current_attempt FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting'",
+            "pairs",
+        ),
+        (
+            "SELECT id, enqueue_time_ms, status_changed_at_ms FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting'",
+            "pairs",
+        ),
+    ];
+    for (query, path) in cases {
+        assert_eq!(explain_path(&sql, query).await, path, "{query}");
+        let rows = id_enqueue_rows(&run(&sql, query).await);
+        assert_rows_match(&rows, &expected, query);
+        assert!(
+            rows.iter().all(|(_, t)| *t != 0),
+            "{query}: enqueue_time_ms must be populated: {rows:?}"
+        );
+    }
+}
+
+#[silo::test]
+async fn rows_lacking_the_value_are_hydrated_individually() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let expected = seed_jobs(&shard, "-", 30).await;
+    for i in 0..10 {
+        strip_enqueue_time_from_job_rows(&shard, "-", &format!("future{i:03}")).await;
+    }
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .unwrap();
+    let sql = engine(&shard);
+    let query = "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-'";
+
+    let before = snapshot(&metrics, &shard);
+    let rows = id_enqueue_rows(&run(&sql, query).await);
+    let after = snapshot(&metrics, &shard);
+
+    assert_eq!(rows.len(), expected.len());
+    assert_rows_match(&rows, &expected, "mixed chunk");
+    assert_eq!(
+        after.fallback - before.fallback,
+        10.0,
+        "one hydration per stripped row"
+    );
+    assert_eq!(
+        after.point_lookups - before.point_lookups,
+        10.0,
+        "rows carrying the value are not looked up"
+    );
+}
+
+#[silo::test]
+async fn row_whose_job_info_is_gone_is_dropped_without_error() {
+    use silo::keys::job_info_key;
+
+    let (_tmp, shard, _metrics) = open_temp_shard_with_metrics().await;
+    let mut expected = seed_jobs(&shard, "-", 5).await;
+    strip_enqueue_time_from_job_rows(&shard, "-", "future000").await;
+    shard
+        .db()
+        .delete(&job_info_key("-", "future000"))
+        .await
+        .expect("delete JOB_INFO");
+    expected.remove("future000");
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .unwrap();
+    let sql = engine(&shard);
+
+    let rows = id_enqueue_rows(
+        &run(
+            &sql,
+            "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-'",
+        )
+        .await,
+    );
+    assert!(
+        !rows.iter().any(|(id, _)| id == "future000"),
+        "row without JOB_INFO must be absent: {rows:?}"
+    );
+    assert_eq!(rows.len(), expected.len());
+    assert_rows_match(&rows, &expected, "after drop");
+}
+
+#[silo::test]
+async fn waiting_arm_labels_rows_from_its_own_snapshot() {
+    let (_tmp, shard, _metrics) = open_temp_shard_with_metrics().await;
+    seed_jobs(&shard, "-", 5).await;
+    let sql = engine(&shard);
+
+    for round in 0..5 {
+        let id = format!("edge{round}");
+        enqueue_job(&shard, "-", &id, now_ms() + 15).await;
+        let union = run(
+            &sql,
+            "SELECT id, status_kind, enqueue_time_ms FROM jobs WHERE tenant = '-' AND status_kind IN ('Waiting', 'Scheduled')",
+        )
+        .await;
+        let ids = string_column(&union, "id");
+        assert_eq!(
+            ids.iter().filter(|x| **x == id).count(),
+            1,
+            "{id} must appear in exactly one arm: {ids:?}"
+        );
+        let waiting = run(
+            &sql,
+            "SELECT id, status_kind, enqueue_time_ms FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting'",
+        )
+        .await;
+        let labels = string_column(&waiting, "status_kind");
+        assert!(
+            labels.iter().all(|label| label == "Waiting"),
+            "Waiting arm must label every row Waiting: {labels:?}"
+        );
+    }
+}
+
+#[silo::test]
+async fn listing_query_matches_the_job_record_path() {
+    let (_tmp, shard, _metrics) = open_temp_shard_with_metrics().await;
+    let expected = seed_jobs(&shard, "-", 50).await;
+    let sql = engine(&shard);
+    let query = "SELECT id FROM (SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' LIMIT 50000) ORDER BY enqueue_time_ms DESC, id DESC LIMIT 101";
+
+    let job_record_order = string_column(&run(&sql, query).await, "id");
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .unwrap();
+    let index_order = string_column(&run(&sql, query).await, "id");
+
+    let mut want: Vec<(String, i64)> = expected.into_iter().collect();
+    want.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| b.0.cmp(&a.0)));
+    let want: Vec<String> = want.into_iter().map(|(id, _)| id).collect();
+    assert_eq!(job_record_order, want, "job-record path order");
+    assert_eq!(index_order, want, "index path order");
+}
+
+#[silo::test]
+async fn limit_short_circuits_the_index_scan() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let now = now_ms();
+    for i in 0..400 {
+        enqueue_job(&shard, "-", &format!("j{i:04}"), now + 3_600_000 + i).await;
+    }
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .unwrap();
+    let sql = engine(&shard);
+    let query = "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' LIMIT 10";
+    assert_eq!(explain_path(&sql, query).await, "status-index");
+
+    let before = snapshot(&metrics, &shard);
+    let rows = id_enqueue_rows(&run(&sql, query).await);
+    let after = snapshot(&metrics, &shard);
+
+    assert_eq!(rows.len(), 10);
+    let scanned = after.scanned_keys - before.scanned_keys;
+    assert!(scanned < 100.0, "LIMIT 10 scanned {scanned} keys");
+}
+
+#[silo::test]
+async fn waiting_status_query_returns_the_transition_time() {
+    let (_tmp, shard, _metrics) = open_temp_shard_with_metrics().await;
+    seed_jobs(&shard, "-", 2).await;
+    let status = shard.get_job_status("-", "waiting").await.unwrap().unwrap();
+    let scheduled_start = status.next_attempt_starts_after_ms.unwrap();
+    assert_ne!(status.changed_at_ms, scheduled_start);
+    let sql = engine(&shard);
+    let query =
+        "SELECT id, status_changed_at_ms FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting'";
+
+    for complete in [false, true] {
+        shard
+            .set_enqueue_time_backfill_complete(complete)
+            .await
+            .unwrap();
+        assert_eq!(explain_path(&sql, query).await, "pairs");
+        let batches = run(&sql, query).await;
+        let ids = string_column(&batches, "id");
+        assert_eq!(ids, vec!["waiting"]);
+        let changed = batches[0]
+            .column_by_name("status_changed_at_ms")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0);
+        assert_eq!(changed, status.changed_at_ms, "complete={complete}");
+    }
+}

--- a/tests/status_enqueue_time_tests.rs
+++ b/tests/status_enqueue_time_tests.rs
@@ -8,66 +8,7 @@ mod test_helpers;
 
 use silo::job::JobStatusKind;
 use silo::job_store_shard::JobStoreShard;
-use silo::keys::{decode_status_index_value, idx_status_time_key, status_index_timestamp};
 use test_helpers::*;
-
-/// Read the index entry value for the job's current status through the db
-/// handle and decode it with the public codec.
-async fn index_entry_enqueue_time(
-    shard: &JobStoreShard,
-    tenant: &str,
-    job_id: &str,
-) -> Option<i64> {
-    let status = shard
-        .get_job_status(tenant, job_id)
-        .await
-        .expect("get status")
-        .expect("status exists");
-    let key = idx_status_time_key(
-        tenant,
-        status.kind.as_str(),
-        status_index_timestamp(&status),
-        job_id,
-    );
-    let value = shard
-        .db()
-        .get(&key)
-        .await
-        .expect("get index entry")
-        .expect("index entry exists");
-    decode_status_index_value(&value)
-}
-
-/// Assert the status record and the index entry both carry exactly the
-/// `enqueue_time_ms` stored in `JOB_INFO`.
-async fn assert_rows_carry_job_info_enqueue_time(
-    shard: &JobStoreShard,
-    tenant: &str,
-    job_id: &str,
-    context: &str,
-) {
-    let expected = shard
-        .get_job(tenant, job_id)
-        .await
-        .expect("get job")
-        .expect("job exists")
-        .enqueue_time_ms();
-    let status = shard
-        .get_job_status(tenant, job_id)
-        .await
-        .expect("get status")
-        .expect("status exists");
-    assert_eq!(
-        status.enqueue_time_ms,
-        Some(expected),
-        "{context}: status record enqueue_time_ms"
-    );
-    assert_eq!(
-        index_entry_enqueue_time(shard, tenant, job_id).await,
-        Some(expected),
-        "{context}: index entry enqueue_time_ms"
-    );
-}
 
 async fn enqueue_at(shard: &JobStoreShard, tenant: &str, start_at_ms: i64) -> String {
     shard
@@ -305,17 +246,6 @@ async fn reimport_preserves_original_enqueue_time() {
     let status = shard.get_job_status("-", "reimp").await.unwrap().unwrap();
     assert_eq!(status.kind, JobStatusKind::Succeeded);
     assert_rows_carry_job_info_enqueue_time(&shard, "-", "reimp", "reimport").await;
-}
-
-/// Assert both rows lack the value, as the stripping helper leaves them.
-async fn assert_rows_lack_enqueue_time(shard: &JobStoreShard, tenant: &str, job_id: &str) {
-    let status = shard.get_job_status(tenant, job_id).await.unwrap().unwrap();
-    assert_eq!(status.enqueue_time_ms, None, "stripped status record");
-    assert_eq!(
-        index_entry_enqueue_time(shard, tenant, job_id).await,
-        None,
-        "stripped index entry"
-    );
 }
 
 fn repair_reads(metrics: &silo::metrics::Metrics, shard: &JobStoreShard) -> f64 {

--- a/tests/status_enqueue_time_tests.rs
+++ b/tests/status_enqueue_time_tests.rs
@@ -1,0 +1,741 @@
+//! `enqueue_time_ms` on the status record and the status/time index entry.
+//!
+//! Every write path (enqueue, import, every transition) must leave both rows
+//! carrying the same `enqueue_time_ms` that `JOB_INFO` reports, and a job whose
+//! rows lack the value must be repaired by its next transition.
+
+mod test_helpers;
+
+use silo::job::JobStatusKind;
+use silo::job_store_shard::JobStoreShard;
+use silo::keys::{decode_status_index_value, idx_status_time_key, status_index_timestamp};
+use test_helpers::*;
+
+/// Read the index entry value for the job's current status through the db
+/// handle and decode it with the public codec.
+async fn index_entry_enqueue_time(
+    shard: &JobStoreShard,
+    tenant: &str,
+    job_id: &str,
+) -> Option<i64> {
+    let status = shard
+        .get_job_status(tenant, job_id)
+        .await
+        .expect("get status")
+        .expect("status exists");
+    let key = idx_status_time_key(
+        tenant,
+        status.kind.as_str(),
+        status_index_timestamp(&status),
+        job_id,
+    );
+    let value = shard
+        .db()
+        .get(&key)
+        .await
+        .expect("get index entry")
+        .expect("index entry exists");
+    decode_status_index_value(&value)
+}
+
+/// Assert the status record and the index entry both carry exactly the
+/// `enqueue_time_ms` stored in `JOB_INFO`.
+async fn assert_rows_carry_job_info_enqueue_time(
+    shard: &JobStoreShard,
+    tenant: &str,
+    job_id: &str,
+    context: &str,
+) {
+    let expected = shard
+        .get_job(tenant, job_id)
+        .await
+        .expect("get job")
+        .expect("job exists")
+        .enqueue_time_ms();
+    let status = shard
+        .get_job_status(tenant, job_id)
+        .await
+        .expect("get status")
+        .expect("status exists");
+    assert_eq!(
+        status.enqueue_time_ms,
+        Some(expected),
+        "{context}: status record enqueue_time_ms"
+    );
+    assert_eq!(
+        index_entry_enqueue_time(shard, tenant, job_id).await,
+        Some(expected),
+        "{context}: index entry enqueue_time_ms"
+    );
+}
+
+async fn enqueue_at(shard: &JobStoreShard, tenant: &str, start_at_ms: i64) -> String {
+    shard
+        .enqueue(
+            tenant,
+            None,
+            10u8,
+            start_at_ms,
+            None,
+            msgpack_payload(&serde_json::json!({"k": "v"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue")
+}
+
+#[silo::test]
+async fn enqueue_writes_enqueue_time_to_status_and_index_entry() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let cases = [
+        ("immediate", 0),
+        ("explicit", now_ms()),
+        ("future", now_ms() + 60_000),
+    ];
+
+    for (name, start_at_ms) in cases {
+        let job_id = enqueue_at(&shard, "-", start_at_ms).await;
+        let status = shard
+            .get_job_status("-", &job_id)
+            .await
+            .expect("get status")
+            .expect("status exists");
+        assert_eq!(status.kind, JobStatusKind::Scheduled);
+        assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_id, name).await;
+    }
+}
+
+fn immediate_retry_policy(retry_count: u32) -> silo::retry::RetryPolicy {
+    silo::retry::RetryPolicy {
+        retry_count,
+        initial_interval_ms: 0,
+        max_interval_ms: 0,
+        randomize_interval: false,
+        backoff_factor: 1.0,
+    }
+}
+
+async fn dequeue_one(shard: &JobStoreShard) -> String {
+    let ids = dequeue_task_ids_until(shard, "w", "default", 1).await;
+    ids.into_iter().next().expect("one task")
+}
+
+/// Every transition kind copies the enqueue time forward into the new status
+/// record and index entry.
+#[silo::test]
+async fn transitions_copy_enqueue_time_forward() {
+    use silo::job_attempt::AttemptOutcome;
+
+    let (_tmp, shard) = open_temp_shard().await;
+
+    // Job A: running -> retry -> running -> failed -> restart -> running -> succeeded.
+    let job_a = shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            0,
+            Some(immediate_retry_policy(1)),
+            msgpack_payload(&serde_json::json!({"job": "a"})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue a");
+
+    let task = dequeue_one(&shard).await;
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_a, "dequeue -> Running").await;
+
+    shard
+        .report_attempt_outcome(
+            &task,
+            AttemptOutcome::Error {
+                error_code: "E".into(),
+                error: vec![],
+            },
+        )
+        .await
+        .expect("report error with retry");
+    let status = shard.get_job_status("-", &job_a).await.unwrap().unwrap();
+    assert_eq!(status.kind, JobStatusKind::Scheduled);
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_a, "failure with retry").await;
+
+    let task = dequeue_one(&shard).await;
+    shard
+        .report_attempt_outcome(
+            &task,
+            AttemptOutcome::Error {
+                error_code: "E".into(),
+                error: vec![],
+            },
+        )
+        .await
+        .expect("report final error");
+    let status = shard.get_job_status("-", &job_a).await.unwrap().unwrap();
+    assert_eq!(status.kind, JobStatusKind::Failed);
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_a, "final failure").await;
+
+    shard.restart_job("-", &job_a).await.expect("restart");
+    let status = shard.get_job_status("-", &job_a).await.unwrap().unwrap();
+    assert_eq!(status.kind, JobStatusKind::Scheduled);
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_a, "restart").await;
+
+    let task = dequeue_one(&shard).await;
+    shard
+        .report_attempt_outcome(&task, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report success");
+    let status = shard.get_job_status("-", &job_a).await.unwrap().unwrap();
+    assert_eq!(status.kind, JobStatusKind::Succeeded);
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_a, "success").await;
+
+    // Job B: future scheduled -> expedite -> cancel.
+    let job_b = enqueue_at(&shard, "-", now_ms() + 60_000).await;
+    shard.expedite_job("-", &job_b).await.expect("expedite");
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_b, "expedite").await;
+
+    shard.cancel_job("-", &job_b).await.expect("cancel");
+    let status = shard.get_job_status("-", &job_b).await.unwrap().unwrap();
+    assert_eq!(status.kind, JobStatusKind::Cancelled);
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_b, "cancel").await;
+}
+
+fn import_params(id: &str, enqueue_time_ms: i64) -> silo::job_store_shard::import::ImportJobParams {
+    silo::job_store_shard::import::ImportJobParams {
+        id: id.to_string(),
+        priority: 50,
+        enqueue_time_ms,
+        start_at_ms: 0,
+        retry_policy: None,
+        payload: msgpack_payload(&serde_json::json!({"imported": true})),
+        limits: vec![],
+        metadata: None,
+        task_group: "default".to_string(),
+        attempts: vec![],
+    }
+}
+
+fn succeeded_attempt(finished_at_ms: i64) -> silo::job_store_shard::import::ImportedAttempt {
+    silo::job_store_shard::import::ImportedAttempt {
+        status: silo::job_store_shard::import::ImportedAttemptStatus::Succeeded { result: vec![] },
+        started_at_ms: finished_at_ms - 1000,
+        finished_at_ms,
+    }
+}
+
+fn failed_attempt(finished_at_ms: i64) -> silo::job_store_shard::import::ImportedAttempt {
+    silo::job_store_shard::import::ImportedAttempt {
+        status: silo::job_store_shard::import::ImportedAttemptStatus::Failed {
+            error_code: "ERR".to_string(),
+            error: vec![],
+        },
+        started_at_ms: finished_at_ms - 1000,
+        finished_at_ms,
+    }
+}
+
+/// Import writes the effective enqueue time it stores in `JOB_INFO` into both
+/// rows, for scheduled and terminal imports alike.
+#[silo::test]
+async fn import_writes_enqueue_time_to_status_and_index_entry() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let explicit = 1_700_000_000_000;
+
+    let mut terminal = import_params("imp-terminal", explicit);
+    terminal.attempts = vec![succeeded_attempt(explicit + 5_000)];
+    let cases = vec![
+        (
+            "scheduled explicit",
+            import_params("imp-scheduled", explicit),
+            JobStatusKind::Scheduled,
+        ),
+        (
+            "scheduled clamped",
+            import_params("imp-clamped", 0),
+            JobStatusKind::Scheduled,
+        ),
+        ("terminal", terminal, JobStatusKind::Succeeded),
+    ];
+
+    for (name, params, expected_kind) in cases {
+        let job_id = params.id.clone();
+        let results = shard.import_jobs("-", vec![params]).await.expect("import");
+        assert!(results[0].success, "{name}: import must succeed");
+        let status = shard.get_job_status("-", &job_id).await.unwrap().unwrap();
+        assert_eq!(status.kind, expected_kind, "{name}: status kind");
+        assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_id, name).await;
+    }
+}
+
+/// Reimport keeps the job's original enqueue time in both rows even when the
+/// reimport request names a different one.
+#[silo::test]
+async fn reimport_preserves_original_enqueue_time() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let original = 1_700_000_000_000;
+
+    let mut first = import_params("reimp", original);
+    first.attempts = vec![failed_attempt(original + 5_000)];
+    let results = shard.import_jobs("-", vec![first]).await.expect("import");
+    assert!(results[0].success);
+    let status = shard.get_job_status("-", "reimp").await.unwrap().unwrap();
+    assert_eq!(status.kind, JobStatusKind::Failed);
+
+    let mut again = import_params("reimp", original + 99_000);
+    again.attempts = vec![
+        failed_attempt(original + 5_000),
+        succeeded_attempt(original + 9_000),
+    ];
+    let results = shard.import_jobs("-", vec![again]).await.expect("reimport");
+    assert!(
+        results[0].success,
+        "reimport must succeed: {:?}",
+        results[0].error
+    );
+
+    let job = shard.get_job("-", "reimp").await.unwrap().unwrap();
+    assert_eq!(
+        job.enqueue_time_ms(),
+        original,
+        "JOB_INFO keeps the original"
+    );
+    let status = shard.get_job_status("-", "reimp").await.unwrap().unwrap();
+    assert_eq!(status.kind, JobStatusKind::Succeeded);
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", "reimp", "reimport").await;
+}
+
+/// Assert both rows lack the value, as the stripping helper leaves them.
+async fn assert_rows_lack_enqueue_time(shard: &JobStoreShard, tenant: &str, job_id: &str) {
+    let status = shard.get_job_status(tenant, job_id).await.unwrap().unwrap();
+    assert_eq!(status.enqueue_time_ms, None, "stripped status record");
+    assert_eq!(
+        index_entry_enqueue_time(shard, tenant, job_id).await,
+        None,
+        "stripped index entry"
+    );
+}
+
+fn repair_reads(metrics: &silo::metrics::Metrics, shard: &JobStoreShard) -> f64 {
+    metrics.enqueue_time_repair_reads_value(shard.name())
+}
+
+/// A job whose rows lack the value is repaired by its next transition.
+#[silo::test]
+async fn rows_without_enqueue_time_are_repaired_by_next_transition() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    let job_id = enqueue_at(&shard, "-", now_ms()).await;
+    strip_enqueue_time_from_job_rows(&shard, "-", &job_id).await;
+    assert_rows_lack_enqueue_time(&shard, "-", &job_id).await;
+
+    let before = repair_reads(&metrics, &shard);
+    shard.cancel_job("-", &job_id).await.expect("cancel");
+
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_id, "cancel repairs").await;
+    let reads = repair_reads(&metrics, &shard) - before;
+    assert!(reads <= 1.0, "at most one repair read, recorded {reads}");
+}
+
+/// Transitions that already hold a `JobView` repair the rows without any
+/// extra `JOB_INFO` read.
+#[silo::test]
+async fn transitions_with_job_view_repair_without_a_read() {
+    use silo::job_attempt::AttemptOutcome;
+
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+
+    // dequeue
+    let job = enqueue_at(&shard, "-", 0).await;
+    strip_enqueue_time_from_job_rows(&shard, "-", &job).await;
+    let before = repair_reads(&metrics, &shard);
+    let task = dequeue_one(&shard).await;
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job, "dequeue").await;
+    assert_eq!(
+        repair_reads(&metrics, &shard) - before,
+        0.0,
+        "dequeue reads"
+    );
+
+    // error branch of report-outcome (retry scheduled)
+    strip_enqueue_time_from_job_rows(&shard, "-", &job).await;
+    let before = repair_reads(&metrics, &shard);
+    shard
+        .report_attempt_outcome(
+            &task,
+            AttemptOutcome::Error {
+                error_code: "E".into(),
+                error: vec![],
+            },
+        )
+        .await
+        .expect("report error");
+    let status = shard.get_job_status("-", &job).await.unwrap().unwrap();
+    assert_eq!(status.kind, JobStatusKind::Failed);
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job, "report error").await;
+    assert_eq!(
+        repair_reads(&metrics, &shard) - before,
+        0.0,
+        "report error reads"
+    );
+
+    // restart
+    strip_enqueue_time_from_job_rows(&shard, "-", &job).await;
+    let before = repair_reads(&metrics, &shard);
+    shard.restart_job("-", &job).await.expect("restart");
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job, "restart").await;
+    assert_eq!(
+        repair_reads(&metrics, &shard) - before,
+        0.0,
+        "restart reads"
+    );
+
+    // direct lease
+    strip_enqueue_time_from_job_rows(&shard, "-", &job).await;
+    let before = repair_reads(&metrics, &shard);
+    shard.lease_task("-", &job, "w").await.expect("lease_task");
+    let status = shard.get_job_status("-", &job).await.unwrap().unwrap();
+    assert_eq!(status.kind, JobStatusKind::Running);
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job, "lease_task").await;
+    assert_eq!(
+        repair_reads(&metrics, &shard) - before,
+        0.0,
+        "lease_task reads"
+    );
+
+    // expedite
+    let future = enqueue_at(&shard, "-", now_ms() + 60_000).await;
+    strip_enqueue_time_from_job_rows(&shard, "-", &future).await;
+    let before = repair_reads(&metrics, &shard);
+    shard.expedite_job("-", &future).await.expect("expedite");
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &future, "expedite").await;
+    assert_eq!(
+        repair_reads(&metrics, &shard) - before,
+        0.0,
+        "expedite reads"
+    );
+
+    // reimport
+    let mut first = import_params("reimp-view", 1_700_000_000_000);
+    first.attempts = vec![failed_attempt(1_700_000_005_000)];
+    shard.import_jobs("-", vec![first]).await.expect("import");
+    strip_enqueue_time_from_job_rows(&shard, "-", "reimp-view").await;
+    let before = repair_reads(&metrics, &shard);
+    let mut again = import_params("reimp-view", 1_700_000_000_000);
+    again.attempts = vec![
+        failed_attempt(1_700_000_005_000),
+        succeeded_attempt(1_700_000_009_000),
+    ];
+    let results = shard.import_jobs("-", vec![again]).await.expect("reimport");
+    assert!(results[0].success, "{:?}", results[0].error);
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", "reimp-view", "reimport").await;
+    assert_eq!(
+        repair_reads(&metrics, &shard) - before,
+        0.0,
+        "reimport reads"
+    );
+}
+
+/// Gauge-relevant transitions without a `JobView` in scope repair the rows
+/// with exactly one `JOB_INFO` read, and leave the metric alone when the rows
+/// already carry the value.
+#[silo::test]
+async fn gauge_path_transitions_repair_with_exactly_one_read() {
+    use silo::job_attempt::AttemptOutcome;
+
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+
+    for stripped in [true, false] {
+        let expected_reads = if stripped { 1.0 } else { 0.0 };
+        let label = if stripped { "stripped" } else { "intact" };
+
+        // cancel of a scheduled job
+        let job = enqueue_at(&shard, "-", now_ms() + 60_000).await;
+        if stripped {
+            strip_enqueue_time_from_job_rows(&shard, "-", &job).await;
+        }
+        let before = repair_reads(&metrics, &shard);
+        shard.cancel_job("-", &job).await.expect("cancel");
+        assert_rows_carry_job_info_enqueue_time(&shard, "-", &job, "cancel").await;
+        assert_eq!(
+            repair_reads(&metrics, &shard) - before,
+            expected_reads,
+            "{label}: cancel reads"
+        );
+
+        // success branch of report-outcome
+        let job = enqueue_at(&shard, "-", 0).await;
+        let task = dequeue_one(&shard).await;
+        if stripped {
+            strip_enqueue_time_from_job_rows(&shard, "-", &job).await;
+        }
+        let before = repair_reads(&metrics, &shard);
+        shard
+            .report_attempt_outcome(&task, AttemptOutcome::Success { result: vec![] })
+            .await
+            .expect("report success");
+        assert_rows_carry_job_info_enqueue_time(&shard, "-", &job, "success").await;
+        assert_eq!(
+            repair_reads(&metrics, &shard) - before,
+            expected_reads,
+            "{label}: success reads"
+        );
+
+        // cancelled branch of report-outcome
+        let job = enqueue_at(&shard, "-", 0).await;
+        let task = dequeue_one(&shard).await;
+        if stripped {
+            strip_enqueue_time_from_job_rows(&shard, "-", &job).await;
+        }
+        let before = repair_reads(&metrics, &shard);
+        shard
+            .report_attempt_outcome(&task, AttemptOutcome::Cancelled)
+            .await
+            .expect("report cancelled");
+        let status = shard.get_job_status("-", &job).await.unwrap().unwrap();
+        assert_eq!(status.kind, JobStatusKind::Cancelled);
+        assert_rows_carry_job_info_enqueue_time(&shard, "-", &job, "cancelled").await;
+        assert_eq!(
+            repair_reads(&metrics, &shard) - before,
+            expected_reads,
+            "{label}: cancelled reads"
+        );
+    }
+}
+
+/// Retargeting a scheduled job's task key (a rate-limit retry) has no
+/// `JobView` in scope and is not gauge-relevant, so a job whose rows lack the
+/// value costs exactly one dedicated `JOB_INFO` read.
+#[silo::test]
+async fn task_key_retarget_repairs_with_exactly_one_read() {
+    use silo::gubernator::{MockGubernatorClient, RateLimitClient};
+    use silo::job::{GubernatorAlgorithm, GubernatorRateLimit, Limit, RateLimitRetryPolicy};
+
+    let gubernator = MockGubernatorClient::new_arc();
+    // Exhaust the limit up front so the CheckRateLimit task parks the job on a
+    // retry row at a fresh start time.
+    gubernator
+        .check_rate_limit(
+            "api",
+            "retarget",
+            1,
+            1,
+            60_000,
+            silo::pb::gubernator::Algorithm::TokenBucket,
+            0,
+        )
+        .await
+        .expect("exhaust");
+    let rate_limit = GubernatorRateLimit {
+        name: "api".to_string(),
+        unique_key: "retarget".to_string(),
+        limit: 1,
+        duration_ms: 60_000,
+        hits: 1,
+        algorithm: GubernatorAlgorithm::TokenBucket,
+        behavior: 0,
+        retry_policy: RateLimitRetryPolicy {
+            initial_backoff_ms: 60_000,
+            max_backoff_ms: 60_000,
+            backoff_multiplier: 1.0,
+            max_retries: 5,
+        },
+    };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = silo::settings::DatabaseConfig {
+        name: "test".to_string(),
+        backend: silo::settings::Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        ..Default::default()
+    };
+    let metrics = silo::metrics::init().expect("init metrics");
+    let shard = JobStoreShard::open(
+        &cfg,
+        gubernator,
+        Some(metrics.clone()),
+        silo::shard_range::ShardRange::full(),
+    )
+    .await
+    .expect("open shard");
+
+    for stripped in [true, false] {
+        let expected_reads = if stripped { 1.0 } else { 0.0 };
+        let job = shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                0,
+                None,
+                msgpack_payload(&serde_json::json!({"rl": stripped})),
+                vec![Limit::RateLimit(rate_limit.clone())],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+        let scheduled = shard.get_job_status("-", &job).await.unwrap().unwrap();
+        if stripped {
+            strip_enqueue_time_from_job_rows(&shard, "-", &job).await;
+        }
+
+        let before = repair_reads(&metrics, &shard);
+        let tasks = shard
+            .dequeue("w", "default", 1)
+            .await
+            .expect("dequeue")
+            .tasks;
+        assert!(
+            tasks.is_empty(),
+            "over-limit check must not hand out a task"
+        );
+
+        let retargeted = shard.get_job_status("-", &job).await.unwrap().unwrap();
+        assert_eq!(retargeted.kind, JobStatusKind::Scheduled);
+        assert_ne!(
+            retargeted.next_attempt_starts_after_ms, scheduled.next_attempt_starts_after_ms,
+            "status must point at the retry row"
+        );
+        assert_rows_carry_job_info_enqueue_time(&shard, "-", &job, "retarget").await;
+        assert_eq!(
+            repair_reads(&metrics, &shard) - before,
+            expected_reads,
+            "stripped={stripped}: retarget reads"
+        );
+    }
+}
+
+async fn status_counts(
+    shard: &JobStoreShard,
+    tenant: &str,
+) -> std::collections::HashMap<String, i64> {
+    shard
+        .scan_tenant_status_counters(None)
+        .await
+        .expect("scan counters")
+        .into_iter()
+        .filter(|(t, _, _)| t == tenant)
+        .map(|(_, status, count)| (status, count))
+        .collect()
+}
+
+/// Enqueue and import each move the tenant status counter for the written
+/// status by exactly one.
+#[silo::test]
+async fn enqueue_and_import_move_tenant_status_counters_by_one() {
+    let (_tmp, shard) = open_temp_shard().await;
+
+    enqueue_at(&shard, "-", 0).await;
+    enqueue_at(&shard, "-", now_ms() + 60_000).await;
+    let counts = status_counts(&shard, "-").await;
+    assert_eq!(
+        counts.get("Scheduled"),
+        Some(&2),
+        "after enqueue: {counts:?}"
+    );
+
+    let mut terminal = import_params("counter-terminal", 1_700_000_000_000);
+    terminal.attempts = vec![succeeded_attempt(1_700_000_005_000)];
+    shard
+        .import_jobs("-", vec![terminal, import_params("counter-scheduled", 0)])
+        .await
+        .expect("import");
+    let counts = status_counts(&shard, "-").await;
+    assert_eq!(
+        counts.get("Scheduled"),
+        Some(&3),
+        "after import: {counts:?}"
+    );
+    assert_eq!(
+        counts.get("Succeeded"),
+        Some(&1),
+        "after import: {counts:?}"
+    );
+}
+
+/// The public marker method sets and clears the marker key and the in-memory
+/// flag together, and the getter reflects it immediately.
+#[silo::test]
+async fn backfill_completion_marker_and_flag_move_together() {
+    use silo::keys::enqueue_time_backfill_complete_key;
+
+    let (_tmp, shard) = open_temp_shard().await;
+    let key = enqueue_time_backfill_complete_key();
+    assert!(!shard.enqueue_time_backfill_complete(), "fresh shard");
+    assert!(
+        shard.db().get(&key).await.unwrap().is_none(),
+        "fresh shard marker"
+    );
+
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .expect("set");
+    assert!(shard.enqueue_time_backfill_complete(), "after set");
+    assert!(
+        shard.db().get(&key).await.unwrap().is_some(),
+        "marker after set"
+    );
+
+    shard
+        .set_enqueue_time_backfill_complete(false)
+        .await
+        .expect("clear");
+    assert!(!shard.enqueue_time_backfill_complete(), "after clear");
+    assert!(
+        shard.db().get(&key).await.unwrap().is_none(),
+        "marker after clear"
+    );
+}
+
+/// A reopened shard reads the flag from the persisted marker.
+#[silo::test]
+async fn reopened_shard_reads_backfill_flag_from_marker() {
+    use silo::gubernator::MockGubernatorClient;
+    use silo::settings::{Backend, DatabaseConfig};
+    use silo::shard_range::ShardRange;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = DatabaseConfig {
+        name: "test".to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        ..Default::default()
+    };
+    let open = || {
+        JobStoreShard::open(
+            &cfg,
+            MockGubernatorClient::new_arc(),
+            None,
+            ShardRange::full(),
+        )
+    };
+
+    let shard = open().await.expect("open");
+    shard
+        .set_enqueue_time_backfill_complete(true)
+        .await
+        .expect("set");
+    shard.close().await.expect("close");
+
+    let shard = open().await.expect("reopen");
+    assert!(
+        shard.enqueue_time_backfill_complete(),
+        "flag read from marker at open"
+    );
+    shard
+        .set_enqueue_time_backfill_complete(false)
+        .await
+        .expect("clear");
+    shard.close().await.expect("close");
+
+    let shard = open().await.expect("reopen after clear");
+    assert!(
+        !shard.enqueue_time_backfill_complete(),
+        "cleared marker read at open"
+    );
+}

--- a/tests/status_enqueue_time_tests.rs
+++ b/tests/status_enqueue_time_tests.rs
@@ -265,7 +265,7 @@ async fn rows_without_enqueue_time_are_repaired_by_next_transition() {
 
     assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_id, "cancel repairs").await;
     let reads = repair_reads(&metrics, &shard) - before;
-    assert!(reads <= 1.0, "at most one repair read, recorded {reads}");
+    assert_eq!(reads, 1.0, "exactly one repair read, recorded {reads}");
 }
 
 /// Transitions that already hold a `JobView` repair the rows without any
@@ -288,7 +288,7 @@ async fn transitions_with_job_view_repair_without_a_read() {
         "dequeue reads"
     );
 
-    // error branch of report-outcome (retry scheduled)
+    // error branch of report-outcome (no retry policy, lands Failed)
     strip_enqueue_time_from_job_rows(&shard, "-", &job).await;
     let before = repair_reads(&metrics, &shard);
     shard
@@ -624,35 +624,21 @@ async fn backfill_completion_marker_and_flag_move_together() {
 /// A reopened shard reads the flag from the persisted marker.
 #[silo::test]
 async fn reopened_shard_reads_backfill_flag_from_marker() {
-    use silo::gubernator::MockGubernatorClient;
-    use silo::settings::{Backend, DatabaseConfig};
     use silo::shard_range::ShardRange;
 
     let tmp = tempfile::tempdir().unwrap();
-    let cfg = DatabaseConfig {
-        name: "test".to_string(),
-        backend: Backend::Fs,
-        path: tmp.path().to_string_lossy().to_string(),
-        slatedb: Some(fast_flush_slatedb_settings()),
-        ..Default::default()
-    };
-    let open = || {
-        JobStoreShard::open(
-            &cfg,
-            MockGubernatorClient::new_arc(),
-            None,
-            ShardRange::full(),
-        )
-    };
+    let path = tmp.path().to_string_lossy().to_string();
+    let metrics = silo::metrics::init().expect("init metrics");
+    let open = || open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |_| {});
 
-    let shard = open().await.expect("open");
+    let shard = open().await;
     shard
         .set_enqueue_time_backfill_complete(true)
         .await
         .expect("set");
     shard.close().await.expect("close");
 
-    let shard = open().await.expect("reopen");
+    let shard = open().await;
     assert!(
         shard.enqueue_time_backfill_complete(),
         "flag read from marker at open"
@@ -663,9 +649,51 @@ async fn reopened_shard_reads_backfill_flag_from_marker() {
         .expect("clear");
     shard.close().await.expect("close");
 
-    let shard = open().await.expect("reopen after clear");
+    let shard = open().await;
     assert!(
         !shard.enqueue_time_backfill_complete(),
         "cleared marker read at open"
+    );
+}
+
+/// A terminal transition on a shard with row expiry writes both rows with the
+/// value and with the expiry.
+#[silo::test]
+async fn terminal_transition_writes_value_and_expiry_on_both_rows() {
+    use silo::job_attempt::AttemptOutcome;
+    use silo::keys::{idx_status_time_key, job_status_key, status_index_timestamp};
+
+    let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+    let job_id = enqueue_at(&shard, "-", 0).await;
+    let task = dequeue_one(&shard).await;
+    shard
+        .report_attempt_outcome(&task, AttemptOutcome::Success { result: vec![] })
+        .await
+        .expect("report success");
+
+    assert_rows_carry_job_info_enqueue_time(&shard, "-", &job_id, "terminal").await;
+    let status = shard.get_job_status("-", &job_id).await.unwrap().unwrap();
+    assert_eq!(status.kind, JobStatusKind::Succeeded);
+    let status_row = shard
+        .db()
+        .get_key_value(&job_status_key("-", &job_id))
+        .await
+        .unwrap()
+        .expect("status row");
+    let index_row = shard
+        .db()
+        .get_key_value(&idx_status_time_key(
+            "-",
+            status.kind.as_str(),
+            status_index_timestamp(&status),
+            &job_id,
+        ))
+        .await
+        .unwrap()
+        .expect("index row");
+    assert!(status_row.expire_ts.is_some(), "status row carries expiry");
+    assert_eq!(
+        index_row.expire_ts, status_row.expire_ts,
+        "index row carries the same expiry"
     );
 }

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -696,3 +696,63 @@ pub fn metric_value_or_zero(body: &str, substrings: &[&str]) -> f64 {
         .and_then(|(_, v)| v.parse::<f64>().ok())
         .unwrap_or(0.0)
 }
+
+fn put_preserving_expiry(
+    batch: &mut slatedb::WriteBatch,
+    key: &[u8],
+    value: &[u8],
+    expire_ts: Option<i64>,
+) {
+    use slatedb::config::{PutOptions, Ttl};
+    match expire_ts {
+        Some(ts) => batch.put_with_options(
+            key,
+            value,
+            &PutOptions {
+                ttl: Ttl::ExpireAt(ts),
+            },
+        ),
+        None => batch.put(key, value),
+    }
+}
+
+/// Rewrite a job's status record and status/time index entry into the shape
+/// of rows that lack `enqueue_time_ms`: the status record without the field
+/// and the index entry with an empty value. Each row keeps its existing
+/// `expire_ts`. Shared by the query, transition-repair and backfill tests.
+pub async fn strip_enqueue_time_from_job_rows(shard: &JobStoreShard, tenant: &str, job_id: &str) {
+    use silo::codec::{decode_job_status_owned, encode_job_status};
+    use silo::keys::{idx_status_time_key, job_status_key, status_index_timestamp};
+
+    let status_key = job_status_key(tenant, job_id);
+    let status_kv = shard
+        .db()
+        .get_key_value(&status_key)
+        .await
+        .expect("get status row")
+        .expect("status row exists");
+    let mut status = decode_job_status_owned(&status_kv.value).expect("decode status");
+    status.enqueue_time_ms = None;
+    let index_key = idx_status_time_key(
+        tenant,
+        status.kind.as_str(),
+        status_index_timestamp(&status),
+        job_id,
+    );
+    let index_kv = shard
+        .db()
+        .get_key_value(&index_key)
+        .await
+        .expect("get index row")
+        .expect("index row exists");
+
+    let mut batch = slatedb::WriteBatch::new();
+    put_preserving_expiry(
+        &mut batch,
+        &status_key,
+        &encode_job_status(&status),
+        status_kv.expire_ts,
+    );
+    put_preserving_expiry(&mut batch, &index_key, &[], index_kv.expire_ts);
+    shard.db().write(batch).await.expect("write stripped rows");
+}

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -867,22 +867,3 @@ pub async fn open_shard_at_path(
         .await
         .expect("open shard")
 }
-
-/// Open a temp shard with the enqueue-time backfill sweep enabled and fast
-/// pauses, for tests that seed rows through a different handle first.
-pub async fn open_temp_shard_with_enqueue_time_backfill(
-    batch_size: usize,
-) -> (
-    tempfile::TempDir,
-    Arc<JobStoreShard>,
-    silo::metrics::Metrics,
-) {
-    let tmp = tempfile::tempdir().unwrap();
-    let metrics = silo::metrics::init().expect("init metrics");
-    let path = tmp.path().to_string_lossy().to_string();
-    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |cfg| {
-        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(batch_size);
-    })
-    .await;
-    (tmp, shard, metrics)
-}

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -209,6 +209,7 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            enqueue_time_backfill: silo::settings::EnqueueTimeBackfillConfig::default(),
         },
         ShardRange::full(),
     )
@@ -255,6 +256,7 @@ pub async fn open_temp_shard_with_grant_scanner_config(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            enqueue_time_backfill: silo::settings::EnqueueTimeBackfillConfig::default(),
         },
         ShardRange::full(),
     )
@@ -755,4 +757,132 @@ pub async fn strip_enqueue_time_from_job_rows(shard: &JobStoreShard, tenant: &st
     );
     put_preserving_expiry(&mut batch, &index_key, &[], index_kv.expire_ts);
     shard.db().write(batch).await.expect("write stripped rows");
+}
+
+/// Read the status/time index entry value for the job's current status
+/// through the db handle and decode it with the public codec.
+pub async fn index_entry_enqueue_time(
+    shard: &JobStoreShard,
+    tenant: &str,
+    job_id: &str,
+) -> Option<i64> {
+    use silo::keys::{decode_status_index_value, idx_status_time_key, status_index_timestamp};
+
+    let status = shard
+        .get_job_status(tenant, job_id)
+        .await
+        .expect("get status")
+        .expect("status exists");
+    let key = idx_status_time_key(
+        tenant,
+        status.kind.as_str(),
+        status_index_timestamp(&status),
+        job_id,
+    );
+    let value = shard
+        .db()
+        .get(&key)
+        .await
+        .expect("get index entry")
+        .expect("index entry exists");
+    decode_status_index_value(&value)
+}
+
+/// Assert the status record and the index entry both carry exactly the
+/// `enqueue_time_ms` stored in `JOB_INFO`.
+pub async fn assert_rows_carry_job_info_enqueue_time(
+    shard: &JobStoreShard,
+    tenant: &str,
+    job_id: &str,
+    context: &str,
+) {
+    let expected = shard
+        .get_job(tenant, job_id)
+        .await
+        .expect("get job")
+        .expect("job exists")
+        .enqueue_time_ms();
+    let status = shard
+        .get_job_status(tenant, job_id)
+        .await
+        .expect("get status")
+        .expect("status exists");
+    assert_eq!(
+        status.enqueue_time_ms,
+        Some(expected),
+        "{context}: status record enqueue_time_ms"
+    );
+    assert_eq!(
+        index_entry_enqueue_time(shard, tenant, job_id).await,
+        Some(expected),
+        "{context}: index entry enqueue_time_ms"
+    );
+}
+
+/// Assert both rows lack the value, as `strip_enqueue_time_from_job_rows`
+/// leaves them.
+pub async fn assert_rows_lack_enqueue_time(shard: &JobStoreShard, tenant: &str, job_id: &str) {
+    let status = shard
+        .get_job_status(tenant, job_id)
+        .await
+        .expect("get status")
+        .expect("status exists");
+    assert_eq!(status.enqueue_time_ms, None, "stripped status record");
+    assert_eq!(
+        index_entry_enqueue_time(shard, tenant, job_id).await,
+        None,
+        "stripped index entry"
+    );
+}
+
+/// Sweep settings for tests: enabled, with the given batch size and a 1 ms
+/// pause between batches.
+pub fn fast_enqueue_time_backfill(batch_size: usize) -> silo::settings::EnqueueTimeBackfillConfig {
+    silo::settings::EnqueueTimeBackfillConfig {
+        enabled: true,
+        batch_size,
+        pause_ms: 1,
+    }
+}
+
+/// Open (or reopen) a shard on the local filesystem at `path`, letting the
+/// caller adjust the database config before the open. Every setting not
+/// touched by `configure` keeps its default, so the enqueue-time backfill
+/// sweep stays off unless the caller enables it.
+pub async fn open_shard_at_path(
+    path: &str,
+    range: ShardRange,
+    metrics: silo::metrics::Metrics,
+    configure: impl FnOnce(&mut DatabaseConfig),
+) -> Arc<JobStoreShard> {
+    let mut cfg = DatabaseConfig {
+        name: "test".to_string(),
+        backend: Backend::Fs,
+        path: path.to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        ..Default::default()
+    };
+    configure(&mut cfg);
+    JobStoreShard::open(&cfg, MockGubernatorClient::new_arc(), Some(metrics), range)
+        .await
+        .expect("open shard")
+}
+
+/// Open a temp shard with the enqueue-time backfill sweep enabled and fast
+/// pauses, for tests that seed rows through a different handle first.
+pub async fn open_temp_shard_with_enqueue_time_backfill(
+    batch_size: usize,
+) -> (
+    tempfile::TempDir,
+    Arc<JobStoreShard>,
+    silo::metrics::Metrics,
+) {
+    let tmp = tempfile::tempdir().unwrap();
+    let metrics = silo::metrics::init().expect("init metrics");
+    let path = tmp.path().to_string_lossy().to_string();
+    let shard = open_shard_at_path(&path, ShardRange::full(), metrics.clone(), |cfg| {
+        cfg.enqueue_time_backfill = fast_enqueue_time_backfill(batch_size);
+    })
+    .await;
+    (tmp, shard, metrics)
 }


### PR DESCRIPTION
## Why

The IDE queues page lists a tenant's jobs newest-first by `enqueue_time_ms`. That column lived only in the `JOB_INFO` record, so any query projecting it forced the jobs scanner onto a per-row `JOB_INFO` decode (the `job_info`/`job_status` merge join for a tenant scan, batched point-lookups for status-filtered scans). On tenants with hundreds of thousands of jobs the listing query exceeds the statement timeout, while the same shape projecting only index-served columns completes comfortably. This PR makes `enqueue_time_ms` an index-served column.

## What changes

The five commits are meant to be read in order; each stands on its own.

1. **Status record and index entry carry the enqueue time.** The `JobStatus` flatbuffer gains a nullable `enqueue_time_ms` (appended, so existing records decode with `None`), and the status/time index entry's value, empty until now, carries the same value as a big-endian i64. One counter-free row writer produces both rows so they cannot drift; the counter-merging wrapper calls it. Transitions copy the value forward from the incoming status, the old status record, or a `JobView` already in scope, and fall back to at most one `JOB_INFO` read, counted on `silo_enqueue_time_repair_reads_total`. The shard gains a backfill-completion flag mirrored by a marker key.
2. **One-shot backfill sweep.** A per-shard background task, behind the new `[database.enqueue_time_backfill]` setting (off by default), walks `JOB_STATUS` in batches, fills the value into rows that lack it inside a conflict-detecting transaction, keeps each row's `expire_ts` exactly, moves no counters, checkpoints progress so a restart resumes, and sets the completion marker when done. A row a concurrent transition rewrites is skipped, because that transition wrote the value itself.
3. **Query engine.** Projection analysis makes one decision: `enqueue_time_ms` is index-served exactly when the status-index fast path is entered with it projected. Tenant-scoped `Status` and `StatusUnion` strategies take the index path regardless of the marker (their alternative already reads `JOB_INFO` per row); a tenant-scoped `FullScan` takes it once the shard's marker is set. Entries whose value is missing are hydrated individually from `JOB_INFO` and counted on `silo_enqueue_time_fallback_hydrations_total`. `EXPLAIN` now names the path taken (`status-counters`, `status-index`, `fullscan-join`, `pairs`), and the describe hook applies the same dispatch as the scan.
4. **Benchmark.** The query benchmark suite gains the editor's listing shape, measured on a clone of the golden shard in three states (marker set, marker cleared, index values stripped). The golden shard metadata carries a format version so a cached dataset from before the schema change is regenerated rather than reused.
5. **Review hardening.** The sweep skips undecodable rows and restarts from unreadable progress instead of wedging, checks cancellation per row, and writes its final progress and marker atomically; tests widen to cover hydration on every index-served shape and a 120k-job tenant.

## Rollout

Old and new nodes stay correct in both directions: an old node writes empty index values and status records without the field, which a new node treats as "unknown" and hydrates; an old node ignores the value and the appended field. Enabling `enqueue_time_backfill` in the deployment configuration is the rollout step for existing shards; nothing in this PR turns it on.

## Reviewing

Docs updated: the querying guide lists which `jobs` columns are index-served, and the server-configuration reference documents the sweep settings. The 120k-job test is `#[ignore]` because its import takes minutes; run it with `cargo test --test query_index_enqueue_time_tests -- --ignored`.