### PR TITLE
Serve the queues page listing from a per-tenant enqueue-time index

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -18,7 +18,7 @@ Tenants are assigned to shards via range-based partitioning (`src/shard_range.rs
 
 ## Storage
 
-Each shard is backed by a SlateDB instance (an LSM on object storage). Keys are binary-encoded using `storekey` for lexicographic ordering (`src/keys.rs`). Key prefixes: `0x01` job info, `0x02` job status, `0x03` status/time index, `0x04` metadata index, `0x05` tasks (execution queue), `0x06` leases, `0x07` attempts, `0x08`/`0x09` concurrency requests/holders, `0x0A` cancelled, `0x0B` floating limits, `0xF0+` counters/cleanup.
+Each shard is backed by a SlateDB instance (an LSM on object storage). Keys are binary-encoded using `storekey` for lexicographic ordering (`src/keys.rs`). Key prefixes: `0x01` job info, `0x02` job status, `0x03` status/time index, `0x04` metadata index, `0x05` tasks (execution queue), `0x06` leases, `0x07` attempts, `0x08`/`0x09` concurrency requests/holders, `0x0A` cancelled, `0x0B` floating limits, `0x0C` enqueue-time index, `0xF0+` counters/cleanup/backfill markers.
 
 ## Shard Lifecycle
 

--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -617,6 +617,7 @@ pub async fn clone_golden_shard(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            enqueue_time_index_backfill: Default::default(),
             grant_scanner: silo::concurrency::GrantScannerConfig::default(),
             concurrency_reconcile_scan_slice:
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,

--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -559,6 +559,16 @@ pub async fn clone_golden_shard(
     clone_name: &str,
     metadata: &GoldenShardMetadata,
 ) -> (CloneGuard, Arc<JobStoreShard>) {
+    clone_golden_shard_with_metrics(clone_name, metadata, None).await
+}
+
+/// Clone the golden shard and open it with an optional metrics registry, for
+/// benchmarks that read the query counters (scanned keys, point lookups).
+pub async fn clone_golden_shard_with_metrics(
+    clone_name: &str,
+    metadata: &GoldenShardMetadata,
+    metrics: Option<silo::metrics::Metrics>,
+) -> (CloneGuard, Arc<JobStoreShard>) {
     let root = Path::new(GOLDEN_DATA_DIR)
         .parent()
         .expect("golden data dir must have a parent");
@@ -608,7 +618,7 @@ pub async fn clone_golden_shard(
             }),
             memory_cache: None,
             rate_limiter: NullGubernatorClient::new(),
-            metrics: None,
+            metrics,
             concurrency_reconcile_interval: Duration::from_millis(
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_INTERVAL_MS,
             ),

--- a/benches/grant_latency.rs
+++ b/benches/grant_latency.rs
@@ -271,6 +271,7 @@ async fn open_shard(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            enqueue_time_index_backfill: Default::default(),
             grant_scanner: silo::concurrency::GrantScannerConfig::default(),
             concurrency_reconcile_scan_slice:
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,

--- a/benches/query_performance.rs
+++ b/benches/query_performance.rs
@@ -48,6 +48,10 @@ async fn main() {
     let shard = open_golden_shard_readonly(&metadata).await;
 
     let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("query engine");
+    assert!(
+        !shard.enqueue_time_index_complete(),
+        "the read-only open must not have backfilled the cached golden shard"
+    );
 
     // Sanity check: total count
     let df = engine
@@ -261,7 +265,135 @@ async fn main() {
     println!();
 
     shard.close().await.expect("close shard");
+
+    run_listing_benchmarks(&metadata, large_tenant).await;
+    println!();
+
     println!("Done.");
+}
+
+/// The editor's listing page as it should be written for the enqueue-time
+/// index: newest first, `id ASC` tiebreak, one page of 101 rows.
+fn ordered_listing_query(tenant: &str, offset: usize) -> String {
+    format!(
+        "SELECT id FROM jobs WHERE tenant = '{tenant}' ORDER BY enqueue_time_ms DESC, id ASC LIMIT 101 OFFSET {offset}"
+    )
+}
+
+/// The editor's listing shape as Gadget sends it today: a bounded sample of
+/// one tenant ordered newest-first with an `id DESC` tiebreak, which keeps a
+/// sort over the sample even on the index path.
+fn gadget_listing_query(tenant: &str) -> String {
+    format!(
+        "SELECT id FROM (SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '{tenant}' LIMIT 50000) ORDER BY enqueue_time_ms DESC, id DESC LIMIT 101"
+    )
+}
+
+/// Run `bench_query` and also report the index keys one execution scans, read
+/// from the clone's scanned-keys counter.
+async fn bench_query_with_keys(
+    engine: &ShardQueryEngine,
+    metrics: &silo::metrics::Metrics,
+    shard_name: &str,
+    label: &str,
+    query: &str,
+) {
+    let before = metrics.query_scanned_keys_value(shard_name);
+    let df = engine.sql(query).await.expect("sql");
+    let batches = df.collect().await.expect("collect");
+    let scanned = metrics.query_scanned_keys_value(shard_name) - before;
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    let r = bench_query(engine, label, query).await;
+    r.print();
+    println!("  {:<30} rows={} scanned_keys={}", "", rows, scanned);
+}
+
+/// Measure the listing shapes on a clone of the golden shard opened with
+/// metrics: after the backfill sweep runs to completion on the clone (the
+/// index path), with the completion marker cleared (the job-record path, the
+/// `main` baseline), and the Gadget subquery shape with its `id DESC` tiebreak
+/// on the index path. Also reports the sweep's own cost on the clone.
+async fn run_listing_benchmarks(metadata: &GoldenShardMetadata, tenant: &str) {
+    let metrics = silo::metrics::init().expect("init metrics");
+    let (_guard, shard) =
+        clone_golden_shard_with_metrics("listing", metadata, Some(metrics.clone())).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("query engine");
+    let shard_name = shard.name().to_string();
+
+    println!("--- Editor Listing Query ({}) ---", tenant);
+    assert!(
+        !shard.enqueue_time_index_complete(),
+        "the cached golden shard predates the index; its clone must start incomplete"
+    );
+    let sweep_started = Instant::now();
+    let sweep = shard
+        .backfill_enqueue_time_index(256, std::time::Duration::ZERO)
+        .await
+        .expect("backfill sweep");
+    println!(
+        "  backfill sweep: {} rows scanned, {} entries written in {}",
+        sweep.rows_scanned,
+        sweep.rows_written,
+        format_duration(sweep_started.elapsed())
+    );
+    assert!(sweep.complete, "sweep must complete on the clone");
+    // Read the new entries from SSTs like the rest of the shard rather than
+    // from the memtable the sweep just filled.
+    shard
+        .db()
+        .flush_with_options(slatedb::config::FlushOptions {
+            flush_type: slatedb::config::FlushType::MemTable,
+        })
+        .await
+        .expect("flush index entries");
+
+    let shapes = [
+        ("unfiltered", ordered_listing_query(tenant, 0)),
+        ("offset5000", ordered_listing_query(tenant, 5000)),
+    ];
+    for (name, query) in &shapes {
+        bench_query_with_keys(
+            &engine,
+            &metrics,
+            &shard_name,
+            &format!("listing_{name}_index"),
+            query,
+        )
+        .await;
+    }
+    bench_query_with_keys(
+        &engine,
+        &metrics,
+        &shard_name,
+        "listing_unfiltered_gadget_tiebreak",
+        &gadget_listing_query(tenant),
+    )
+    .await;
+
+    shard
+        .set_enqueue_time_index_complete(false)
+        .await
+        .expect("clear marker");
+    for (name, query) in &shapes {
+        bench_query_with_keys(
+            &engine,
+            &metrics,
+            &shard_name,
+            &format!("listing_{name}_marker_cleared"),
+            query,
+        )
+        .await;
+    }
+    bench_query_with_keys(
+        &engine,
+        &metrics,
+        &shard_name,
+        "listing_unfiltered_gadget_tiebreak_marker_cleared",
+        &gadget_listing_query(tenant),
+    )
+    .await;
+
+    shard.close().await.expect("close listing clone");
 }
 
 async fn run_tenant_queries(engine: &ShardQueryEngine, tenant: &str) {

--- a/benches/query_performance.rs
+++ b/benches/query_performance.rs
@@ -264,6 +264,13 @@ async fn main() {
 
     println!();
 
+    // The read-only open passes the default (disabled) backfill setting, so
+    // no sweep can have run against the cached golden shard; check again
+    // here, after every open-time task has had time to act.
+    assert!(
+        !shard.enqueue_time_index_complete(),
+        "the cached golden shard must not have been backfilled"
+    );
     shard.close().await.expect("close shard");
 
     run_listing_benchmarks(&metadata, large_tenant).await;
@@ -280,8 +287,8 @@ fn ordered_listing_query(tenant: &str, offset: usize) -> String {
     )
 }
 
-/// The editor's listing shape as Gadget sends it today: a bounded sample of
-/// one tenant ordered newest-first with an `id DESC` tiebreak, which keeps a
+/// The editor's listing shape as Gadget sends it: a bounded sample of one
+/// tenant ordered newest-first with an `id DESC` tiebreak, which keeps a
 /// sort over the sample even on the index path.
 fn gadget_listing_query(tenant: &str) -> String {
     format!(
@@ -289,30 +296,49 @@ fn gadget_listing_query(tenant: &str) -> String {
     )
 }
 
+/// The first column of every batch, as strings.
+fn first_column_strings(batches: &[datafusion::arrow::record_batch::RecordBatch]) -> Vec<String> {
+    batches
+        .iter()
+        .flat_map(|b| {
+            let col = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .expect("string column");
+            (0..b.num_rows())
+                .map(|i| col.value(i).to_string())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
 /// Run `bench_query` and also report the index keys one execution scans, read
-/// from the clone's scanned-keys counter.
+/// from the clone's scanned-keys counter. Returns that execution's first
+/// column so callers can check the states return the same rows.
 async fn bench_query_with_keys(
     engine: &ShardQueryEngine,
     metrics: &silo::metrics::Metrics,
     shard_name: &str,
     label: &str,
     query: &str,
-) {
+) -> Vec<String> {
     let before = metrics.query_scanned_keys_value(shard_name);
     let df = engine.sql(query).await.expect("sql");
     let batches = df.collect().await.expect("collect");
     let scanned = metrics.query_scanned_keys_value(shard_name) - before;
-    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    let rows: Vec<String> = first_column_strings(&batches);
     let r = bench_query(engine, label, query).await;
     r.print();
-    println!("  {:<30} rows={} scanned_keys={}", "", rows, scanned);
+    println!("  {:<30} rows={} scanned_keys={}", "", rows.len(), scanned);
+    rows
 }
 
 /// Measure the listing shapes on a clone of the golden shard opened with
 /// metrics: after the backfill sweep runs to completion on the clone (the
-/// index path), with the completion marker cleared (the job-record path, the
-/// `main` baseline), and the Gadget subquery shape with its `id DESC` tiebreak
-/// on the index path. Also reports the sweep's own cost on the clone.
+/// index path) and with the completion marker cleared (the job-record path),
+/// including the Gadget subquery shape with its `id DESC` tiebreak. Also
+/// reports the sweep's own cost on the clone.
 async fn run_listing_benchmarks(metadata: &GoldenShardMetadata, tenant: &str) {
     let metrics = silo::metrics::init().expect("init metrics");
     let (_guard, shard) =
@@ -323,7 +349,7 @@ async fn run_listing_benchmarks(metadata: &GoldenShardMetadata, tenant: &str) {
     println!("--- Editor Listing Query ({}) ---", tenant);
     assert!(
         !shard.enqueue_time_index_complete(),
-        "the cached golden shard predates the index; its clone must start incomplete"
+        "the clone must start without the completion marker"
     );
     let sweep_started = Instant::now();
     let sweep = shard
@@ -336,6 +362,9 @@ async fn run_listing_benchmarks(metadata: &GoldenShardMetadata, tenant: &str) {
         sweep.rows_written,
         format_duration(sweep_started.elapsed())
     );
+    if sweep.rows_written == 0 {
+        println!("  (golden shard already carried the index; sweep cost is enumerate-only)");
+    }
     assert!(sweep.complete, "sweep must complete on the clone");
     // Read the new entries from SSTs like the rest of the shard rather than
     // from the memtable the sweep just filled.
@@ -350,9 +379,11 @@ async fn run_listing_benchmarks(metadata: &GoldenShardMetadata, tenant: &str) {
     let shapes = [
         ("unfiltered", ordered_listing_query(tenant, 0)),
         ("offset5000", ordered_listing_query(tenant, 5000)),
+        ("gadget", gadget_listing_query(tenant)),
     ];
+    let mut index_rows = Vec::with_capacity(shapes.len());
     for (name, query) in &shapes {
-        bench_query_with_keys(
+        let rows = bench_query_with_keys(
             &engine,
             &metrics,
             &shard_name,
@@ -360,22 +391,15 @@ async fn run_listing_benchmarks(metadata: &GoldenShardMetadata, tenant: &str) {
             query,
         )
         .await;
+        index_rows.push(rows);
     }
-    bench_query_with_keys(
-        &engine,
-        &metrics,
-        &shard_name,
-        "listing_unfiltered_gadget_tiebreak",
-        &gadget_listing_query(tenant),
-    )
-    .await;
 
     shard
         .set_enqueue_time_index_complete(false)
         .await
         .expect("clear marker");
-    for (name, query) in &shapes {
-        bench_query_with_keys(
+    for ((name, query), expected) in shapes.iter().zip(&index_rows) {
+        let rows = bench_query_with_keys(
             &engine,
             &metrics,
             &shard_name,
@@ -383,15 +407,31 @@ async fn run_listing_benchmarks(metadata: &GoldenShardMetadata, tenant: &str) {
             query,
         )
         .await;
+        // The Gadget shape's inner sample is the newest 50k rows on the index
+        // path but the first 50k in key order on the job-record path, so its
+        // truth is the unbounded newest-first query rather than the same SQL.
+        if *name == "gadget" {
+            let truth = engine
+                .sql(&format!(
+                    "SELECT id FROM jobs WHERE tenant = '{tenant}' ORDER BY enqueue_time_ms DESC, id DESC LIMIT 101"
+                ))
+                .await
+                .expect("sql")
+                .collect()
+                .await
+                .expect("collect");
+            let truth: Vec<String> = first_column_strings(&truth);
+            assert_eq!(
+                expected, &truth,
+                "listing_gadget: the index path must return the true newest rows"
+            );
+        } else {
+            assert_eq!(
+                &rows, expected,
+                "listing_{name}: the index path and the job-record path must return the same rows"
+            );
+        }
     }
-    bench_query_with_keys(
-        &engine,
-        &metrics,
-        &shard_name,
-        "listing_unfiltered_gadget_tiebreak_marker_cleared",
-        &gadget_listing_query(tenant),
-    )
-    .await;
 
     shard.close().await.expect("close listing clone");
 }

--- a/docs/src/content/docs/guides/internals.mdx
+++ b/docs/src/content/docs/guides/internals.mdx
@@ -45,7 +45,8 @@ Silo uses the [storekey](https://crates.io/crates/storekey) crate for binary key
 | 0x09 | Concurrency holder | Tasks holding concurrency slots: `(tenant, queue, task_id)` |
 | 0x0A | Job cancelled | Cancellation flags: `(tenant, job_id)` |
 | 0x0B | Floating limit | Dynamic concurrency limit state: `(tenant, queue_key)` |
-| 0xF0-0xFF | System | Internal counters, cleanup state, and metadata. Includes per-shard total/completed job counters (`0xF0`, `0xF1`), cleanup progress (`0xF2`-`0xF6`), per-queue concurrency requester counters (`0xF7`), and per-tenant status counters (`0xF8`) maintained via merge operator on every status transition. |
+| 0x0C | Enqueue-time index | Secondary index for a tenant's jobs newest-first: `(tenant, inverted_enqueue_time_ms, job_id)` |
+| 0xF0-0xFF | System | Internal counters, cleanup state, and metadata. Includes per-shard total/completed job counters (`0xF0`, `0xF1`), cleanup progress (`0xF2`-`0xF6`), per-queue concurrency requester counters (`0xF7`), per-tenant status counters (`0xF8`) maintained via merge operator on every status transition, and the enqueue-time index backfill's progress checkpoint and completion marker (`0xFB`, `0xFC`). |
 
 ## Clustering approach
 

--- a/docs/src/content/docs/guides/querying.mdx
+++ b/docs/src/content/docs/guides/querying.mdx
@@ -101,6 +101,8 @@ The primary table containing all job data.
 | `next_attempt_starts_after_ms` | Int64 (nullable) | Unix timestamp in milliseconds when the next attempt is scheduled to start. Present for `Waiting`/`Scheduled` jobs, null otherwise |
 | `metadata` | Map&lt;String, String&gt; (nullable) | Key-value metadata attached to the job |
 
+Each tenant's jobs are also indexed by `enqueue_time_ms`, newest first. A tenant-scoped query that projects only `shard_id`, `tenant`, `id`, and `enqueue_time_ms` is served from that index once the shard's index backfill has completed (the `enqueue_time_index_backfill` database setting enables the backfill), and its rows arrive in `enqueue_time_ms DESC, id ASC` order. Silo declares that ordering to the query planner, so an `ORDER BY enqueue_time_ms DESC, id ASC` on such a query runs without a sort and a `LIMIT` (with or without `OFFSET`) reads only the keys it returns. See [Listing Jobs](#listing-jobs) and [Scan strategy priority](#scan-strategy-priority).
+
 ### `tasks` Table
 
 Exposes the internal task execution queue for **debugging purposes**. Tasks are the ephemeral work items that drive job execution — they are created when jobs are enqueued and deleted when workers lease them.
@@ -185,8 +187,28 @@ Use `current_attempt` to distinguish between freshly enqueued jobs (`current_att
 
 ### Listing Jobs
 
+The newest-first listing is cheapest when it projects only columns the enqueue-time index carries. This shape reads exactly `LIMIT` index keys on a shard whose index backfill has completed, with no sort and no job-record reads; fetch the other columns for the page afterwards by id:
+
 ```sql
--- All jobs for a tenant
+-- Newest 50 jobs for a tenant, served from the enqueue-time index
+SELECT id, enqueue_time_ms
+FROM jobs
+WHERE tenant = 'customer-123'
+ORDER BY enqueue_time_ms DESC, id ASC
+LIMIT 50
+
+-- The next page: reads 100 index keys, returns the last 50
+SELECT id, enqueue_time_ms
+FROM jobs
+WHERE tenant = 'customer-123'
+ORDER BY enqueue_time_ms DESC, id ASC
+LIMIT 50 OFFSET 50
+```
+
+The tiebreak must be `id ASC` and the projection must stay within `shard_id`, `tenant`, `id`, and `enqueue_time_ms`. Projecting any other column (or filtering by anything but `tenant`) moves the query to a path that reads status or job records, and the `ORDER BY` becomes a sort over every row scanned:
+
+```sql
+-- Reads each job's record to project status and task group, then sorts
 SELECT id, status_kind, priority, task_group
 FROM jobs
 WHERE tenant = 'customer-123'
@@ -394,6 +416,8 @@ Silo picks the best scan strategy from your filters in this priority order:
 5. **Full scan** — no indexed filter — scans all jobs for the tenant
 
 Only one index-backed filter is used per query. If you combine filters (e.g., status + metadata), the highest-priority one drives the scan and the rest are applied as post-filters.
+
+A full scan is not always a walk over job records. When the query has a `tenant` filter, no other indexed filter, and a projection limited to `shard_id`, `tenant`, `id`, and `enqueue_time_ms`, Silo walks the tenant's enqueue-time index instead, newest first, on any shard whose index backfill has completed. `EXPLAIN` names the path on the `SiloExecutionPlan` line (`path=EnqueueTimeIndex`); the same shape on a shard still being backfilled shows `path=StatusIndex` or `path=FullScanJoin` and returns the same rows.
 
 ```sql
 -- Uses ExactId scan (priority 1), even though status filter is also present

--- a/docs/src/content/docs/guides/querying.mdx
+++ b/docs/src/content/docs/guides/querying.mdx
@@ -101,7 +101,7 @@ The primary table containing all job data.
 | `next_attempt_starts_after_ms` | Int64 (nullable) | Unix timestamp in milliseconds when the next attempt is scheduled to start. Present for `Waiting`/`Scheduled` jobs, null otherwise |
 | `metadata` | Map&lt;String, String&gt; (nullable) | Key-value metadata attached to the job |
 
-Each tenant's jobs are also indexed by `enqueue_time_ms`, newest first. A tenant-scoped query that projects only `shard_id`, `tenant`, `id`, and `enqueue_time_ms` is served from that index once the shard's index backfill has completed (the `enqueue_time_index_backfill` database setting enables the backfill), and its rows arrive in `enqueue_time_ms DESC, id ASC` order. Silo declares that ordering to the query planner, so an `ORDER BY enqueue_time_ms DESC, id ASC` on such a query runs without a sort and a `LIMIT` (with or without `OFFSET`) reads only the keys it returns. See [Listing Jobs](#listing-jobs) and [Scan strategy priority](#scan-strategy-priority).
+Each tenant's jobs are also indexed by `enqueue_time_ms`, newest first. A tenant-scoped query that projects only `shard_id`, `tenant`, `id`, and `enqueue_time_ms` is served from that index once the shard's index backfill has completed (`enqueue_time_index_backfill.enabled = true` in the database config starts the backfill), and its rows arrive in `enqueue_time_ms DESC, id ASC` order. Silo declares that ordering to the query planner, so an `ORDER BY enqueue_time_ms DESC, id ASC` on such a query runs without a sort, and a `LIMIT` reads only `OFFSET + LIMIT` index keys rather than the whole tenant. See [Listing Jobs](#listing-jobs) and [Scan strategy priority](#scan-strategy-priority).
 
 ### `tasks` Table
 
@@ -205,7 +205,7 @@ ORDER BY enqueue_time_ms DESC, id ASC
 LIMIT 50 OFFSET 50
 ```
 
-The tiebreak must be `id ASC` and the projection must stay within `shard_id`, `tenant`, `id`, and `enqueue_time_ms`. Projecting any other column (or filtering by anything but `tenant`) moves the query to a path that reads status or job records, and the `ORDER BY` becomes a sort over every row scanned:
+The tiebreak must be `id ASC` and the projection must stay within `shard_id`, `tenant`, `id`, and `enqueue_time_ms`. Projecting or filtering on any column outside those four, or adding an indexed filter (`id`, `status_kind`, metadata), moves the query to a path that reads status or job records, and the `ORDER BY` becomes a sort over every row scanned:
 
 ```sql
 -- Reads each job's record to project status and task group, then sorts

--- a/src/cluster_query.rs
+++ b/src/cluster_query.rs
@@ -497,8 +497,10 @@ impl ExecutionPlan for ClusterExecutionPlan {
                         TableKind::Tasks => Arc::new(TasksScanner::new(Arc::clone(&shard))),
                     };
 
-                    // Execute the scan - scanner handles projection via schema
-                    let mut stream = scanner.scan(schema, &filters, batch_size, limit);
+                    // Resolve the path once, then execute it - scanner handles
+                    // projection via schema
+                    let decision = scanner.resolve(&schema, &filters, limit);
+                    let mut stream = scanner.scan(&decision, schema, &filters, batch_size, limit);
 
                     while let Some(result) = stream.next().await {
                         match result {

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -304,7 +304,7 @@ impl ShardFactory {
                         completed_job_expire_s: template.completed_job_expire_s,
                         terminal_job_expire_s: template.terminal_job_expire_s,
                         count_from_status_counters: template.count_from_status_counters,
-                        enqueue_time_index_backfill: Default::default(),
+                        enqueue_time_index_backfill: template.enqueue_time_index_backfill.clone(),
                     },
                     range.clone(),
                 )
@@ -1128,6 +1128,8 @@ impl ShardFactory {
                 completed_job_expire_s: self.template.completed_job_expire_s,
                 terminal_job_expire_s: self.template.terminal_job_expire_s,
                 count_from_status_counters: self.template.count_from_status_counters,
+                // A pre-commit open of a closed shard runs no background
+                // sweeps, like `counter_reconciliation_seconds` above.
                 enqueue_time_index_backfill: Default::default(),
             },
             ShardRange::full(),

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -304,6 +304,7 @@ impl ShardFactory {
                         completed_job_expire_s: template.completed_job_expire_s,
                         terminal_job_expire_s: template.terminal_job_expire_s,
                         count_from_status_counters: template.count_from_status_counters,
+                        enqueue_time_index_backfill: Default::default(),
                     },
                     range.clone(),
                 )
@@ -1127,6 +1128,7 @@ impl ShardFactory {
                 completed_job_expire_s: self.template.completed_job_expire_s,
                 terminal_job_expire_s: self.template.terminal_job_expire_s,
                 count_from_status_counters: self.template.count_from_status_counters,
+                enqueue_time_index_backfill: Default::default(),
             },
             ShardRange::full(),
         )

--- a/src/instrumented_db.rs
+++ b/src/instrumented_db.rs
@@ -190,6 +190,18 @@ impl InstrumentedDbTransaction {
         self.inner.get(key).instrument(self.span.clone()).await
     }
 
+    /// Read a row with its metadata (notably `expire_ts`), tracking the key
+    /// in the transaction's read set like `get`.
+    pub async fn get_key_value<K: AsRef<[u8]> + Send>(
+        &self,
+        key: K,
+    ) -> Result<Option<KeyValue>, slatedb::Error> {
+        self.inner
+            .get_key_value(key)
+            .instrument(self.span.clone())
+            .await
+    }
+
     pub async fn scan<K, T>(&self, range: T) -> Result<InstrumentedDbIterator, slatedb::Error>
     where
         K: AsRef<[u8]> + Send,

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -11,9 +11,9 @@ use crate::job_store_shard::helpers::{DbWriteBatcher, decode_job_status_owned};
 use crate::keys::{
     self, end_bound, parse_attempt_key, parse_concurrency_holder_key,
     parse_concurrency_request_key, parse_concurrency_requester_counter_key,
-    parse_floating_limit_key, parse_job_cancelled_key, parse_job_info_key, parse_job_status_key,
-    parse_metadata_index_key, parse_status_time_index_key, parse_tenant_status_counter_key,
-    tasks_prefix,
+    parse_enqueue_time_index_key, parse_floating_limit_key, parse_job_cancelled_key,
+    parse_job_info_key, parse_job_status_key, parse_metadata_index_key,
+    parse_status_time_index_key, parse_tenant_status_counter_key, tasks_prefix,
 };
 use crate::shard_range::ShardRange;
 use slatedb::WriteBatch;
@@ -167,6 +167,11 @@ impl JobStoreShard {
             (
                 vec![prefix::FLOATING_LIMIT],
                 Box::new(|key, _| parse_floating_limit_key(key).map(|p| p.tenant)),
+            ),
+            // Enqueue-time index keys (0x0C)
+            (
+                vec![prefix::IDX_ENQUEUE_TIME],
+                Box::new(|key, _| parse_enqueue_time_index_key(key).map(|p| p.tenant)),
             ),
             // Concurrency requester counter keys (0xF7)
             (

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -20,8 +20,8 @@ use crate::job_store_shard::helpers::{
     retry_on_txn_conflict,
 };
 use crate::keys::{
-    idx_metadata_key, idx_status_time_key, job_info_key, job_status_key, status_index_timestamp,
-    tenant_status_counter_key,
+    idx_enqueue_time_key, idx_metadata_key, idx_status_time_key, job_info_key, job_status_key,
+    status_index_timestamp, tenant_status_counter_key,
 };
 use crate::retry::RetryPolicy;
 use crate::task::{GubernatorRateLimitData, Task};
@@ -436,6 +436,7 @@ impl JobStoreShard {
         let job_status_kind = job_status.kind;
 
         writer.put(job_info_key(tenant, job_id), &job_value)?;
+        writer.put(idx_enqueue_time_key(tenant, start_at_ms, job_id), [])?;
 
         // Maintain metadata secondary index
         for (mk, mv) in &job.metadata {

--- a/src/job_store_shard/enqueue_time_index_backfill.rs
+++ b/src/job_store_shard/enqueue_time_index_backfill.rs
@@ -1,0 +1,369 @@
+//! One-shot backfill of the enqueue-time index (`IDX_ENQUEUE_TIME`) for jobs
+//! created before the index existed.
+//!
+//! The sweep walks `JOB_INFO` inside the shard's tenant range in small
+//! batches. Enumeration runs outside any transaction (a transactional scan
+//! would register the whole range in the read set and abort on every busy
+//! tenant); each batch's writes then run in a serializable-snapshot
+//! transaction that re-reads `JOB_INFO` and the entry per row, so a delete or
+//! terminal transition that lands mid-batch wins. A conflicting batch is
+//! retried and then split into per-row transactions, so a row that still has
+//! `JOB_INFO` is never skipped: transitions do not write the entry, and a
+//! skipped live job would be missing from the index for good.
+//!
+//! Progress is checkpointed after every batch and the sweep resumes from that
+//! key after a restart. A completion marker, mirrored by an in-memory flag,
+//! records that the sweep never needs to run again and gates the query
+//! engine's index-served listing path.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use slatedb::IsolationLevel;
+use tracing::{debug, error, info, warn};
+
+use crate::job::JobView;
+use crate::job_store_shard::helpers::{
+    is_txn_conflict, put_with_optional_expire, retry_on_txn_conflict,
+};
+use crate::job_store_shard::{JobStoreShard, JobStoreShardError, shard_name_jitter_ms};
+use crate::keys::{
+    end_bound, enqueue_time_index_backfill_complete_key, enqueue_time_index_backfill_progress_key,
+    idx_enqueue_time_key, jobs_prefix, parse_job_info_key,
+};
+
+/// Upper bound on the deterministic delay before a shard's background sweep
+/// starts, so shards opening together do not scan in lockstep.
+const START_JITTER_MS: u64 = 1_000;
+
+/// Progress checkpoint persisted after every batch.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
+struct BackfillProgress {
+    /// Last `JOB_INFO` key processed, hex-encoded; the next batch starts
+    /// just after it.
+    last_key: Option<String>,
+    rows_scanned: u64,
+    rows_written: u64,
+}
+
+/// Outcome of a run of the sweep.
+#[derive(Debug, Clone)]
+pub struct EnqueueTimeIndexBackfillResult {
+    /// `JOB_INFO` rows inside the shard's range the sweep examined.
+    pub rows_scanned: u64,
+    /// Index entries the sweep wrote.
+    pub rows_written: u64,
+    /// Whether the completion marker is set.
+    pub complete: bool,
+    /// Whether the run stopped early because the shard is closing.
+    pub cancelled: bool,
+}
+
+/// A `JOB_INFO` row the enumerating scan found inside the shard's range.
+struct Candidate {
+    key: Vec<u8>,
+    tenant: String,
+    job_id: String,
+}
+
+impl JobStoreShard {
+    /// Whether this shard's enqueue-time index covers every job, so the
+    /// query engine may serve listings from it.
+    pub fn enqueue_time_index_complete(&self) -> bool {
+        self.enqueue_time_index_complete.load(Ordering::Acquire)
+    }
+
+    /// Set or clear the completion marker directly, bypassing the sweep.
+    pub async fn set_enqueue_time_index_complete(
+        &self,
+        complete: bool,
+    ) -> Result<(), JobStoreShardError> {
+        let key = enqueue_time_index_backfill_complete_key();
+        if complete {
+            self.db.put(&key, []).await?;
+        } else {
+            self.db.delete(&key).await?;
+        }
+        self.enqueue_time_index_complete
+            .store(complete, Ordering::Release);
+        Ok(())
+    }
+
+    /// Load the persisted completion marker into the in-memory flag.
+    pub(crate) async fn load_enqueue_time_index_complete(&self) -> Result<(), JobStoreShardError> {
+        let complete = self
+            .db
+            .get(&enqueue_time_index_backfill_complete_key())
+            .await?
+            .is_some();
+        self.enqueue_time_index_complete
+            .store(complete, Ordering::Release);
+        Ok(())
+    }
+
+    /// Run the sweep to completion (or until the shard starts closing),
+    /// resuming from the persisted checkpoint. Returns immediately when the
+    /// completion marker is already set.
+    pub async fn backfill_enqueue_time_index(
+        &self,
+        batch_size: usize,
+        pause: Duration,
+    ) -> Result<EnqueueTimeIndexBackfillResult, JobStoreShardError> {
+        let batch_size = batch_size.max(1);
+        let mut progress = self.load_backfill_progress().await?;
+        if self.enqueue_time_index_complete() {
+            return Ok(Self::backfill_result(&progress, true, false));
+        }
+
+        info!(
+            shard = %self.name,
+            resuming_from = ?progress.last_key,
+            "starting enqueue-time index backfill"
+        );
+
+        loop {
+            if self.cancellation.is_cancelled() {
+                info!(
+                    shard = %self.name,
+                    rows_scanned = progress.rows_scanned,
+                    rows_written = progress.rows_written,
+                    "enqueue-time index backfill cancelled (shard closing)"
+                );
+                return Ok(Self::backfill_result(&progress, false, true));
+            }
+
+            let candidates = self
+                .enumerate_backfill_candidates(&progress, batch_size)
+                .await?;
+            let Some(last) = candidates.last() else {
+                break;
+            };
+            let last_key = hex::encode(&last.key);
+            let written = self.write_backfill_batch(&candidates).await?;
+
+            progress.rows_scanned += candidates.len() as u64;
+            progress.rows_written += written;
+            progress.last_key = Some(last_key);
+            self.save_backfill_progress(&progress).await?;
+            debug!(
+                shard = %self.name,
+                rows_scanned = progress.rows_scanned,
+                rows_written = progress.rows_written,
+                "enqueue-time index backfill checkpoint"
+            );
+
+            // A short batch means the scan reached the end of the range.
+            if candidates.len() < batch_size {
+                break;
+            }
+            if !pause.is_zero() {
+                tokio::select! {
+                    biased;
+                    _ = self.cancellation.cancelled() => {}
+                    _ = tokio::time::sleep(pause) => {}
+                }
+            }
+        }
+
+        self.set_enqueue_time_index_complete(true).await?;
+        self.db
+            .delete(&enqueue_time_index_backfill_progress_key())
+            .await?;
+        info!(
+            shard = %self.name,
+            rows_scanned = progress.rows_scanned,
+            rows_written = progress.rows_written,
+            "enqueue-time index backfill complete"
+        );
+        Ok(Self::backfill_result(&progress, true, false))
+    }
+
+    /// Spawn the background sweep at shard open when it is enabled and has
+    /// not completed. Starts after a shard-deterministic delay.
+    pub(crate) fn spawn_enqueue_time_index_backfill(self: &Arc<Self>) {
+        let cfg = self.enqueue_time_index_backfill.clone();
+        if !cfg.enabled || self.enqueue_time_index_complete() {
+            return;
+        }
+        let shard = Arc::clone(self);
+        let cancellation = self.cancellation.clone();
+        let shard_name = self.name.clone();
+
+        let task = tokio::spawn(async move {
+            let jitter_ms = shard_name_jitter_ms(&shard_name, START_JITTER_MS);
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => return,
+                _ = tokio::time::sleep(Duration::from_millis(jitter_ms)) => {}
+            }
+
+            match shard
+                .backfill_enqueue_time_index(cfg.batch_size, Duration::from_millis(cfg.pause_ms))
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => error!(
+                    shard = %shard_name,
+                    error = %e,
+                    "enqueue-time index backfill failed; it resumes from its checkpoint on the next open"
+                ),
+            }
+        });
+        *self
+            .enqueue_time_index_backfill_task
+            .lock()
+            .expect("backfill task lock") = Some(task);
+    }
+
+    fn backfill_result(
+        progress: &BackfillProgress,
+        complete: bool,
+        cancelled: bool,
+    ) -> EnqueueTimeIndexBackfillResult {
+        EnqueueTimeIndexBackfillResult {
+            rows_scanned: progress.rows_scanned,
+            rows_written: progress.rows_written,
+            complete,
+            cancelled,
+        }
+    }
+
+    /// Pull up to `batch_size` in-range `JOB_INFO` rows after the checkpoint,
+    /// outside any transaction.
+    async fn enumerate_backfill_candidates(
+        &self,
+        progress: &BackfillProgress,
+        batch_size: usize,
+    ) -> Result<Vec<Candidate>, JobStoreShardError> {
+        let start = match &progress.last_key {
+            Some(last) => {
+                let mut key = hex::decode(last).map_err(|e| {
+                    JobStoreShardError::Codec(format!(
+                        "enqueue-time index backfill checkpoint: {e}"
+                    ))
+                })?;
+                // The smallest key strictly greater than the checkpoint.
+                key.push(0x00);
+                key
+            }
+            None => jobs_prefix(),
+        };
+        let end = end_bound(&jobs_prefix());
+
+        let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let mut candidates = Vec::with_capacity(batch_size);
+        while candidates.len() < batch_size {
+            let Some(kv) = iter.next().await? else {
+                break;
+            };
+            let Some(parsed) = parse_job_info_key(&kv.key) else {
+                warn!(
+                    shard = %self.name,
+                    key = %hex::encode(&kv.key),
+                    "enqueue-time index backfill: unparseable JOB_INFO key"
+                );
+                continue;
+            };
+            if !self.range.contains_tenant(&parsed.tenant) {
+                continue;
+            }
+            candidates.push(Candidate {
+                key: kv.key.to_vec(),
+                tenant: parsed.tenant,
+                job_id: parsed.job_id,
+            });
+        }
+        Ok(candidates)
+    }
+
+    /// Write the batch's missing entries: the whole batch in one transaction,
+    /// retried once on conflict, then one transaction per row with backoff.
+    async fn write_backfill_batch(
+        &self,
+        candidates: &[Candidate],
+    ) -> Result<u64, JobStoreShardError> {
+        for _ in 0..2 {
+            match self.write_backfill_txn(candidates).await {
+                Err(e) if is_txn_conflict(&e) => debug!(
+                    shard = %self.name,
+                    rows = candidates.len(),
+                    "enqueue-time index backfill batch conflicted, retrying"
+                ),
+                result => return result,
+            }
+        }
+
+        let mut written = 0;
+        for candidate in candidates {
+            written += retry_on_txn_conflict("enqueue_time_index_backfill_row", || {
+                self.write_backfill_txn(std::slice::from_ref(candidate))
+            })
+            .await?;
+        }
+        Ok(written)
+    }
+
+    /// One serializable-snapshot transaction over `candidates`: re-read each
+    /// job's `JOB_INFO` (skipping rows deleted since enumeration) and its
+    /// entry (skipping rows already indexed), then write the missing entries
+    /// carrying the job's current `expire_ts`.
+    async fn write_backfill_txn(
+        &self,
+        candidates: &[Candidate],
+    ) -> Result<u64, JobStoreShardError> {
+        let txn = self.db.begin(IsolationLevel::SerializableSnapshot).await?;
+        let mut written = 0;
+        for candidate in candidates {
+            let Some(info) = txn.get_key_value(&candidate.key).await? else {
+                continue;
+            };
+            let view = match JobView::new(info.value) {
+                Ok(view) => view,
+                Err(e) => {
+                    warn!(
+                        shard = %self.name,
+                        tenant = %candidate.tenant,
+                        job_id = %candidate.job_id,
+                        error = %e,
+                        "enqueue-time index backfill: undecodable JOB_INFO, skipping"
+                    );
+                    continue;
+                }
+            };
+            let entry_key =
+                idx_enqueue_time_key(&candidate.tenant, view.enqueue_time_ms(), &candidate.job_id);
+            if txn.get(&entry_key).await?.is_some() {
+                continue;
+            }
+            put_with_optional_expire(&txn, &entry_key, [], info.expire_ts)?;
+            written += 1;
+        }
+        if written > 0 {
+            txn.commit().await?;
+        }
+        Ok(written)
+    }
+
+    async fn load_backfill_progress(&self) -> Result<BackfillProgress, JobStoreShardError> {
+        match self
+            .db
+            .get(&enqueue_time_index_backfill_progress_key())
+            .await?
+        {
+            Some(data) => Ok(serde_json::from_slice(&data)?),
+            None => Ok(BackfillProgress::default()),
+        }
+    }
+
+    async fn save_backfill_progress(
+        &self,
+        progress: &BackfillProgress,
+    ) -> Result<(), JobStoreShardError> {
+        let data = serde_json::to_vec(progress)?;
+        self.db
+            .put(&enqueue_time_index_backfill_progress_key(), &data)
+            .await?;
+        Ok(())
+    }
+}

--- a/src/job_store_shard/enqueue_time_index_backfill.rs
+++ b/src/job_store_shard/enqueue_time_index_backfill.rs
@@ -8,8 +8,9 @@
 //! transaction that re-reads `JOB_INFO` and the entry per row, so a delete or
 //! terminal transition that lands mid-batch wins. A conflicting batch is
 //! retried and then split into per-row transactions, so a row that still has
-//! `JOB_INFO` is never skipped: transitions do not write the entry, and a
-//! skipped live job would be missing from the index for good.
+//! `JOB_INFO` is never skipped: a transition with no retention TTL leaves the
+//! entry untouched, so a skipped live job would be missing from the index for
+//! good.
 //!
 //! Progress is checkpointed after every batch and the sweep resumes from that
 //! key after a restart. A completion marker, mirrored by an in-memory flag,
@@ -37,11 +38,19 @@ use crate::keys::{
 /// starts, so shards opening together do not scan in lockstep.
 const START_JITTER_MS: u64 = 1_000;
 
+/// Longest pause between attempts when the background sweep fails with an
+/// error other than a transaction conflict (an object-store hiccup, say).
+const MAX_RETRY_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Rows a batch may walk, as a multiple of its in-range batch size, before it
+/// checkpoints even when most of them are outside the shard's range.
+const WALK_MULTIPLIER: usize = 4;
+
 /// Progress checkpoint persisted after every batch.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 struct BackfillProgress {
-    /// Last `JOB_INFO` key processed, hex-encoded; the next batch starts
-    /// just after it.
+    /// Last `JOB_INFO` key examined (in or out of range), hex-encoded; the
+    /// next batch starts just after it.
     last_key: Option<String>,
     rows_scanned: u64,
     rows_written: u64,
@@ -65,6 +74,16 @@ struct Candidate {
     key: Vec<u8>,
     tenant: String,
     job_id: String,
+}
+
+/// One batch of the enumerating scan.
+struct BackfillBatch {
+    candidates: Vec<Candidate>,
+    /// The last `JOB_INFO` key the scan examined, in or out of range; the
+    /// next batch starts just after it.
+    last_walked_key: Option<Vec<u8>>,
+    /// Whether the scan reached the end of the `JOB_INFO` range.
+    exhausted: bool,
 }
 
 impl JobStoreShard {
@@ -111,10 +130,14 @@ impl JobStoreShard {
         pause: Duration,
     ) -> Result<EnqueueTimeIndexBackfillResult, JobStoreShardError> {
         let batch_size = batch_size.max(1);
-        let mut progress = self.load_backfill_progress().await?;
         if self.enqueue_time_index_complete() {
-            return Ok(Self::backfill_result(&progress, true, false));
+            return Ok(Self::backfill_result(
+                &BackfillProgress::default(),
+                true,
+                false,
+            ));
         }
+        let mut progress = self.load_backfill_progress().await?;
 
         info!(
             shard = %self.name,
@@ -133,28 +156,31 @@ impl JobStoreShard {
                 return Ok(Self::backfill_result(&progress, false, true));
             }
 
-            let candidates = self
+            let batch = self
                 .enumerate_backfill_candidates(&progress, batch_size)
                 .await?;
-            let Some(last) = candidates.last() else {
-                break;
-            };
-            let last_key = hex::encode(&last.key);
-            let written = self.write_backfill_batch(&candidates).await?;
+            // A batch that walked nothing without exhausting the range was
+            // cut short by cancellation; the loop head reports it next.
+            if let Some(last_walked) = &batch.last_walked_key {
+                let written = if batch.candidates.is_empty() {
+                    0
+                } else {
+                    self.write_backfill_batch(&batch.candidates).await?
+                };
 
-            progress.rows_scanned += candidates.len() as u64;
-            progress.rows_written += written;
-            progress.last_key = Some(last_key);
-            self.save_backfill_progress(&progress).await?;
-            debug!(
-                shard = %self.name,
-                rows_scanned = progress.rows_scanned,
-                rows_written = progress.rows_written,
-                "enqueue-time index backfill checkpoint"
-            );
+                progress.rows_scanned += batch.candidates.len() as u64;
+                progress.rows_written += written;
+                progress.last_key = Some(hex::encode(last_walked));
+                self.save_backfill_progress(&progress).await?;
+                debug!(
+                    shard = %self.name,
+                    rows_scanned = progress.rows_scanned,
+                    rows_written = progress.rows_written,
+                    "enqueue-time index backfill checkpoint"
+                );
+            }
 
-            // A short batch means the scan reached the end of the range.
-            if candidates.len() < batch_size {
+            if batch.exhausted {
                 break;
             }
             if !pause.is_zero() {
@@ -198,22 +224,38 @@ impl JobStoreShard {
                 _ = tokio::time::sleep(Duration::from_millis(jitter_ms)) => {}
             }
 
-            match shard
-                .backfill_enqueue_time_index(cfg.batch_size, Duration::from_millis(cfg.pause_ms))
-                .await
-            {
-                Ok(_) => {}
-                Err(e) => error!(
-                    shard = %shard_name,
-                    error = %e,
-                    "enqueue-time index backfill failed; it resumes from its checkpoint on the next open"
-                ),
+            // The sweep is idempotent and resumes from its checkpoint, so an
+            // error is retried with capped backoff rather than leaving the
+            // shard without an index until its next open.
+            let mut backoff = Duration::from_secs(1);
+            loop {
+                match shard
+                    .backfill_enqueue_time_index(
+                        cfg.batch_size,
+                        Duration::from_millis(cfg.pause_ms),
+                    )
+                    .await
+                {
+                    Ok(_) => return,
+                    Err(e) => error!(
+                        shard = %shard_name,
+                        error = %e,
+                        retry_in_s = backoff.as_secs(),
+                        "enqueue-time index backfill failed; retrying from its checkpoint"
+                    ),
+                }
+                tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => return,
+                    _ = tokio::time::sleep(backoff) => {}
+                }
+                backoff = (backoff * 2).min(MAX_RETRY_BACKOFF);
             }
         });
         *self
             .enqueue_time_index_backfill_task
-            .lock()
-            .expect("backfill task lock") = Some(task);
+            .try_lock()
+            .expect("backfill task slot is uncontended at open") = Some(task);
     }
 
     fn backfill_result(
@@ -230,12 +272,14 @@ impl JobStoreShard {
     }
 
     /// Pull up to `batch_size` in-range `JOB_INFO` rows after the checkpoint,
-    /// outside any transaction.
+    /// outside any transaction. The walk is also bounded by rows examined, so
+    /// a long run of out-of-range rows (a split child before its cleanup)
+    /// still checkpoints, pauses, and observes cancellation per batch.
     async fn enumerate_backfill_candidates(
         &self,
         progress: &BackfillProgress,
         batch_size: usize,
-    ) -> Result<Vec<Candidate>, JobStoreShardError> {
+    ) -> Result<BackfillBatch, JobStoreShardError> {
         let start = match &progress.last_key {
             Some(last) => {
                 let mut key = hex::decode(last).map_err(|e| {
@@ -252,11 +296,23 @@ impl JobStoreShard {
         let end = end_bound(&jobs_prefix());
 
         let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
-        let mut candidates = Vec::with_capacity(batch_size);
-        while candidates.len() < batch_size {
+        let walk_limit = batch_size.saturating_mul(WALK_MULTIPLIER);
+        let mut batch = BackfillBatch {
+            candidates: Vec::with_capacity(batch_size),
+            last_walked_key: None,
+            exhausted: false,
+        };
+        let mut walked = 0usize;
+        while batch.candidates.len() < batch_size
+            && walked < walk_limit
+            && !self.cancellation.is_cancelled()
+        {
             let Some(kv) = iter.next().await? else {
+                batch.exhausted = true;
                 break;
             };
+            walked += 1;
+            batch.last_walked_key = Some(kv.key.to_vec());
             let Some(parsed) = parse_job_info_key(&kv.key) else {
                 warn!(
                     shard = %self.name,
@@ -268,13 +324,13 @@ impl JobStoreShard {
             if !self.range.contains_tenant(&parsed.tenant) {
                 continue;
             }
-            candidates.push(Candidate {
+            batch.candidates.push(Candidate {
                 key: kv.key.to_vec(),
                 tenant: parsed.tenant,
                 job_id: parsed.job_id,
             });
         }
-        Ok(candidates)
+        Ok(batch)
     }
 
     /// Write the batch's missing entries: the whole batch in one transaction,

--- a/src/job_store_shard/helpers.rs
+++ b/src/job_store_shard/helpers.rs
@@ -404,9 +404,7 @@ where
     for attempt in 0..MAX_RETRIES {
         match f().await {
             Ok(val) => return Ok(val),
-            Err(JobStoreShardError::Slate(ref e))
-                if e.kind() == slatedb::ErrorKind::Transaction || is_clock_tick_error(e) =>
-            {
+            Err(ref e) if is_txn_conflict(e) => {
                 if attempt + 1 < MAX_RETRIES {
                     let delay_ms = 10 * (1 << attempt); // 10ms, 20ms, 40ms, 80ms
                     tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
@@ -425,6 +423,17 @@ where
     Err(JobStoreShardError::TransactionConflict(
         operation_name.to_string(),
     ))
+}
+
+/// Whether an error is a transient transaction failure worth retrying: a
+/// serializable-snapshot conflict or SlateDB's `InvalidClockTick` race.
+pub(crate) fn is_txn_conflict(e: &JobStoreShardError) -> bool {
+    match e {
+        JobStoreShardError::Slate(e) => {
+            e.kind() == slatedb::ErrorKind::Transaction || is_clock_tick_error(e)
+        }
+        _ => false,
+    }
 }
 
 /// Check if a SlateDB error is an InvalidClockTick error.

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -19,8 +19,8 @@ use crate::job_store_shard::helpers::{
 };
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
-    attempt_key, attempt_prefix, concurrency_holder_key, end_bound, idx_metadata_key,
-    job_cancelled_key, job_info_key, job_status_key,
+    attempt_key, attempt_prefix, concurrency_holder_key, end_bound, idx_enqueue_time_key,
+    idx_metadata_key, job_cancelled_key, job_info_key, job_status_key,
 };
 use crate::retry::{RetryPolicy, retries_exhausted};
 use crate::task::Task;
@@ -211,6 +211,12 @@ impl JobStoreShard {
         };
         let job_value = encode_job_info(&job);
         put_with_optional_expire(&txn, &info_key, &job_value, terminal_expire_ts)?;
+        put_with_optional_expire(
+            &txn,
+            idx_enqueue_time_key(tenant, effective_enqueue_time_ms, job_id),
+            [],
+            terminal_expire_ts,
+        )?;
 
         // Write metadata secondary index
         for (mk, mv) in &job.metadata {
@@ -584,6 +590,14 @@ impl JobStoreShard {
         let updated_job_value = encode_job_info(&updated_job);
         let info_key = job_info_key(tenant, job_id);
         put_with_optional_expire(&txn, &info_key, &updated_job_value, terminal_expire_ts)?;
+        // The entry's TTL must always match JOB_INFO's: a reimport landing in
+        // a non-terminal status clears it, a terminal one sets it.
+        put_with_optional_expire(
+            &txn,
+            idx_enqueue_time_key(tenant, updated_job.enqueue_time_ms, job_id),
+            [],
+            terminal_expire_ts,
+        )?;
 
         // === Clean up old scheduling state ===
 

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -17,8 +17,8 @@ use crate::job_store_shard::holder_release_guard::PendingHolderReleaseGuard;
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
 use crate::keys::{
     attempt_key, attempt_prefix, concurrency_holder_key, concurrency_holders_tenant_prefix,
-    end_bound, floating_limit_state_key, idx_metadata_key, job_cancelled_key, job_info_key,
-    leased_task_key, parse_concurrency_holder_key,
+    end_bound, floating_limit_state_key, idx_enqueue_time_key, idx_metadata_key, job_cancelled_key,
+    job_info_key, leased_task_key, parse_concurrency_holder_key,
 };
 use crate::task::{DEFAULT_LEASE_MS, HeartbeatResult};
 use tracing::{debug, info_span};
@@ -757,6 +757,7 @@ impl JobStoreShard {
     /// Records covered:
     ///   - `JOB_INFO`            (read existing bytes, re-put with TTL)
     ///   - `IDX_METADATA`        (one entry per metadata pair on the job)
+    ///   - `IDX_ENQUEUE_TIME`    (the job's listing entry, keyed by its enqueue time)
     ///   - `ATTEMPT`             (scan all attempt rows for the job, re-put each)
     ///   - `JOB_CANCELLED`       (re-put with TTL if present)
     ///
@@ -784,18 +785,15 @@ impl JobStoreShard {
         expire_ts: i64,
     ) -> Result<(), JobStoreShardError> {
         let info_key = job_info_key(tenant, job_id);
-        let metadata_pairs = if let Some(info_raw) = writer.get(&info_key).await? {
+        if let Some(info_raw) = writer.get(&info_key).await? {
             let view = JobView::new(info_raw.clone())?;
-            let pairs = view.metadata();
             writer.put_with_expire(&info_key, info_raw, expire_ts)?;
-            pairs
-        } else {
-            Vec::new()
-        };
-
-        for (mk, mv) in &metadata_pairs {
-            let mkey = idx_metadata_key(tenant, mk, mv, job_id);
-            writer.put_with_expire(&mkey, [], expire_ts)?;
+            for (mk, mv) in &view.metadata() {
+                let mkey = idx_metadata_key(tenant, mk, mv, job_id);
+                writer.put_with_expire(&mkey, [], expire_ts)?;
+            }
+            let entry_key = idx_enqueue_time_key(tenant, view.enqueue_time_ms(), job_id);
+            writer.put_with_expire(&entry_key, [], expire_ts)?;
         }
 
         let attempt_start = attempt_prefix(tenant, job_id);
@@ -810,5 +808,44 @@ impl JobStoreShard {
         }
 
         Ok(())
+    }
+
+    /// Counterpart to [`Self::expire_terminal_job_records`] for a job leaving
+    /// a terminal status: re-put `JOB_INFO`, its `IDX_METADATA` rows, its
+    /// `ATTEMPT` rows, and its `IDX_ENQUEUE_TIME` entry with no row TTL, so a
+    /// job that is live again does not lose its metadata, attempt history, or
+    /// listing entry when the old terminal retention elapses.
+    ///
+    /// `JOB_CANCELLED` is deliberately not revived: the caller deletes it in
+    /// the same transaction, and the write set is last-write-wins per key.
+    ///
+    /// Returns the job's decoded `JOB_INFO`, or `JobNotFound` when absent.
+    pub(crate) async fn revive_terminal_job_records<W: WriteBatcher>(
+        &self,
+        writer: &mut W,
+        tenant: &str,
+        job_id: &str,
+    ) -> Result<JobView, JobStoreShardError> {
+        let info_key = job_info_key(tenant, job_id);
+        let Some(info_raw) = writer.get(&info_key).await? else {
+            return Err(JobStoreShardError::JobNotFound(job_id.to_string()));
+        };
+        let view = JobView::new(info_raw.clone())?;
+        writer.put(&info_key, info_raw)?;
+        for (mk, mv) in &view.metadata() {
+            writer.put(idx_metadata_key(tenant, mk, mv, job_id), [])?;
+        }
+        writer.put(
+            idx_enqueue_time_key(tenant, view.enqueue_time_ms(), job_id),
+            [],
+        )?;
+
+        let attempt_start = attempt_prefix(tenant, job_id);
+        let mut iter = writer.scan_prefix(&attempt_start).await?;
+        while let Some(kv) = iter.next().await? {
+            writer.put(&kv.key, &kv.value)?;
+        }
+
+        Ok(view)
     }
 }

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -263,7 +263,7 @@ pub struct JobStoreShard {
     /// The background backfill sweep spawned at open, if any; `close` waits
     /// for it to stop at a batch boundary before closing the database.
     pub(crate) enqueue_time_index_backfill_task:
-        std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+        tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 #[derive(Debug, Error)]
@@ -622,7 +622,7 @@ impl JobStoreShard {
             count_from_status_counters,
             enqueue_time_index_backfill,
             enqueue_time_index_complete: AtomicBool::new(false),
-            enqueue_time_index_backfill_task: std::sync::Mutex::new(None),
+            enqueue_time_index_backfill_task: tokio::sync::Mutex::new(None),
         });
 
         // The completion flag gates the query engine's index-served listing
@@ -737,13 +737,11 @@ impl JobStoreShard {
 
         // The backfill sweep observes the cancellation at its next batch
         // boundary; wait for it so no batch is writing while the database
-        // closes.
-        let backfill_task = self
-            .enqueue_time_index_backfill_task
-            .lock()
-            .expect("backfill task lock")
-            .take();
-        if let Some(task) = backfill_task
+        // closes. The handle stays in its slot until the wait finishes, so a
+        // close that times out and is retried waits again instead of closing
+        // the database under a running batch.
+        let mut backfill_task = self.enqueue_time_index_backfill_task.lock().await;
+        if let Some(task) = backfill_task.as_mut()
             && let Err(e) = task.await
         {
             tracing::warn!(
@@ -752,6 +750,8 @@ impl JobStoreShard {
                 "enqueue-time index backfill task did not stop cleanly"
             );
         }
+        *backfill_task = None;
+        drop(backfill_task);
 
         // If we have a local WAL with flush_on_close enabled, flush memtable to SSTs first
         if let Some(ref wal_config) = self.wal_close_config

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod counters;
 mod dequeue;
 mod drop_tenant_holders;
 mod enqueue;
+mod enqueue_time_index_backfill;
 mod expedite;
 mod floating;
 pub(crate) mod helpers;
@@ -19,6 +20,7 @@ pub(crate) mod scan;
 
 pub use cleanup::{CleanupProgress, CleanupResult};
 pub use drop_tenant_holders::DropTenantStats;
+pub use enqueue_time_index_backfill::EnqueueTimeIndexBackfillResult;
 
 pub use counters::{
     JobStatusTruth, ReconcileSummary, ShardCounters, TenantStatusCounterScanRange,
@@ -38,6 +40,7 @@ use slatedb_common::metrics::DefaultMetricsRecorder;
 use std::sync::Arc;
 #[cfg(feature = "server")]
 use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
@@ -54,7 +57,7 @@ use crate::keys::{attempt_key, job_info_key, job_status_key};
 use crate::metrics::Metrics;
 #[cfg(feature = "server")]
 use crate::query::ShardQueryEngine;
-use crate::settings::DatabaseConfig;
+use crate::settings::{DatabaseConfig, EnqueueTimeIndexBackfillConfig};
 use crate::shard_range::ShardRange;
 use crate::storage::resolve_object_store;
 use crate::task::{LeasedRefreshTask, LeasedTask};
@@ -128,6 +131,25 @@ pub struct OpenShardOptions {
     /// statements from per-status counters instead of scanning the status index.
     /// Populated from `DatabaseConfig::count_from_status_counters`.
     pub count_from_status_counters: bool,
+    /// One-shot backfill of the enqueue-time index for pre-existing jobs.
+    /// Populated from `DatabaseConfig::enqueue_time_index_backfill`; the
+    /// default leaves the sweep disabled.
+    pub enqueue_time_index_backfill: EnqueueTimeIndexBackfillConfig,
+}
+
+/// A start delay in `[0, max_ms)` derived from the shard name (FNV-1a), so
+/// background tasks on shards that open together are staggered the same way
+/// on every run rather than stampeding object storage.
+pub(crate) fn shard_name_jitter_ms(shard_name: &str, max_ms: u64) -> u64 {
+    if max_ms == 0 {
+        return 0;
+    }
+    let mut h: u64 = 1469598103934665603;
+    for b in shard_name.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(1099511628211);
+    }
+    h % max_ms
 }
 
 /// Compute the row TTL (`expire_ts`, epoch ms) for a job that reached the
@@ -233,6 +255,15 @@ pub struct JobStoreShard {
     /// When true, the query engine answers unfiltered per-tenant `COUNT(*)`
     /// from per-status counters instead of a full status-index scan.
     pub(crate) count_from_status_counters: bool,
+    /// Settings for the enqueue-time index backfill sweep.
+    pub(crate) enqueue_time_index_backfill: EnqueueTimeIndexBackfillConfig,
+    /// Whether the enqueue-time index covers every job on this shard. Mirrors
+    /// the persisted completion marker; loaded at open.
+    pub(crate) enqueue_time_index_complete: AtomicBool,
+    /// The background backfill sweep spawned at open, if any; `close` waits
+    /// for it to stop at a batch boundary before closing the database.
+    pub(crate) enqueue_time_index_backfill_task:
+        std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 #[derive(Debug, Error)]
@@ -426,6 +457,7 @@ impl JobStoreShard {
                 completed_job_expire_s: cfg.completed_job_expire_s,
                 terminal_job_expire_s: cfg.terminal_job_expire_s,
                 count_from_status_counters: cfg.count_from_status_counters,
+                enqueue_time_index_backfill: cfg.enqueue_time_index_backfill.clone(),
             },
             range,
         )
@@ -470,6 +502,7 @@ impl JobStoreShard {
             completed_job_expire_s,
             terminal_job_expire_s,
             count_from_status_counters,
+            enqueue_time_index_backfill,
         } = options;
 
         // Wall-clock timer for the whole open, used to emit per-phase debug
@@ -587,7 +620,15 @@ impl JobStoreShard {
             completed_job_expire_s,
             terminal_job_expire_s,
             count_from_status_counters,
+            enqueue_time_index_backfill,
+            enqueue_time_index_complete: AtomicBool::new(false),
+            enqueue_time_index_backfill_task: std::sync::Mutex::new(None),
         });
+
+        // The completion flag gates the query engine's index-served listing
+        // path, so it must reflect the persisted marker before the shard
+        // serves anything.
+        shard.load_enqueue_time_index_complete().await?;
 
         // Install the chain resumer before starting the grant scanner so the
         // scanner's first wake-up has a working callback for resuming limit
@@ -643,6 +684,10 @@ impl JobStoreShard {
             shard.spawn_counter_reconcile_task(range, interval_seconds);
         }
 
+        // Backfill the enqueue-time index for jobs that predate it. A no-op
+        // unless enabled in the database config and not yet complete.
+        shard.spawn_enqueue_time_index_backfill();
+
         // Set the shard creation timestamp if this is the first time opening
         let created_at_started = std::time::Instant::now();
         shard.set_created_at_ms_if_unset().await?;
@@ -689,6 +734,24 @@ impl JobStoreShard {
         self.cancellation.cancel();
         self.brokers.stop();
         self.concurrency.stop_grant_scanner();
+
+        // The backfill sweep observes the cancellation at its next batch
+        // boundary; wait for it so no batch is writing while the database
+        // closes.
+        let backfill_task = self
+            .enqueue_time_index_backfill_task
+            .lock()
+            .expect("backfill task lock")
+            .take();
+        if let Some(task) = backfill_task
+            && let Err(e) = task.await
+        {
+            tracing::warn!(
+                shard = %self.name,
+                error = %e,
+                "enqueue-time index backfill task did not stop cleanly"
+            );
+        }
 
         // If we have a local WAL with flush_on_close enabled, flush memtable to SSTs first
         if let Some(ref wal_config) = self.wal_close_config
@@ -1046,17 +1109,8 @@ impl JobStoreShard {
         tokio::spawn(async move {
             // Deterministic jitter based on shard name so we don't stampede
             // object storage when many shards open simultaneously.
-            let interval_ms = reconcile_interval.as_millis() as u64;
-            let jitter_ms = if interval_ms > 0 {
-                let mut h: u64 = 1469598103934665603;
-                for b in shard_name.as_bytes() {
-                    h ^= *b as u64;
-                    h = h.wrapping_mul(1099511628211);
-                }
-                h % interval_ms
-            } else {
-                0
-            };
+            let jitter_ms =
+                shard_name_jitter_ms(&shard_name, reconcile_interval.as_millis() as u64);
 
             tokio::select! {
                 biased;

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -1612,7 +1612,7 @@ impl JobStoreShard {
     ///
     /// Returns an error if the job is currently running (has active leases/holders) or has pending tasks/requests. Jobs must finish or permanently fail before deletion.
     pub async fn delete_job(&self, tenant: &str, id: &str) -> Result<(), JobStoreShardError> {
-        use crate::keys::idx_metadata_key;
+        use crate::keys::{idx_enqueue_time_key, idx_metadata_key};
         use slatedb::WriteBatch;
 
         // Check if job is running or has pending state
@@ -1642,13 +1642,15 @@ impl JobStoreShard {
             );
             batch.delete(&timek);
         }
-        // Clean up metadata index entries (load job info to enumerate metadata)
+        // Clean up metadata and enqueue-time index entries (load job info to
+        // enumerate metadata and recover the enqueue time)
         let job_metric_info = if let Some(raw) = self.db.get(&job_info_key_bytes).await? {
             let view = JobView::new(raw)?;
             for (mk, mv) in view.metadata().into_iter() {
                 let mkey = idx_metadata_key(tenant, &mk, &mv, id);
                 batch.delete(&mkey);
             }
+            batch.delete(idx_enqueue_time_key(tenant, view.enqueue_time_ms(), id));
             Some((view.task_group().to_string(), view.metadata()))
         } else {
             None

--- a/src/job_store_shard/restart.rs
+++ b/src/job_store_shard/restart.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use crate::dst_events::{self, DstEvent};
 use crate::job::{JobStatus, JobStatusKind};
 use crate::job_store_shard::helpers::{
-    TxnWriter, decode_job_status_owned, load_job_view, now_epoch_ms, retry_on_txn_conflict,
+    TxnWriter, decode_job_status_owned, now_epoch_ms, retry_on_txn_conflict,
 };
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{attempt_prefix, job_cancelled_key, job_status_key};
@@ -117,8 +117,12 @@ impl JobStoreShard {
             txn.delete(&cancelled_key)?;
         }
 
-        // Get the job info first to know the priority and compute start_at_ms
-        let job_view = load_job_view(&TxnWriter(&txn), tenant, id).await?;
+        // Re-put the job's rows without the terminal-retention TTL they may
+        // carry, and read the job info to know the priority and compute
+        // start_at_ms.
+        let job_view = self
+            .revive_terminal_job_records(&mut TxnWriter(&txn), tenant, id)
+            .await?;
         let priority = job_view.priority();
         let start_at_ms = job_view.enqueue_time_ms().max(now_ms);
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -34,6 +34,8 @@ pub mod prefix {
     pub const CLEANUP_COMPLETED_AT: u8 = 0xF6;
     pub const COUNTER_CONCURRENCY_REQUESTERS: u8 = 0xF7;
     pub const COUNTER_TENANT_STATUS: u8 = 0xF8;
+    pub const ENQUEUE_TIME_INDEX_BACKFILL_PROGRESS: u8 = 0xFB;
+    pub const ENQUEUE_TIME_INDEX_BACKFILL_COMPLETE: u8 = 0xFC;
 }
 
 /// Encode a key with its namespace prefix.
@@ -668,6 +670,17 @@ pub fn shard_created_at_key() -> Vec<u8> {
 /// Only set after a split cleanup finishes.
 pub fn cleanup_completed_at_key() -> Vec<u8> {
     vec![prefix::CLEANUP_COMPLETED_AT]
+}
+
+/// Key for the enqueue-time index backfill sweep's progress checkpoint.
+pub fn enqueue_time_index_backfill_progress_key() -> Vec<u8> {
+    vec![prefix::ENQUEUE_TIME_INDEX_BACKFILL_PROGRESS]
+}
+
+/// Key for the marker recording that the enqueue-time index backfill sweep
+/// has completed on this shard.
+pub fn enqueue_time_index_backfill_complete_key() -> Vec<u8> {
+    vec![prefix::ENQUEUE_TIME_INDEX_BACKFILL_COMPLETE]
 }
 
 /// Key for the per-queue concurrency requester counter.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -24,6 +24,7 @@ pub mod prefix {
     pub const CONCURRENCY_HOLDER: u8 = 0x09;
     pub const JOB_CANCELLED: u8 = 0x0A;
     pub const FLOATING_LIMIT: u8 = 0x0B;
+    pub const IDX_ENQUEUE_TIME: u8 = 0x0C;
     pub const COUNTER_TOTAL_JOBS: u8 = 0xF0;
     pub const COUNTER_COMPLETED_JOBS: u8 = 0xF1;
     pub const CLEANUP_PROGRESS: u8 = 0xF2;
@@ -187,6 +188,65 @@ pub fn status_index_timestamp(status: &JobStatus) -> i64 {
     } else {
         status.changed_at_ms
     }
+}
+
+/// Map an `i64` onto `u64` preserving order over the whole range, then
+/// reverse it, so that ascending byte order of the result equals descending
+/// `enqueue_time_ms`. Unlike the status/time index this does not clamp at
+/// zero: enqueue stores the caller's raw `start_at_ms`, which can be negative.
+fn invert_enqueue_time(enqueue_time_ms: i64) -> u64 {
+    u64::MAX - ((enqueue_time_ms as u64) ^ (1u64 << 63))
+}
+
+fn uninvert_enqueue_time(inverted: u64) -> i64 {
+    ((u64::MAX - inverted) ^ (1u64 << 63)) as i64
+}
+
+/// Index: a tenant's jobs ordered by `enqueue_time_ms` descending, then job id
+/// ascending. Written once at job creation; the value is empty.
+pub fn idx_enqueue_time_key(tenant: &str, enqueue_time_ms: i64, job_id: &str) -> Vec<u8> {
+    encode_with_prefix(
+        prefix::IDX_ENQUEUE_TIME,
+        &(tenant, invert_enqueue_time(enqueue_time_ms), job_id),
+    )
+}
+
+/// Prefix for scanning a tenant's enqueue-time index newest-first.
+pub fn idx_enqueue_time_tenant_prefix(tenant: &str) -> Vec<u8> {
+    encode_with_prefix(prefix::IDX_ENQUEUE_TIME, &(tenant,))
+}
+
+/// Prefix for scanning all enqueue-time index entries (cross-tenant).
+pub fn idx_enqueue_time_all_prefix() -> Vec<u8> {
+    vec![prefix::IDX_ENQUEUE_TIME]
+}
+
+/// Parsed enqueue-time index key components.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedEnqueueTimeIndexKey {
+    pub tenant: String,
+    pub inverted_enqueue_time: u64,
+    pub job_id: String,
+}
+
+impl ParsedEnqueueTimeIndexKey {
+    /// Get the original enqueue time from the inverted value.
+    pub fn enqueue_time_ms(&self) -> i64 {
+        uninvert_enqueue_time(self.inverted_enqueue_time)
+    }
+}
+
+/// Parse an enqueue-time index key back to its components.
+pub fn parse_enqueue_time_index_key(key: &[u8]) -> Option<ParsedEnqueueTimeIndexKey> {
+    if key.first() != Some(&prefix::IDX_ENQUEUE_TIME) {
+        return None;
+    }
+    let (tenant, inverted_enqueue_time, job_id): (String, u64, String) = decode(&key[1..]).ok()?;
+    Some(ParsedEnqueueTimeIndexKey {
+        tenant,
+        inverted_enqueue_time,
+        job_id,
+    })
 }
 
 /// Index: jobs by metadata key/value (unsorted within key/value).

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -218,11 +218,6 @@ pub fn idx_enqueue_time_tenant_prefix(tenant: &str) -> Vec<u8> {
     encode_with_prefix(prefix::IDX_ENQUEUE_TIME, &(tenant,))
 }
 
-/// Prefix for scanning all enqueue-time index entries (cross-tenant).
-pub fn idx_enqueue_time_all_prefix() -> Vec<u8> {
-    vec![prefix::IDX_ENQUEUE_TIME]
-}
-
 /// Parsed enqueue-time index key components.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedEnqueueTimeIndexKey {

--- a/src/query.rs
+++ b/src/query.rs
@@ -254,11 +254,67 @@ impl ShardQueryEngine {
     }
 }
 
+/// A scanner's planning-time decision for one scan. Scanners that dispatch
+/// between several paths store their choice here so that execution and
+/// EXPLAIN follow the same decision the planner made.
+pub trait ScanPath: std::fmt::Debug + Send + Sync + 'static {
+    fn as_any(&self) -> &dyn Any;
+}
+
+/// Placeholder for scanners with a single path.
+#[derive(Debug)]
+struct NoScanPath;
+
+impl ScanPath for NoScanPath {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// The resolved decision carried on a plan from planning to execution.
+/// Cheap to clone: plans are cloned by DataFusion's optimizer passes.
+#[derive(Debug, Clone)]
+pub struct ScanDecision {
+    path: Arc<dyn ScanPath>,
+}
+
+impl ScanDecision {
+    pub fn new(path: impl ScanPath) -> Self {
+        Self {
+            path: Arc::new(path),
+        }
+    }
+
+    /// The decision for a scanner with a single path.
+    pub fn single_path() -> Self {
+        Self::new(NoScanPath)
+    }
+
+    /// The scanner-specific decision, if it is of type `T`.
+    pub fn path<T: ScanPath>(&self) -> Option<&T> {
+        self.path.as_any().downcast_ref::<T>()
+    }
+}
+
 /// Scan trait for table scanners.
 /// Implementors provide streaming access to table data with filter pushdown.
 pub trait Scan: std::fmt::Debug + Send + Sync + 'static {
+    /// Resolve the path this scan will take for the given projection, filters,
+    /// and limit. Called once at planning time; the plan hands the result to
+    /// `scan` and `describe`, so a decision never changes between planning and
+    /// execution.
+    fn resolve(
+        &self,
+        _projection: &SchemaRef,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> ScanDecision {
+        ScanDecision::single_path()
+    }
+
     fn scan(
         &self,
+        decision: &ScanDecision,
         projection: SchemaRef,
         filters: &[Expr],
         batch_size: usize,
@@ -267,7 +323,12 @@ pub trait Scan: std::fmt::Debug + Send + Sync + 'static {
 
     /// Describe the scan strategy for EXPLAIN output. Returns a human-readable
     /// description of what index/scan path will be used for the given filters.
-    fn describe(&self, _filters: &[Expr], _limit: Option<usize>) -> String {
+    fn describe(
+        &self,
+        _decision: &ScanDecision,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> String {
         "CustomScan".to_string()
     }
 
@@ -350,6 +411,8 @@ struct SiloExecutionPlan {
     scanner: ScannerRef,
     limit: Option<usize>,
     filters: Vec<Expr>,
+    /// The scanner's path decision, resolved once when the plan is built.
+    decision: ScanDecision,
     plan_properties: PlanProperties,
 }
 
@@ -360,6 +423,7 @@ impl SiloExecutionPlan {
         limit: Option<usize>,
         scanner: ScannerRef,
     ) -> Self {
+        let decision = scanner.resolve(&projected_schema, filters, limit);
         let eq = EquivalenceProperties::new(projected_schema.clone());
         let props = PlanProperties::new(
             eq,
@@ -373,6 +437,7 @@ impl SiloExecutionPlan {
             scanner,
             limit,
             filters: filters.to_vec(),
+            decision,
             plan_properties: props,
         }
     }
@@ -412,6 +477,7 @@ impl ExecutionPlan for SiloExecutionPlan {
     ) -> DfResult<SendableRecordBatchStream> {
         let batch_size = context.session_config().batch_size();
         Ok(self.scanner.scan(
+            &self.decision,
             self.projected_schema.clone(),
             &self.filters,
             batch_size,
@@ -429,7 +495,9 @@ impl DisplayAs for SiloExecutionPlan {
             DisplayFormatType::Default
             | DisplayFormatType::Verbose
             | DisplayFormatType::TreeRender => {
-                let desc = self.scanner.describe(&self.filters, self.limit);
+                let desc = self
+                    .scanner
+                    .describe(&self.decision, &self.filters, self.limit);
                 write!(f, "SiloExecutionPlan: {}", desc)
             }
         }
@@ -957,10 +1025,105 @@ fn analyze_projection(projection: &SchemaRef, strategy: &JobsScanStrategy) -> Pr
     }
 }
 
-impl Scan for JobsScanner {
-    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+/// The physical path a jobs scan executes, chosen at planning time from the
+/// strategy, the projection, the limit, and the shard's state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JobsScanPath {
+    /// Empty-projection full-tenant scan with no LIMIT — the shape of
+    /// `SELECT COUNT(*) FROM jobs WHERE tenant = ...`. Answers the row tally
+    /// from the per-status counters (O(#statuses)) rather than walking an
+    /// index. Shapes like `EXISTS`/`SELECT 1 ... LIMIT n` push a scan limit and
+    /// want actual rows, not a (reconciler-lagged) counter tally, so they are
+    /// excluded.
+    CountFromCounters,
+    /// Tenant-scoped scan whose projection needs only columns carried by the
+    /// enqueue-time index key, on a shard whose index backfill has completed.
+    /// Walks the tenant's index range newest-first with no point lookups.
+    EnqueueTimeIndex,
+    /// Scan the status/time index directly, no point lookups: the projection
+    /// needs only tenant, id, status_kind, or status_changed_at_ms.
+    StatusIndex,
+    /// Full scan streaming `job_info` in windows, merge-joined against
+    /// `job_status` when a status column is projected.
+    FullScanJoin,
+    /// Index-backed `(tenant, id)` pairs hydrated by point lookups.
+    JobPairs,
+}
+
+/// The jobs scanner's resolved decision for one plan.
+#[derive(Debug, Clone)]
+pub struct JobsScanDecision {
+    pub strategy: JobsScanStrategy,
+    pub path: JobsScanPath,
+}
+
+impl ScanPath for JobsScanDecision {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Whether every projected column is carried by the enqueue-time index key.
+/// An empty projection is not key-served: it is the COUNT(*) shape, which
+/// keeps its own path.
+fn projection_served_by_enqueue_time_index(projection: &SchemaRef) -> bool {
+    !projection.fields().is_empty()
+        && projection.fields().iter().all(|f| {
+            matches!(
+                f.name().as_str(),
+                "shard_id" | "tenant" | "id" | "enqueue_time_ms"
+            )
+        })
+}
+
+impl JobsScanner {
+    fn resolve_jobs(
+        &self,
+        projection: &SchemaRef,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> JobsScanDecision {
         let strategy = parse_jobs_scan_strategy(filters);
-        format!("jobs[{}], limit={:?}", strategy, limit)
+        let needs = analyze_projection(projection, &strategy);
+        let tenant_full_scan = matches!(&strategy, JobsScanStrategy::FullScan { tenant: Some(_) });
+        let path = if projection.fields().is_empty()
+            && limit.is_none()
+            && self.shard.count_from_status_counters
+            && tenant_full_scan
+        {
+            JobsScanPath::CountFromCounters
+        } else if tenant_full_scan
+            && projection_served_by_enqueue_time_index(projection)
+            && self.shard.enqueue_time_index_complete()
+        {
+            JobsScanPath::EnqueueTimeIndex
+        } else if needs.use_status_index_path {
+            JobsScanPath::StatusIndex
+        } else if needs.need_job_info && matches!(strategy, JobsScanStrategy::FullScan { .. }) {
+            JobsScanPath::FullScanJoin
+        } else {
+            JobsScanPath::JobPairs
+        };
+        JobsScanDecision { strategy, path }
+    }
+}
+
+impl Scan for JobsScanner {
+    fn resolve(
+        &self,
+        projection: &SchemaRef,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> ScanDecision {
+        ScanDecision::new(self.resolve_jobs(projection, filters, limit))
+    }
+
+    fn describe(&self, decision: &ScanDecision, filters: &[Expr], limit: Option<usize>) -> String {
+        let decision = self.jobs_decision(decision, filters, limit, &JobsScanner::base_schema());
+        format!(
+            "jobs[{}], limit={:?}, path={:?}",
+            decision.strategy, limit, decision.path
+        )
     }
 
     fn classify_filters(&self, filters: &[&Expr]) -> Vec<TableProviderFilterPushDown> {
@@ -969,12 +1132,14 @@ impl Scan for JobsScanner {
 
     fn scan(
         &self,
+        decision: &ScanDecision,
         projection: SchemaRef,
         filters: &[Expr],
         batch_size: usize,
         limit: Option<usize>,
     ) -> SendableRecordBatchStream {
-        let strategy = parse_jobs_scan_strategy(filters);
+        let JobsScanDecision { strategy, path } =
+            self.jobs_decision(decision, filters, limit, &projection);
         let shard = Arc::clone(&self.shard);
         let needs = analyze_projection(&projection, &strategy);
 
@@ -982,53 +1147,149 @@ impl Scan for JobsScanner {
         // the underlying scan cursor(s). Because nothing is spawned, dropping the
         // returned stream (statement timeout, client disconnect, LIMIT satisfied)
         // drops the cursor and stops the scan at its next `.await` — no zombies.
-        let inner: Pin<Box<dyn Stream<Item = DfResult<RecordBatch>> + Send>> =
-            if projection.fields().is_empty()
-                && limit.is_none()
-                && shard.count_from_status_counters
-                && matches!(&strategy, JobsScanStrategy::FullScan { tenant: Some(_) })
-            {
-                // Empty-projection full-tenant scan with no LIMIT — the shape of
-                // `SELECT COUNT(*) FROM jobs WHERE tenant = ...`. Answer the row
-                // tally from the per-status counters (O(#statuses)) rather than
-                // walking the index. The `limit.is_none()` guard excludes shapes
-                // like `EXISTS`/`SELECT 1 ... LIMIT n` that push a scan limit and
-                // want actual rows, not a (reconciler-lagged) counter tally.
-                Box::pin(count_from_counters_stream(
-                    shard,
-                    projection.clone(),
-                    strategy,
-                ))
-            } else if needs.use_status_index_path {
-                Box::pin(status_index_stream(
-                    shard,
-                    projection.clone(),
-                    strategy,
-                    batch_size,
-                    limit,
-                ))
-            } else if needs.need_job_info && matches!(strategy, JobsScanStrategy::FullScan { .. }) {
-                Box::pin(fullscan_join_stream(
-                    shard,
-                    projection.clone(),
-                    needs,
-                    strategy,
-                    batch_size,
-                    limit,
-                ))
-            } else {
-                Box::pin(job_pairs_stream(
-                    shard,
-                    projection.clone(),
-                    needs,
-                    strategy,
-                    batch_size,
-                    limit,
-                ))
-            };
+        let inner: Pin<Box<dyn Stream<Item = DfResult<RecordBatch>> + Send>> = match path {
+            JobsScanPath::CountFromCounters => Box::pin(count_from_counters_stream(
+                shard,
+                projection.clone(),
+                strategy,
+            )),
+            JobsScanPath::EnqueueTimeIndex => Box::pin(enqueue_time_index_stream(
+                shard,
+                projection.clone(),
+                strategy,
+                batch_size,
+                limit,
+            )),
+            JobsScanPath::StatusIndex => Box::pin(status_index_stream(
+                shard,
+                projection.clone(),
+                strategy,
+                batch_size,
+                limit,
+            )),
+            JobsScanPath::FullScanJoin => Box::pin(fullscan_join_stream(
+                shard,
+                projection.clone(),
+                needs,
+                strategy,
+                batch_size,
+                limit,
+            )),
+            JobsScanPath::JobPairs => Box::pin(job_pairs_stream(
+                shard,
+                projection.clone(),
+                needs,
+                strategy,
+                batch_size,
+                limit,
+            )),
+        };
 
         Box::pin(RecordBatchStreamAdapter::new(projection, inner))
     }
+}
+
+impl JobsScanner {
+    /// The plan's resolved decision, or a fresh resolution when the plan
+    /// carries a decision of another scanner's type.
+    fn jobs_decision(
+        &self,
+        decision: &ScanDecision,
+        filters: &[Expr],
+        limit: Option<usize>,
+        projection: &SchemaRef,
+    ) -> JobsScanDecision {
+        decision
+            .path::<JobsScanDecision>()
+            .cloned()
+            .unwrap_or_else(|| self.resolve_jobs(projection, filters, limit))
+    }
+}
+
+/// Streams a tenant's enqueue-time index newest-first in bounded chunks,
+/// emitting RecordBatches whose every column comes from the index key. No
+/// point lookups: the index never holds an entry for a job whose `JOB_INFO`
+/// is gone, so nothing needs hydrating or verifying.
+fn enqueue_time_index_stream(
+    shard: Arc<JobStoreShard>,
+    projection: SchemaRef,
+    strategy: JobsScanStrategy,
+    batch_size: usize,
+    limit: Option<usize>,
+) -> impl Stream<Item = DfResult<RecordBatch>> {
+    async_stream::try_stream! {
+        let JobsScanStrategy::FullScan { tenant: Some(tenant) } = strategy else {
+            return; // guarded by the resolver; nothing to emit otherwise
+        };
+        let shard_id = shard.name().to_string();
+        let start = crate::keys::idx_enqueue_time_tenant_prefix(&tenant);
+        let end = crate::keys::end_bound(&start);
+        let mut cursor = shard
+            .open_range_cursor(start, end, &crate::scan_options())
+            .await
+            .map_err(exec_err)?;
+        let mut sent = 0usize;
+        loop {
+            if limit.is_some_and(|l| sent >= l) {
+                break;
+            }
+            // The cursor counts every key it pulls, so never pull more than
+            // the LIMIT still needs.
+            let want = limit.map_or(batch_size, |l| batch_size.min(l - sent));
+            let chunk = cursor.next_kv_chunk(want).await.map_err(exec_err)?;
+            if chunk.is_empty() {
+                break;
+            }
+            let mut rows: Vec<(String, String, i64)> = Vec::with_capacity(chunk.len());
+            for kv in &chunk {
+                let Some(p) = crate::keys::parse_enqueue_time_index_key(&kv.key)
+                    .filter(|p| !p.job_id.is_empty())
+                else {
+                    continue;
+                };
+                let enqueue_time_ms = p.enqueue_time_ms();
+                rows.push((p.tenant, p.job_id, enqueue_time_ms));
+            }
+            if rows.is_empty() {
+                continue;
+            }
+            if let Some(l) = limit {
+                rows.truncate(l - sent);
+            }
+            let batch = build_enqueue_time_index_batch(&projection, &shard_id, &rows)?;
+            sent += batch.num_rows();
+            yield batch;
+        }
+    }
+}
+
+fn build_enqueue_time_index_batch(
+    projection: &SchemaRef,
+    shard_id: &str,
+    rows: &[(String, String, i64)],
+) -> DfResult<RecordBatch> {
+    let n = rows.len();
+    let mut cols: Vec<ArrayRef> = Vec::with_capacity(projection.fields().len());
+    for f in projection.fields() {
+        let col: ArrayRef = match f.name().as_str() {
+            "shard_id" => Arc::new(StringArray::from(vec![shard_id; n])),
+            "tenant" => Arc::new(StringArray::from(
+                rows.iter().map(|(t, _, _)| t.as_str()).collect::<Vec<_>>(),
+            )),
+            "id" => Arc::new(StringArray::from(
+                rows.iter()
+                    .map(|(_, id, _)| id.as_str())
+                    .collect::<Vec<_>>(),
+            )),
+            "enqueue_time_ms" => Arc::new(Int64Array::from(
+                rows.iter().map(|(_, _, t)| *t).collect::<Vec<_>>(),
+            )),
+            _ => new_null_array(f.data_type(), n),
+        };
+        cols.push(col);
+    }
+    RecordBatch::try_new(Arc::clone(projection), cols)
+        .map_err(|e| DataFusionError::Execution(e.to_string()))
 }
 
 /// COUNT(*)-over-a-tenant fast path: sum the transactionally-maintained
@@ -2077,7 +2338,7 @@ impl QueuesScanner {
 }
 
 impl Scan for QueuesScanner {
-    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+    fn describe(&self, _decision: &ScanDecision, filters: &[Expr], limit: Option<usize>) -> String {
         let mut tenant = None;
         let mut queue = None;
         let mut entry_type = None;
@@ -2099,6 +2360,7 @@ impl Scan for QueuesScanner {
 
     fn scan(
         &self,
+        _decision: &ScanDecision,
         projection: SchemaRef,
         filters: &[Expr],
         batch_size: usize,
@@ -2411,7 +2673,7 @@ impl std::fmt::Debug for TenantCountsScanner {
 }
 
 impl Scan for TenantCountsScanner {
-    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+    fn describe(&self, _decision: &ScanDecision, filters: &[Expr], limit: Option<usize>) -> String {
         let tenant_range = parse_tenant_counts_scan_range(filters)
             .map(|range| describe_tenant_status_counter_scan_range(&range))
             .unwrap_or_else(|| "all".to_string());
@@ -2420,6 +2682,7 @@ impl Scan for TenantCountsScanner {
 
     fn scan(
         &self,
+        _decision: &ScanDecision,
         projection: SchemaRef,
         filters: &[Expr],
         _batch_size: usize,
@@ -2498,7 +2761,7 @@ impl std::fmt::Debug for QueueCountsScanner {
 }
 
 impl Scan for QueueCountsScanner {
-    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+    fn describe(&self, _decision: &ScanDecision, filters: &[Expr], limit: Option<usize>) -> String {
         let mut tenant = None;
         for f in filters {
             if let Some((col, val)) = parse_eq_filter(f)
@@ -2512,6 +2775,7 @@ impl Scan for QueueCountsScanner {
 
     fn scan(
         &self,
+        _decision: &ScanDecision,
         projection: SchemaRef,
         filters: &[Expr],
         _batch_size: usize,
@@ -2810,7 +3074,7 @@ fn variant_type_name(vt: crate::fb::silo::fb::TaskVariant) -> &'static str {
 }
 
 impl Scan for TasksScanner {
-    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+    fn describe(&self, _decision: &ScanDecision, filters: &[Expr], limit: Option<usize>) -> String {
         let strategy = parse_tasks_scan_strategy(filters);
         format!("tasks[{}], limit={:?}", strategy, limit)
     }
@@ -2821,6 +3085,7 @@ impl Scan for TasksScanner {
 
     fn scan(
         &self,
+        _decision: &ScanDecision,
         projection: SchemaRef,
         filters: &[Expr],
         batch_size: usize,

--- a/src/query.rs
+++ b/src/query.rs
@@ -318,7 +318,7 @@ impl ScanDecision {
     }
 
     /// The scanner-specific decision, if it is of type `T`.
-    pub fn path<T: ScanPath>(&self) -> Option<&T> {
+    pub fn downcast<T: ScanPath>(&self) -> Option<&T> {
         self.path.as_any().downcast_ref::<T>()
     }
 
@@ -460,8 +460,9 @@ impl SiloExecutionPlan {
     ) -> Self {
         let decision = scanner.resolve(&projected_schema, filters, limit);
         // Declare the path's ordering only when every ordering column is in
-        // the projected schema; a prefix of the ordering would be a false
-        // promise, and a query that needs the order projects the columns.
+        // the projected schema: a subset that omits the leading column is not
+        // an ordering of the stream, and a query that needs the order
+        // projects the columns.
         let ordering: Vec<PhysicalSortExpr> = decision
             .output_ordering()
             .iter()
@@ -1216,8 +1217,8 @@ impl Scan for JobsScanner {
         }
     }
 
-    fn describe(&self, decision: &ScanDecision, filters: &[Expr], limit: Option<usize>) -> String {
-        let decision = self.jobs_decision(decision, filters, limit, &JobsScanner::base_schema());
+    fn describe(&self, decision: &ScanDecision, _filters: &[Expr], limit: Option<usize>) -> String {
+        let decision = Self::jobs_decision(decision);
         format!(
             "jobs[{}], limit={:?}, path={:?}",
             decision.strategy, limit, decision.path
@@ -1232,12 +1233,11 @@ impl Scan for JobsScanner {
         &self,
         decision: &ScanDecision,
         projection: SchemaRef,
-        filters: &[Expr],
+        _filters: &[Expr],
         batch_size: usize,
         limit: Option<usize>,
     ) -> SendableRecordBatchStream {
-        let JobsScanDecision { strategy, path } =
-            self.jobs_decision(decision, filters, limit, &projection);
+        let JobsScanDecision { strategy, path } = Self::jobs_decision(decision);
         let shard = Arc::clone(&self.shard);
         let needs = analyze_projection(&projection, &strategy);
 
@@ -1288,19 +1288,14 @@ impl Scan for JobsScanner {
 }
 
 impl JobsScanner {
-    /// The plan's resolved decision, or a fresh resolution when the plan
-    /// carries a decision of another scanner's type.
-    fn jobs_decision(
-        &self,
-        decision: &ScanDecision,
-        filters: &[Expr],
-        limit: Option<usize>,
-        projection: &SchemaRef,
-    ) -> JobsScanDecision {
+    /// The plan's resolved decision. A plan is only ever executed by the
+    /// scanner that resolved it, so any other decision type is a programming
+    /// error.
+    fn jobs_decision(decision: &ScanDecision) -> JobsScanDecision {
         decision
-            .path::<JobsScanDecision>()
+            .downcast::<JobsScanDecision>()
             .cloned()
-            .unwrap_or_else(|| self.resolve_jobs(projection, filters, limit))
+            .expect("JobsScanner given another scanner's decision")
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use datafusion::arrow::array::{
     Array, ArrayRef, Int64Array, StringArray, UInt8Array, UInt32Array, new_null_array,
 };
+use datafusion::arrow::compute::SortOptions;
 use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::Session as CatalogSession;
@@ -16,7 +17,8 @@ use datafusion::execution::TaskContext;
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::TableProviderFilterPushDown;
 use datafusion::logical_expr::{BinaryExpr, Expr, Operator};
-use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_expr::expressions::col;
+use datafusion::physical_expr::{EquivalenceProperties, PhysicalSortExpr};
 use datafusion::physical_plan::display::{DisplayAs, DisplayFormatType};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType, SchedulingType};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
@@ -271,17 +273,34 @@ impl ScanPath for NoScanPath {
     }
 }
 
+/// One column of the ordering a scan path guarantees on its output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrderingColumn {
+    pub name: String,
+    pub descending: bool,
+}
+
 /// The resolved decision carried on a plan from planning to execution.
 /// Cheap to clone: plans are cloned by DataFusion's optimizer passes.
 #[derive(Debug, Clone)]
 pub struct ScanDecision {
     path: Arc<dyn ScanPath>,
+    /// The output ordering the path guarantees, by projected column name;
+    /// empty when the path promises none. Nulls sort last, which is
+    /// immaterial while every ordering column is non-nullable.
+    output_ordering: Vec<OrderingColumn>,
+    /// Whether the path enforces a pushed-down fetch itself. A path that
+    /// ignores its limit must leave this false, since the planner removes the
+    /// limit node above a plan that accepts a fetch.
+    accepts_fetch: bool,
 }
 
 impl ScanDecision {
     pub fn new(path: impl ScanPath) -> Self {
         Self {
             path: Arc::new(path),
+            output_ordering: Vec::new(),
+            accepts_fetch: false,
         }
     }
 
@@ -290,9 +309,25 @@ impl ScanDecision {
         Self::new(NoScanPath)
     }
 
+    /// Declare the ordering the path guarantees and that it enforces a
+    /// pushed-down fetch.
+    pub fn ordered_with_fetch(mut self, output_ordering: Vec<OrderingColumn>) -> Self {
+        self.output_ordering = output_ordering;
+        self.accepts_fetch = true;
+        self
+    }
+
     /// The scanner-specific decision, if it is of type `T`.
     pub fn path<T: ScanPath>(&self) -> Option<&T> {
         self.path.as_any().downcast_ref::<T>()
+    }
+
+    pub fn output_ordering(&self) -> &[OrderingColumn] {
+        &self.output_ordering
+    }
+
+    pub fn accepts_fetch(&self) -> bool {
+        self.accepts_fetch
     }
 }
 
@@ -424,7 +459,28 @@ impl SiloExecutionPlan {
         scanner: ScannerRef,
     ) -> Self {
         let decision = scanner.resolve(&projected_schema, filters, limit);
-        let eq = EquivalenceProperties::new(projected_schema.clone());
+        // Declare the path's ordering only when every ordering column is in
+        // the projected schema; a prefix of the ordering would be a false
+        // promise, and a query that needs the order projects the columns.
+        let ordering: Vec<PhysicalSortExpr> = decision
+            .output_ordering()
+            .iter()
+            .filter_map(|c| {
+                let expr = col(&c.name, &projected_schema).ok()?;
+                Some(PhysicalSortExpr::new(
+                    expr,
+                    SortOptions {
+                        descending: c.descending,
+                        nulls_first: false,
+                    },
+                ))
+            })
+            .collect();
+        let eq = if !ordering.is_empty() && ordering.len() == decision.output_ordering().len() {
+            EquivalenceProperties::new_with_orderings(projected_schema.clone(), [ordering])
+        } else {
+            EquivalenceProperties::new(projected_schema.clone())
+        };
         let props = PlanProperties::new(
             eq,
             Partitioning::UnknownPartitioning(1),
@@ -486,6 +542,31 @@ impl ExecutionPlan for SiloExecutionPlan {
     }
     fn statistics(&self) -> DfResult<Statistics> {
         Ok(Statistics::default())
+    }
+    fn fetch(&self) -> Option<usize> {
+        if self.decision.accepts_fetch() {
+            self.limit
+        } else {
+            None
+        }
+    }
+    /// Accept a pushed-down fetch (skip plus limit) on paths that enforce
+    /// their limit. The planner removes the limit node above the returned
+    /// plan, so every other path returns `None` and keeps its limit operator.
+    /// The path, ordering, filters, and plan properties are unchanged; the
+    /// limit becomes the tighter of the two.
+    fn with_fetch(&self, fetch: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        if !self.decision.accepts_fetch() {
+            return None;
+        }
+        let limit = match (self.limit, fetch) {
+            (Some(current), Some(new)) => Some(current.min(new)),
+            (current, new) => current.or(new),
+        };
+        Some(Arc::new(Self {
+            limit,
+            ..self.clone()
+        }))
     }
 }
 
@@ -1115,7 +1196,24 @@ impl Scan for JobsScanner {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> ScanDecision {
-        ScanDecision::new(self.resolve_jobs(projection, filters, limit))
+        let jobs = self.resolve_jobs(projection, filters, limit);
+        let path = jobs.path;
+        let decision = ScanDecision::new(jobs);
+        match path {
+            // The index range is walked in key order, which is exactly
+            // `enqueue_time_ms DESC, id ASC`, and the stream stops at its limit.
+            JobsScanPath::EnqueueTimeIndex => decision.ordered_with_fetch(vec![
+                OrderingColumn {
+                    name: "enqueue_time_ms".to_string(),
+                    descending: true,
+                },
+                OrderingColumn {
+                    name: "id".to_string(),
+                    descending: false,
+                },
+            ]),
+            _ => decision,
+        }
     }
 
     fn describe(&self, decision: &ScanDecision, filters: &[Expr], limit: Option<usize>) -> String {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -403,6 +403,10 @@ pub struct DatabaseTemplate {
     /// `DatabaseConfig::count_from_status_counters`. Defaults to true.
     #[serde(default = "default_count_from_status_counters")]
     pub count_from_status_counters: bool,
+    /// One-shot backfill of the enqueue-time index for pre-existing jobs.
+    /// See `EnqueueTimeIndexBackfillConfig`; disabled by default.
+    #[serde(default)]
+    pub enqueue_time_index_backfill: EnqueueTimeIndexBackfillConfig,
     /// Optional SlateDB-specific settings for tuning database performance.
     /// If not specified, SlateDB defaults are used. When partially specified,
     /// unspecified fields use SlateDB defaults.
@@ -441,6 +445,7 @@ impl Default for DatabaseTemplate {
             terminal_job_expire_s: None,
             periodic_full_compaction_s: None,
             count_from_status_counters: default_count_from_status_counters(),
+            enqueue_time_index_backfill: EnqueueTimeIndexBackfillConfig::default(),
             slatedb: None,
             memory_cache: None,
         }
@@ -728,6 +733,45 @@ fn default_count_from_status_counters() -> bool {
     true
 }
 
+fn default_enqueue_time_index_backfill_batch_size() -> usize {
+    256
+}
+
+fn default_enqueue_time_index_backfill_pause_ms() -> u64 {
+    10
+}
+
+/// Settings for the one-shot per-shard sweep that writes the enqueue-time
+/// index entry (`IDX_ENQUEUE_TIME`) for jobs created before the index
+/// existed. The sweep runs once per shard, checkpoints its progress, and
+/// records a completion marker; the query engine serves listings from the
+/// index only on shards whose marker is set.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct EnqueueTimeIndexBackfillConfig {
+    /// When true, a shard whose sweep has not completed runs it in the
+    /// background after opening. Defaults to false; enabling it is the
+    /// rollout step for index-served listings.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Rows the sweep examines per transaction. Defaults to 256.
+    #[serde(default = "default_enqueue_time_index_backfill_batch_size")]
+    pub batch_size: usize,
+    /// Pause between batches, in milliseconds, to keep the sweep from
+    /// crowding out foreground writes. Defaults to 10.
+    #[serde(default = "default_enqueue_time_index_backfill_pause_ms")]
+    pub pause_ms: u64,
+}
+
+impl Default for EnqueueTimeIndexBackfillConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            batch_size: default_enqueue_time_index_backfill_batch_size(),
+            pause_ms: default_enqueue_time_index_backfill_pause_ms(),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseConfig {
     pub name: String,
@@ -814,6 +858,10 @@ pub struct DatabaseConfig {
     /// counting.
     #[serde(default = "default_count_from_status_counters")]
     pub count_from_status_counters: bool,
+    /// One-shot backfill of the enqueue-time index for pre-existing jobs.
+    /// See `EnqueueTimeIndexBackfillConfig`; disabled by default.
+    #[serde(default)]
+    pub enqueue_time_index_backfill: EnqueueTimeIndexBackfillConfig,
     /// Optional SlateDB-specific settings for tuning database performance.
     /// If not specified, SlateDB defaults are used. When partially specified,
     /// unspecified fields use SlateDB defaults.
@@ -851,6 +899,7 @@ impl Default for DatabaseConfig {
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: default_count_from_status_counters(),
+            enqueue_time_index_backfill: EnqueueTimeIndexBackfillConfig::default(),
             slatedb: None,
             memory_cache: None,
         }

--- a/tests/config_and_db_tests.rs
+++ b/tests/config_and_db_tests.rs
@@ -1029,3 +1029,38 @@ async fn factory_passes_slatedb_settings_to_shards() {
     let result = shard.db().get(b"key").await.expect("get");
     assert_eq!(result.unwrap().as_ref(), b"value");
 }
+
+#[silo::test]
+fn parse_toml_enqueue_time_index_backfill_defaults_off() {
+    let toml_str = r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+"#;
+    let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
+    let backfill = &cfg.database.enqueue_time_index_backfill;
+    assert!(!backfill.enabled, "the backfill sweep is off by default");
+    assert_eq!(backfill.batch_size, 256);
+    assert_eq!(backfill.pause_ms, 10);
+}
+
+#[silo::test]
+fn parse_toml_enqueue_time_index_backfill_opt_in() {
+    let toml_str = r#"
+[database]
+backend = "fs"
+path = "/tmp/silo-%shard%"
+
+[database.enqueue_time_index_backfill]
+enabled = true
+batch_size = 64
+"#;
+    let cfg: AppConfig = toml::from_str(toml_str).expect("parse TOML");
+    let backfill = &cfg.database.enqueue_time_index_backfill;
+    assert!(backfill.enabled);
+    assert_eq!(backfill.batch_size, 64);
+    assert_eq!(
+        backfill.pause_ms, 10,
+        "unspecified fields keep their defaults"
+    );
+}

--- a/tests/enqueue_time_index_backfill_tests.rs
+++ b/tests/enqueue_time_index_backfill_tests.rs
@@ -21,9 +21,19 @@ use test_helpers::*;
 
 const TENANT: &str = "-";
 
-/// Open (or reopen) a shard at `path` with the given backfill settings.
+/// Open (or reopen) a full-range shard at `path` with the given backfill settings.
 async fn open_shard_at(
     path: &std::path::Path,
+    terminal_expire_s: Option<u64>,
+    backfill: EnqueueTimeIndexBackfillConfig,
+) -> Arc<JobStoreShard> {
+    open_shard_with_range(path, ShardRange::full(), terminal_expire_s, backfill).await
+}
+
+/// Open (or reopen) a shard at `path` owning `range`.
+async fn open_shard_with_range(
+    path: &std::path::Path,
+    range: ShardRange,
     terminal_expire_s: Option<u64>,
     backfill: EnqueueTimeIndexBackfillConfig,
 ) -> Arc<JobStoreShard> {
@@ -37,23 +47,27 @@ async fn open_shard_at(
         enqueue_time_index_backfill: backfill,
         ..Default::default()
     };
-    JobStoreShard::open(
-        &cfg,
-        MockGubernatorClient::new_arc(),
-        None,
-        ShardRange::full(),
-    )
-    .await
-    .expect("open shard")
+    JobStoreShard::open(&cfg, MockGubernatorClient::new_arc(), None, range)
+        .await
+        .expect("open shard")
 }
 
 async fn enqueue_many(shard: &JobStoreShard, prefix: &str, count: usize) -> Vec<String> {
+    enqueue_many_for(shard, TENANT, prefix, count).await
+}
+
+async fn enqueue_many_for(
+    shard: &JobStoreShard,
+    tenant: &str,
+    prefix: &str,
+    count: usize,
+) -> Vec<String> {
     let mut ids = Vec::with_capacity(count);
     for i in 0..count {
         let id = format!("{prefix}-{i:04}");
         shard
             .enqueue(
-                TENANT,
+                tenant,
                 Some(id.clone()),
                 10u8,
                 now_ms() + i as i64,
@@ -73,15 +87,19 @@ async fn enqueue_many(shard: &JobStoreShard, prefix: &str, count: usize) -> Vec<
 /// Remove the index entries for `ids`, simulating jobs created before the
 /// index existed.
 async fn strip_entries(shard: &JobStoreShard, ids: &[String]) {
+    strip_entries_for(shard, TENANT, ids).await
+}
+
+async fn strip_entries_for(shard: &JobStoreShard, tenant: &str, ids: &[String]) {
     for id in ids {
         let job = shard
-            .get_job(TENANT, id)
+            .get_job(tenant, id)
             .await
             .expect("get_job")
             .expect("job exists");
         shard
             .db()
-            .delete(idx_enqueue_time_key(TENANT, job.enqueue_time_ms(), id))
+            .delete(idx_enqueue_time_key(tenant, job.enqueue_time_ms(), id))
             .await
             .expect("delete entry");
     }
@@ -90,7 +108,11 @@ async fn strip_entries(shard: &JobStoreShard, ids: &[String]) {
 
 /// The tenant's index entries as job ids, in index order.
 async fn indexed_ids(db: &InstrumentedDb) -> Vec<String> {
-    let start = idx_enqueue_time_tenant_prefix(TENANT);
+    indexed_ids_for(db, TENANT).await
+}
+
+async fn indexed_ids_for(db: &InstrumentedDb, tenant: &str) -> Vec<String> {
+    let start = idx_enqueue_time_tenant_prefix(tenant);
     let end = end_bound(&start);
     let mut iter = db.scan::<Vec<u8>, _>(start..end).await.expect("scan");
     let mut ids = Vec::new();
@@ -475,4 +497,74 @@ async fn enabled_sweep_on_an_empty_shard_sets_the_marker() {
             .is_some(),
         "marker persisted"
     );
+}
+
+/// A split child is a clone of its parent, so it inherits the parent's
+/// checkpoint and any entries the parent already wrote. The parent's range
+/// contains the child's, so every in-range job before the checkpoint is
+/// already indexed and the child only has to finish the walk.
+#[silo::test]
+async fn split_child_resumes_the_parents_checkpoint_and_indexes_every_in_range_job() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Tenant hashes: zzz (6d85...) is inside [, 8000...), aaa (ae01...) is outside.
+    let left_child = ShardRange::new("", "8000000000000000");
+    let parent = open_shard_at(tmp.path(), None, Default::default()).await;
+    let outside = enqueue_many_for(&parent, "aaa", "a", 120).await;
+    let inside = enqueue_many_for(&parent, "zzz", "z", 120).await;
+    strip_entries_for(&parent, "aaa", &outside).await;
+    strip_entries_for(&parent, "zzz", &inside).await;
+    parent.close().await.expect("close");
+
+    // The parent's sweep walks aaa's rows first (key order), then zzz's;
+    // stop it partway through zzz so the checkpoint sits inside the child's
+    // own tenant.
+    let parent = open_shard_at(tmp.path(), None, enabled(1, 10)).await;
+    poll_until(
+        || async { indexed_ids_for(parent.db(), "zzz").await.len() },
+        |n| *n >= 10,
+        15_000,
+    )
+    .await;
+    parent.close().await.expect("close");
+
+    let child = open_shard_with_range(tmp.path(), left_child, None, Default::default()).await;
+    assert!(!child.enqueue_time_index_complete());
+    let indexed_by_parent = indexed_ids_for(child.db(), "zzz").await.len();
+    assert!(
+        (10..120).contains(&indexed_by_parent),
+        "the parent must stop partway through zzz, got {indexed_by_parent}"
+    );
+    let result = child
+        .backfill_enqueue_time_index(7, Duration::ZERO)
+        .await
+        .expect("backfill");
+    assert!(result.complete, "{result:?}");
+    assert_eq!(sorted(indexed_ids_for(child.db(), "zzz").await), inside);
+}
+
+/// A child cloned from a parent whose sweep completed inherits the marker,
+/// and every job in the child's range is already indexed.
+#[silo::test]
+async fn split_child_inherits_a_completed_parent_index() {
+    let tmp = tempfile::tempdir().unwrap();
+    let parent = open_shard_at(tmp.path(), None, Default::default()).await;
+    let inside = enqueue_many_for(&parent, "zzz", "z", 30).await;
+    enqueue_many_for(&parent, "aaa", "a", 30).await;
+    strip_entries_for(&parent, "zzz", &inside).await;
+    let result = parent
+        .backfill_enqueue_time_index(8, Duration::ZERO)
+        .await
+        .expect("backfill");
+    assert!(result.complete);
+    parent.close().await.expect("close");
+
+    let child = open_shard_with_range(
+        tmp.path(),
+        ShardRange::new("", "8000000000000000"),
+        None,
+        enabled(8, 0),
+    )
+    .await;
+    assert!(child.enqueue_time_index_complete(), "marker inherited");
+    assert_eq!(sorted(indexed_ids_for(child.db(), "zzz").await), inside);
 }

--- a/tests/enqueue_time_index_backfill_tests.rs
+++ b/tests/enqueue_time_index_backfill_tests.rs
@@ -1,0 +1,501 @@
+//! The one-shot per-shard sweep that writes missing `IDX_ENQUEUE_TIME`
+//! entries for jobs created before the index existed, and the completion
+//! marker that gates the query path.
+
+mod test_helpers;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use silo::gubernator::MockGubernatorClient;
+use silo::instrumented_db::InstrumentedDb;
+use silo::job_attempt::AttemptOutcome;
+use silo::job_store_shard::JobStoreShard;
+use silo::keys::{
+    end_bound, idx_enqueue_time_key, idx_enqueue_time_tenant_prefix, job_info_key,
+    parse_enqueue_time_index_key,
+};
+use silo::settings::{Backend, DatabaseConfig, EnqueueTimeIndexBackfillConfig};
+use silo::shard_range::ShardRange;
+use test_helpers::*;
+
+const TENANT: &str = "-";
+
+/// Open (or reopen) a shard at `path` with the given backfill settings.
+async fn open_shard_at(
+    path: &std::path::Path,
+    terminal_expire_s: Option<u64>,
+    backfill: EnqueueTimeIndexBackfillConfig,
+) -> Arc<JobStoreShard> {
+    let cfg = DatabaseConfig {
+        name: "test".to_string(),
+        backend: Backend::Fs,
+        path: path.to_string_lossy().to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        completed_job_expire_s: terminal_expire_s,
+        terminal_job_expire_s: terminal_expire_s,
+        enqueue_time_index_backfill: backfill,
+        ..Default::default()
+    };
+    JobStoreShard::open(
+        &cfg,
+        MockGubernatorClient::new_arc(),
+        None,
+        ShardRange::full(),
+    )
+    .await
+    .expect("open shard")
+}
+
+async fn enqueue_many(shard: &JobStoreShard, prefix: &str, count: usize) -> Vec<String> {
+    let mut ids = Vec::with_capacity(count);
+    for i in 0..count {
+        let id = format!("{prefix}-{i:04}");
+        shard
+            .enqueue(
+                TENANT,
+                Some(id.clone()),
+                10u8,
+                now_ms() + i as i64,
+                None,
+                msgpack_payload(&serde_json::json!({"i": i})),
+                vec![],
+                None,
+                "default",
+            )
+            .await
+            .expect("enqueue");
+        ids.push(id);
+    }
+    ids
+}
+
+/// Remove the index entries for `ids`, simulating jobs created before the
+/// index existed.
+async fn strip_entries(shard: &JobStoreShard, ids: &[String]) {
+    for id in ids {
+        let job = shard
+            .get_job(TENANT, id)
+            .await
+            .expect("get_job")
+            .expect("job exists");
+        shard
+            .db()
+            .delete(idx_enqueue_time_key(TENANT, job.enqueue_time_ms(), id))
+            .await
+            .expect("delete entry");
+    }
+    shard.db().flush().await.expect("flush");
+}
+
+/// The tenant's index entries as job ids, in index order.
+async fn indexed_ids(db: &InstrumentedDb) -> Vec<String> {
+    let start = idx_enqueue_time_tenant_prefix(TENANT);
+    let end = end_bound(&start);
+    let mut iter = db.scan::<Vec<u8>, _>(start..end).await.expect("scan");
+    let mut ids = Vec::new();
+    while let Some(kv) = iter.next().await.expect("next") {
+        ids.push(parse_enqueue_time_index_key(&kv.key).expect("key").job_id);
+    }
+    ids
+}
+
+async fn expire_ts_of(db: &InstrumentedDb, key: &[u8]) -> Option<i64> {
+    db.get_key_value(key)
+        .await
+        .expect("get_key_value")
+        .unwrap_or_else(|| panic!("row {key:?} should be present"))
+        .expire_ts
+}
+
+fn sorted(mut ids: Vec<String>) -> Vec<String> {
+    ids.sort();
+    ids
+}
+
+#[silo::test]
+async fn sweep_writes_only_missing_entries_and_reports_counts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let shard = open_shard_at(tmp.path(), None, Default::default()).await;
+    let ids = enqueue_many(&shard, "job", 10).await;
+    strip_entries(&shard, &ids[2..7]).await;
+    assert_eq!(indexed_ids(shard.db()).await.len(), 5);
+
+    let result = shard
+        .backfill_enqueue_time_index(3, Duration::ZERO)
+        .await
+        .expect("backfill");
+
+    assert!(result.complete, "{result:?}");
+    assert!(!result.cancelled, "{result:?}");
+    assert_eq!(result.rows_scanned, 10);
+    assert_eq!(result.rows_written, 5);
+    assert_eq!(sorted(indexed_ids(shard.db()).await), ids);
+    assert!(shard.enqueue_time_index_complete());
+}
+
+#[silo::test]
+async fn sweep_carries_the_terminal_ttl_of_the_job_it_indexes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let shard = open_shard_at(tmp.path(), Some(60), Default::default()).await;
+    let ids = enqueue_many(&shard, "job", 2).await;
+    let tasks = shard
+        .dequeue("worker", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    let done_id = tasks[0].attempt().job_id().to_string();
+    shard
+        .report_attempt_outcome(
+            tasks[0].attempt().task_id(),
+            AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("report");
+    strip_entries(&shard, &ids).await;
+
+    shard
+        .backfill_enqueue_time_index(100, Duration::ZERO)
+        .await
+        .expect("backfill");
+
+    let db = shard.db();
+    for id in &ids {
+        let job = shard.get_job(TENANT, id).await.unwrap().unwrap();
+        let entry_ttl =
+            expire_ts_of(db, &idx_enqueue_time_key(TENANT, job.enqueue_time_ms(), id)).await;
+        let info_ttl = expire_ts_of(db, &job_info_key(TENANT, id)).await;
+        assert_eq!(
+            entry_ttl, info_ttl,
+            "entry TTL for {id} must match JOB_INFO"
+        );
+        assert_eq!(
+            entry_ttl.is_some(),
+            *id == done_id,
+            "only the terminal job {done_id} carries a TTL"
+        );
+    }
+}
+
+#[silo::test]
+async fn completion_marker_gates_the_sweep_and_survives_reopen() {
+    let tmp = tempfile::tempdir().unwrap();
+    let shard = open_shard_at(tmp.path(), None, Default::default()).await;
+    let ids = enqueue_many(&shard, "job", 3).await;
+    strip_entries(&shard, &ids).await;
+    assert!(!shard.enqueue_time_index_complete());
+
+    shard
+        .set_enqueue_time_index_complete(true)
+        .await
+        .expect("set marker");
+    assert!(shard.enqueue_time_index_complete());
+    let result = shard
+        .backfill_enqueue_time_index(100, Duration::ZERO)
+        .await
+        .expect("backfill");
+    assert!(result.complete);
+    assert_eq!(
+        result.rows_scanned, 0,
+        "a completed sweep must not run again"
+    );
+    assert!(indexed_ids(shard.db()).await.is_empty());
+
+    shard.close().await.expect("close");
+    let shard = open_shard_at(tmp.path(), None, Default::default()).await;
+    assert!(
+        shard.enqueue_time_index_complete(),
+        "marker must survive reopen"
+    );
+
+    shard
+        .set_enqueue_time_index_complete(false)
+        .await
+        .expect("clear marker");
+    assert!(!shard.enqueue_time_index_complete());
+    let result = shard
+        .backfill_enqueue_time_index(100, Duration::ZERO)
+        .await
+        .expect("backfill");
+    assert_eq!(result.rows_written, 3);
+    assert_eq!(sorted(indexed_ids(shard.db()).await), ids);
+}
+
+/// Every job in the tenant has exactly one entry with the job's enqueue time
+/// and TTL, and no entry points at a missing job.
+async fn assert_index_matches_jobs(shard: &JobStoreShard) {
+    let db = shard.db();
+    let start = idx_enqueue_time_tenant_prefix(TENANT);
+    let end = end_bound(&start);
+    let mut iter = db.scan::<Vec<u8>, _>(start..end).await.expect("scan");
+    let mut indexed: Vec<(String, i64, Option<i64>)> = Vec::new();
+    while let Some(kv) = iter.next().await.expect("next") {
+        let parsed = parse_enqueue_time_index_key(&kv.key).expect("key");
+        let enqueue_time_ms = parsed.enqueue_time_ms();
+        indexed.push((parsed.job_id, enqueue_time_ms, kv.expire_ts));
+    }
+    indexed.sort();
+
+    let start = silo::keys::job_info_prefix(TENANT);
+    let end = end_bound(&start);
+    let mut iter = db.scan::<Vec<u8>, _>(start..end).await.expect("scan");
+    let mut jobs: Vec<(String, i64, Option<i64>)> = Vec::new();
+    while let Some(kv) = iter.next().await.expect("next") {
+        let parsed = silo::keys::parse_job_info_key(&kv.key).expect("key");
+        let view = silo::job::JobView::new(kv.value).expect("decode");
+        jobs.push((parsed.job_id, view.enqueue_time_ms(), kv.expire_ts));
+    }
+    jobs.sort();
+
+    assert_eq!(
+        indexed, jobs,
+        "index entries must match JOB_INFO rows exactly"
+    );
+}
+
+#[silo::test]
+async fn job_deleted_during_the_sweep_has_no_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let shard = open_shard_at(tmp.path(), None, Default::default()).await;
+    let ids = enqueue_many(&shard, "job", 60).await;
+    strip_entries(&shard, &ids).await;
+    // Only a terminal job can be deleted.
+    let victim = ids[40].clone();
+    let tasks = shard
+        .dequeue("worker", "default", 60)
+        .await
+        .expect("dequeue")
+        .tasks;
+    let victim_task = tasks
+        .iter()
+        .find(|t| t.attempt().job_id() == victim)
+        .expect("victim dequeued");
+    shard
+        .report_attempt_outcome(
+            victim_task.attempt().task_id(),
+            AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("report");
+
+    let sweeper = Arc::clone(&shard);
+    let sweep = tokio::spawn(async move {
+        sweeper
+            .backfill_enqueue_time_index(1, Duration::from_millis(5))
+            .await
+            .expect("backfill")
+    });
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    shard.delete_job(TENANT, &victim).await.expect("delete_job");
+    let result = sweep.await.expect("join");
+
+    assert!(result.complete);
+    assert!(!indexed_ids(shard.db()).await.contains(&victim));
+    assert_index_matches_jobs(&shard).await;
+}
+
+#[silo::test]
+async fn job_finishing_during_the_sweep_gets_an_entry_with_its_ttl() {
+    let tmp = tempfile::tempdir().unwrap();
+    let shard = open_shard_at(tmp.path(), Some(60), Default::default()).await;
+    let ids = enqueue_many(&shard, "job", 60).await;
+    strip_entries(&shard, &ids).await;
+    let tasks = shard
+        .dequeue("worker", "default", 60)
+        .await
+        .expect("dequeue")
+        .tasks;
+    let late = tasks
+        .iter()
+        .find(|t| t.attempt().job_id() == ids[45])
+        .expect("dequeued");
+
+    let sweeper = Arc::clone(&shard);
+    let sweep = tokio::spawn(async move {
+        sweeper
+            .backfill_enqueue_time_index(1, Duration::from_millis(5))
+            .await
+            .expect("backfill")
+    });
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    shard
+        .report_attempt_outcome(
+            late.attempt().task_id(),
+            AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("report");
+    let result = sweep.await.expect("join");
+
+    assert!(result.complete);
+    let info_ttl = expire_ts_of(shard.db(), &job_info_key(TENANT, &ids[45])).await;
+    assert!(info_ttl.is_some(), "finished job carries a TTL");
+    assert_index_matches_jobs(&shard).await;
+}
+
+#[silo::test]
+async fn sweep_completes_under_sustained_concurrent_writes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let shard = open_shard_at(tmp.path(), Some(60), Default::default()).await;
+    let ids = enqueue_many(&shard, "seed", 200).await;
+    strip_entries(&shard, &ids).await;
+
+    let sweep_done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let sweeper = Arc::clone(&shard);
+    let sweep = tokio::spawn(async move {
+        sweeper
+            .backfill_enqueue_time_index(8, Duration::from_millis(1))
+            .await
+            .expect("backfill")
+    });
+    // Finish seeded jobs (each re-puts JOB_INFO with a TTL, conflicting with
+    // any batch that read it), delete some, and enqueue new ones, until the
+    // sweep is done.
+    let writer = Arc::clone(&shard);
+    let stop = Arc::clone(&sweep_done);
+    let churn = tokio::spawn(async move {
+        let mut round = 0usize;
+        while !stop.load(std::sync::atomic::Ordering::Acquire) {
+            let tasks = writer
+                .dequeue("worker", "default", 5)
+                .await
+                .expect("dequeue")
+                .tasks;
+            if tasks.is_empty() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                continue;
+            }
+            for task in &tasks {
+                writer
+                    .report_attempt_outcome(
+                        task.attempt().task_id(),
+                        AttemptOutcome::Success { result: vec![] },
+                    )
+                    .await
+                    .expect("report");
+            }
+            if round % 3 == 0 {
+                let doomed = tasks[0].attempt().job_id().to_string();
+                writer.delete_job(TENANT, &doomed).await.expect("delete");
+            }
+            enqueue_many(&writer, &format!("late-{round}"), 1).await;
+            round += 1;
+        }
+    });
+    let result = sweep.await.expect("join");
+    sweep_done.store(true, std::sync::atomic::Ordering::Release);
+    churn.await.expect("churn");
+
+    assert!(result.complete, "{result:?}");
+    assert!(!result.cancelled, "{result:?}");
+    assert_index_matches_jobs(&shard).await;
+}
+
+fn enabled(batch_size: usize, pause_ms: u64) -> EnqueueTimeIndexBackfillConfig {
+    EnqueueTimeIndexBackfillConfig {
+        enabled: true,
+        batch_size,
+        pause_ms,
+    }
+}
+
+async fn persisted_rows_scanned(db: &InstrumentedDb) -> u64 {
+    let Some(raw) = db
+        .get(&silo::keys::enqueue_time_index_backfill_progress_key())
+        .await
+        .expect("get")
+    else {
+        return 0;
+    };
+    let progress: serde_json::Value = serde_json::from_slice(&raw).expect("json");
+    progress["rows_scanned"].as_u64().unwrap_or(0)
+}
+
+#[silo::test]
+async fn close_stops_the_sweep_and_it_resumes_from_its_checkpoint_after_reopen() {
+    let tmp = tempfile::tempdir().unwrap();
+    let shard = open_shard_at(tmp.path(), None, Default::default()).await;
+    let ids = enqueue_many(&shard, "job", 200).await;
+    strip_entries(&shard, &ids).await;
+    shard.close().await.expect("close");
+
+    // The background sweep starts on open and checkpoints after every row.
+    let shard = open_shard_at(tmp.path(), None, enabled(1, 20)).await;
+    assert!(!shard.enqueue_time_index_complete());
+    let scanned_before_close =
+        poll_until(|| persisted_rows_scanned(shard.db()), |n| *n >= 5, 10_000).await;
+    shard.close().await.expect("close");
+
+    let shard = open_shard_at(tmp.path(), None, Default::default()).await;
+    assert!(
+        !shard.enqueue_time_index_complete(),
+        "sweep was interrupted"
+    );
+    let resumed = persisted_rows_scanned(shard.db()).await;
+    assert!(
+        resumed >= scanned_before_close && resumed < 200,
+        "checkpoint {resumed} should be persisted and partial"
+    );
+    let result = shard
+        .backfill_enqueue_time_index(50, Duration::ZERO)
+        .await
+        .expect("backfill");
+    assert!(result.complete);
+    assert_eq!(
+        result.rows_scanned, 200,
+        "counts accumulate across the resume"
+    );
+    assert_eq!(result.rows_written, 200);
+    assert!(shard.enqueue_time_index_complete());
+    assert_eq!(sorted(indexed_ids(shard.db()).await), ids);
+    shard.close().await.expect("close");
+
+    let shard = open_shard_at(tmp.path(), None, enabled(1, 20)).await;
+    assert!(
+        shard.enqueue_time_index_complete(),
+        "marker survives reopen"
+    );
+    tokio::time::sleep(Duration::from_millis(1_200)).await;
+    let result = shard
+        .backfill_enqueue_time_index(50, Duration::ZERO)
+        .await
+        .expect("backfill");
+    assert_eq!(result.rows_scanned, 0, "a completed sweep never runs again");
+}
+
+#[silo::test]
+async fn default_settings_spawn_no_sweep() {
+    let tmp = tempfile::tempdir().unwrap();
+    let shard = open_shard_at(tmp.path(), None, Default::default()).await;
+    let ids = enqueue_many(&shard, "job", 3).await;
+    strip_entries(&shard, &ids).await;
+    tokio::time::sleep(Duration::from_millis(1_200)).await;
+
+    assert!(!shard.enqueue_time_index_complete());
+    assert!(
+        indexed_ids(shard.db()).await.is_empty(),
+        "nothing backfilled"
+    );
+    assert_eq!(persisted_rows_scanned(shard.db()).await, 0);
+}
+
+#[silo::test]
+async fn enabled_sweep_on_an_empty_shard_sets_the_marker() {
+    let tmp = tempfile::tempdir().unwrap();
+    let shard = open_shard_at(tmp.path(), None, enabled(256, 10)).await;
+    poll_until(
+        || async { shard.enqueue_time_index_complete() },
+        |done| *done,
+        10_000,
+    )
+    .await;
+    assert!(
+        shard
+            .db()
+            .get(&silo::keys::enqueue_time_index_backfill_complete_key())
+            .await
+            .expect("get")
+            .is_some(),
+        "marker persisted"
+    );
+}

--- a/tests/enqueue_time_index_backfill_tests.rs
+++ b/tests/enqueue_time_index_backfill_tests.rs
@@ -254,7 +254,7 @@ async fn assert_index_matches_jobs(shard: &JobStoreShard) {
 }
 
 #[silo::test]
-async fn job_deleted_during_the_sweep_has_no_entry() {
+async fn job_deleted_while_the_sweep_runs_has_no_entry() {
     let tmp = tempfile::tempdir().unwrap();
     let shard = open_shard_at(tmp.path(), None, Default::default()).await;
     let ids = enqueue_many(&shard, "job", 60).await;
@@ -295,7 +295,7 @@ async fn job_deleted_during_the_sweep_has_no_entry() {
 }
 
 #[silo::test]
-async fn job_finishing_during_the_sweep_gets_an_entry_with_its_ttl() {
+async fn job_finishing_while_the_sweep_runs_gets_an_entry_with_its_ttl() {
     let tmp = tempfile::tempdir().unwrap();
     let shard = open_shard_at(tmp.path(), Some(60), Default::default()).await;
     let ids = enqueue_many(&shard, "job", 60).await;
@@ -399,16 +399,8 @@ fn enabled(batch_size: usize, pause_ms: u64) -> EnqueueTimeIndexBackfillConfig {
     }
 }
 
-async fn persisted_rows_scanned(db: &InstrumentedDb) -> u64 {
-    let Some(raw) = db
-        .get(&silo::keys::enqueue_time_index_backfill_progress_key())
-        .await
-        .expect("get")
-    else {
-        return 0;
-    };
-    let progress: serde_json::Value = serde_json::from_slice(&raw).expect("json");
-    progress["rows_scanned"].as_u64().unwrap_or(0)
+async fn indexed_count(db: &InstrumentedDb) -> usize {
+    indexed_ids(db).await.len()
 }
 
 #[silo::test]
@@ -422,8 +414,7 @@ async fn close_stops_the_sweep_and_it_resumes_from_its_checkpoint_after_reopen()
     // The background sweep starts on open and checkpoints after every row.
     let shard = open_shard_at(tmp.path(), None, enabled(1, 20)).await;
     assert!(!shard.enqueue_time_index_complete());
-    let scanned_before_close =
-        poll_until(|| persisted_rows_scanned(shard.db()), |n| *n >= 5, 10_000).await;
+    let indexed_before_close = poll_until(|| indexed_count(shard.db()), |n| *n >= 5, 10_000).await;
     shard.close().await.expect("close");
 
     let shard = open_shard_at(tmp.path(), None, Default::default()).await;
@@ -431,10 +422,10 @@ async fn close_stops_the_sweep_and_it_resumes_from_its_checkpoint_after_reopen()
         !shard.enqueue_time_index_complete(),
         "sweep was interrupted"
     );
-    let resumed = persisted_rows_scanned(shard.db()).await;
+    let resumed = indexed_count(shard.db()).await;
     assert!(
-        resumed >= scanned_before_close && resumed < 200,
-        "checkpoint {resumed} should be persisted and partial"
+        resumed >= indexed_before_close && resumed < 200,
+        "{resumed} entries should survive the close and leave the sweep partial"
     );
     let result = shard
         .backfill_enqueue_time_index(50, Duration::ZERO)
@@ -448,19 +439,6 @@ async fn close_stops_the_sweep_and_it_resumes_from_its_checkpoint_after_reopen()
     assert_eq!(result.rows_written, 200);
     assert!(shard.enqueue_time_index_complete());
     assert_eq!(sorted(indexed_ids(shard.db()).await), ids);
-    shard.close().await.expect("close");
-
-    let shard = open_shard_at(tmp.path(), None, enabled(1, 20)).await;
-    assert!(
-        shard.enqueue_time_index_complete(),
-        "marker survives reopen"
-    );
-    tokio::time::sleep(Duration::from_millis(1_200)).await;
-    let result = shard
-        .backfill_enqueue_time_index(50, Duration::ZERO)
-        .await
-        .expect("backfill");
-    assert_eq!(result.rows_scanned, 0, "a completed sweep never runs again");
 }
 
 #[silo::test]
@@ -476,7 +454,6 @@ async fn default_settings_spawn_no_sweep() {
         indexed_ids(shard.db()).await.is_empty(),
         "nothing backfilled"
     );
-    assert_eq!(persisted_rows_scanned(shard.db()).await, 0);
 }
 
 #[silo::test]

--- a/tests/enqueue_time_index_ordering_tests.rs
+++ b/tests/enqueue_time_index_ordering_tests.rs
@@ -1,0 +1,390 @@
+//! The ordering the enqueue-time index path declares to DataFusion, and the
+//! fetch it accepts: `ORDER BY enqueue_time_ms DESC, id ASC LIMIT n` runs as
+//! a range scan of `n` index keys with no sort operator.
+
+mod test_helpers;
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, StringArray};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::physical_plan::{ExecutionPlan, displayable};
+use silo::job::{ConcurrencyLimit, Limit};
+use silo::job_store_shard::JobStoreShard;
+use silo::query::ShardQueryEngine;
+use test_helpers::*;
+
+const ENQUEUE_INDEX_LABEL: &str = "path=EnqueueTimeIndex";
+const ORDERED_LISTING: &str =
+    "SELECT id FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms DESC, id ASC LIMIT 101";
+
+/// Enqueue `count` jobs whose enqueue times collide in pairs, so the `id`
+/// tiebreak matters. Writes are issued concurrently in chunks so large
+/// seeds share flushes instead of awaiting one durable write per job.
+async fn seed(shard: &JobStoreShard, count: usize) {
+    let base = now_ms();
+    for chunk in (0..count).collect::<Vec<_>>().chunks(200) {
+        let writes = chunk.iter().map(|&i| {
+            shard.enqueue(
+                "-",
+                Some(format!("job-{i:05}")),
+                (i % 7) as u8,
+                base - ((i / 2) as i64) * 1_000,
+                None,
+                msgpack_payload(&serde_json::json!({"i": i})),
+                vec![],
+                None,
+                "default",
+            )
+        });
+        for result in futures::future::join_all(writes).await {
+            result.expect("enqueue");
+        }
+    }
+}
+
+async fn mark_complete(shard: &JobStoreShard, complete: bool) {
+    shard
+        .set_enqueue_time_index_complete(complete)
+        .await
+        .expect("set marker");
+}
+
+async fn explain(engine: &ShardQueryEngine, query: &str) -> String {
+    engine.explain(query).await.expect("explain")
+}
+
+fn plan_line(explain: &str) -> String {
+    explain
+        .lines()
+        .find(|l| l.contains("SiloExecutionPlan:"))
+        .unwrap_or_else(|| panic!("no SiloExecutionPlan line in EXPLAIN:\n{explain}"))
+        .trim()
+        .to_string()
+}
+
+async fn ids(engine: &ShardQueryEngine, query: &str) -> Vec<String> {
+    let batches = engine
+        .sql(query)
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    string_column(&batches, 0)
+}
+
+fn string_column(batches: &[RecordBatch], idx: usize) -> Vec<String> {
+    batches
+        .iter()
+        .flat_map(|b| {
+            let col = b
+                .column(idx)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("string column");
+            (0..b.num_rows())
+                .map(|i| col.value(i).to_string())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+async fn row_count(engine: &ShardQueryEngine, query: &str) -> usize {
+    engine
+        .sql(query)
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect")
+        .iter()
+        .map(|b| b.num_rows())
+        .sum()
+}
+
+/// The leaf `SiloExecutionPlan` node of a physical plan.
+fn silo_leaf(plan: &Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    find_silo_leaf(plan).expect("plan has a SiloExecutionPlan leaf")
+}
+
+fn find_silo_leaf(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
+    if plan.name() == "SiloExecutionPlan" {
+        return Some(Arc::clone(plan));
+    }
+    plan.children().into_iter().find_map(find_silo_leaf)
+}
+
+fn one_line(plan: &dyn ExecutionPlan) -> String {
+    displayable(plan).one_line().to_string()
+}
+
+fn ordering_text(plan: &dyn ExecutionPlan) -> String {
+    plan.properties()
+        .output_ordering()
+        .map(|o| {
+            o.iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default()
+}
+
+#[silo::test]
+async fn matching_order_by_runs_without_a_sort_and_pushes_the_fetch() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    seed(&shard, 300).await;
+    mark_complete(&shard, true).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    let plan_text = explain(&engine, ORDERED_LISTING).await;
+    assert!(
+        !plan_text.contains("SortExec"),
+        "declared ordering must eliminate the sort:\n{plan_text}"
+    );
+    let line = plan_line(&plan_text);
+    assert!(line.contains(ENQUEUE_INDEX_LABEL), "{line}");
+    assert!(line.contains("limit=Some(101)"), "fetch pushed: {line}");
+
+    let before = metrics.query_scanned_keys_value(shard.name());
+    let got = ids(&engine, ORDERED_LISTING).await;
+    let scanned = metrics.query_scanned_keys_value(shard.name()) - before;
+    assert_eq!(got.len(), 101);
+    assert!(
+        scanned <= 101.0,
+        "scanned {scanned} keys for a 101-row page"
+    );
+
+    mark_complete(&shard, false).await;
+    let plan_text = explain(&engine, ORDERED_LISTING).await;
+    assert!(
+        plan_text.contains("SortExec"),
+        "job-record path keeps its sort:\n{plan_text}"
+    );
+    assert_eq!(ids(&engine, ORDERED_LISTING).await, got);
+}
+
+#[silo::test]
+async fn with_fetch_preserves_path_ordering_and_filters() {
+    let (_tmp, shard) = open_temp_shard().await;
+    seed(&shard, 10).await;
+    mark_complete(&shard, true).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    let plan = engine
+        .get_physical_plan(ORDERED_LISTING)
+        .await
+        .expect("plan");
+    let leaf = silo_leaf(&plan);
+    assert_eq!(leaf.fetch(), Some(101));
+    assert_eq!(
+        ordering_text(leaf.as_ref()),
+        "enqueue_time_ms@1 DESC NULLS LAST, id@0 ASC NULLS LAST"
+    );
+    let text = one_line(leaf.as_ref());
+    assert!(text.contains(ENQUEUE_INDEX_LABEL), "{text}");
+    assert!(text.contains("tenant"), "filters retained: {text}");
+
+    let tighter = leaf
+        .with_fetch(Some(50))
+        .expect("index path accepts a fetch");
+    assert_eq!(tighter.fetch(), Some(50));
+    assert_eq!(
+        ordering_text(tighter.as_ref()),
+        ordering_text(leaf.as_ref())
+    );
+    assert_eq!(
+        one_line(tighter.as_ref()),
+        text.replace("limit=Some(101)", "limit=Some(50)")
+    );
+    assert!(
+        leaf.with_fetch(Some(500)).expect("accepts").fetch() == Some(101),
+        "a looser fetch keeps the tighter limit"
+    );
+
+    mark_complete(&shard, false).await;
+    let plan = engine
+        .get_physical_plan("SELECT id, priority FROM jobs WHERE tenant = '-'")
+        .await
+        .expect("plan");
+    let leaf = silo_leaf(&plan);
+    assert_eq!(leaf.fetch(), None);
+    assert!(
+        leaf.with_fetch(Some(5)).is_none(),
+        "other paths refuse a fetch"
+    );
+    assert_eq!(
+        ordering_text(leaf.as_ref()),
+        "",
+        "other paths declare no ordering"
+    );
+}
+
+#[silo::test]
+async fn offset_pages_scan_only_skip_plus_fetch_and_match_the_record_path() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    seed(&shard, 5_200).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let query = "SELECT id FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms DESC, id ASC LIMIT 101 OFFSET 5000";
+
+    mark_complete(&shard, false).await;
+    let from_records = ids(&engine, query).await;
+    assert_eq!(from_records.len(), 101);
+
+    mark_complete(&shard, true).await;
+    let before = metrics.query_scanned_keys_value(shard.name());
+    let from_index = ids(&engine, query).await;
+    let scanned = metrics.query_scanned_keys_value(shard.name()) - before;
+    assert_eq!(from_index, from_records);
+    assert!(
+        scanned <= 5_101.0,
+        "OFFSET 5000 LIMIT 101 scanned {scanned} keys"
+    );
+}
+
+#[silo::test]
+async fn consecutive_offset_pages_are_disjoint_and_cover_the_tenant() {
+    let (_tmp, shard) = open_temp_shard().await;
+    seed(&shard, 250).await;
+    mark_complete(&shard, true).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    let mut paged = Vec::new();
+    for offset in [0, 100, 200] {
+        let page = ids(
+            &engine,
+            &format!("SELECT id FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms DESC, id ASC LIMIT 100 OFFSET {offset}"),
+        )
+        .await;
+        assert_eq!(page.len(), if offset == 200 { 50 } else { 100 });
+        paged.extend(page);
+    }
+    let whole = ids(
+        &engine,
+        "SELECT id FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms DESC, id ASC",
+    )
+    .await;
+    assert_eq!(
+        paged, whole,
+        "pages concatenate to the full ordered listing"
+    );
+    let distinct: std::collections::HashSet<&String> = paged.iter().collect();
+    assert_eq!(distinct.len(), 250, "pages are disjoint and complete");
+}
+
+#[silo::test]
+async fn non_matching_order_by_keeps_its_sort_and_stays_correct() {
+    let (_tmp, shard) = open_temp_shard().await;
+    seed(&shard, 60).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let queries = [
+        "SELECT id FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms ASC LIMIT 20",
+        "SELECT id FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms DESC, id DESC LIMIT 20",
+        "SELECT id FROM jobs WHERE tenant = '-' ORDER BY priority, id LIMIT 20",
+    ];
+    for query in queries {
+        mark_complete(&shard, false).await;
+        let expected = ids(&engine, query).await;
+        mark_complete(&shard, true).await;
+        let plan_text = explain(&engine, query).await;
+        assert!(plan_text.contains("SortExec"), "{query}:\n{plan_text}");
+        assert_eq!(ids(&engine, query).await, expected, "{query}");
+    }
+}
+
+#[silo::test]
+async fn gadget_listing_shape_takes_the_index_path_and_returns_the_true_newest() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    seed(&shard, 300).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let gadget = "SELECT id FROM (SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' LIMIT 50000) ORDER BY enqueue_time_ms DESC, id DESC LIMIT 101 OFFSET 0";
+
+    mark_complete(&shard, false).await;
+    let expected = ids(
+        &engine,
+        "SELECT id FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms DESC, id DESC LIMIT 101",
+    )
+    .await;
+
+    mark_complete(&shard, true).await;
+    let line = plan_line(&explain(&engine, gadget).await);
+    assert!(line.contains(ENQUEUE_INDEX_LABEL), "{line}");
+    let lookups_before = metrics.query_point_lookups_value(shard.name());
+    let got = ids(&engine, gadget).await;
+    let lookups = metrics.query_point_lookups_value(shard.name()) - lookups_before;
+    assert_eq!(got, expected);
+    assert_eq!(lookups, 0.0, "no job-record reads on the index path");
+}
+
+#[silo::test]
+async fn limit_on_other_tables_is_unchanged() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    for (tenant, queue) in [("t1", "q1"), ("t2", "q2"), ("t3", "q3")] {
+        for i in 0..2 {
+            shard
+                .enqueue(
+                    tenant,
+                    Some(format!("{tenant}-{i}")),
+                    10u8,
+                    now,
+                    None,
+                    msgpack_payload(&serde_json::json!({})),
+                    vec![Limit::Concurrency(ConcurrencyLimit {
+                        key: queue.to_string(),
+                        max_concurrency: 1,
+                    })],
+                    None,
+                    "default",
+                )
+                .await
+                .expect("enqueue");
+        }
+    }
+    shard.dequeue("w", "default", 3).await.expect("dequeue");
+    shard
+        .set_enqueue_time_index_complete(true)
+        .await
+        .expect("marker");
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    assert_eq!(
+        row_count(&engine, "SELECT * FROM tenant_counts LIMIT 2").await,
+        2
+    );
+    assert_eq!(
+        row_count(&engine, "SELECT * FROM queue_counts LIMIT 2").await,
+        2
+    );
+
+    let cases = [
+        (
+            "SELECT * FROM queues LIMIT 2",
+            "SiloExecutionPlan: queues[tenant=None, queue=None, entry_type=None], limit=Some(2)",
+        ),
+        (
+            "SELECT * FROM tasks LIMIT 2",
+            "SiloExecutionPlan: tasks[FullScan], limit=Some(2)",
+        ),
+        (
+            "SELECT * FROM tenant_counts LIMIT 2",
+            "SiloExecutionPlan: tenant_counts[all], limit=Some(2)",
+        ),
+        (
+            "SELECT * FROM queue_counts LIMIT 2",
+            "SiloExecutionPlan: queue_counts[tenant=None], limit=Some(2)",
+        ),
+        (
+            "SELECT id, priority FROM jobs WHERE tenant = 't1' LIMIT 2",
+            "SiloExecutionPlan: jobs[FullScan(tenant=Some(\"t1\"))], limit=Some(2), path=FullScanJoin",
+        ),
+    ];
+    for (query, expected) in cases {
+        assert_eq!(
+            plan_line(&explain(&engine, query).await),
+            expected,
+            "{query}"
+        );
+    }
+}

--- a/tests/enqueue_time_index_ordering_tests.rs
+++ b/tests/enqueue_time_index_ordering_tests.rs
@@ -388,3 +388,60 @@ async fn limit_on_other_tables_is_unchanged() {
         );
     }
 }
+
+/// A residual filter above the index path keeps the limit above the filter,
+/// so a page is never cut short by rows the filter rejects.
+#[silo::test]
+async fn residual_filters_keep_the_limit_above_the_scan() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    seed(&shard, 200).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    // The newest rows carry the largest enqueue times; a cutoff at the median
+    // rejects roughly the first hundred index keys.
+    let cutoff = {
+        let times = engine
+            .sql(
+                "SELECT enqueue_time_ms FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms DESC",
+            )
+            .await
+            .expect("sql")
+            .collect()
+            .await
+            .expect("collect");
+        let col = times[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Int64Array>()
+            .expect("int64");
+        col.value(100)
+    };
+    let queries = [
+        format!(
+            "SELECT id FROM jobs WHERE tenant = '-' AND enqueue_time_ms <= {cutoff} ORDER BY enqueue_time_ms DESC, id ASC LIMIT 5"
+        ),
+        "SELECT id FROM jobs WHERE tenant = '-' AND id LIKE 'job-1%' ORDER BY enqueue_time_ms DESC, id ASC LIMIT 5".to_string(),
+        "SELECT id FROM jobs WHERE tenant = '-' AND id LIKE 'job-19%' LIMIT 3".to_string(),
+    ];
+
+    for query in &queries {
+        mark_complete(&shard, false).await;
+        let expected = ids(&engine, query).await;
+        mark_complete(&shard, true).await;
+        let plan_text = explain(&engine, query).await;
+        let line = plan_line(&plan_text);
+        assert!(line.contains(ENQUEUE_INDEX_LABEL), "{query}:\n{plan_text}");
+        assert!(
+            plan_text.contains("FilterExec") && line.contains("limit=None"),
+            "{query}: the limit must stay above the residual filter:\n{plan_text}"
+        );
+        let before = metrics.query_scanned_keys_value(shard.name());
+        let got = ids(&engine, query).await;
+        let scanned = metrics.query_scanned_keys_value(shard.name()) - before;
+        assert_eq!(got, expected, "{query}");
+        assert!(
+            !got.is_empty() && scanned > got.len() as f64,
+            "{query}: the scan must walk past the rejected keys (scanned {scanned} for {} rows)",
+            got.len()
+        );
+    }
+}

--- a/tests/enqueue_time_index_ordering_tests.rs
+++ b/tests/enqueue_time_index_ordering_tests.rs
@@ -27,7 +27,7 @@ async fn seed(shard: &JobStoreShard, count: usize) {
         let writes = chunk.iter().map(|&i| {
             shard.enqueue(
                 "-",
-                Some(format!("job-{i:05}")),
+                Some(format!("job-{i}")),
                 (i % 7) as u8,
                 base - ((i / 2) as i64) * 1_000,
                 None,
@@ -279,7 +279,7 @@ async fn non_matching_order_by_keeps_its_sort_and_stays_correct() {
     seed(&shard, 60).await;
     let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
     let queries = [
-        "SELECT id FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms ASC LIMIT 20",
+        "SELECT id FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms ASC, id ASC LIMIT 20",
         "SELECT id FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms DESC, id DESC LIMIT 20",
         "SELECT id FROM jobs WHERE tenant = '-' ORDER BY priority, id LIMIT 20",
     ];

--- a/tests/enqueue_time_index_query_tests.rs
+++ b/tests/enqueue_time_index_query_tests.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use datafusion::arrow::array::{Array, Int64Array, StringArray};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::execution::context::SessionContext;
+use datafusion::prelude::SessionConfig;
 use silo::job_store_shard::JobStoreShard;
 use silo::query::ShardQueryEngine;
 use test_helpers::*;
@@ -102,6 +103,7 @@ async fn key_served_tenant_projections_take_the_index_path_when_complete() {
         "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-'",
         "SELECT id FROM jobs WHERE tenant = '-' LIMIT 5",
         "SELECT shard_id, tenant, id, enqueue_time_ms FROM jobs WHERE tenant = '-'",
+        "SELECT shard_id FROM jobs WHERE tenant = '-'",
     ];
 
     mark_complete(&shard, true).await;
@@ -282,4 +284,89 @@ async fn a_resolved_plan_keeps_its_path_after_the_flag_clears() {
 
     assert_eq!(rows_of(&batches), expected);
     assert_eq!(lookups, 0.0, "the plan must still execute the index path");
+}
+
+#[silo::test]
+async fn index_path_streams_correctly_across_small_batches() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    seed(&shard, 50).await;
+    mark_complete(&shard, true).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let query = "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' LIMIT 23";
+    let expected = id_time_rows(&engine, query).await;
+    assert_eq!(expected.len(), 23);
+
+    // A batch size that does not divide the limit exercises the chunk clamp
+    // and the accumulation across chunks.
+    let plan = engine.get_physical_plan(query).await.expect("plan");
+    let small_batches = SessionContext::new_with_config(SessionConfig::new().with_batch_size(7));
+    let scanned_before = metrics.query_scanned_keys_value(shard.name());
+    let batches = datafusion::physical_plan::collect(plan, small_batches.task_ctx())
+        .await
+        .expect("collect");
+    let scanned = metrics.query_scanned_keys_value(shard.name()) - scanned_before;
+
+    assert!(
+        batches.len() >= 4,
+        "expected several small batches, got {}",
+        batches.len()
+    );
+    assert_eq!(rows_of(&batches), expected);
+    assert!(scanned <= 23.0, "scanned {scanned} keys for LIMIT 23");
+}
+
+#[silo::test]
+async fn deleted_job_never_appears_in_an_index_listing() {
+    let (_tmp, shard) = open_temp_shard().await;
+    seed(&shard, 6).await;
+    mark_complete(&shard, true).await;
+    let tasks = shard
+        .dequeue("worker", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    let doomed = tasks[0].attempt().job_id().to_string();
+    shard
+        .report_attempt_outcome(
+            tasks[0].attempt().task_id(),
+            silo::job_attempt::AttemptOutcome::Success { result: vec![] },
+        )
+        .await
+        .expect("report");
+    shard.delete_job("-", &doomed).await.expect("delete_job");
+
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let query = "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' ORDER BY enqueue_time_ms DESC, id ASC";
+    assert!(
+        explain_line(&engine, query)
+            .await
+            .contains(ENQUEUE_INDEX_LABEL)
+    );
+    let ids: Vec<String> = id_time_rows(&engine, query)
+        .await
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect();
+    assert_eq!(ids.len(), 5);
+    assert!(
+        !ids.contains(&doomed),
+        "{doomed} was deleted but is still listed"
+    );
+}
+
+#[silo::test]
+async fn status_filtered_listings_return_the_same_rows_regardless_of_the_flag() {
+    let (_tmp, shard) = open_temp_shard().await;
+    seed(&shard, 12).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let query = "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting' ORDER BY enqueue_time_ms DESC, id ASC";
+
+    mark_complete(&shard, false).await;
+    let cleared = id_time_rows(&engine, query).await;
+    mark_complete(&shard, true).await;
+    let set = id_time_rows(&engine, query).await;
+
+    assert!(!cleared.is_empty(), "seed includes waiting jobs");
+    assert_eq!(set, cleared);
+    assert!(explain_line(&engine, query).await.contains("path=JobPairs"));
 }

--- a/tests/enqueue_time_index_query_tests.rs
+++ b/tests/enqueue_time_index_query_tests.rs
@@ -1,0 +1,285 @@
+//! The jobs scanner's enqueue-time index path: selected for tenant-scoped,
+//! key-served projections on a shard whose index backfill has completed, and
+//! resolved once at planning time.
+
+mod test_helpers;
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, Int64Array, StringArray};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::execution::context::SessionContext;
+use silo::job_store_shard::JobStoreShard;
+use silo::query::ShardQueryEngine;
+use test_helpers::*;
+
+const ENQUEUE_INDEX_LABEL: &str = "path=EnqueueTimeIndex";
+
+async fn seed(shard: &JobStoreShard, count: usize) {
+    let now = now_ms();
+    for i in 0..count {
+        // Mix of immediate (stored as 0), past, and future enqueue times.
+        let start_at_ms = match i % 3 {
+            0 => 0,
+            1 => now - (i as i64) * 1_000,
+            _ => now + (i as i64) * 1_000,
+        };
+        shard
+            .enqueue(
+                "-",
+                Some(format!("job-{i:04}")),
+                10u8,
+                start_at_ms,
+                None,
+                msgpack_payload(&serde_json::json!({"i": i})),
+                vec![],
+                Some(vec![("k".to_string(), format!("v{}", i % 2))]),
+                "default",
+            )
+            .await
+            .expect("enqueue");
+    }
+}
+
+async fn mark_complete(shard: &JobStoreShard, complete: bool) {
+    shard
+        .set_enqueue_time_index_complete(complete)
+        .await
+        .expect("set marker");
+}
+
+fn plan_line(explain: &str) -> String {
+    explain
+        .lines()
+        .find(|l| l.contains("SiloExecutionPlan:"))
+        .unwrap_or_else(|| panic!("no SiloExecutionPlan line in EXPLAIN:\n{explain}"))
+        .trim()
+        .to_string()
+}
+
+async fn explain_line(engine: &ShardQueryEngine, query: &str) -> String {
+    plan_line(&engine.explain(query).await.expect("explain"))
+}
+
+/// `(id, enqueue_time_ms)` rows from a query projecting exactly those columns.
+async fn id_time_rows(engine: &ShardQueryEngine, query: &str) -> Vec<(String, i64)> {
+    let batches = engine
+        .sql(query)
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    rows_of(&batches)
+}
+
+fn rows_of(batches: &[RecordBatch]) -> Vec<(String, i64)> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("id column");
+        let times = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("enqueue_time_ms column");
+        for i in 0..batch.num_rows() {
+            rows.push((ids.value(i).to_string(), times.value(i)));
+        }
+    }
+    rows
+}
+
+#[silo::test]
+async fn key_served_tenant_projections_take_the_index_path_when_complete() {
+    let (_tmp, shard) = open_temp_shard().await;
+    seed(&shard, 6).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let queries = [
+        "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-'",
+        "SELECT id FROM jobs WHERE tenant = '-' LIMIT 5",
+        "SELECT shard_id, tenant, id, enqueue_time_ms FROM jobs WHERE tenant = '-'",
+    ];
+
+    mark_complete(&shard, true).await;
+    for query in queries {
+        let line = explain_line(&engine, query).await;
+        assert!(
+            line.contains(ENQUEUE_INDEX_LABEL),
+            "{query}: expected the enqueue-index path, got {line}"
+        );
+    }
+
+    mark_complete(&shard, false).await;
+    let line = explain_line(&engine, queries[0]).await;
+    assert!(
+        line.contains("path=FullScanJoin"),
+        "{}: job-record projection must fall back to the join path, got {line}",
+        queries[0]
+    );
+    let line = explain_line(&engine, queries[1]).await;
+    assert!(
+        line.contains("path=StatusIndex"),
+        "{}: id-only projection must fall back to the status index, got {line}",
+        queries[1]
+    );
+}
+
+#[silo::test]
+async fn other_shapes_keep_their_path_regardless_of_the_flag() {
+    let (_tmp, shard) = open_temp_shard().await;
+    seed(&shard, 6).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let cases = [
+        (
+            "SELECT COUNT(*) FROM jobs WHERE tenant = '-'",
+            "path=CountFromCounters",
+        ),
+        (
+            "SELECT id, status_kind FROM jobs WHERE tenant = '-'",
+            "path=StatusIndex",
+        ),
+        (
+            "SELECT id, priority FROM jobs WHERE tenant = '-'",
+            "path=FullScanJoin",
+        ),
+        ("SELECT id, enqueue_time_ms FROM jobs", "path=FullScanJoin"),
+        ("SELECT id FROM jobs", "path=StatusIndex"),
+        (
+            "SELECT id FROM jobs WHERE tenant = '-' AND status_kind = 'Waiting'",
+            "path=JobPairs",
+        ),
+        (
+            "SELECT id FROM jobs WHERE tenant = '-' AND array_contains(element_at(metadata, 'k'), 'v0')",
+            "path=JobPairs",
+        ),
+    ];
+
+    for (query, expected) in cases {
+        mark_complete(&shard, false).await;
+        let cleared = explain_line(&engine, query).await;
+        mark_complete(&shard, true).await;
+        let set = explain_line(&engine, query).await;
+        assert!(
+            cleared.contains(expected),
+            "{query}: expected {expected} with the flag cleared, got {cleared}"
+        );
+        assert_eq!(
+            set, cleared,
+            "{query}: EXPLAIN must not change when the flag is set"
+        );
+        assert!(
+            !set.contains(ENQUEUE_INDEX_LABEL),
+            "{query}: must never take the enqueue-index path"
+        );
+    }
+}
+
+#[silo::test]
+async fn other_tables_keep_their_explain_output() {
+    let (_tmp, shard) = open_temp_shard().await;
+    seed(&shard, 2).await;
+    mark_complete(&shard, true).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let cases = [
+        (
+            "SELECT * FROM queues WHERE tenant = '-'",
+            "SiloExecutionPlan: queues[tenant=Some(\"-\"), queue=None, entry_type=None], limit=None",
+        ),
+        (
+            "SELECT * FROM tasks LIMIT 3",
+            "SiloExecutionPlan: tasks[FullScan], limit=Some(3)",
+        ),
+        (
+            "SELECT * FROM tenant_counts",
+            "SiloExecutionPlan: tenant_counts[all], limit=None",
+        ),
+        (
+            "SELECT * FROM queue_counts WHERE tenant = '-'",
+            "SiloExecutionPlan: queue_counts[tenant=Some(\"-\")], limit=None",
+        ),
+    ];
+    for (query, expected) in cases {
+        assert_eq!(explain_line(&engine, query).await, expected, "{query}");
+    }
+}
+
+#[silo::test]
+async fn index_path_returns_the_same_rows_as_the_job_record_path() {
+    let (_tmp, shard) = open_temp_shard().await;
+    seed(&shard, 30).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let query = "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' ORDER BY id";
+
+    mark_complete(&shard, false).await;
+    let from_records = id_time_rows(&engine, query).await;
+    mark_complete(&shard, true).await;
+    assert!(
+        explain_line(&engine, query)
+            .await
+            .contains(ENQUEUE_INDEX_LABEL)
+    );
+    let from_index = id_time_rows(&engine, query).await;
+
+    assert_eq!(from_records.len(), 30);
+    assert!(
+        from_records.iter().any(|(_, t)| *t == 0),
+        "seed includes a job with enqueue_time_ms of zero"
+    );
+    assert_eq!(from_index, from_records);
+}
+
+#[silo::test]
+async fn index_path_reads_only_index_keys_and_honours_the_scan_limit() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    seed(&shard, 400).await;
+    mark_complete(&shard, true).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+
+    let limited = "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' LIMIT 10";
+    assert!(
+        explain_line(&engine, limited)
+            .await
+            .contains(ENQUEUE_INDEX_LABEL)
+    );
+    let scanned_before = metrics.query_scanned_keys_value(shard.name());
+    let lookups_before = metrics.query_point_lookups_value(shard.name());
+    let rows = id_time_rows(&engine, limited).await;
+    let scanned = metrics.query_scanned_keys_value(shard.name()) - scanned_before;
+    let lookups = metrics.query_point_lookups_value(shard.name()) - lookups_before;
+
+    assert_eq!(rows.len(), 10);
+    assert!(
+        scanned <= 10.0,
+        "LIMIT 10 scanned {scanned} keys; the walk must stop at the limit"
+    );
+    assert_eq!(lookups, 0.0, "the index path performs no point lookups");
+}
+
+#[silo::test]
+async fn a_resolved_plan_keeps_its_path_after_the_flag_clears() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    seed(&shard, 20).await;
+    mark_complete(&shard, true).await;
+    let engine = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("engine");
+    let query = "SELECT id, enqueue_time_ms FROM jobs WHERE tenant = '-' ORDER BY id";
+    let expected = id_time_rows(&engine, query).await;
+    let plan = engine.get_physical_plan(query).await.expect("plan");
+    let plan_text = datafusion::physical_plan::displayable(plan.as_ref())
+        .indent(false)
+        .to_string();
+    assert!(plan_text.contains(ENQUEUE_INDEX_LABEL), "{plan_text}");
+
+    mark_complete(&shard, false).await;
+    let lookups_before = metrics.query_point_lookups_value(shard.name());
+    let batches = datafusion::physical_plan::collect(plan, SessionContext::new().task_ctx())
+        .await
+        .expect("collect");
+    let lookups = metrics.query_point_lookups_value(shard.name()) - lookups_before;
+
+    assert_eq!(rows_of(&batches), expected);
+    assert_eq!(lookups, 0.0, "the plan must still execute the index path");
+}

--- a/tests/enqueue_time_index_tests.rs
+++ b/tests/enqueue_time_index_tests.rs
@@ -1,0 +1,430 @@
+//! Lifecycle maintenance of the enqueue-time index (`IDX_ENQUEUE_TIME`):
+//! written once when a job is created, deleted with the job, and carrying the
+//! same row TTL as the job's other rows through every terminal transition.
+
+mod test_helpers;
+
+use silo::instrumented_db::InstrumentedDb;
+use silo::job::JobStatusKind;
+use silo::job_attempt::AttemptOutcome;
+use silo::job_store_shard::JobStoreShard;
+use silo::job_store_shard::import::{ImportJobParams, ImportedAttempt, ImportedAttemptStatus};
+use silo::keys::{
+    attempt_key, end_bound, idx_enqueue_time_key, idx_enqueue_time_tenant_prefix, idx_metadata_key,
+    job_cancelled_key, job_info_key, job_status_key, parse_enqueue_time_index_key,
+};
+use silo::retry::RetryPolicy;
+use silo::shard_range::ShardRange;
+use test_helpers::*;
+
+/// The row TTL on `key`, panicking if the row is absent.
+async fn expire_ts_of(db: &InstrumentedDb, key: &[u8]) -> Option<i64> {
+    db.get_key_value(key)
+        .await
+        .expect("get_key_value")
+        .unwrap_or_else(|| panic!("row {key:?} should be present"))
+        .expire_ts
+}
+
+/// The job's index entry key, derived from its stored `JOB_INFO`.
+async fn entry_key(shard: &JobStoreShard, tenant: &str, id: &str) -> Vec<u8> {
+    let job = shard
+        .get_job(tenant, id)
+        .await
+        .expect("get_job")
+        .expect("job exists");
+    idx_enqueue_time_key(tenant, job.enqueue_time_ms(), id)
+}
+
+/// Assert the entry carries exactly the TTL that `JOB_INFO` and `JOB_STATUS`
+/// carry, and return that TTL.
+async fn assert_entry_ttl_matches_job(
+    shard: &JobStoreShard,
+    tenant: &str,
+    id: &str,
+) -> Option<i64> {
+    let db = shard.db();
+    let info_ttl = expire_ts_of(db, &job_info_key(tenant, id)).await;
+    let status_ttl = expire_ts_of(db, &job_status_key(tenant, id)).await;
+    let entry_ttl = expire_ts_of(db, &entry_key(shard, tenant, id).await).await;
+    assert_eq!(info_ttl, status_ttl, "JOB_INFO and JOB_STATUS TTLs differ");
+    assert_eq!(entry_ttl, info_ttl, "index entry TTL differs from JOB_INFO");
+    entry_ttl
+}
+
+/// A tenant's index entries in key order: `(enqueue_time_ms, job_id)`.
+async fn index_entries(db: &InstrumentedDb, tenant: &str) -> Vec<(i64, String)> {
+    let start = idx_enqueue_time_tenant_prefix(tenant);
+    let end = end_bound(&start);
+    let mut iter = db.scan::<Vec<u8>, _>(start..end).await.expect("scan");
+    let mut entries = Vec::new();
+    while let Some(kv) = iter.next().await.expect("next") {
+        let parsed = parse_enqueue_time_index_key(&kv.key).expect("enqueue-time index key");
+        entries.push((parsed.enqueue_time_ms(), parsed.job_id));
+    }
+    entries
+}
+
+async fn enqueue_at(shard: &JobStoreShard, tenant: &str, id: &str, start_at_ms: i64) {
+    let payload = msgpack_payload(&serde_json::json!({"id": id}));
+    shard
+        .enqueue(
+            tenant,
+            Some(id.to_string()),
+            10u8,
+            start_at_ms,
+            None,
+            payload,
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+}
+
+fn import_base(id: &str) -> ImportJobParams {
+    ImportJobParams {
+        id: id.to_string(),
+        priority: 50,
+        enqueue_time_ms: 1_700_000_000_000,
+        start_at_ms: 0,
+        retry_policy: None,
+        payload: msgpack_payload(&serde_json::json!({"imported": true})),
+        limits: vec![],
+        metadata: None,
+        task_group: "default".to_string(),
+        attempts: vec![],
+    }
+}
+
+fn import_succeeded_attempt(finished_at_ms: i64) -> ImportedAttempt {
+    ImportedAttempt {
+        status: ImportedAttemptStatus::Succeeded { result: vec![1] },
+        started_at_ms: finished_at_ms - 1000,
+        finished_at_ms,
+    }
+}
+
+/// Dequeue the single pending task on `default` and report `outcome` for it.
+async fn run_next_attempt(shard: &JobStoreShard, outcome: AttemptOutcome) {
+    let tasks = shard
+        .dequeue("worker", "default", 1)
+        .await
+        .expect("dequeue")
+        .tasks;
+    assert_eq!(tasks.len(), 1, "expected exactly one task to dequeue");
+    let task_id = tasks[0].attempt().task_id().to_string();
+    shard
+        .report_attempt_outcome(&task_id, outcome)
+        .await
+        .expect("report_attempt_outcome");
+}
+
+#[silo::test]
+async fn enqueue_writes_one_entry_per_job_ordered_newest_first() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let now = now_ms();
+    enqueue_at(&shard, "-", "older", now - 10_000).await;
+    enqueue_at(&shard, "-", "newer", now + 10_000).await;
+    enqueue_at(&shard, "-", "immediate", 0).await;
+    enqueue_at(&shard, "other", "elsewhere", now).await;
+
+    assert_eq!(
+        index_entries(shard.db(), "-").await,
+        vec![
+            (now + 10_000, "newer".to_string()),
+            (now - 10_000, "older".to_string()),
+            (0, "immediate".to_string()),
+        ]
+    );
+    assert_eq!(
+        index_entries(shard.db(), "other").await,
+        vec![(now, "elsewhere".to_string())]
+    );
+}
+
+#[silo::test]
+async fn first_import_writes_entry_keyed_by_enqueue_time() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let scheduled = import_base("imported-scheduled");
+    let mut terminal = import_base("imported-terminal");
+    terminal.enqueue_time_ms = 1_600_000_000_000;
+    terminal.attempts = vec![import_succeeded_attempt(now_ms() - 1_000)];
+
+    let results = shard
+        .import_jobs("-", vec![scheduled, terminal])
+        .await
+        .expect("import_jobs");
+    assert!(results.iter().all(|r| r.success), "{results:?}");
+
+    assert_eq!(
+        index_entries(shard.db(), "-").await,
+        vec![
+            (1_700_000_000_000, "imported-scheduled".to_string()),
+            (1_600_000_000_000, "imported-terminal".to_string()),
+        ]
+    );
+}
+
+#[silo::test]
+async fn delete_job_removes_entry() {
+    let (_tmp, shard) = open_temp_shard().await;
+    enqueue_at(&shard, "-", "doomed", now_ms()).await;
+    enqueue_at(&shard, "-", "survivor", now_ms() - 1).await;
+    run_next_attempt(&shard, AttemptOutcome::Success { result: vec![] }).await;
+    assert_eq!(
+        shard
+            .get_job_status("-", "doomed")
+            .await
+            .expect("status")
+            .expect("exists")
+            .kind,
+        JobStatusKind::Succeeded
+    );
+
+    shard.delete_job("-", "doomed").await.expect("delete_job");
+
+    let ids: Vec<String> = index_entries(shard.db(), "-")
+        .await
+        .into_iter()
+        .map(|(_, id)| id)
+        .collect();
+    assert_eq!(ids, vec!["survivor".to_string()]);
+}
+
+fn import_failed_attempt(finished_at_ms: i64) -> ImportedAttempt {
+    ImportedAttempt {
+        status: ImportedAttemptStatus::Failed {
+            error_code: "ERR".to_string(),
+            error: vec![4],
+        },
+        started_at_ms: finished_at_ms - 1000,
+        finished_at_ms,
+    }
+}
+
+fn generous_retry_policy() -> RetryPolicy {
+    RetryPolicy {
+        retry_count: 5,
+        initial_interval_ms: 100,
+        max_interval_ms: 10_000,
+        randomize_interval: false,
+        backoff_factor: 2.0,
+    }
+}
+
+#[silo::test]
+async fn terminal_attempt_outcome_tags_entry_with_job_ttl() {
+    let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+    enqueue_at(&shard, "-", "job", now_ms()).await;
+    assert_eq!(assert_entry_ttl_matches_job(&shard, "-", "job").await, None);
+
+    run_next_attempt(&shard, AttemptOutcome::Success { result: vec![] }).await;
+
+    assert!(
+        assert_entry_ttl_matches_job(&shard, "-", "job")
+            .await
+            .is_some(),
+        "terminal job rows should carry a TTL"
+    );
+}
+
+#[silo::test]
+async fn cancel_tags_entry_with_job_ttl() {
+    let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+    enqueue_at(&shard, "-", "job", now_ms() + 60_000).await;
+
+    shard.cancel_job("-", "job").await.expect("cancel_job");
+
+    assert!(
+        assert_entry_ttl_matches_job(&shard, "-", "job")
+            .await
+            .is_some(),
+        "cancelled job rows should carry a TTL"
+    );
+}
+
+#[silo::test]
+async fn terminal_reimport_tags_entry_with_job_ttl() {
+    let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+    shard
+        .import_jobs("-", vec![import_base("job")])
+        .await
+        .expect("initial import");
+    assert_eq!(assert_entry_ttl_matches_job(&shard, "-", "job").await, None);
+
+    let mut terminal = import_base("job");
+    terminal.attempts = vec![import_succeeded_attempt(now_ms() - 1_000)];
+    let results = shard
+        .import_jobs("-", vec![terminal])
+        .await
+        .expect("reimport");
+    assert_eq!(results[0].status, JobStatusKind::Succeeded, "{results:?}");
+
+    assert!(
+        assert_entry_ttl_matches_job(&shard, "-", "job")
+            .await
+            .is_some(),
+        "terminal reimport rows should carry a TTL"
+    );
+}
+
+#[silo::test]
+async fn reimport_landing_scheduled_clears_entry_ttl() {
+    let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+    let failed_at_ms = now_ms() - 5_000;
+    let mut failed = import_base("job");
+    failed.attempts = vec![import_failed_attempt(failed_at_ms)];
+    let results = shard
+        .import_jobs("-", vec![failed])
+        .await
+        .expect("failed import");
+    assert_eq!(results[0].status, JobStatusKind::Failed, "{results:?}");
+    assert!(
+        assert_entry_ttl_matches_job(&shard, "-", "job")
+            .await
+            .is_some(),
+        "failed job rows should carry a TTL"
+    );
+
+    let mut retried = import_base("job");
+    retried.retry_policy = Some(generous_retry_policy());
+    retried.attempts = vec![
+        import_failed_attempt(failed_at_ms),
+        import_failed_attempt(failed_at_ms + 1_000),
+    ];
+    let results = shard
+        .import_jobs("-", vec![retried])
+        .await
+        .expect("reimport");
+    assert_eq!(results[0].status, JobStatusKind::Scheduled, "{results:?}");
+
+    assert_eq!(
+        assert_entry_ttl_matches_job(&shard, "-", "job").await,
+        None,
+        "a job reimported back to Scheduled must carry no TTL"
+    );
+}
+
+#[silo::test]
+async fn restart_revives_every_job_row_without_ttl() {
+    let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+    let payload = msgpack_payload(&serde_json::json!({}));
+    shard
+        .enqueue(
+            "-",
+            Some("job".to_string()),
+            10u8,
+            now_ms(),
+            None,
+            payload,
+            vec![],
+            Some(vec![("env".to_string(), "prod".to_string())]),
+            "default",
+        )
+        .await
+        .expect("enqueue");
+    run_next_attempt(
+        &shard,
+        AttemptOutcome::Error {
+            error_code: "E".to_string(),
+            error: vec![],
+        },
+    )
+    .await;
+    let db = shard.db();
+    let tagged_rows = [
+        job_info_key("-", "job"),
+        idx_metadata_key("-", "env", "prod", "job"),
+        attempt_key("-", "job", 1),
+        entry_key(&shard, "-", "job").await,
+    ];
+    for key in &tagged_rows {
+        assert!(
+            expire_ts_of(db, key).await.is_some(),
+            "failed job row {key:?} should carry a TTL before restart"
+        );
+    }
+
+    shard.restart_job("-", "job").await.expect("restart_job");
+
+    for key in &tagged_rows {
+        assert_eq!(
+            expire_ts_of(db, key).await,
+            None,
+            "restarted job row {key:?} must carry no TTL"
+        );
+    }
+    assert_eq!(assert_entry_ttl_matches_job(&shard, "-", "job").await, None);
+}
+
+#[silo::test]
+async fn restart_of_cancelled_job_removes_cancellation_row() {
+    let (_tmp, shard) = open_temp_shard_with_terminal_expire_s(60).await;
+    enqueue_at(&shard, "-", "job", now_ms() + 60_000).await;
+    shard.cancel_job("-", "job").await.expect("cancel_job");
+    assert!(
+        shard
+            .is_job_cancelled("-", "job")
+            .await
+            .expect("is_job_cancelled"),
+        "job should be cancelled before restart"
+    );
+
+    shard.restart_job("-", "job").await.expect("restart_job");
+
+    assert!(
+        shard
+            .db()
+            .get(&job_cancelled_key("-", "job"))
+            .await
+            .expect("get")
+            .is_none(),
+        "cancellation row must be absent after restart"
+    );
+    assert_eq!(assert_entry_ttl_matches_job(&shard, "-", "job").await, None);
+}
+
+#[silo::test]
+async fn post_split_cleanup_removes_entries_outside_range() {
+    let (_tmp, shard) = open_temp_shard().await;
+    // Tenant hashes: zzz (6d85...) is inside [, 8000...), aaa (ae01...) is outside.
+    enqueue_at(&shard, "aaa", "a1", now_ms()).await;
+    enqueue_at(&shard, "aaa", "a2", now_ms()).await;
+    enqueue_at(&shard, "zzz", "z1", now_ms()).await;
+    shard.db().flush().await.expect("flush");
+
+    let left_range = ShardRange::new("", "8000000000000000");
+    let result = shard
+        .after_split_cleanup_defunct_data(&left_range, 10)
+        .await
+        .expect("cleanup");
+    assert!(result.complete);
+
+    assert!(index_entries(shard.db(), "aaa").await.is_empty());
+    assert_eq!(index_entries(shard.db(), "zzz").await.len(), 1);
+}
+
+#[silo::test]
+async fn reimport_leaves_entry_key_unchanged() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard
+        .import_jobs("-", vec![import_base("job")])
+        .await
+        .expect("initial import");
+
+    let mut reimport = import_base("job");
+    reimport.enqueue_time_ms = 1_800_000_000_000;
+    reimport.attempts = vec![import_succeeded_attempt(now_ms() - 1_000)];
+    let results = shard
+        .import_jobs("-", vec![reimport])
+        .await
+        .expect("reimport");
+    assert!(results[0].success, "{results:?}");
+
+    assert_eq!(
+        index_entries(shard.db(), "-").await,
+        vec![(1_700_000_000_000, "job".to_string())]
+    );
+}

--- a/tests/enqueue_time_index_tests.rs
+++ b/tests/enqueue_time_index_tests.rs
@@ -171,7 +171,7 @@ async fn first_import_writes_entry_keyed_by_enqueue_time() {
 async fn delete_job_removes_entry() {
     let (_tmp, shard) = open_temp_shard().await;
     enqueue_at(&shard, "-", "doomed", now_ms()).await;
-    enqueue_at(&shard, "-", "survivor", now_ms() - 1).await;
+    enqueue_at(&shard, "-", "survivor", now_ms() + 60_000).await;
     run_next_attempt(&shard, AttemptOutcome::Success { result: vec![] }).await;
     assert_eq!(
         shard

--- a/tests/keys_tests.rs
+++ b/tests/keys_tests.rs
@@ -65,9 +65,18 @@ fn enqueue_time_index_tenant_prefix_scopes_scan() {
     let end = end_bound(&prefix);
     let inside = idx_enqueue_time_key("tenant1", 1_000, "job1");
     let other_tenant = idx_enqueue_time_key("tenant10", 1_000, "job1");
-    assert!(inside >= prefix && inside < end);
-    assert!(!(other_tenant >= prefix && other_tenant < end));
-    assert!(parse_enqueue_time_index_key(&job_info_key("tenant1", "job1")).is_none());
+    assert!(
+        inside >= prefix && inside < end,
+        "a tenant1 key must fall inside tenant1's prefix range"
+    );
+    assert!(
+        !(other_tenant >= prefix && other_tenant < end),
+        "a tenant10 key must fall outside tenant1's prefix range"
+    );
+    assert!(
+        parse_enqueue_time_index_key(&job_info_key("tenant1", "job1")).is_none(),
+        "a JOB_INFO key must not parse as an enqueue-time index key"
+    );
 }
 
 #[test]

--- a/tests/keys_tests.rs
+++ b/tests/keys_tests.rs
@@ -1,12 +1,74 @@
 use silo::keys::{
     attempt_key, attempt_prefix, concurrency_holder_key, concurrency_request_job_prefix,
-    concurrency_request_key, end_bound, floating_limit_state_key, idx_metadata_key,
-    idx_status_time_key, idx_status_time_prefix, job_cancelled_key, job_info_key, job_info_prefix,
-    job_status_key, leased_task_key, parse_attempt_key, parse_concurrency_holder_key,
-    parse_concurrency_request_key, parse_floating_limit_key, parse_job_cancelled_key,
+    concurrency_request_key, end_bound, floating_limit_state_key, idx_enqueue_time_key,
+    idx_enqueue_time_tenant_prefix, idx_metadata_key, idx_status_time_key, idx_status_time_prefix,
+    job_cancelled_key, job_info_key, job_info_prefix, job_status_key, leased_task_key,
+    parse_attempt_key, parse_concurrency_holder_key, parse_concurrency_request_key,
+    parse_enqueue_time_index_key, parse_floating_limit_key, parse_job_cancelled_key,
     parse_job_info_key, parse_job_status_key, parse_lease_key, parse_metadata_index_key,
     parse_status_time_index_key, parse_task_key, task_group_prefix, task_key,
 };
+
+#[test]
+fn enqueue_time_index_key_roundtrip_across_sign() {
+    for enqueue_time_ms in [i64::MIN, -2_000, -1, 0, 1, 1_700_000_000_000, i64::MAX] {
+        let key = idx_enqueue_time_key("tenant1", enqueue_time_ms, "job123");
+        let parsed = parse_enqueue_time_index_key(&key)
+            .unwrap_or_else(|| panic!("key for {enqueue_time_ms} should parse"));
+        assert_eq!(parsed.tenant, "tenant1");
+        assert_eq!(parsed.job_id, "job123");
+        assert_eq!(
+            parsed.enqueue_time_ms(),
+            enqueue_time_ms,
+            "round-trip of enqueue_time_ms {enqueue_time_ms}"
+        );
+    }
+}
+
+#[test]
+fn enqueue_time_index_orders_by_time_desc_then_id_asc() {
+    // Newest enqueue time first; ties broken by ascending id. Two distinct
+    // negative times are included because a zero-clamped inversion would
+    // collapse them onto one key.
+    let expected: Vec<(i64, &str)> = vec![
+        (i64::MAX, "a"),
+        (5_000, "a"),
+        (5_000, "b"),
+        (1, "z"),
+        (0, "a"),
+        (0, "b"),
+        (-1, "a"),
+        (-2_000, "a"),
+        (i64::MIN, "a"),
+    ];
+    let mut keys: Vec<(Vec<u8>, (i64, &str))> = expected
+        .iter()
+        .map(|&(t, id)| (idx_enqueue_time_key("t", t, id), (t, id)))
+        .collect();
+    keys.sort_by(|a, b| a.0.cmp(&b.0));
+    let sorted: Vec<(i64, &str)> = keys.into_iter().map(|(_, e)| e).collect();
+    assert_eq!(
+        sorted, expected,
+        "key order must equal enqueue_time_ms DESC, id ASC"
+    );
+
+    let distinct: std::collections::HashSet<Vec<u8>> = expected
+        .iter()
+        .map(|&(t, id)| idx_enqueue_time_key("t", t, id))
+        .collect();
+    assert_eq!(distinct.len(), expected.len(), "every key must be distinct");
+}
+
+#[test]
+fn enqueue_time_index_tenant_prefix_scopes_scan() {
+    let prefix = idx_enqueue_time_tenant_prefix("tenant1");
+    let end = end_bound(&prefix);
+    let inside = idx_enqueue_time_key("tenant1", 1_000, "job1");
+    let other_tenant = idx_enqueue_time_key("tenant10", 1_000, "job1");
+    assert!(inside >= prefix && inside < end);
+    assert!(!(other_tenant >= prefix && other_tenant < end));
+    assert!(parse_enqueue_time_index_key(&job_info_key("tenant1", "job1")).is_none());
+}
 
 #[test]
 fn test_job_info_key_roundtrip() {

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -209,6 +209,7 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            enqueue_time_index_backfill: Default::default(),
         },
         ShardRange::full(),
     )
@@ -255,6 +256,7 @@ pub async fn open_temp_shard_with_grant_scanner_config(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            enqueue_time_index_backfill: Default::default(),
         },
         ShardRange::full(),
     )


### PR DESCRIPTION
## Why

The Gadget IDE queues page lists a tenant's jobs newest-first by `enqueue_time_ms`, but silo has no ordering over that column: it lives only inside the `JOB_INFO` record. Producing one page means reading and decoding a bounded sample of full job records and sorting them in DataFusion. On tenants with hundreds of thousands of jobs the read exceeds the statement timeout, and even when it fits the page is drawn from a sample rather than the true global order.

This is the enqueue-time-index design for that problem, implemented independently of #402 (the status-index design) so the two can be compared. Key-prefix bytes were chosen so either branch can merge first.

## What

- **Index.** A per-tenant `IDX_ENQUEUE_TIME` key family (`0x0C`) keyed by an order-preserving inversion of `enqueue_time_ms` over the full `i64` range and the job id, so key order equals `ORDER BY enqueue_time_ms DESC, id ASC`. The entry is written in the same batch as `JOB_INFO` on enqueue and first import, deleted with the job, and always carries `JOB_INFO`'s row TTL: the terminal-retention helper re-puts it, reimport re-puts it with the reimport's TTL, and restart gains a revive helper that clears the TTL on `JOB_INFO`, the metadata index rows, the attempt rows, and the entry together. Post-split cleanup deletes the family with a defunct tenant's other rows.
- **Backfill.** A one-shot per-shard sweep writes the missing entry for jobs that predate the index, carrying each row's current `expire_ts`. Enumeration runs outside any transaction; each batch's writes run in a serializable-snapshot transaction that re-reads `JOB_INFO` and the entry per row, so a concurrent delete or terminal transition wins. Progress is checkpointed per batch and resumes after restart; a completion marker (mirrored by an in-memory flag) gates the query path. The sweep is configured per database (`enqueue_time_index_backfill`) and is disabled by default; enabling it is the rollout step.
- **Query path.** The `Scan` trait gains a resolve step whose decision the execution plan stores at planning time and hands to `scan` and `describe`, so a plan executes the path it was planned with. A tenant-scoped full scan whose projection needs only `shard_id`, `tenant`, `id`, and `enqueue_time_ms` is served from the index on a shard whose backfill has completed, with no point lookups; every other shape keeps its path. The jobs scanner's EXPLAIN line names the resolved path (`path=...`); other scanners' output is unchanged.
- **Ordering and fetch.** On that path the plan declares `enqueue_time_ms DESC, id ASC` to DataFusion and accepts a pushed-down fetch (through `with_fetch`, not `supports_limit_pushdown`, since two scanners ignore their limit), so the matching `ORDER BY ... LIMIT n OFFSET m` runs without a sort and reads `m + n` index keys. The querying guide documents the ordering guarantee and the query shape that uses it. The internals guide and the agent notes list the new key prefixes.
- **Benchmark.** The query benchmark suite measures the listing shapes on a clone of the golden shard with the sweep run to completion and with the marker cleared, reporting latency and scanned keys per state plus the sweep's own cost, and asserts both paths return the same rows.

## Reviewing

The invariant everything rests on is that the index never holds an entry for a job whose `JOB_INFO` is gone and always shares its TTL; `tests/enqueue_time_index_tests.rs` walks every write path. The sweep's concurrency reasoning is in the module doc of `src/job_store_shard/enqueue_time_index_backfill.rs`. The DataFusion contract (why `with_fetch` and not `supports_limit_pushdown`, why the ordering is declared only when both columns are projected) is in comments on `SiloExecutionPlan` in `src/query.rs`, with the tests in `tests/enqueue_time_index_ordering_tests.rs`.

Related to #402.