### PR TITLE
Make floating limit refresh self-healing and demand-driven

### DIFF
--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -617,6 +617,7 @@ pub async fn clone_golden_shard(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
             grant_scanner: silo::concurrency::GrantScannerConfig::default(),
             concurrency_reconcile_scan_slice:
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,

--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -618,6 +618,8 @@ pub async fn clone_golden_shard(
             terminal_job_expire_s: None,
             count_from_status_counters: true,
             floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
+            broker_tombstone_revive_after_generations:
+                silo::settings::DEFAULT_BROKER_TOMBSTONE_REVIVE_AFTER_GENERATIONS,
             grant_scanner: silo::concurrency::GrantScannerConfig::default(),
             concurrency_reconcile_scan_slice:
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,

--- a/benches/grant_latency.rs
+++ b/benches/grant_latency.rs
@@ -272,6 +272,8 @@ async fn open_shard(
             terminal_job_expire_s: None,
             count_from_status_counters: true,
             floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
+            broker_tombstone_revive_after_generations:
+                silo::settings::DEFAULT_BROKER_TOMBSTONE_REVIVE_AFTER_GENERATIONS,
             grant_scanner: silo::concurrency::GrantScannerConfig::default(),
             concurrency_reconcile_scan_slice:
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,

--- a/benches/grant_latency.rs
+++ b/benches/grant_latency.rs
@@ -271,6 +271,7 @@ async fn open_shard(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
             grant_scanner: silo::concurrency::GrantScannerConfig::default(),
             concurrency_reconcile_scan_slice:
                 silo::settings::DEFAULT_CONCURRENCY_RECONCILE_SCAN_SLICE,

--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -106,9 +106,11 @@ Concurrency limits control how many jobs with the same concurrency key can run s
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `silo_concurrency_tickets_granted_total` | Counter | - | Total concurrency tickets granted |
+| `silo_floating_limit_refresh_reset_total` | Counter | `shard`, `reason` | Floating limit refresh tasks scheduled over an outstanding-refresh flag that silo treated as lost. `reason` is `stale_scheduled`: the flag had been set longer than `floating_refresh_stale_ms` (default 60 s), or the state row carries no scheduled-at stamp |
 
 **Key insights:**
 - Track `silo_concurrency_tickets_granted_total` rate to understand throughput through limited queues
+- `silo_floating_limit_refresh_reset_total` should stay near zero. A steady rate means refresh tasks are being lost between scheduling and completion (a lost task row, lost lease, or broker suppression); the accompanying warn log names the tenant, queue key, and flag age. A state row with no stamp counts once, when its first replacement is written
 
 ### gRPC Metrics
 

--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -74,7 +74,7 @@ The task broker maintains an in-memory buffer of ready tasks for efficient deque
 | `silo_broker_inflight_size` | Gauge | `shard`, `task_group` | Tasks claimed but not yet durably leased per task group |
 | `silo_broker_scan_duration_seconds` | Histogram | `shard` | Duration of broker task scanning operations |
 | `silo_broker_scans_total` | Counter | `shard` | Total number of broker task scan operations |
-| `silo_broker_scan_tasks_read_total` | Counter | `shard`, `task_group`, `outcome` | Tasks read during scans, broken down by outcome: `inserted`, `skipped_future`, `skipped_inflight`, `skipped_tombstone`, `skipped_already_buffered`, `skipped_defunct`, `revived` |
+| `silo_broker_scan_tasks_read_total` | Counter | `shard`, `task_group`, `outcome` | Tasks read during scans, broken down by outcome: `inserted`, `skipped_future`, `skipped_inflight`, `skipped_tombstone`, `skipped_already_buffered`, `skipped_defunct`; plus `revived`, recorded in addition to the row's final outcome (normally `inserted`) |
 | `silo_broker_tombstone_count` | Gauge | `shard`, `task_group` | Number of ack tombstones currently held by the broker |
 
 **Key insights:**
@@ -82,7 +82,7 @@ The task broker maintains an in-memory buffer of ready tasks for efficient deque
 - Break down `silo_broker_buffer_size` by `task_group` to identify which queues are starved vs saturated
 - High `silo_broker_scan_duration_seconds` suggests database pressure
 - `silo_broker_inflight_size` should be transiently low; persistent high values indicate dequeue bottlenecks
-- A high rate of `silo_broker_scan_tasks_read_total` with `outcome="skipped_tombstone"` indicates the scanner is repeatedly encountering recently-acked keys that haven't been compacted away yet. A key that stays re-observed for more than `broker_tombstone_revive_after_generations` scan generations (default 64) is point-read; if its row is still durable the tombstone is dropped, the task is buffered, and the read counts as `outcome="revived"`, so a durable row can never stay hidden until the next restart
+- A high rate of `silo_broker_scan_tasks_read_total` with `outcome="skipped_tombstone"` indicates the scanner is repeatedly encountering recently-acked keys that haven't been compacted away yet. A key that stays re-observed for more than `broker_tombstone_revive_after_generations` scan generations (default 64) is point-read; if its row is still durable the tombstone is dropped, the task is buffered, and the read counts as `outcome="revived"` alongside its final outcome, so a durable row can never stay hidden until the next restart
 - `outcome="revived"` should be rare. Each increment is a task row that the broker believed it had deleted but that was still in the DB; a steady rate points at a write path whose delete is not landing
 - Growing `silo_broker_tombstone_count` may signal that dequeued task keys are persisting in the DB longer than expected
 

--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -74,7 +74,7 @@ The task broker maintains an in-memory buffer of ready tasks for efficient deque
 | `silo_broker_inflight_size` | Gauge | `shard`, `task_group` | Tasks claimed but not yet durably leased per task group |
 | `silo_broker_scan_duration_seconds` | Histogram | `shard` | Duration of broker task scanning operations |
 | `silo_broker_scans_total` | Counter | `shard` | Total number of broker task scan operations |
-| `silo_broker_scan_tasks_read_total` | Counter | `shard`, `task_group`, `outcome` | Tasks read during scans, broken down by outcome: `inserted`, `skipped_future`, `skipped_inflight`, `skipped_tombstone`, `skipped_already_buffered`, `skipped_defunct` |
+| `silo_broker_scan_tasks_read_total` | Counter | `shard`, `task_group`, `outcome` | Tasks read during scans, broken down by outcome: `inserted`, `skipped_future`, `skipped_inflight`, `skipped_tombstone`, `skipped_already_buffered`, `skipped_defunct`, `revived` |
 | `silo_broker_tombstone_count` | Gauge | `shard`, `task_group` | Number of ack tombstones currently held by the broker |
 
 **Key insights:**
@@ -82,7 +82,8 @@ The task broker maintains an in-memory buffer of ready tasks for efficient deque
 - Break down `silo_broker_buffer_size` by `task_group` to identify which queues are starved vs saturated
 - High `silo_broker_scan_duration_seconds` suggests database pressure
 - `silo_broker_inflight_size` should be transiently low; persistent high values indicate dequeue bottlenecks
-- A high rate of `silo_broker_scan_tasks_read_total` with `outcome="skipped_tombstone"` indicates the scanner is repeatedly encountering recently-acked keys that haven't been compacted away yet
+- A high rate of `silo_broker_scan_tasks_read_total` with `outcome="skipped_tombstone"` indicates the scanner is repeatedly encountering recently-acked keys that haven't been compacted away yet. A key that stays re-observed for more than `broker_tombstone_revive_after_generations` scan generations (default 64) is point-read; if its row is still durable the tombstone is dropped, the task is buffered, and the read counts as `outcome="revived"`, so a durable row can never stay hidden until the next restart
+- `outcome="revived"` should be rare. Each increment is a task row that the broker believed it had deleted but that was still in the DB; a steady rate points at a write path whose delete is not landing
 - Growing `silo_broker_tombstone_count` may signal that dequeued task keys are persisting in the DB longer than expected
 
 ### Shard & Coordination Metrics

--- a/schema/internal_storage.fbs
+++ b/schema/internal_storage.fbs
@@ -301,7 +301,8 @@ table FloatingLimitState {
   retry_count: uint32;
   next_retry_at_ms: int64 = null;
   metadata: [KeyValuePair];
-  // Must stay the last field: the table uses implicit field ids and the
-  // decoder is unchecked, so any field placed before `metadata` shifts it.
+  // Append new fields after this one: the table uses implicit field ids, so
+  // inserting a field earlier renumbers every later slot and misreads stored
+  // rows.
   refresh_scheduled_at_ms: int64 = null;
 }

--- a/schema/internal_storage.fbs
+++ b/schema/internal_storage.fbs
@@ -301,4 +301,7 @@ table FloatingLimitState {
   retry_count: uint32;
   next_retry_at_ms: int64 = null;
   metadata: [KeyValuePair];
+  // Must stay the last field: the table uses implicit field ids and the
+  // decoder is unchecked, so any field placed before `metadata` shifts it.
+  refresh_scheduled_at_ms: int64 = null;
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -632,6 +632,7 @@ pub fn encode_floating_limit_state(state: &FloatingLimitState) -> Vec<u8> {
             retry_count: state.retry_count,
             next_retry_at_ms: state.next_retry_at_ms,
             metadata: Some(metadata),
+            refresh_scheduled_at_ms: state.refresh_scheduled_at_ms,
         },
     );
     builder.finish(root, None);
@@ -1145,6 +1146,11 @@ impl DecodedFloatingLimitState {
         fb_kv_pairs_to_owned(self.fb().metadata())
     }
 
+    /// `None` when no refresh is outstanding or the row carries no stamp.
+    pub fn refresh_scheduled_at_ms(&self) -> Option<i64> {
+        self.fb().refresh_scheduled_at_ms()
+    }
+
     /// Materialize an owned FloatingLimitState from the FlatBuffer data.
     pub fn to_owned(&self) -> FloatingLimitState {
         let f = self.fb();
@@ -1157,6 +1163,7 @@ impl DecodedFloatingLimitState {
             retry_count: f.retry_count(),
             next_retry_at_ms: f.next_retry_at_ms(),
             metadata: self.metadata(),
+            refresh_scheduled_at_ms: f.refresh_scheduled_at_ms(),
         }
     }
 }

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -154,9 +154,10 @@ pub trait LimitChainResumer: Send + Sync {
     fn wakeup_task_groups(&self, _groups: &[String]) {}
 
     /// The grant scanner found the floating queue `(tenant, queue)` at
-    /// capacity with a backlog and skipped its request scan. The shard-side
-    /// implementation decides whether a refresh of the queue's cap is due
-    /// and, if so, writes and commits the refresh task. Default is a no-op
+    /// capacity with pending grant demand and skipped its request scan. The
+    /// shard-side implementation verifies a waiter exists, decides whether a
+    /// refresh of the queue's cap is due and, if so, writes and commits the
+    /// refresh task. Default is a no-op
     /// for resumers with no shard access.
     async fn maybe_schedule_floating_refresh(
         &self,
@@ -2287,15 +2288,6 @@ impl ConcurrencyManager {
                 if let Some(ref m) = self.metrics {
                     m.record_concurrency_grant_precheck_skip(&self.shard);
                 }
-                // A saturated floating queue with a backlog is exactly the
-                // shape whose cap should track the API-side controller. The
-                // shard judges readiness and picks the task group; the
-                // scanner only reports that the queue is at capacity.
-                if let (Some(state), Some(resumer)) = (floating_state, self.chain_resumer()) {
-                    resumer
-                        .maybe_schedule_floating_refresh(tenant, queue, &state)
-                        .await;
-                }
                 tracing::debug!(
                     tenant = %tenant,
                     queue = %queue,
@@ -2306,6 +2298,17 @@ impl ConcurrencyManager {
                     "grant scanner: queue at capacity, skipping request scan"
                 );
                 record_invocation(0, 0);
+                // A saturated floating queue with pending grant demand is exactly
+                // the shape whose cap should track the API-side controller. The
+                // shard verifies a waiter exists, judges readiness, and picks
+                // the task group; the scanner only reports the saturation. The
+                // invocation is recorded above so its duration stays the cost
+                // of the precheck itself.
+                if let (Some(state), Some(resumer)) = (floating_state, self.chain_resumer()) {
+                    resumer
+                        .maybe_schedule_floating_refresh(tenant, queue, &state)
+                        .await;
+                }
                 return Vec::new();
             }
         }

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -54,8 +54,8 @@ use crate::job_store_shard::counters::{decode_counter, encode_counter};
 use crate::job_store_shard::helpers::{WriteBatcher, live_terminal_row_exists};
 
 use crate::codec::{
-    decode_concurrency_action, decode_floating_limit_state, encode_concurrency_action,
-    encode_holder, encode_task,
+    DecodedFloatingLimitState, decode_concurrency_action, decode_floating_limit_state,
+    encode_concurrency_action, encode_holder, encode_task,
 };
 use crate::dst_events::{self, DstEvent};
 use crate::job::{ConcurrencyLimit, JobStatusKind, JobView, Limit};
@@ -152,6 +152,19 @@ pub trait LimitChainResumer: Send + Sync {
     /// scanner's drain iteration to finish every other queue's pass. Default
     /// is a no-op for resumers with no broker access.
     fn wakeup_task_groups(&self, _groups: &[String]) {}
+
+    /// The grant scanner found the floating queue `(tenant, queue)` at
+    /// capacity with a backlog and skipped its request scan. The shard-side
+    /// implementation decides whether a refresh of the queue's cap is due
+    /// and, if so, writes and commits the refresh task. Default is a no-op
+    /// for resumers with no shard access.
+    async fn maybe_schedule_floating_refresh(
+        &self,
+        _tenant: &str,
+        _queue: &str,
+        _state: &DecodedFloatingLimitState,
+    ) {
+    }
 }
 
 impl From<slatedb::Error> for ConcurrencyError {
@@ -1150,24 +1163,33 @@ impl ConcurrencyManager {
         Self::resolve_queue_capacity_from_limits(db, tenant, queue, limits).await
     }
 
-    /// Point-read the durable floating-limit state row for (tenant, queue) and
-    /// return its current max concurrency. None when the row is missing or
-    /// unreadable — callers choose their own fallback (the scan path falls back
-    /// to the limit's default_max_concurrency; the pre-scan gate treats it as
-    /// unknown and lets the scan run).
+    /// Point-read the durable floating-limit state row for (tenant, queue).
+    /// None when the row is missing or unreadable — callers choose their own
+    /// fallback (the scan path falls back to the limit's
+    /// default_max_concurrency; the pre-scan gate treats it as unknown and
+    /// lets the scan run). The decoded row carries the capacity
+    /// (`current_max_concurrency`) and the refresh bookkeeping the pre-scan
+    /// gate hands to the chain resumer.
+    async fn floating_state(
+        db: &InstrumentedDb,
+        tenant: &str,
+        queue: &str,
+    ) -> Option<DecodedFloatingLimitState> {
+        let state_key = floating_limit_state_key(tenant, queue);
+        match db.get(&state_key).await {
+            Ok(Some(raw)) => decode_floating_limit_state(raw).ok(),
+            _ => None,
+        }
+    }
+
     async fn floating_state_capacity(
         db: &InstrumentedDb,
         tenant: &str,
         queue: &str,
     ) -> Option<usize> {
-        let state_key = floating_limit_state_key(tenant, queue);
-        match db.get(&state_key).await {
-            Ok(Some(raw)) => match decode_floating_limit_state(raw) {
-                Ok(state) => Some(state.current_max_concurrency() as usize),
-                Err(_) => None,
-            },
-            _ => None,
-        }
+        Self::floating_state(db, tenant, queue)
+            .await
+            .map(|state| state.current_max_concurrency() as usize)
     }
 
     async fn resolve_queue_capacity_from_limits(
@@ -1202,17 +1224,21 @@ impl ConcurrencyManager {
     /// or a Floating limit whose state row is missing/unreadable — in which
     /// case the caller must fall back to the scan, which resolves capacity
     /// from the request's embedded limits and re-populates the cache.
+    ///
+    /// For a Floating limit the decoded state row rides along so the pre-scan
+    /// gate can hand it to the chain resumer without a second read.
     async fn known_queue_capacity(
         &self,
         db: &InstrumentedDb,
         tenant: &str,
         queue: &str,
-    ) -> Option<usize> {
+    ) -> Option<(usize, Option<DecodedFloatingLimitState>)> {
         let cached = self.cached_queue_limit(tenant, queue)?;
         match cached.limit_type {
-            ConcurrencyLimitType::Fixed => Some(cached.max_concurrency as usize),
+            ConcurrencyLimitType::Fixed => Some((cached.max_concurrency as usize, None)),
             ConcurrencyLimitType::Floating => {
-                Self::floating_state_capacity(db, tenant, queue).await
+                let state = Self::floating_state(db, tenant, queue).await?;
+                Some((state.current_max_concurrency() as usize, Some(state)))
             }
         }
     }
@@ -2253,12 +2279,22 @@ impl ConcurrencyManager {
         // first request and re-warms the cache. Accepted trade-offs: stale
         // request cleanup for a saturated queue pauses until a slot frees, and
         // a lowered fixed limit gates old requests that embed a higher one.
-        if let Some(capacity) = self.known_queue_capacity(db, tenant, queue).await {
+        if let Some((capacity, floating_state)) = self.known_queue_capacity(db, tenant, queue).await
+        {
             let effective_capacity = self.scanner_effective_capacity(capacity);
             let holders = self.counts.holder_count(tenant, queue);
             if effective_capacity.saturating_sub(holders) == 0 {
                 if let Some(ref m) = self.metrics {
                     m.record_concurrency_grant_precheck_skip(&self.shard);
+                }
+                // A saturated floating queue with a backlog is exactly the
+                // shape whose cap should track the API-side controller. The
+                // shard judges readiness and picks the task group; the
+                // scanner only reports that the queue is at capacity.
+                if let (Some(state), Some(resumer)) = (floating_state, self.chain_resumer()) {
+                    resumer
+                        .maybe_schedule_floating_refresh(tenant, queue, &state)
+                        .await;
                 }
                 tracing::debug!(
                     tenant = %tenant,

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -305,6 +305,8 @@ impl ShardFactory {
                         terminal_job_expire_s: template.terminal_job_expire_s,
                         count_from_status_counters: template.count_from_status_counters,
                         floating_refresh_stale_ms: template.floating_refresh_stale_ms,
+                        broker_tombstone_revive_after_generations: template
+                            .broker_tombstone_revive_after_generations,
                     },
                     range.clone(),
                 )
@@ -1129,6 +1131,9 @@ impl ShardFactory {
                 terminal_job_expire_s: self.template.terminal_job_expire_s,
                 count_from_status_counters: self.template.count_from_status_counters,
                 floating_refresh_stale_ms: self.template.floating_refresh_stale_ms,
+                broker_tombstone_revive_after_generations: self
+                    .template
+                    .broker_tombstone_revive_after_generations,
             },
             ShardRange::full(),
         )

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -304,6 +304,7 @@ impl ShardFactory {
                         completed_job_expire_s: template.completed_job_expire_s,
                         terminal_job_expire_s: template.terminal_job_expire_s,
                         count_from_status_counters: template.count_from_status_counters,
+                        floating_refresh_stale_ms: template.floating_refresh_stale_ms,
                     },
                     range.clone(),
                 )
@@ -1127,6 +1128,7 @@ impl ShardFactory {
                 completed_job_expire_s: self.template.completed_job_expire_s,
                 terminal_job_expire_s: self.template.terminal_job_expire_s,
                 count_from_status_counters: self.template.count_from_status_counters,
+                floating_refresh_stale_ms: self.template.floating_refresh_stale_ms,
             },
             ShardRange::full(),
         )

--- a/src/job.rs
+++ b/src/job.rs
@@ -50,6 +50,11 @@ pub struct FloatingLimitState {
     pub next_retry_at_ms: Option<i64>,
     /// Opaque metadata passed to workers during refresh
     pub metadata: Vec<(String, String)>,
+    /// When the outstanding refresh task was scheduled (epoch ms); `None`
+    /// when no refresh is outstanding. A set `refresh_task_scheduled` older
+    /// than the shard's stale threshold, or with this field absent, is
+    /// treated as no outstanding refresh so a lost task cannot pin the cap.
+    pub refresh_scheduled_at_ms: Option<i64>,
 }
 
 /// Rate limiting algorithm used by Gubernator

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -847,23 +847,28 @@ impl JobStoreShard {
                 Limit::FloatingConcurrency(fl) if fl.key == queue => Some(fl),
                 _ => None,
             });
+            // An earlier ticket on this queue in the same iteration already ran
+            // this decision against the same durable row and `now_ms`.
+            let already_converted = state
+                .converted_requests
+                .iter()
+                .any(|(t, q)| t == &tenant && q == &queue);
             if let Some(fl) = floating
                 && !req_task_group.is_empty()
+                && !already_converted
             {
                 let fl_state = self
                     .get_or_create_floating_limit_state(&mut writer, &tenant, fl)
                     .await?;
-                if self.floating_limit_refresh_ready(&fl_state, now_ms) {
-                    self.maybe_schedule_floating_limit_refresh(
-                        &mut writer,
-                        &tenant,
-                        fl,
-                        &fl_state,
-                        now_ms,
-                        &req_task_group,
-                        true,
-                    )?;
-                }
+                self.maybe_schedule_floating_limit_refresh(
+                    &mut writer,
+                    &tenant,
+                    &fl.key,
+                    &fl_state,
+                    now_ms,
+                    &req_task_group,
+                    true,
+                )?;
             }
             state
                 .converted_requests

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -838,6 +838,33 @@ impl JobStoreShard {
                 &task_id,
                 &limits,
             )?;
+            // The ticket just became a waiter on this queue. Its request row
+            // sits in the uncommitted batch, invisible to the durable waiter
+            // probe, so the ticket supplies the waiter signal directly (as
+            // the enqueue path does for a job that just requested a ticket).
+            // A task under an empty group lands where no broker scans.
+            let floating = limits.iter().find_map(|limit| match limit {
+                Limit::FloatingConcurrency(fl) if fl.key == queue => Some(fl),
+                _ => None,
+            });
+            if let Some(fl) = floating
+                && !req_task_group.is_empty()
+            {
+                let fl_state = self
+                    .get_or_create_floating_limit_state(&mut writer, &tenant, fl)
+                    .await?;
+                if self.floating_limit_refresh_ready(&fl_state, now_ms) {
+                    self.maybe_schedule_floating_limit_refresh(
+                        &mut writer,
+                        &tenant,
+                        fl,
+                        &fl_state,
+                        now_ms,
+                        &req_task_group,
+                        true,
+                    )?;
+                }
+            }
             state
                 .converted_requests
                 .push((tenant.clone(), queue.clone()));

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -1633,7 +1633,13 @@ mod claimed_inflight_guard_tests {
             .await
             .expect("open in-memory db");
         let db = InstrumentedDb::new(Arc::new(db), tracing::Span::none());
-        TaskBrokerRegistry::new(db, "shard".to_string(), None, ShardRange::full())
+        TaskBrokerRegistry::new(
+            db,
+            "shard".to_string(),
+            None,
+            ShardRange::full(),
+            crate::settings::DEFAULT_BROKER_TOMBSTONE_REVIVE_AFTER_GENERATIONS,
+        )
     }
 
     /// Drop without disarm releases in-flight on the broker registry.

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -853,22 +853,28 @@ impl JobStoreShard {
                 .converted_requests
                 .iter()
                 .any(|(t, q)| t == &tenant && q == &queue);
+            // The refresh is optional: an unreadable state row must not fail
+            // the conversion, or the same head ticket would be retried on
+            // every claim and stall the task group.
             if let Some(fl) = floating
                 && !req_task_group.is_empty()
                 && !already_converted
+                && let Err(e) = self
+                    .schedule_floating_refresh_for_ticket(
+                        &mut writer,
+                        &tenant,
+                        fl,
+                        now_ms,
+                        &req_task_group,
+                    )
+                    .await
             {
-                let fl_state = self
-                    .get_or_create_floating_limit_state(&mut writer, &tenant, fl)
-                    .await?;
-                self.maybe_schedule_floating_limit_refresh(
-                    &mut writer,
-                    &tenant,
-                    &fl.key,
-                    &fl_state,
-                    now_ms,
-                    &req_task_group,
-                    true,
-                )?;
+                tracing::warn!(
+                    tenant = %tenant,
+                    queue = %queue,
+                    error = %e,
+                    "converted ticket to a waiter but could not schedule a floating limit refresh"
+                );
             }
             state
                 .converted_requests

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -701,7 +701,7 @@ impl JobStoreShard {
                     let state = self
                         .get_or_create_floating_limit_state(writer, tenant, fl)
                         .await?;
-                    let refresh_ready = JobStoreShard::floating_limit_refresh_ready(&state, now_ms);
+                    let refresh_ready = self.floating_limit_refresh_ready(&state, now_ms);
 
                     // Try immediate grant using current max concurrency
                     let current_max = state.current_max_concurrency();

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -753,7 +753,7 @@ impl JobStoreShard {
                         self.maybe_schedule_floating_limit_refresh(
                             writer,
                             tenant,
-                            fl,
+                            &fl.key,
                             &state,
                             now_ms,
                             task_group,

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -4,14 +4,14 @@ use slatedb::WriteBatch;
 use uuid::Uuid;
 
 use crate::codec::{
-    DecodedFloatingLimitState, decode_floating_limit_state, decode_lease,
-    encode_floating_limit_state, encode_task,
+    DecodedFloatingLimitState, decode_concurrency_action, decode_floating_limit_state,
+    decode_lease, encode_floating_limit_state, encode_task,
 };
-use crate::job::{FloatingConcurrencyLimit, FloatingLimitState};
-use crate::job_store_shard::helpers::{WriteBatcher, now_epoch_ms};
+use crate::job::{FloatingConcurrencyLimit, FloatingLimitState, JobView};
+use crate::job_store_shard::helpers::{DbWriteBatcher, WriteBatcher, now_epoch_ms};
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
-    concurrency_request_prefix, end_bound, floating_limit_state_key, leased_task_key,
+    concurrency_request_prefix, end_bound, floating_limit_state_key, job_info_key, leased_task_key,
 };
 use crate::task::Task;
 
@@ -73,6 +73,87 @@ impl JobStoreShard {
         Ok(iter.next().await?.is_some())
     }
 
+    /// Task group of the head waiting request on `(tenant, queue_key)`, the
+    /// group a scanner-originated refresh task is written under. A stored
+    /// request record may carry an empty group; the job's info row supplies
+    /// it then, as the scanner's own resume path does. `None` when there is
+    /// no waiter, the record or job info is unreadable, or the group is still
+    /// empty: a task under an empty group lands in a range no broker serves.
+    pub(crate) async fn peek_head_waiting_request_task_group(
+        &self,
+        tenant: &str,
+        queue_key: &str,
+    ) -> Result<Option<String>, JobStoreShardError> {
+        let start = concurrency_request_prefix(tenant, queue_key);
+        let end = end_bound(&start);
+        let mut iter = self.db.scan::<Vec<u8>, _>(start..end).await?;
+        let Some(kv) = iter.next().await? else {
+            return Ok(None);
+        };
+        let Ok(decoded) = decode_concurrency_action(kv.value) else {
+            return Ok(None);
+        };
+        let Some(request) = decoded.fb().variant_as_enqueue_task() else {
+            return Ok(None);
+        };
+        let task_group = request.task_group().unwrap_or_default();
+        if !task_group.is_empty() {
+            return Ok(Some(task_group.to_string()));
+        }
+        let job_id = request.job_id().unwrap_or_default();
+        let Some(raw) = self.db.get(&job_info_key(tenant, job_id)).await? else {
+            return Ok(None);
+        };
+        let Ok(job) = JobView::new(raw) else {
+            return Ok(None);
+        };
+        Ok(Some(job.task_group().to_string()).filter(|g| !g.is_empty()))
+    }
+
+    /// Schedule a refresh for a floating queue the grant scanner found at
+    /// capacity with a backlog. Readiness is judged here with the shard's
+    /// stale threshold; the task group comes from the head waiter. The task
+    /// and state are committed in their own batch and the group's broker is
+    /// woken so the task is claimable without waiting out scan backoff.
+    /// Returns whether a task was written.
+    pub(crate) async fn schedule_floating_refresh_from_scanner(
+        &self,
+        tenant: &str,
+        queue_key: &str,
+        state: &DecodedFloatingLimitState,
+    ) -> Result<bool, JobStoreShardError> {
+        let now_ms = now_epoch_ms();
+        if !self.floating_limit_refresh_ready(state, now_ms) {
+            return Ok(false);
+        }
+        let Some(task_group) = self
+            .peek_head_waiting_request_task_group(tenant, queue_key)
+            .await?
+        else {
+            return Ok(false);
+        };
+        let fl = FloatingConcurrencyLimit {
+            key: queue_key.to_string(),
+            default_max_concurrency: state.default_max_concurrency(),
+            refresh_interval_ms: state.refresh_interval_ms(),
+            metadata: state.metadata(),
+        };
+        let mut batch = WriteBatch::new();
+        let mut writer = DbWriteBatcher::new(&self.db, &mut batch);
+        self.maybe_schedule_floating_limit_refresh(
+            &mut writer,
+            tenant,
+            &fl,
+            state,
+            now_ms,
+            &task_group,
+            true,
+        )?;
+        self.db.write(batch).await?;
+        self.brokers.wakeup(&task_group);
+        Ok(true)
+    }
+
     /// Get or create the floating limit state for a given queue key.
     /// Returns a zero-copy decoded view. For the rare "just created" case,
     /// we encode then decode to return the same type (extra decode is fine for cold path).
@@ -110,7 +191,13 @@ impl JobStoreShard {
     }
 
     /// Check if a floating limit refresh is needed and schedule it if so.
-    /// This method is called during enqueue and dequeue operations to lazily trigger refreshes.
+    ///
+    /// Three call sites lazily trigger refreshes, each supplying its own
+    /// waiter signal and task group: the enqueue path (a job that just
+    /// became a waiter, or a durable-waiter probe), the RequestTicket
+    /// handler at dequeue (a scheduled-start ticket that just landed as a
+    /// waiter), and the grant scanner's at-capacity precheck via
+    /// `schedule_floating_refresh_from_scanner` (the head waiter's group).
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn maybe_schedule_floating_limit_refresh<W: WriteBatcher>(
         &self,

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -178,6 +178,26 @@ impl JobStoreShard {
         Ok(true)
     }
 
+    /// Schedule a refresh for a RequestTicket that just landed as a waiter on
+    /// a floating queue. The ticket's own request row sits in the uncommitted
+    /// batch, invisible to the durable waiter probe, so the ticket supplies
+    /// the waiter signal directly. Returns whether a task was written.
+    pub(crate) async fn schedule_floating_refresh_for_ticket<W: WriteBatcher>(
+        &self,
+        writer: &mut W,
+        tenant: &str,
+        fl: &FloatingConcurrencyLimit,
+        now_ms: i64,
+        task_group: &str,
+    ) -> Result<bool, JobStoreShardError> {
+        let state = self
+            .get_or_create_floating_limit_state(writer, tenant, fl)
+            .await?;
+        self.maybe_schedule_floating_limit_refresh(
+            writer, tenant, &fl.key, &state, now_ms, task_group, true,
+        )
+    }
+
     /// Get or create the floating limit state for a given queue key.
     /// Returns a zero-copy decoded view. For the rare "just created" case,
     /// we encode then decode to return the same type (extra decode is fine for cold path).

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -16,11 +16,36 @@ use crate::keys::{
 use crate::task::Task;
 
 impl JobStoreShard {
-    pub(crate) fn floating_limit_refresh_ready(
+    /// True when the state's outstanding-refresh flag is set but the refresh
+    /// was scheduled longer ago than the shard's stale threshold, or carries
+    /// no stamp at all. Such a refresh is treated as lost: no task row,
+    /// lease, or in-memory suppression may pin a tenant's cap forever.
+    pub(crate) fn floating_limit_refresh_stale(
+        &self,
         state: &DecodedFloatingLimitState,
         now_ms: i64,
     ) -> bool {
-        if state.refresh_task_scheduled() {
+        state.refresh_task_scheduled()
+            && state
+                .refresh_scheduled_at_ms()
+                .is_none_or(|at| now_ms - at > self.floating_refresh_stale_ms)
+    }
+
+    /// True when a refresh task is scheduled and still trusted to complete.
+    fn floating_limit_refresh_outstanding(
+        &self,
+        state: &DecodedFloatingLimitState,
+        now_ms: i64,
+    ) -> bool {
+        state.refresh_task_scheduled() && !self.floating_limit_refresh_stale(state, now_ms)
+    }
+
+    pub(crate) fn floating_limit_refresh_ready(
+        &self,
+        state: &DecodedFloatingLimitState,
+        now_ms: i64,
+    ) -> bool {
+        if self.floating_limit_refresh_outstanding(state, now_ms) {
             return false;
         }
 
@@ -74,6 +99,7 @@ impl JobStoreShard {
             retry_count: 0,
             next_retry_at_ms: None,
             metadata: fl.metadata.clone(),
+            refresh_scheduled_at_ms: None,
         };
 
         let state_bytes = encode_floating_limit_state(&state);
@@ -96,8 +122,7 @@ impl JobStoreShard {
         task_group: &str,
         has_waiters: bool,
     ) -> Result<(), JobStoreShardError> {
-        // Check if refresh is already scheduled
-        if state.refresh_task_scheduled() {
+        if self.floating_limit_refresh_outstanding(state, now_ms) {
             return Ok(());
         }
 
@@ -113,6 +138,21 @@ impl JobStoreShard {
 
         if !should_refresh || in_backoff || !has_waiters {
             return Ok(());
+        }
+
+        // Reaching here with the flag still set means the outstanding refresh
+        // aged out; this write replaces it.
+        if state.refresh_task_scheduled() {
+            let age_ms = state.refresh_scheduled_at_ms().map(|at| now_ms - at);
+            tracing::warn!(
+                tenant = %tenant,
+                queue_key = %fl.key,
+                age_ms = ?age_ms,
+                "floating limit refresh flag is stale; scheduling a replacement refresh"
+            );
+            if let Some(m) = &self.metrics {
+                m.record_floating_limit_refresh_reset(&self.name, "stale_scheduled");
+            }
         }
 
         // Schedule a refresh task
@@ -143,6 +183,7 @@ impl JobStoreShard {
         // Update state to mark refresh as scheduled
         let new_state = FloatingLimitState {
             refresh_task_scheduled: true,
+            refresh_scheduled_at_ms: Some(now_ms),
             ..state.to_owned()
         };
         let state_key = floating_limit_state_key(tenant, &fl.key);
@@ -197,6 +238,7 @@ impl JobStoreShard {
             current_max_concurrency: new_max_concurrency,
             last_refreshed_at_ms: now_ms,
             refresh_task_scheduled: false,
+            refresh_scheduled_at_ms: None,
             retry_count: 0,
             next_retry_at_ms: None,
             ..decoded_state.to_owned()
@@ -293,10 +335,14 @@ impl JobStoreShard {
             .has_waiting_concurrency_requests(&tenant, &queue_key)
             .await?;
 
+        // The retry task's key starts at `next_retry_at`, which can sit up to
+        // the backoff cap in the future; stamping that (not now) keeps the
+        // retry from reading as stale before it is even claimable.
         let new_state = FloatingLimitState {
             retry_count: new_retry_count,
             next_retry_at_ms: Some(next_retry_at),
             refresh_task_scheduled: has_waiters,
+            refresh_scheduled_at_ms: has_waiters.then_some(next_retry_at),
             ..decoded_state.to_owned()
         };
 

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -20,11 +20,7 @@ impl JobStoreShard {
     /// was scheduled longer ago than the shard's stale threshold, or carries
     /// no stamp at all. Such a refresh is treated as lost: no task row,
     /// lease, or in-memory suppression may pin a tenant's cap forever.
-    pub(crate) fn floating_limit_refresh_stale(
-        &self,
-        state: &DecodedFloatingLimitState,
-        now_ms: i64,
-    ) -> bool {
+    fn floating_limit_refresh_stale(&self, state: &DecodedFloatingLimitState, now_ms: i64) -> bool {
         state.refresh_task_scheduled()
             && state
                 .refresh_scheduled_at_ms()
@@ -90,8 +86,17 @@ impl JobStoreShard {
         let Some(kv) = iter.next().await? else {
             return Ok(None);
         };
-        let Ok(decoded) = decode_concurrency_action(kv.value) else {
-            return Ok(None);
+        let decoded = match decode_concurrency_action(kv.value) {
+            Ok(decoded) => decoded,
+            Err(e) => {
+                tracing::warn!(
+                    tenant = %tenant,
+                    queue_key = %queue_key,
+                    error = %e,
+                    "head waiting request is unreadable; not scheduling a floating limit refresh"
+                );
+                return Ok(None);
+            }
         };
         let Some(request) = decoded.fb().variant_as_enqueue_task() else {
             return Ok(None);
@@ -104,18 +109,29 @@ impl JobStoreShard {
         let Some(raw) = self.db.get(&job_info_key(tenant, job_id)).await? else {
             return Ok(None);
         };
-        let Ok(job) = JobView::new(raw) else {
-            return Ok(None);
+        let job = match JobView::new(raw) {
+            Ok(job) => job,
+            Err(e) => {
+                tracing::warn!(
+                    tenant = %tenant,
+                    queue_key = %queue_key,
+                    job_id = %job_id,
+                    error = %e,
+                    "head waiter's job info is unreadable; not scheduling a floating limit refresh"
+                );
+                return Ok(None);
+            }
         };
         Ok(Some(job.task_group().to_string()).filter(|g| !g.is_empty()))
     }
 
     /// Schedule a refresh for a floating queue the grant scanner found at
-    /// capacity with a backlog. Readiness is judged here with the shard's
-    /// stale threshold; the task group comes from the head waiter. The task
-    /// and state are committed in their own batch and the group's broker is
-    /// woken so the task is claimable without waiting out scan backoff.
-    /// Returns whether a task was written.
+    /// capacity with pending grant demand. Readiness is judged here with the
+    /// shard's stale threshold; the task group comes from the head waiter,
+    /// whose presence is what establishes the backlog. The task and state are
+    /// committed in their own batch and the group's broker is woken so the
+    /// task is claimable without waiting out scan backoff. Returns whether a
+    /// task was written.
     pub(crate) async fn schedule_floating_refresh_from_scanner(
         &self,
         tenant: &str,
@@ -126,29 +142,37 @@ impl JobStoreShard {
         if !self.floating_limit_refresh_ready(state, now_ms) {
             return Ok(false);
         }
+        // The scanner's row is a snapshot from its precheck. A refresh outcome
+        // committed since then must not be overwritten from that snapshot, so
+        // readiness and the write use a fresh read of the row.
+        let state_key = floating_limit_state_key(tenant, queue_key);
+        let Some(raw) = self.db.get(&state_key).await? else {
+            return Ok(false);
+        };
+        let state = &decode_floating_limit_state(raw)?;
+        if !self.floating_limit_refresh_ready(state, now_ms) {
+            return Ok(false);
+        }
         let Some(task_group) = self
             .peek_head_waiting_request_task_group(tenant, queue_key)
             .await?
         else {
             return Ok(false);
         };
-        let fl = FloatingConcurrencyLimit {
-            key: queue_key.to_string(),
-            default_max_concurrency: state.default_max_concurrency(),
-            refresh_interval_ms: state.refresh_interval_ms(),
-            metadata: state.metadata(),
-        };
         let mut batch = WriteBatch::new();
         let mut writer = DbWriteBatcher::new(&self.db, &mut batch);
-        self.maybe_schedule_floating_limit_refresh(
+        let written = self.maybe_schedule_floating_limit_refresh(
             &mut writer,
             tenant,
-            &fl,
+            queue_key,
             state,
             now_ms,
             &task_group,
             true,
         )?;
+        if !written {
+            return Ok(false);
+        }
         self.db.write(batch).await?;
         self.brokers.wakeup(&task_group);
         Ok(true)
@@ -191,6 +215,7 @@ impl JobStoreShard {
     }
 
     /// Check if a floating limit refresh is needed and schedule it if so.
+    /// Returns whether a refresh task was written.
     ///
     /// Three call sites lazily trigger refreshes, each supplying its own
     /// waiter signal and task group: the enqueue path (a job that just
@@ -203,14 +228,14 @@ impl JobStoreShard {
         &self,
         writer: &mut W,
         tenant: &str,
-        fl: &FloatingConcurrencyLimit,
+        queue_key: &str,
         state: &DecodedFloatingLimitState,
         now_ms: i64,
         task_group: &str,
         has_waiters: bool,
-    ) -> Result<(), JobStoreShardError> {
+    ) -> Result<bool, JobStoreShardError> {
         if self.floating_limit_refresh_outstanding(state, now_ms) {
-            return Ok(());
+            return Ok(false);
         }
 
         // Check if we need to refresh based on interval
@@ -224,7 +249,7 @@ impl JobStoreShard {
             .unwrap_or(false);
 
         if !should_refresh || in_backoff || !has_waiters {
-            return Ok(());
+            return Ok(false);
         }
 
         // Reaching here with the flag still set means the outstanding refresh
@@ -233,7 +258,7 @@ impl JobStoreShard {
             let age_ms = state.refresh_scheduled_at_ms().map(|at| now_ms - at);
             tracing::warn!(
                 tenant = %tenant,
-                queue_key = %fl.key,
+                queue_key = %queue_key,
                 age_ms = ?age_ms,
                 "floating limit refresh flag is stale; scheduling a replacement refresh"
             );
@@ -247,7 +272,7 @@ impl JobStoreShard {
         let refresh_task = Task::RefreshFloatingLimit {
             task_id: task_id.clone(),
             tenant: tenant.to_string(),
-            queue_key: fl.key.clone(),
+            queue_key: queue_key.to_string(),
             current_max_concurrency: state.current_max_concurrency(),
             last_refreshed_at_ms: state.last_refreshed_at_ms(),
             metadata: state.metadata(),
@@ -256,7 +281,7 @@ impl JobStoreShard {
 
         // Use a synthetic task key with a special job_id format for floating refresh tasks
         let task_value = encode_task(&refresh_task);
-        let synthetic_job_id = format!("floating_refresh:{}", fl.key);
+        let synthetic_job_id = format!("floating_refresh:{queue_key}");
         let task_key_bytes = crate::keys::task_key(
             task_group,
             now_ms,
@@ -273,18 +298,18 @@ impl JobStoreShard {
             refresh_scheduled_at_ms: Some(now_ms),
             ..state.to_owned()
         };
-        let state_key = floating_limit_state_key(tenant, &fl.key);
+        let state_key = floating_limit_state_key(tenant, queue_key);
         let state_value = encode_floating_limit_state(&new_state);
         writer.put(&state_key, &state_value)?;
 
         tracing::debug!(
-            queue_key = %fl.key,
+            queue_key = %queue_key,
             current_max = state.current_max_concurrency(),
             last_refreshed = state.last_refreshed_at_ms(),
             "scheduled floating limit refresh task"
         );
 
-        Ok(())
+        Ok(true)
     }
 
     /// Report a successful floating limit refresh from a worker.

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -660,6 +660,7 @@ impl JobStoreShard {
         // We don't increment retry_count here - we rely on the normal periodic refresh mechanism
         let new_state = FloatingLimitState {
             refresh_task_scheduled: false,
+            refresh_scheduled_at_ms: None,
             ..decoded_state.to_owned()
         };
 

--- a/src/job_store_shard/limit_chain.rs
+++ b/src/job_store_shard/limit_chain.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, Weak};
 use async_trait::async_trait;
 use slatedb::WriteBatch;
 
+use crate::codec::DecodedFloatingLimitState;
 use crate::concurrency::{ConcurrencyError, LimitChainResumer, ResumeChainParams};
 use crate::job_store_shard::helpers::DbWriteBatcher;
 use crate::job_store_shard::{
@@ -117,6 +118,28 @@ impl LimitChainResumer for ShardChainResumer {
     fn wakeup_task_groups(&self, groups: &[String]) {
         if let Some(shard) = self.shard.upgrade() {
             shard.brokers.wakeup_groups(groups);
+        }
+    }
+
+    async fn maybe_schedule_floating_refresh(
+        &self,
+        tenant: &str,
+        queue: &str,
+        state: &DecodedFloatingLimitState,
+    ) {
+        let Some(shard) = self.shard.upgrade() else {
+            return;
+        };
+        if let Err(e) = shard
+            .schedule_floating_refresh_from_scanner(tenant, queue, state)
+            .await
+        {
+            tracing::warn!(
+                error = %e,
+                tenant = %tenant,
+                queue = %queue,
+                "grant scanner: failed to schedule floating limit refresh"
+            );
         }
     }
 }

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -128,6 +128,10 @@ pub struct OpenShardOptions {
     /// statements from per-status counters instead of scanning the status index.
     /// Populated from `DatabaseConfig::count_from_status_counters`.
     pub count_from_status_counters: bool,
+    /// How long (ms) a floating limit's outstanding-refresh flag is trusted
+    /// before a replacement refresh may be scheduled. Populated from
+    /// `DatabaseConfig::floating_refresh_stale_ms`.
+    pub floating_refresh_stale_ms: u64,
 }
 
 /// Compute the row TTL (`expire_ts`, epoch ms) for a job that reached the
@@ -233,6 +237,9 @@ pub struct JobStoreShard {
     /// When true, the query engine answers unfiltered per-tenant `COUNT(*)`
     /// from per-status counters instead of a full status-index scan.
     pub(crate) count_from_status_counters: bool,
+    /// Age (ms) past which a set `refresh_task_scheduled` flag is treated as
+    /// a lost refresh rather than an outstanding one.
+    pub(crate) floating_refresh_stale_ms: i64,
 }
 
 #[derive(Debug, Error)]
@@ -426,6 +433,7 @@ impl JobStoreShard {
                 completed_job_expire_s: cfg.completed_job_expire_s,
                 terminal_job_expire_s: cfg.terminal_job_expire_s,
                 count_from_status_counters: cfg.count_from_status_counters,
+                floating_refresh_stale_ms: cfg.floating_refresh_stale_ms,
             },
             range,
         )
@@ -470,6 +478,7 @@ impl JobStoreShard {
             completed_job_expire_s,
             terminal_job_expire_s,
             count_from_status_counters,
+            floating_refresh_stale_ms,
         } = options;
 
         // Wall-clock timer for the whole open, used to emit per-phase debug
@@ -587,6 +596,7 @@ impl JobStoreShard {
             completed_job_expire_s,
             terminal_job_expire_s,
             count_from_status_counters,
+            floating_refresh_stale_ms: i64::try_from(floating_refresh_stale_ms).unwrap_or(i64::MAX),
         });
 
         // Install the chain resumer before starting the grant scanner so the

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -604,6 +604,8 @@ impl JobStoreShard {
             completed_job_expire_s,
             terminal_job_expire_s,
             count_from_status_counters,
+            // Epoch-ms arithmetic needs an i64; a value past i64::MAX saturates
+            // and means only stamp-less rows ever read as stale.
             floating_refresh_stale_ms: i64::try_from(floating_refresh_stale_ms).unwrap_or(i64::MAX),
         });
 

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -132,6 +132,10 @@ pub struct OpenShardOptions {
     /// before a replacement refresh may be scheduled. Populated from
     /// `DatabaseConfig::floating_refresh_stale_ms`.
     pub floating_refresh_stale_ms: u64,
+    /// Scan generations an ack tombstone may keep suppressing a re-observed
+    /// task key before the broker point-reads the row. Populated from
+    /// `DatabaseConfig::broker_tombstone_revive_after_generations`.
+    pub broker_tombstone_revive_after_generations: u64,
 }
 
 /// Compute the row TTL (`expire_ts`, epoch ms) for a job that reached the
@@ -434,6 +438,8 @@ impl JobStoreShard {
                 terminal_job_expire_s: cfg.terminal_job_expire_s,
                 count_from_status_counters: cfg.count_from_status_counters,
                 floating_refresh_stale_ms: cfg.floating_refresh_stale_ms,
+                broker_tombstone_revive_after_generations: cfg
+                    .broker_tombstone_revive_after_generations,
             },
             range,
         )
@@ -479,6 +485,7 @@ impl JobStoreShard {
             terminal_job_expire_s,
             count_from_status_counters,
             floating_refresh_stale_ms,
+            broker_tombstone_revive_after_generations,
         } = options;
 
         // Wall-clock timer for the whole open, used to emit per-phase debug
@@ -572,6 +579,7 @@ impl JobStoreShard {
             name.clone(),
             metrics.clone(),
             range.clone(),
+            broker_tombstone_revive_after_generations,
         );
 
         let shard = Arc::new(Self {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -573,6 +573,7 @@ impl Metrics {
         skipped_tombstone: u64,
         skipped_already_buffered: u64,
         skipped_defunct: u64,
+        revived: u64,
     ) {
         for (outcome, count) in [
             ("inserted", inserted),
@@ -581,6 +582,7 @@ impl Metrics {
             ("skipped_tombstone", skipped_tombstone),
             ("skipped_already_buffered", skipped_already_buffered),
             ("skipped_defunct", skipped_defunct),
+            ("revived", revived),
         ] {
             self.broker_scan_tasks_read
                 .with_label_values(&[shard, task_group, outcome])

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -226,6 +226,9 @@ pub struct Metrics {
     /// Sizes of the grant scanner's pending lanes, labeled `lane=hot|cold`.
     concurrency_pending_grants: GaugeVec,
     concurrency_grant_next_hop_skips: CounterVec,
+    /// Floating limit refreshes forced open after the outstanding-refresh flag
+    /// was found stale, labelled by `reason`.
+    floating_limit_refresh_resets: CounterVec,
 
     // SlateDB watcher metrics (driven by Db::subscribe)
     slatedb_durable_seq: GaugeVec,
@@ -815,6 +818,14 @@ impl Metrics {
     pub fn record_concurrency_grant_next_hop_skip(&self, shard: &str) {
         self.concurrency_grant_next_hop_skips
             .with_label_values(&[shard])
+            .inc();
+    }
+
+    /// Record a floating limit refresh scheduled over an outstanding-refresh
+    /// flag that was treated as lost (`reason` = `stale_scheduled`).
+    pub fn record_floating_limit_refresh_reset(&self, shard: &str, reason: &str) {
+        self.floating_limit_refresh_resets
+            .with_label_values(&[shard, reason])
             .inc();
     }
 
@@ -2499,6 +2510,17 @@ pub fn init() -> anyhow::Result<Metrics> {
         )?,
     );
 
+    let floating_limit_refresh_resets = register(
+        &registry,
+        CounterVec::new(
+            Opts::new(
+                "silo_floating_limit_refresh_reset_total",
+                "Floating limit refresh tasks scheduled over an outstanding-refresh flag that was treated as lost, by reason",
+            ),
+            &["shard", "reason"],
+        )?,
+    );
+
     // SlateDB watcher metrics (driven by Db::subscribe)
     let slatedb_durable_seq = register(
         &registry,
@@ -2625,6 +2647,7 @@ pub fn init() -> anyhow::Result<Metrics> {
         concurrency_reconcile_duration,
         concurrency_pending_grants,
         concurrency_grant_next_hop_skips,
+        floating_limit_refresh_resets,
         slatedb_durable_seq,
         slatedb_manifest_revisions,
         slatedb_manifest_last_l0_seq,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -257,8 +257,10 @@ fn default_grant_scanner_live_headroom_fraction() -> f64 {
 
 /// Default for `floating_refresh_stale_ms`: how long a floating limit's
 /// outstanding-refresh flag is trusted before silo treats the refresh as
-/// lost and allows a replacement to be scheduled. Well past any worker
-/// lease duration, so a legitimately in-flight refresh is never this old.
+/// lost and allows a replacement to be scheduled. A refresh whose lease is
+/// heartbeated past this, or that waited this long to be leased, gets a
+/// surplus replacement; both are leased and reported through the same
+/// path and the last outcome wins.
 pub const DEFAULT_FLOATING_REFRESH_STALE_MS: u64 = 60_000;
 
 fn default_floating_refresh_stale_ms() -> u64 {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -255,6 +255,17 @@ fn default_grant_scanner_live_headroom_fraction() -> f64 {
     DEFAULT_GRANT_SCANNER_LIVE_HEADROOM_FRACTION
 }
 
+/// Default for `floating_refresh_stale_ms`: how long a floating limit's
+/// outstanding-refresh flag is trusted before silo treats the refresh as
+/// lost and allows a replacement to be scheduled. A worker lease is 10 s and
+/// the production refresh interval is 500 ms, so a legitimately in-flight
+/// refresh is never this old.
+pub const DEFAULT_FLOATING_REFRESH_STALE_MS: u64 = 60_000;
+
+fn default_floating_refresh_stale_ms() -> u64 {
+    DEFAULT_FLOATING_REFRESH_STALE_MS
+}
+
 /// Default for `grant_scanner_commit_chunk_size`: max grants a
 /// `process_grants` pass accumulates before committing their edits durably
 /// and waking the granted task groups' brokers. Smaller chunks stream grants
@@ -362,6 +373,12 @@ pub struct DatabaseTemplate {
     /// below 1 are treated as 1. Defaults to 16.
     #[serde(default = "default_grant_scanner_commit_chunk_size")]
     pub grant_scanner_commit_chunk_size: usize,
+    /// How long (ms) a floating limit's outstanding-refresh flag is trusted
+    /// before the refresh is treated as lost and a replacement may be
+    /// scheduled. Rows carrying no scheduled-at stamp are treated as stale
+    /// immediately. Defaults to 60000.
+    #[serde(default = "default_floating_refresh_stale_ms")]
+    pub floating_refresh_stale_ms: u64,
     /// When set, jobs that finished successfully (Succeeded) have all of their
     /// associated KV records re-put with a SlateDB row TTL expiring this many
     /// seconds in the future. `None` (the default) disables the behaviour for
@@ -437,6 +454,7 @@ impl Default for DatabaseTemplate {
                 default_grant_scanner_next_hop_skip_min_backlog(),
             grant_scanner_live_headroom_fraction: default_grant_scanner_live_headroom_fraction(),
             grant_scanner_commit_chunk_size: default_grant_scanner_commit_chunk_size(),
+            floating_refresh_stale_ms: default_floating_refresh_stale_ms(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             periodic_full_compaction_s: None,
@@ -797,6 +815,12 @@ pub struct DatabaseConfig {
     /// Defaults to 16.
     #[serde(default = "default_grant_scanner_commit_chunk_size")]
     pub grant_scanner_commit_chunk_size: usize,
+    /// How long (ms) a floating limit's outstanding-refresh flag is trusted
+    /// before the refresh is treated as lost and a replacement may be
+    /// scheduled. Rows carrying no scheduled-at stamp are treated as stale
+    /// immediately. Defaults to 60000.
+    #[serde(default = "default_floating_refresh_stale_ms")]
+    pub floating_refresh_stale_ms: u64,
     /// TTL (seconds) applied to Succeeded jobs' associated records. See
     /// `DatabaseTemplate::completed_job_expire_s` for details.
     #[serde(default)]
@@ -848,6 +872,7 @@ impl Default for DatabaseConfig {
                 default_grant_scanner_next_hop_skip_min_backlog(),
             grant_scanner_live_headroom_fraction: default_grant_scanner_live_headroom_fraction(),
             grant_scanner_commit_chunk_size: default_grant_scanner_commit_chunk_size(),
+            floating_refresh_stale_ms: default_floating_refresh_stale_ms(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: default_count_from_status_counters(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -266,6 +266,16 @@ fn default_floating_refresh_stale_ms() -> u64 {
     DEFAULT_FLOATING_REFRESH_STALE_MS
 }
 
+/// Default for `broker_tombstone_revive_after_generations`: how many scan
+/// generations an ack tombstone may keep suppressing a re-observed task key
+/// before the broker point-reads the row and, if it is still durable,
+/// buffers it again. The same order as tombstone retention.
+pub const DEFAULT_BROKER_TOMBSTONE_REVIVE_AFTER_GENERATIONS: u64 = 64;
+
+fn default_broker_tombstone_revive_after_generations() -> u64 {
+    DEFAULT_BROKER_TOMBSTONE_REVIVE_AFTER_GENERATIONS
+}
+
 /// Default for `grant_scanner_commit_chunk_size`: max grants a
 /// `process_grants` pass accumulates before committing their edits durably
 /// and waking the granted task groups' brokers. Smaller chunks stream grants
@@ -379,6 +389,11 @@ pub struct DatabaseTemplate {
     /// immediately. Defaults to 60000.
     #[serde(default = "default_floating_refresh_stale_ms")]
     pub floating_refresh_stale_ms: u64,
+    /// Scan generations an ack tombstone may keep suppressing a task key the
+    /// scanner keeps re-observing before the broker point-reads the row and
+    /// revives it if it is still durable. Defaults to 64.
+    #[serde(default = "default_broker_tombstone_revive_after_generations")]
+    pub broker_tombstone_revive_after_generations: u64,
     /// When set, jobs that finished successfully (Succeeded) have all of their
     /// associated KV records re-put with a SlateDB row TTL expiring this many
     /// seconds in the future. `None` (the default) disables the behaviour for
@@ -455,6 +470,8 @@ impl Default for DatabaseTemplate {
             grant_scanner_live_headroom_fraction: default_grant_scanner_live_headroom_fraction(),
             grant_scanner_commit_chunk_size: default_grant_scanner_commit_chunk_size(),
             floating_refresh_stale_ms: default_floating_refresh_stale_ms(),
+            broker_tombstone_revive_after_generations:
+                default_broker_tombstone_revive_after_generations(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             periodic_full_compaction_s: None,
@@ -821,6 +838,11 @@ pub struct DatabaseConfig {
     /// immediately. Defaults to 60000.
     #[serde(default = "default_floating_refresh_stale_ms")]
     pub floating_refresh_stale_ms: u64,
+    /// Scan generations an ack tombstone may keep suppressing a task key the
+    /// scanner keeps re-observing before the broker point-reads the row and
+    /// revives it if it is still durable. Defaults to 64.
+    #[serde(default = "default_broker_tombstone_revive_after_generations")]
+    pub broker_tombstone_revive_after_generations: u64,
     /// TTL (seconds) applied to Succeeded jobs' associated records. See
     /// `DatabaseTemplate::completed_job_expire_s` for details.
     #[serde(default)]
@@ -873,6 +895,8 @@ impl Default for DatabaseConfig {
             grant_scanner_live_headroom_fraction: default_grant_scanner_live_headroom_fraction(),
             grant_scanner_commit_chunk_size: default_grant_scanner_commit_chunk_size(),
             floating_refresh_stale_ms: default_floating_refresh_stale_ms(),
+            broker_tombstone_revive_after_generations:
+                default_broker_tombstone_revive_after_generations(),
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: default_count_from_status_counters(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -257,9 +257,8 @@ fn default_grant_scanner_live_headroom_fraction() -> f64 {
 
 /// Default for `floating_refresh_stale_ms`: how long a floating limit's
 /// outstanding-refresh flag is trusted before silo treats the refresh as
-/// lost and allows a replacement to be scheduled. A worker lease is 10 s and
-/// the production refresh interval is 500 ms, so a legitimately in-flight
-/// refresh is never this old.
+/// lost and allows a replacement to be scheduled. Well past any worker
+/// lease duration, so a legitimately in-flight refresh is never this old.
 pub const DEFAULT_FLOATING_REFRESH_STALE_MS: u64 = 60_000;
 
 fn default_floating_refresh_stale_ms() -> u64 {
@@ -832,15 +831,14 @@ pub struct DatabaseConfig {
     /// Defaults to 16.
     #[serde(default = "default_grant_scanner_commit_chunk_size")]
     pub grant_scanner_commit_chunk_size: usize,
-    /// How long (ms) a floating limit's outstanding-refresh flag is trusted
-    /// before the refresh is treated as lost and a replacement may be
-    /// scheduled. Rows carrying no scheduled-at stamp are treated as stale
-    /// immediately. Defaults to 60000.
+    /// How long (ms) an outstanding floating limit refresh is trusted. See
+    /// `DatabaseTemplate::floating_refresh_stale_ms` for details. Defaults
+    /// to 60000.
     #[serde(default = "default_floating_refresh_stale_ms")]
     pub floating_refresh_stale_ms: u64,
-    /// Scan generations an ack tombstone may keep suppressing a task key the
-    /// scanner keeps re-observing before the broker point-reads the row and
-    /// revives it if it is still durable. Defaults to 64.
+    /// Scan generations an ack tombstone may suppress a re-observed task key.
+    /// See `DatabaseTemplate::broker_tombstone_revive_after_generations` for
+    /// details. Defaults to 64.
     #[serde(default = "default_broker_tombstone_revive_after_generations")]
     pub broker_tombstone_revive_after_generations: u64,
     /// TTL (seconds) applied to Succeeded jobs' associated records. See
@@ -1087,5 +1085,29 @@ mod tests {
         )
         .expect("config with periodic_full_compaction_s should parse");
         assert_eq!(db.periodic_full_compaction_s, Some(5));
+    }
+
+    #[test]
+    fn floating_refresh_settings_default_on_both_carriers() {
+        let template: DatabaseTemplate = toml::from_str(
+            r#"
+            backend = "memory"
+            path = "/tmp/silo-%shard%"
+            "#,
+        )
+        .expect("template without refresh settings should parse");
+        assert_eq!(template.floating_refresh_stale_ms, 60_000);
+        assert_eq!(template.broker_tombstone_revive_after_generations, 64);
+
+        let config: DatabaseConfig = toml::from_str(
+            r#"
+            name = "shard"
+            backend = "memory"
+            path = "/tmp/silo-shard"
+            "#,
+        )
+        .expect("config without refresh settings should parse");
+        assert_eq!(config.floating_refresh_stale_ms, 60_000);
+        assert_eq!(config.broker_tombstone_revive_after_generations, 64);
     }
 }

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -30,6 +30,17 @@ pub struct BrokerTask {
     pub decoded: DecodedTask,
 }
 
+/// Suppression record for a durably deleted task key.
+///
+/// Expiry is keyed to `last_seen` so persistent stale observations extend
+/// suppression; the revive bound is keyed to `inserted_at` so a key that a
+/// scan keeps yielding is eventually point-read rather than hidden forever.
+#[derive(Debug, Clone, Copy)]
+struct AckTombstone {
+    inserted_at: u64,
+    last_seen: u64,
+}
+
 /// A single per-task-group broker that scans only its own key range.
 ///
 /// - Maintains a sorted buffer of ready tasks using a skiplist keyed by the task key bytes.
@@ -44,9 +55,12 @@ pub struct TaskBroker {
     buffer: Arc<SkipMap<Vec<u8>, BrokerTask>>,
     // The set of tasks already read out of the DB and claimed by a worker but not yet durably leased. Required so that the scanner doesn't re-add tasks that are in the middle of being dequeued to the buffer.
     inflight: Arc<Mutex<HashSet<Vec<u8>>>>,
-    // Tombstones for task keys that were durably acked, keyed by the most recent
-    // scan generation where that key should be suppressed.
-    ack_tombstones: Arc<Mutex<HashMap<Vec<u8>, u64>>>,
+    // Tombstones for task keys that were durably acked, so a stale scan cannot
+    // re-buffer a row the broker has already deleted.
+    ack_tombstones: Arc<Mutex<HashMap<Vec<u8>, AckTombstone>>>,
+    // Scan generations a tombstone may keep suppressing a re-observed key
+    // before the scanner point-reads the row to check the delete landed.
+    tombstone_revive_after_generations: u64,
     // Monotonic generation numbers for scanner iterations.
     scan_generation_started: Arc<AtomicU64>,
     scan_generation_completed: Arc<AtomicU64>,
@@ -79,6 +93,7 @@ impl TaskBroker {
         shard_name: String,
         metrics: Option<Metrics>,
         range: ShardRange,
+        tombstone_revive_after_generations: u64,
     ) -> Arc<Self> {
         Arc::new(Self {
             task_group,
@@ -101,6 +116,7 @@ impl TaskBroker {
             shard_name,
             metrics,
             range,
+            tombstone_revive_after_generations,
         })
     }
 
@@ -120,9 +136,8 @@ impl TaskBroker {
         self.scan_generation_completed
             .store(generation, Ordering::SeqCst);
         let mut tombstones = self.ack_tombstones.lock().unwrap();
-        tombstones.retain(|_, last_seen_generation| {
-            generation.saturating_sub(*last_seen_generation)
-                <= Self::ACK_TOMBSTONE_RETAIN_GENERATIONS
+        tombstones.retain(|_, tombstone| {
+            generation.saturating_sub(tombstone.last_seen) <= Self::ACK_TOMBSTONE_RETAIN_GENERATIONS
         });
     }
 
@@ -150,6 +165,7 @@ impl TaskBroker {
         let mut skipped_tombstone = 0u64;
         let mut skipped_already_buffered = 0u64;
         let mut skipped_defunct = 0u64;
+        let mut revived = 0u64;
         while inserted < self.scan_batch && self.buffer.len() < self.target_buffer {
             let Ok(Some(kv)) = iter.next().await else {
                 break;
@@ -179,22 +195,37 @@ impl TaskBroker {
             }
 
             // Skip keys that were recently durably acked to avoid stale scan re-inserts.
-            // Refresh generation so persistent stale observations extend suppression.
-            let suppress_due_to_tombstone = {
+            // Refresh last_seen so persistent stale observations extend suppression.
+            let tombstone_age = {
                 let mut tombstones = self.ack_tombstones.lock().unwrap();
-                if let Some(last_seen_generation) = tombstones.get_mut(&key_bytes) {
-                    *last_seen_generation = generation;
-                    true
-                } else {
-                    false
-                }
+                tombstones.get_mut(&key_bytes).map(|tombstone| {
+                    tombstone.last_seen = generation;
+                    generation.saturating_sub(tombstone.inserted_at)
+                })
             };
-            if suppress_due_to_tombstone {
-                skipped_tombstone += 1;
-                continue;
+            let mut value = kv.value;
+            if let Some(age) = tombstone_age {
+                if age <= self.tombstone_revive_after_generations {
+                    skipped_tombstone += 1;
+                    continue;
+                }
+                // A key re-observed past the bound may be a row whose delete
+                // never landed. A point get sees a fresher view than the range
+                // scan that yielded the key; the guard is not held across it.
+                match self.db.get(&key_bytes).await {
+                    Ok(Some(durable)) => {
+                        self.ack_tombstones.lock().unwrap().remove(&key_bytes);
+                        revived += 1;
+                        value = durable;
+                    }
+                    _ => {
+                        skipped_tombstone += 1;
+                        continue;
+                    }
+                }
             }
 
-            let decoded = match decode_task_validated(kv.value.clone()) {
+            let decoded = match decode_task_validated(value) {
                 Ok(t) => t,
                 Err(_) => continue, // Skip malformed tasks
             };
@@ -247,6 +278,7 @@ impl TaskBroker {
                 skipped_tombstone,
                 skipped_already_buffered,
                 skipped_defunct,
+                revived,
             );
             m.set_broker_tombstone_count(
                 &self.shard_name,
@@ -494,7 +526,13 @@ impl TaskBroker {
             inflight.remove(k);
         }
         for k in tombstone_keys {
-            tombstones.insert(k.clone(), generation);
+            tombstones.insert(
+                k.clone(),
+                AckTombstone {
+                    inserted_at: generation,
+                    last_seen: generation,
+                },
+            );
         }
     }
 
@@ -525,6 +563,7 @@ pub struct TaskBrokerRegistry {
     shard_name: String,
     metrics: Option<Metrics>,
     range: ShardRange,
+    tombstone_revive_after_generations: u64,
     brokers: DashMap<String, Arc<TaskBroker>>,
 }
 
@@ -534,12 +573,14 @@ impl TaskBrokerRegistry {
         shard_name: String,
         metrics: Option<Metrics>,
         range: ShardRange,
+        tombstone_revive_after_generations: u64,
     ) -> Arc<Self> {
         Arc::new(Self {
             db,
             shard_name,
             metrics,
             range,
+            tombstone_revive_after_generations,
             brokers: DashMap::new(),
         })
     }
@@ -561,6 +602,7 @@ impl TaskBrokerRegistry {
                     self.shard_name.clone(),
                     self.metrics.clone(),
                     self.range.clone(),
+                    self.tombstone_revive_after_generations,
                 );
                 b.start();
                 b
@@ -713,6 +755,7 @@ mod inflight_release_tests {
             "shard".to_string(),
             None,
             ShardRange::full(),
+            TaskBroker::ACK_TOMBSTONE_RETAIN_GENERATIONS,
         )
     }
 

--- a/src/task_broker.rs
+++ b/src/task_broker.rs
@@ -84,7 +84,7 @@ pub struct TaskBroker {
 
 impl TaskBroker {
     // Keep ack tombstones for a bounded number of completed scan generations and
-    // refresh the tombstone generation whenever a stale key is observed again.
+    // refresh `last_seen` whenever a stale key is observed again.
     const ACK_TOMBSTONE_RETAIN_GENERATIONS: u64 = 64;
 
     fn new(
@@ -209,16 +209,30 @@ impl TaskBroker {
                     skipped_tombstone += 1;
                     continue;
                 }
-                // A key re-observed past the bound may be a row whose delete
-                // never landed. A point get sees a fresher view than the range
-                // scan that yielded the key; the guard is not held across it.
+                // A key re-observed past the bound is either a stale scan or a
+                // row rewritten under the same key after the delete. A point get
+                // sees a fresher view than the range scan that yielded the key;
+                // the guard is not held across it.
                 match self.db.get(&key_bytes).await {
                     Ok(Some(durable)) => {
                         self.ack_tombstones.lock().unwrap().remove(&key_bytes);
                         revived += 1;
                         value = durable;
                     }
-                    _ => {
+                    Ok(None) => {
+                        // The delete is confirmed. Re-arm the bound so a stale
+                        // scan costs one point read per bound window, not one
+                        // per generation.
+                        if let Some(tombstone) =
+                            self.ack_tombstones.lock().unwrap().get_mut(&key_bytes)
+                        {
+                            tombstone.inserted_at = generation;
+                        }
+                        skipped_tombstone += 1;
+                        continue;
+                    }
+                    Err(e) => {
+                        debug!(error = %e, "tombstone revive point read failed; keeping suppression");
                         skipped_tombstone += 1;
                         continue;
                     }
@@ -743,6 +757,10 @@ mod inflight_release_tests {
     use crate::task::Task;
 
     async fn empty_broker() -> Arc<TaskBroker> {
+        broker_with_revive_bound(TaskBroker::ACK_TOMBSTONE_RETAIN_GENERATIONS).await
+    }
+
+    async fn broker_with_revive_bound(bound: u64) -> Arc<TaskBroker> {
         let store = Arc::new(slatedb::object_store::memory::InMemory::new());
         let db = slatedb::DbBuilder::new("test", store)
             .build()
@@ -755,8 +773,52 @@ mod inflight_release_tests {
             "shard".to_string(),
             None,
             ShardRange::full(),
-            TaskBroker::ACK_TOMBSTONE_RETAIN_GENERATIONS,
+            bound,
         )
+    }
+
+    /// A tombstoned key that a scan keeps yielding is suppressed while its
+    /// age (generations since insertion) is within the bound and point-read
+    /// once past it; a row still present is revived and buffered.
+    #[tokio::test]
+    async fn tombstoned_key_is_revived_only_past_the_bound() {
+        let broker = broker_with_revive_bound(1).await;
+        let entry = sample_broker_task("revive-boundary");
+        let row = encode_task(&entry.decoded.to_task().expect("task"));
+        broker.db.put(&entry.key, &row).await.expect("put row");
+        let now_ms = crate::job_store_shard::now_epoch_ms();
+
+        let generation = broker.begin_scan_generation();
+        assert_eq!(broker.scan_tasks(now_ms, generation).await, 1);
+        assert_eq!(broker.claim_ready(1).len(), 1);
+        broker.ack_durable(
+            std::slice::from_ref(&entry.key),
+            std::slice::from_ref(&entry.key),
+        );
+
+        // Age 1: within the bound, suppressed without a point read.
+        let generation = broker.begin_scan_generation();
+        assert_eq!(broker.scan_tasks(now_ms, generation).await, 0);
+        assert_eq!(broker.buffer_len(), 0);
+        assert!(
+            broker
+                .ack_tombstones
+                .lock()
+                .unwrap()
+                .contains_key(&entry.key)
+        );
+
+        // Age 2: past the bound, point-read, present, revived.
+        let generation = broker.begin_scan_generation();
+        assert_eq!(broker.scan_tasks(now_ms, generation).await, 1);
+        assert_eq!(broker.buffer_len(), 1);
+        assert!(
+            !broker
+                .ack_tombstones
+                .lock()
+                .unwrap()
+                .contains_key(&entry.key)
+        );
     }
 
     fn sample_broker_task(job_id: &str) -> BrokerTask {

--- a/tests/broker_tombstone_revive_tests.rs
+++ b/tests/broker_tombstone_revive_tests.rs
@@ -57,49 +57,16 @@ async fn enqueue_floating(shard: &JobStoreShard, queue: &str, tag: u32) {
         .expect("enqueue floating job");
 }
 
-/// Each dequeue against an empty buffer wakes the broker scanner, so repeated
-/// dequeues advance scan generations without waiting out the scanner's backoff.
-async fn dequeue_until_refresh_task_leased(
-    shard: &JobStoreShard,
-    attempts: usize,
-) -> Option<String> {
-    for _ in 0..attempts {
-        let result = shard
-            .dequeue("worker-2", "default", 10)
-            .await
-            .expect("dequeue");
-        if let Some(task) = result.refresh_tasks.first() {
-            return Some(task.task_id.clone());
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    None
+fn read_revived_total(metrics: &silo::metrics::Metrics) -> f64 {
+    metric_value_or_zero(
+        &gather_metrics_text(metrics),
+        &["silo_broker_scan_tasks_read_total", "outcome=\"revived\""],
+    )
 }
 
-fn read_scan_outcome_total(metrics: &silo::metrics::Metrics, outcome: &str) -> f64 {
-    metrics
-        .registry()
-        .gather()
-        .into_iter()
-        .find(|f| f.get_name() == "silo_broker_scan_tasks_read_total")
-        .map(|f| {
-            f.get_metric()
-                .iter()
-                .filter(|m| {
-                    m.get_label()
-                        .iter()
-                        .any(|l| l.get_name() == "outcome" && l.get_value() == outcome)
-                })
-                .map(|m| m.get_counter().get_value())
-                .sum()
-        })
-        .unwrap_or(0.0)
-}
-
-/// The env-621258 shape: a refresh task row the broker acked and tombstoned
-/// is still durable under the same bytes. With a revive bound of one scan
-/// generation, driving scans through dequeue wakeups must lease it again
-/// without a process restart.
+/// A refresh task row the broker acked and tombstoned is still durable under
+/// the same bytes. With a revive bound of one scan generation, driving scans
+/// through dequeue wakeups must lease it again without a process restart.
 #[silo::test]
 async fn tombstoned_task_row_still_durable_is_revived_and_leased() {
     let (_tmp, shard, metrics) = open_temp_shard_with_tombstone_revive_after_generations(1).await;
@@ -113,9 +80,12 @@ async fn tombstoned_task_row_still_durable_is_revived_and_leased() {
         .expect("refresh task row is durable before dequeue");
 
     // Dequeue acks the row: the key is deleted and tombstoned in the broker.
-    let first = dequeue_until_refresh_task_leased(&shard, 50)
-        .await
-        .expect("refresh task leased once");
+    let first =
+        dequeue_refresh_tasks_until(&shard, "worker-1", "default", 1, Duration::from_secs(30))
+            .await
+            .refresh_tasks[0]
+            .task_id
+            .clone();
     shard
         .report_refresh_success(&first, 1)
         .await
@@ -133,23 +103,24 @@ async fn tombstoned_task_row_still_durable_is_revived_and_leased() {
         .expect("put row back");
     shard.db().flush().await.expect("flush");
 
-    let second = dequeue_until_refresh_task_leased(&shard, 200).await;
-    assert!(
-        second.is_some(),
-        "a durable row re-observed past the revive bound must be leased again"
-    );
-    assert_eq!(second.as_deref(), Some(first.as_str()));
-    assert_eq!(read_scan_outcome_total(&metrics, "revived"), 1.0);
+    let second =
+        dequeue_refresh_tasks_until(&shard, "worker-2", "default", 1, Duration::from_secs(30))
+            .await
+            .refresh_tasks[0]
+            .task_id
+            .clone();
+    assert_eq!(second, first, "the revived row is the same task");
+    assert_eq!(read_revived_total(&metrics), 1.0);
     assert!(
         find_refresh_task_row(&shard).await.is_none(),
         "the revived row is deleted by its second dequeue"
     );
 }
 
-/// A key that was acked and whose row is truly gone stays suppressed: no
-/// phantom lease, no phantom buffer entry, and no revival.
+/// A durably deleted task row is never re-leased and leaves no buffer entry
+/// while its tombstone ages past the revive bound.
 #[silo::test]
-async fn tombstoned_task_row_that_is_gone_is_never_revived() {
+async fn durably_deleted_row_is_not_re_leased_and_leaves_no_buffer_entry() {
     let (_tmp, shard, metrics) = open_temp_shard_with_tombstone_revive_after_generations(1).await;
 
     shard
@@ -167,20 +138,8 @@ async fn tombstoned_task_row_that_is_gone_is_never_revived() {
         .await
         .expect("enqueue");
 
-    let leased = poll_until(
-        || async {
-            shard
-                .dequeue("worker-1", "default", 10)
-                .await
-                .expect("dequeue")
-                .tasks
-                .len()
-        },
-        |&n| n == 1,
-        5000,
-    )
-    .await;
-    assert_eq!(leased, 1);
+    let leased = dequeue_task_ids_until(&shard, "worker-1", "default", 1).await;
+    assert_eq!(leased.len(), 1);
     assert_eq!(count_task_keys(shard.db()).await, 0);
 
     // Drive scan generations well past the bound.
@@ -196,7 +155,7 @@ async fn tombstoned_task_row_that_is_gone_is_never_revived() {
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
     assert_eq!(shard.broker_buffer_len(), 0);
-    assert_eq!(read_scan_outcome_total(&metrics, "revived"), 0.0);
+    assert_eq!(read_revived_total(&metrics), 0.0);
     assert_eq!(
         count_lease_keys(shard.db()).await,
         1,

--- a/tests/broker_tombstone_revive_tests.rs
+++ b/tests/broker_tombstone_revive_tests.rs
@@ -1,0 +1,205 @@
+//! Tests for bounded ack-tombstone suppression in the task broker.
+//!
+//! After a dequeue durably deletes a task row, the broker keeps an in-memory
+//! tombstone so a stale scan cannot re-buffer the row. A row that is still
+//! durable in the DB must not stay hidden behind that tombstone forever: once
+//! the key has been re-observed past the revive bound, the broker point-reads
+//! it and, if present, buffers it again. A key whose row is truly gone stays
+//! suppressed.
+
+mod test_helpers;
+
+use std::time::Duration;
+
+use silo::codec::decode_task_validated;
+use silo::job_store_shard::JobStoreShard;
+use test_helpers::*;
+
+/// Scan the durable task rows and return the first RefreshFloatingLimit row.
+async fn find_refresh_task_row(shard: &JobStoreShard) -> Option<(Vec<u8>, bytes::Bytes)> {
+    let start = silo::keys::tasks_prefix();
+    let end = silo::keys::end_bound(&start);
+    let mut iter = shard
+        .db()
+        .scan::<Vec<u8>, _>(start..end)
+        .await
+        .expect("scan tasks");
+    while let Some(kv) = iter.next().await.expect("iterate tasks") {
+        let decoded = decode_task_validated(kv.value.clone()).expect("decode task");
+        if decoded.as_refresh_floating_limit().is_some() {
+            return Some((kv.key.to_vec(), kv.value));
+        }
+    }
+    None
+}
+
+async fn enqueue_floating(shard: &JobStoreShard, queue: &str, tag: u32) {
+    shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            now_ms(),
+            None,
+            msgpack_payload(&serde_json::json!({"j": tag})),
+            vec![silo::job::Limit::FloatingConcurrency(
+                silo::job::FloatingConcurrencyLimit {
+                    key: queue.to_string(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 100,
+                    metadata: vec![],
+                },
+            )],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue floating job");
+}
+
+/// Each dequeue against an empty buffer wakes the broker scanner, so repeated
+/// dequeues advance scan generations without waiting out the scanner's backoff.
+async fn dequeue_until_refresh_task_leased(
+    shard: &JobStoreShard,
+    attempts: usize,
+) -> Option<String> {
+    for _ in 0..attempts {
+        let result = shard
+            .dequeue("worker-2", "default", 10)
+            .await
+            .expect("dequeue");
+        if let Some(task) = result.refresh_tasks.first() {
+            return Some(task.task_id.clone());
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    None
+}
+
+fn read_scan_outcome_total(metrics: &silo::metrics::Metrics, outcome: &str) -> f64 {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|f| f.get_name() == "silo_broker_scan_tasks_read_total")
+        .map(|f| {
+            f.get_metric()
+                .iter()
+                .filter(|m| {
+                    m.get_label()
+                        .iter()
+                        .any(|l| l.get_name() == "outcome" && l.get_value() == outcome)
+                })
+                .map(|m| m.get_counter().get_value())
+                .sum()
+        })
+        .unwrap_or(0.0)
+}
+
+/// The env-621258 shape: a refresh task row the broker acked and tombstoned
+/// is still durable under the same bytes. With a revive bound of one scan
+/// generation, driving scans through dequeue wakeups must lease it again
+/// without a process restart.
+#[silo::test]
+async fn tombstoned_task_row_still_durable_is_revived_and_leased() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_tombstone_revive_after_generations(1).await;
+    let queue = "tombstone-revive-q";
+
+    // A holder plus a waiter schedules a refresh task row.
+    enqueue_floating(&shard, queue, 1).await;
+    enqueue_floating(&shard, queue, 2).await;
+    let (row_key, row_value) = find_refresh_task_row(&shard)
+        .await
+        .expect("refresh task row is durable before dequeue");
+
+    // Dequeue acks the row: the key is deleted and tombstoned in the broker.
+    let first = dequeue_until_refresh_task_leased(&shard, 50)
+        .await
+        .expect("refresh task leased once");
+    shard
+        .report_refresh_success(&first, 1)
+        .await
+        .expect("report refresh success");
+    assert!(
+        find_refresh_task_row(&shard).await.is_none(),
+        "dequeue deletes the refresh task row"
+    );
+
+    // The row comes back under the exact same bytes.
+    shard
+        .db()
+        .put(&row_key, &row_value)
+        .await
+        .expect("put row back");
+    shard.db().flush().await.expect("flush");
+
+    let second = dequeue_until_refresh_task_leased(&shard, 200).await;
+    assert!(
+        second.is_some(),
+        "a durable row re-observed past the revive bound must be leased again"
+    );
+    assert_eq!(second.as_deref(), Some(first.as_str()));
+    assert_eq!(read_scan_outcome_total(&metrics, "revived"), 1.0);
+    assert!(
+        find_refresh_task_row(&shard).await.is_none(),
+        "the revived row is deleted by its second dequeue"
+    );
+}
+
+/// A key that was acked and whose row is truly gone stays suppressed: no
+/// phantom lease, no phantom buffer entry, and no revival.
+#[silo::test]
+async fn tombstoned_task_row_that_is_gone_is_never_revived() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_tombstone_revive_after_generations(1).await;
+
+    shard
+        .enqueue(
+            "-",
+            Some("gone-job".to_string()),
+            10u8,
+            now_ms(),
+            None,
+            msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue");
+
+    let leased = poll_until(
+        || async {
+            shard
+                .dequeue("worker-1", "default", 10)
+                .await
+                .expect("dequeue")
+                .tasks
+                .len()
+        },
+        |&n| n == 1,
+        5000,
+    )
+    .await;
+    assert_eq!(leased, 1);
+    assert_eq!(count_task_keys(shard.db()).await, 0);
+
+    // Drive scan generations well past the bound.
+    for _ in 0..20 {
+        let result = shard
+            .dequeue("worker-2", "default", 10)
+            .await
+            .expect("dequeue");
+        assert!(
+            result.tasks.is_empty(),
+            "a deleted row must never be leased"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(shard.broker_buffer_len(), 0);
+    assert_eq!(read_scan_outcome_total(&metrics, "revived"), 0.0);
+    assert_eq!(
+        count_lease_keys(shard.db()).await,
+        1,
+        "only the real lease exists"
+    );
+}

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -346,6 +346,7 @@ fn test_floating_limit_state_roundtrip() {
         retry_count: 2,
         next_retry_at_ms: Some(8000),
         metadata: vec![("source".to_string(), "api".to_string())],
+        refresh_scheduled_at_ms: None,
     };
     let encoded = encode_floating_limit_state(&state);
     let decoded = decode_floating_limit_state(encoded).unwrap();
@@ -370,6 +371,7 @@ fn test_floating_limit_state_roundtrip_none_retry() {
         retry_count: 0,
         next_retry_at_ms: None,
         metadata: vec![],
+        refresh_scheduled_at_ms: None,
     };
     let encoded = encode_floating_limit_state(&state);
     let decoded = decode_floating_limit_state(encoded).unwrap();
@@ -606,4 +608,63 @@ fn test_decoded_task_as_bytes_passthrough() {
 fn test_decoded_task_invalid_data() {
     let result = decode_task_validated(vec![0xFF, 0xFF]);
     assert!(result.is_err());
+}
+
+/// A floating limit state row encoded by a build whose table ends at
+/// `metadata`, with no `refresh_scheduled_at_ms` slot. It carries
+/// `current_max_concurrency: 19`, `last_refreshed_at_ms: 1_756_400_000_000`,
+/// `refresh_task_scheduled: true`, `refresh_interval_ms: 500`,
+/// `default_max_concurrency: 5`, `retry_count: 3`,
+/// `next_retry_at_ms: Some(1_756_400_060_000)`, and two metadata pairs.
+const FLOATING_LIMIT_STATE_WITHOUT_SCHEDULED_AT: &[u8] = &[
+    24, 0, 0, 0, 20, 0, 48, 0, 8, 0, 24, 0, 7, 0, 32, 0, 12, 0, 16, 0, 40, 0, 20, 0, 20, 0, 0, 0,
+    0, 0, 0, 1, 19, 0, 0, 0, 5, 0, 0, 0, 3, 0, 0, 0, 28, 0, 0, 0, 0, 28, 153, 241, 152, 1, 0, 0,
+    244, 1, 0, 0, 0, 0, 0, 0, 96, 6, 154, 241, 152, 1, 0, 0, 2, 0, 0, 0, 48, 0, 0, 0, 4, 0, 0, 0,
+    224, 255, 255, 255, 16, 0, 0, 0, 4, 0, 0, 0, 3, 0, 0, 0, 97, 112, 105, 0, 6, 0, 0, 0, 115, 111,
+    117, 114, 99, 101, 0, 0, 8, 0, 12, 0, 4, 0, 8, 0, 8, 0, 0, 0, 40, 0, 0, 0, 4, 0, 0, 0, 26, 0,
+    0, 0, 112, 108, 97, 116, 102, 111, 114, 109, 45, 116, 101, 110, 97, 110, 116, 45, 101, 110,
+    118, 45, 54, 49, 52, 54, 57, 54, 0, 0, 3, 0, 0, 0, 101, 110, 118, 0,
+];
+
+#[silo::test]
+fn test_floating_limit_state_without_scheduled_at_decodes_with_trailing_fields_intact() {
+    let decoded =
+        decode_floating_limit_state(FLOATING_LIMIT_STATE_WITHOUT_SCHEDULED_AT.to_vec()).unwrap();
+    assert_eq!(decoded.current_max_concurrency(), 19);
+    assert_eq!(decoded.last_refreshed_at_ms(), 1_756_400_000_000);
+    assert!(decoded.refresh_task_scheduled());
+    assert_eq!(decoded.refresh_interval_ms(), 500);
+    assert_eq!(decoded.default_max_concurrency(), 5);
+    assert_eq!(decoded.retry_count(), 3);
+    assert_eq!(decoded.next_retry_at_ms(), Some(1_756_400_060_000));
+    assert_eq!(
+        decoded.metadata(),
+        vec![
+            ("env".to_string(), "platform-tenant-env-614696".to_string()),
+            ("source".to_string(), "api".to_string()),
+        ]
+    );
+    assert_eq!(decoded.refresh_scheduled_at_ms(), None);
+    assert_eq!(decoded.to_owned().refresh_scheduled_at_ms, None);
+}
+
+#[silo::test]
+fn test_floating_limit_state_roundtrip_refresh_scheduled_at() {
+    let state = FloatingLimitState {
+        current_max_concurrency: 10,
+        last_refreshed_at_ms: 5000,
+        refresh_task_scheduled: true,
+        refresh_interval_ms: 30000,
+        default_max_concurrency: 5,
+        retry_count: 0,
+        next_retry_at_ms: None,
+        metadata: vec![("source".to_string(), "api".to_string())],
+        refresh_scheduled_at_ms: Some(5500),
+    };
+    let encoded = encode_floating_limit_state(&state);
+    let decoded = decode_floating_limit_state(encoded).unwrap();
+    assert_eq!(decoded.refresh_scheduled_at_ms(), Some(5500));
+    assert_eq!(decoded.next_retry_at_ms(), None);
+    assert_eq!(decoded.metadata().len(), 1);
+    assert_eq!(decoded.to_owned().refresh_scheduled_at_ms, Some(5500));
 }

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -610,8 +610,8 @@ fn test_decoded_task_invalid_data() {
     assert!(result.is_err());
 }
 
-/// A floating limit state row encoded by a build whose table ends at
-/// `metadata`, with no `refresh_scheduled_at_ms` slot. It carries
+/// A floating limit state row whose table has eight vtable slots ending at
+/// `metadata` and no `refresh_scheduled_at_ms` slot. It carries
 /// `current_max_concurrency: 19`, `last_refreshed_at_ms: 1_756_400_000_000`,
 /// `refresh_task_scheduled: true`, `refresh_interval_ms: 500`,
 /// `default_max_concurrency: 5`, `retry_count: 3`,

--- a/tests/floating_concurrency_tests.rs
+++ b/tests/floating_concurrency_tests.rs
@@ -2242,6 +2242,9 @@ async fn fc_before_concurrency_wedges_floating_only_jobs_via_orphaned_holder() {
 // Aging out an outstanding refresh flag
 // ---------------------------------------------------------------------------
 
+const REFRESH_INTERVAL_MS: i64 = 100;
+const DEQUEUE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 fn floating_limit(queue: &str, refresh_interval_ms: i64) -> silo::job::Limit {
     silo::job::Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
         key: queue.to_string(),
@@ -2251,21 +2254,31 @@ fn floating_limit(queue: &str, refresh_interval_ms: i64) -> silo::job::Limit {
     })
 }
 
-async fn enqueue_floating(shard: &silo::job_store_shard::JobStoreShard, queue: &str, tag: u32) {
+/// Enqueue a job on `queue` under `task_group`, returning its job id.
+async fn enqueue_floating_in_group(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+    tag: u32,
+    task_group: &str,
+) -> String {
     shard
         .enqueue(
             "-",
-            None,
+            Some(format!("{queue}-job-{tag}")),
             10u8,
             now_ms(),
             None,
             test_helpers::msgpack_payload(&serde_json::json!({"j": tag})),
-            vec![floating_limit(queue, 100)],
+            vec![floating_limit(queue, REFRESH_INTERVAL_MS)],
             None,
-            "default",
+            task_group,
         )
         .await
-        .expect("enqueue floating job");
+        .expect("enqueue floating job")
+}
+
+async fn enqueue_floating(shard: &silo::job_store_shard::JobStoreShard, queue: &str, tag: u32) {
+    enqueue_floating_in_group(shard, queue, tag, "default").await;
 }
 
 /// Overwrite the durable floating limit state row for `queue` with the flag
@@ -2279,7 +2292,7 @@ async fn write_orphaned_refresh_state(
         current_max_concurrency: 1,
         last_refreshed_at_ms: 0,
         refresh_task_scheduled: true,
-        refresh_interval_ms: 100,
+        refresh_interval_ms: REFRESH_INTERVAL_MS,
         default_max_concurrency: 1,
         retry_count: 0,
         next_retry_at_ms: None,
@@ -2297,14 +2310,22 @@ async fn write_orphaned_refresh_state(
     shard.db().flush().await.expect("flush state");
 }
 
-async fn count_refresh_tasks(shard: &silo::job_store_shard::JobStoreShard, queue: &str) -> usize {
+async fn count_refresh_tasks_in_group(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+    task_group: &str,
+) -> usize {
     shard
-        .peek_tasks("default", 100)
+        .peek_tasks(task_group, 100)
         .await
         .expect("peek tasks")
         .iter()
         .filter(|t| matches!(t, Task::RefreshFloatingLimit { queue_key, .. } if queue_key == queue))
         .count()
+}
+
+async fn count_refresh_tasks(shard: &silo::job_store_shard::JobStoreShard, queue: &str) -> usize {
+    count_refresh_tasks_in_group(shard, queue, "default").await
 }
 
 async fn read_floating_state(
@@ -2320,28 +2341,34 @@ async fn read_floating_state(
     silo::codec::decode_floating_limit_state(raw).expect("decode state")
 }
 
-fn read_refresh_reset_total(metrics: &silo::metrics::Metrics) -> f64 {
-    metrics
-        .registry()
-        .gather()
-        .into_iter()
-        .find(|f| f.get_name() == "silo_floating_limit_refresh_reset_total")
-        .map(|f| {
-            f.get_metric()
-                .iter()
-                .filter(|m| {
-                    m.get_label()
-                        .iter()
-                        .any(|l| l.get_name() == "reason" && l.get_value() == "stale_scheduled")
-                })
-                .map(|m| m.get_counter().get_value())
-                .sum()
-        })
-        .unwrap_or(0.0)
+/// Rewrite the state row with `last_refreshed_at_ms` at zero so the refresh
+/// interval has elapsed, keeping every other field.
+async fn backdate_last_refreshed(shard: &silo::job_store_shard::JobStoreShard, queue: &str) {
+    let mut state = read_floating_state(shard, queue).await.to_owned();
+    state.last_refreshed_at_ms = 0;
+    shard
+        .db()
+        .put(
+            &silo::keys::floating_limit_state_key("-", queue),
+            &silo::codec::encode_floating_limit_state(&state),
+        )
+        .await
+        .expect("put backdated state");
+    shard.db().flush().await.expect("flush");
 }
 
-/// The env-614696 shape: `refresh_task_scheduled` is set but no task row and
-/// no lease exist, so nothing will ever clear it. A waiter-producing enqueue
+fn read_refresh_reset_total(metrics: &silo::metrics::Metrics) -> f64 {
+    metric_value_or_zero(
+        &gather_metrics_text(metrics),
+        &[
+            "silo_floating_limit_refresh_reset_total",
+            "reason=\"stale_scheduled\"",
+        ],
+    )
+}
+
+/// A state row with `refresh_task_scheduled` set but no task row and no
+/// lease behind it, so nothing will ever clear it. A waiter-producing enqueue
 /// must schedule a replacement refresh once the stamp is older than the
 /// threshold, and must not while the stamp is fresh.
 #[silo::test]
@@ -2381,8 +2408,8 @@ async fn floating_limit_orphaned_refresh_flag_ages_out_after_threshold() {
     );
 }
 
-/// Schedule a refresh for `queue` by parking a waiter behind a holder, then
-/// lease it. The returned dequeue holds the refresh task and the holder job.
+/// Park j2 behind j1 on `queue` and lease the refresh the enqueue path
+/// scheduled. The returned dequeue holds the refresh task and the holder job.
 async fn schedule_and_lease_refresh(
     shard: &silo::job_store_shard::JobStoreShard,
     queue: &str,
@@ -2390,16 +2417,7 @@ async fn schedule_and_lease_refresh(
     enqueue_floating(shard, queue, 1).await;
     enqueue_floating(shard, queue, 2).await;
     assert_eq!(count_refresh_tasks(shard, queue).await, 1);
-    let result = shard
-        .dequeue("worker-1", "default", 10)
-        .await
-        .expect("dequeue");
-    assert_eq!(
-        result.refresh_tasks.len(),
-        1,
-        "refresh task should be leased"
-    );
-    result
+    dequeue_refresh_tasks_until(shard, "worker-1", "default", 1, DEQUEUE_TIMEOUT).await
 }
 
 #[silo::test]
@@ -2419,8 +2437,10 @@ async fn floating_limit_just_scheduled_refresh_is_stamped_and_not_replaced() {
         "stamp {stamp} should be now"
     );
 
-    // A later waiter in a different millisecond sees a trusted refresh.
-    std::thread::sleep(std::time::Duration::from_millis(3));
+    // A later waiter in a different millisecond sees a trusted refresh and
+    // writes no second row. Refresh task keys are millisecond-keyed, so a
+    // wrongly written second row would be distinct and observable.
+    std::thread::sleep(std::time::Duration::from_millis(2));
     enqueue_floating(&shard, queue, 3).await;
     assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
     assert_eq!(
@@ -2594,13 +2614,10 @@ async fn floating_limit_late_success_on_superseded_refresh_applies_cleanly() {
     assert_eq!(state.refresh_scheduled_at_ms(), None);
 
     // The replacement is still leasable and its outcome applies too.
-    let result = shard
-        .dequeue("worker-2", "default", 10)
-        .await
-        .expect("dequeue replacement");
-    assert_eq!(result.refresh_tasks.len(), 1);
+    let replacement =
+        dequeue_refresh_tasks_until(&shard, "worker-2", "default", 1, DEQUEUE_TIMEOUT).await;
     shard
-        .report_refresh_success(&result.refresh_tasks[0].task_id, 11)
+        .report_refresh_success(&replacement.refresh_tasks[0].task_id, 11)
         .await
         .expect("replacement success applies");
     let state = read_floating_state(&shard, queue).await;
@@ -2652,23 +2669,40 @@ async fn floating_limit_stale_threshold_setting_governs_age_out() {
 // Scheduling refreshes from the grant-scanner and RequestTicket paths
 // ---------------------------------------------------------------------------
 
-/// Park j2 behind j1 on `queue`, lease j1 and the refresh the enqueue path
-/// scheduled, and report that refresh as succeeded so the flag is clear and
-/// `last_refreshed_at_ms` is current. Leaves one durable waiter and a warm
-/// limit cache with no refresh outstanding.
-async fn settle_backlog_with_fresh_refresh(
+/// Park a waiter under `waiter_group` behind a holder under `default`, lease
+/// the refresh the enqueue path scheduled, report it as succeeded, and
+/// backdate `last_refreshed_at_ms` so the interval has elapsed. Leaves one
+/// durable waiter, a warm limit cache, and no refresh outstanding. Returns the
+/// waiter's job id.
+async fn settle_backlog_with_fresh_refresh_in_group(
     shard: &silo::job_store_shard::JobStoreShard,
     queue: &str,
-) {
-    let leased = schedule_and_lease_refresh(shard, queue).await;
+    waiter_group: &str,
+) -> String {
+    enqueue_floating(shard, queue, 1).await;
+    let waiter = enqueue_floating_in_group(shard, queue, 2, waiter_group).await;
+    let leased =
+        dequeue_refresh_tasks_until(shard, "worker-1", waiter_group, 1, DEQUEUE_TIMEOUT).await;
     shard
         .report_refresh_success(&leased.refresh_tasks[0].task_id, 1)
         .await
         .expect("report refresh success");
+    backdate_last_refreshed(shard, queue).await;
     let state = read_floating_state(shard, queue).await;
     assert!(!state.refresh_task_scheduled());
-    assert_eq!(count_refresh_tasks(shard, queue).await, 0);
+    assert_eq!(
+        count_refresh_tasks_in_group(shard, queue, waiter_group).await,
+        0
+    );
     assert_eq!(count_concurrency_requests(shard.db()).await, 1);
+    waiter
+}
+
+async fn settle_backlog_with_fresh_refresh(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+) {
+    settle_backlog_with_fresh_refresh_in_group(shard, queue, "default").await;
 }
 
 /// A deep backlog with no fresh enqueues: the grant scanner's at-capacity
@@ -2680,8 +2714,6 @@ async fn floating_limit_scanner_pass_schedules_refresh_for_waiting_backlog() {
     let queue = "fl-scanner-refresh-q";
     settle_backlog_with_fresh_refresh(&shard, queue).await;
 
-    // Interval (100 ms) elapses with no enqueue activity.
-    std::thread::sleep(std::time::Duration::from_millis(150));
     shard.process_concurrency_grants("-", queue, 1).await;
 
     assert_eq!(
@@ -2693,15 +2725,8 @@ async fn floating_limit_scanner_pass_schedules_refresh_for_waiting_backlog() {
     assert!(state.refresh_task_scheduled());
     assert!(state.refresh_scheduled_at_ms().is_some());
 
-    let result = shard
-        .dequeue("worker-3", "default", 10)
-        .await
-        .expect("dequeue");
-    assert_eq!(
-        result.refresh_tasks.len(),
-        1,
-        "the refresh task is claimable"
-    );
+    let result =
+        dequeue_refresh_tasks_until(&shard, "worker-3", "default", 1, DEQUEUE_TIMEOUT).await;
     assert_eq!(result.refresh_tasks[0].queue_key, queue);
     assert_eq!(result.refresh_tasks[0].task_group, "default");
 }
@@ -2716,7 +2741,6 @@ async fn floating_limit_scanner_pass_is_noop_without_resumer() {
         .take_chain_resumer_for_test()
         .expect("resumer installed at open");
 
-    std::thread::sleep(std::time::Duration::from_millis(150));
     shard.process_concurrency_grants("-", queue, 1).await;
 
     assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
@@ -2729,7 +2753,8 @@ async fn floating_limit_scanner_pass_is_noop_without_resumer() {
 
 /// A scheduled-start job whose RequestTicket lands as the queue's only waiter
 /// supplies the waiter signal itself: no durable waiter exists before the
-/// ticket is processed, and the enqueue path never counted it as one.
+/// ticket is processed, and the enqueue path never counted it as one. The
+/// grant scanner is stopped so only the ticket handler can schedule.
 #[silo::test]
 async fn floating_limit_request_ticket_landing_as_only_waiter_schedules_refresh() {
     let (_tmp, shard) = open_temp_shard().await;
@@ -2751,7 +2776,7 @@ async fn floating_limit_request_ticket_landing_as_only_waiter_schedules_refresh(
             start_at,
             None,
             test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
-            vec![floating_limit(queue, 100)],
+            vec![floating_limit(queue, REFRESH_INTERVAL_MS)],
             None,
             "default",
         )
@@ -2766,26 +2791,34 @@ async fn floating_limit_request_ticket_landing_as_only_waiter_schedules_refresh(
     );
 
     // Once due, the ticket is claimed, finds the queue full, and lands as the
-    // only waiter. The interval (100 ms, last refreshed at 0) has elapsed.
-    let scheduled = poll_until(
-        || async {
-            let _ = shard
-                .dequeue("worker-1", "default", 10)
-                .await
-                .expect("dequeue");
-            read_floating_state(&shard, queue)
-                .await
-                .refresh_task_scheduled()
-        },
-        |&scheduled| scheduled,
-        5000,
-    )
-    .await;
-    assert!(
-        scheduled,
-        "the ticket landing as a waiter schedules the refresh"
-    );
+    // only waiter. The interval has elapsed (last refreshed at zero). The same
+    // dequeue may go on to lease the refresh task it just wrote.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut leased_refresh_tasks = 0usize;
+    loop {
+        let result = shard
+            .dequeue("worker-1", "default", 10)
+            .await
+            .expect("dequeue");
+        leased_refresh_tasks += result.refresh_tasks.len();
+        if read_floating_state(&shard, queue)
+            .await
+            .refresh_task_scheduled()
+        {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the ticket landing as a waiter schedules the refresh"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
     assert_eq!(count_concurrency_requests(shard.db()).await, 1);
+    assert_eq!(
+        count_refresh_tasks(&shard, queue).await + leased_refresh_tasks,
+        1,
+        "the refresh task lands under the ticket's task group"
+    );
 }
 
 /// The scanner-originated refresh is written under the head waiter's task
@@ -2795,31 +2828,8 @@ async fn floating_limit_scanner_refresh_carries_head_waiter_task_group() {
     let (_tmp, shard) = open_temp_shard().await;
     shard.stop_grant_scanner();
     let queue = "fl-scanner-group-q";
+    settle_backlog_with_fresh_refresh_in_group(&shard, queue, "beta").await;
 
-    enqueue_floating(&shard, queue, 1).await;
-    shard
-        .enqueue(
-            "-",
-            None,
-            10u8,
-            now_ms(),
-            None,
-            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
-            vec![floating_limit(queue, 100)],
-            None,
-            "beta",
-        )
-        .await
-        .expect("enqueue beta waiter");
-    // The beta enqueue scheduled a refresh under beta; settle it.
-    let leased = shard.dequeue("w", "beta", 10).await.expect("dequeue beta");
-    assert_eq!(leased.refresh_tasks.len(), 1);
-    shard
-        .report_refresh_success(&leased.refresh_tasks[0].task_id, 1)
-        .await
-        .expect("settle refresh");
-
-    std::thread::sleep(std::time::Duration::from_millis(150));
     shard.process_concurrency_grants("-", queue, 1).await;
 
     assert_eq!(
@@ -2827,14 +2837,8 @@ async fn floating_limit_scanner_refresh_carries_head_waiter_task_group() {
         0,
         "not under default"
     );
-    let beta_tasks = shard.peek_tasks("beta", 100).await.expect("peek beta");
     assert_eq!(
-        beta_tasks
-            .iter()
-            .filter(
-                |t| matches!(t, Task::RefreshFloatingLimit { queue_key, .. } if queue_key == queue)
-            )
-            .count(),
+        count_refresh_tasks_in_group(&shard, queue, "beta").await,
         1,
         "the refresh is written under the head waiter's group"
     );
@@ -2876,21 +2880,54 @@ async fn rewrite_head_waiter_task_group(
     shard.db().flush().await.expect("flush");
 }
 
+/// A stored request record with an empty task group takes the group from the
+/// job's info row, which is `beta` here while the holder is under `default`.
 #[silo::test]
 async fn floating_limit_scanner_refresh_falls_back_to_job_info_task_group() {
     let (_tmp, shard) = open_temp_shard().await;
     shard.stop_grant_scanner();
     let queue = "fl-scanner-fallback-q";
-    settle_backlog_with_fresh_refresh(&shard, queue).await;
-    rewrite_head_waiter_task_group(&shard, "", vec![floating_limit(queue, 100)]).await;
+    settle_backlog_with_fresh_refresh_in_group(&shard, queue, "beta").await;
+    rewrite_head_waiter_task_group(&shard, "", vec![floating_limit(queue, REFRESH_INTERVAL_MS)])
+        .await;
 
-    std::thread::sleep(std::time::Duration::from_millis(150));
     shard.process_concurrency_grants("-", queue, 1).await;
 
     assert_eq!(
         count_refresh_tasks(&shard, queue).await,
+        0,
+        "not under default"
+    );
+    assert_eq!(
+        count_refresh_tasks_in_group(&shard, queue, "beta").await,
         1,
         "an empty stored group falls back to the job's task group"
+    );
+}
+
+#[silo::test]
+async fn floating_limit_scanner_refresh_skips_empty_group_without_job_info() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-scanner-no-job-info-q";
+    let waiter = settle_backlog_with_fresh_refresh_in_group(&shard, queue, "beta").await;
+    rewrite_head_waiter_task_group(&shard, "", vec![floating_limit(queue, REFRESH_INTERVAL_MS)])
+        .await;
+    shard
+        .db()
+        .delete(&silo::keys::job_info_key("-", &waiter))
+        .await
+        .expect("delete job info");
+    shard.db().flush().await.expect("flush");
+
+    shard.process_concurrency_grants("-", queue, 1).await;
+
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+    assert_eq!(count_refresh_tasks_in_group(&shard, queue, "beta").await, 0);
+    assert!(
+        !read_floating_state(&shard, queue)
+            .await
+            .refresh_task_scheduled()
     );
 }
 
@@ -2910,7 +2947,6 @@ async fn floating_limit_scanner_refresh_skips_unreadable_head_waiter() {
         .expect("corrupt request");
     shard.db().flush().await.expect("flush");
 
-    std::thread::sleep(std::time::Duration::from_millis(150));
     shard.process_concurrency_grants("-", queue, 1).await;
 
     assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
@@ -2922,57 +2958,27 @@ async fn floating_limit_scanner_refresh_skips_unreadable_head_waiter() {
 }
 
 /// Two refresh rows for one queue, as racing writers in different
-/// milliseconds produce. Both are leased and reported; the last outcome
-/// wins and the flag ends cleared.
+/// milliseconds produce: the first waiter schedules one, and a second waiter
+/// schedules another after the flag is aged out while the first row is still
+/// durable. Both are leased and reported; the last outcome wins and the flag
+/// ends cleared.
 #[silo::test]
 async fn floating_limit_two_refresh_rows_are_both_leased_and_reported() {
     let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
     let queue = "fl-two-rows-q";
     enqueue_floating(&shard, queue, 1).await;
-    write_orphaned_refresh_state(&shard, queue, Some(now_ms())).await;
-
-    let base = now_ms();
-    for (i, task_id) in ["refresh-a", "refresh-b"].iter().enumerate() {
-        let at = base + i as i64;
-        let task = Task::RefreshFloatingLimit {
-            task_id: task_id.to_string(),
-            tenant: "-".to_string(),
-            queue_key: queue.to_string(),
-            current_max_concurrency: 1,
-            last_refreshed_at_ms: 0,
-            metadata: vec![],
-            task_group: "default".to_string(),
-        };
-        let key = silo::keys::task_key(
-            "default",
-            at,
-            0,
-            &format!("floating_refresh:{queue}"),
-            0,
-            at,
-        );
-        shard
-            .db()
-            .put(&key, &silo::codec::encode_task(&task))
-            .await
-            .expect("seed refresh row");
-    }
-    shard.db().flush().await.expect("flush");
+    enqueue_floating(&shard, queue, 2).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
+    write_orphaned_refresh_state(&shard, queue, Some(now_ms() - 120_000)).await;
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    enqueue_floating(&shard, queue, 3).await;
     assert_eq!(count_refresh_tasks(&shard, queue).await, 2);
 
-    let mut leased: Vec<String> = Vec::new();
-    for _ in 0..100 {
-        let result = shard.dequeue("w", "default", 10).await.expect("dequeue");
-        leased.extend(result.refresh_tasks.iter().map(|t| t.task_id.clone()));
-        if leased.len() >= 2 {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-    }
-    assert_eq!(leased.len(), 2, "both refresh rows are leased");
-    for (i, task_id) in leased.iter().enumerate() {
+    let leased = dequeue_refresh_tasks_until(&shard, "w", "default", 2, DEQUEUE_TIMEOUT).await;
+    for (i, task) in leased.refresh_tasks.iter().enumerate() {
         shard
-            .report_refresh_success(task_id, 5 + i as u32)
+            .report_refresh_success(&task.task_id, 5 + i as u32)
             .await
             .expect("report success");
     }
@@ -2982,9 +2988,4 @@ async fn floating_limit_two_refresh_rows_are_both_leased_and_reported() {
     assert_eq!(state.refresh_scheduled_at_ms(), None);
     assert_eq!(state.current_max_concurrency(), 6, "the last outcome wins");
     assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
-    assert_eq!(
-        count_lease_keys(shard.db()).await,
-        1,
-        "only the holder's lease remains"
-    );
 }

--- a/tests/floating_concurrency_tests.rs
+++ b/tests/floating_concurrency_tests.rs
@@ -2647,3 +2647,344 @@ async fn floating_limit_stale_threshold_setting_governs_age_out() {
     assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
     assert_eq!(read_refresh_reset_total(&metrics), 1.0);
 }
+
+// ---------------------------------------------------------------------------
+// Scheduling refreshes from the grant-scanner and RequestTicket paths
+// ---------------------------------------------------------------------------
+
+/// Park j2 behind j1 on `queue`, lease j1 and the refresh the enqueue path
+/// scheduled, and report that refresh as succeeded so the flag is clear and
+/// `last_refreshed_at_ms` is current. Leaves one durable waiter and a warm
+/// limit cache with no refresh outstanding.
+async fn settle_backlog_with_fresh_refresh(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+) {
+    let leased = schedule_and_lease_refresh(shard, queue).await;
+    shard
+        .report_refresh_success(&leased.refresh_tasks[0].task_id, 1)
+        .await
+        .expect("report refresh success");
+    let state = read_floating_state(shard, queue).await;
+    assert!(!state.refresh_task_scheduled());
+    assert_eq!(count_refresh_tasks(shard, queue).await, 0);
+    assert_eq!(count_concurrency_requests(shard.db()).await, 1);
+}
+
+/// A deep backlog with no fresh enqueues: the grant scanner's at-capacity
+/// pass over the queue schedules the refresh once the interval has elapsed.
+#[silo::test]
+async fn floating_limit_scanner_pass_schedules_refresh_for_waiting_backlog() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-scanner-refresh-q";
+    settle_backlog_with_fresh_refresh(&shard, queue).await;
+
+    // Interval (100 ms) elapses with no enqueue activity.
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    shard.process_concurrency_grants("-", queue, 1).await;
+
+    assert_eq!(
+        count_refresh_tasks(&shard, queue).await,
+        1,
+        "the scanner pass over a saturated floating queue schedules the refresh"
+    );
+    let state = read_floating_state(&shard, queue).await;
+    assert!(state.refresh_task_scheduled());
+    assert!(state.refresh_scheduled_at_ms().is_some());
+
+    let result = shard
+        .dequeue("worker-3", "default", 10)
+        .await
+        .expect("dequeue");
+    assert_eq!(
+        result.refresh_tasks.len(),
+        1,
+        "the refresh task is claimable"
+    );
+    assert_eq!(result.refresh_tasks[0].queue_key, queue);
+    assert_eq!(result.refresh_tasks[0].task_group, "default");
+}
+
+#[silo::test]
+async fn floating_limit_scanner_pass_is_noop_without_resumer() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-scanner-no-resumer-q";
+    settle_backlog_with_fresh_refresh(&shard, queue).await;
+    let _resumer = shard
+        .take_chain_resumer_for_test()
+        .expect("resumer installed at open");
+
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    shard.process_concurrency_grants("-", queue, 1).await;
+
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+    assert!(
+        !read_floating_state(&shard, queue)
+            .await
+            .refresh_task_scheduled()
+    );
+}
+
+/// A scheduled-start job whose RequestTicket lands as the queue's only waiter
+/// supplies the waiter signal itself: no durable waiter exists before the
+/// ticket is processed, and the enqueue path never counted it as one.
+#[silo::test]
+async fn floating_limit_request_ticket_landing_as_only_waiter_schedules_refresh() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-ticket-waiter-q";
+
+    // j1 holds the single slot; its enqueue schedules nothing (no waiters).
+    enqueue_floating(&shard, queue, 1).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+
+    // j2 starts in the future: its enqueue writes a RequestTicket task, not a
+    // durable waiter, so it schedules no refresh either.
+    let start_at = now_ms() + 300;
+    shard
+        .enqueue(
+            "-",
+            Some("fl-ticket-job".to_string()),
+            10u8,
+            start_at,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![floating_limit(queue, 100)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue scheduled job");
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+    assert_eq!(count_concurrency_requests(shard.db()).await, 0);
+    assert!(
+        !read_floating_state(&shard, queue)
+            .await
+            .refresh_task_scheduled()
+    );
+
+    // Once due, the ticket is claimed, finds the queue full, and lands as the
+    // only waiter. The interval (100 ms, last refreshed at 0) has elapsed.
+    let scheduled = poll_until(
+        || async {
+            let _ = shard
+                .dequeue("worker-1", "default", 10)
+                .await
+                .expect("dequeue");
+            read_floating_state(&shard, queue)
+                .await
+                .refresh_task_scheduled()
+        },
+        |&scheduled| scheduled,
+        5000,
+    )
+    .await;
+    assert!(
+        scheduled,
+        "the ticket landing as a waiter schedules the refresh"
+    );
+    assert_eq!(count_concurrency_requests(shard.db()).await, 1);
+}
+
+/// The scanner-originated refresh is written under the head waiter's task
+/// group, which need not be the holder's group.
+#[silo::test]
+async fn floating_limit_scanner_refresh_carries_head_waiter_task_group() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-scanner-group-q";
+
+    enqueue_floating(&shard, queue, 1).await;
+    shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![floating_limit(queue, 100)],
+            None,
+            "beta",
+        )
+        .await
+        .expect("enqueue beta waiter");
+    // The beta enqueue scheduled a refresh under beta; settle it.
+    let leased = shard.dequeue("w", "beta", 10).await.expect("dequeue beta");
+    assert_eq!(leased.refresh_tasks.len(), 1);
+    shard
+        .report_refresh_success(&leased.refresh_tasks[0].task_id, 1)
+        .await
+        .expect("settle refresh");
+
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    shard.process_concurrency_grants("-", queue, 1).await;
+
+    assert_eq!(
+        count_refresh_tasks(&shard, queue).await,
+        0,
+        "not under default"
+    );
+    let beta_tasks = shard.peek_tasks("beta", 100).await.expect("peek beta");
+    assert_eq!(
+        beta_tasks
+            .iter()
+            .filter(
+                |t| matches!(t, Task::RefreshFloatingLimit { queue_key, .. } if queue_key == queue)
+            )
+            .count(),
+        1,
+        "the refresh is written under the head waiter's group"
+    );
+}
+
+/// Rewrite the queue's single waiting request record with the given task
+/// group, keeping every other field.
+async fn rewrite_head_waiter_task_group(
+    shard: &silo::job_store_shard::JobStoreShard,
+    task_group: &str,
+    limits: Vec<silo::job::Limit>,
+) {
+    let (key, value) = first_concurrency_request_kv(shard.db())
+        .await
+        .expect("one waiting request");
+    let decoded = silo::codec::decode_concurrency_action(value).expect("decode request");
+    let fb = decoded.fb();
+    let et = fb.variant_as_enqueue_task().expect("enqueue task variant");
+    let action = silo::task::ConcurrencyAction::EnqueueTask {
+        start_time_ms: et.start_time_ms(),
+        priority: et.priority(),
+        job_id: et.job_id().unwrap_or_default().to_string(),
+        attempt_number: et.attempt_number(),
+        relative_attempt_number: et.relative_attempt_number(),
+        task_group: task_group.to_string(),
+        limit_index: et.limit_index(),
+        held_queues: et
+            .held_queues()
+            .map(|v| v.iter().map(|s| s.to_string()).collect())
+            .unwrap_or_default(),
+        task_id: et.task_id().unwrap_or_default().to_string(),
+        limits,
+    };
+    shard
+        .db()
+        .put(&key, &silo::codec::encode_concurrency_action(&action))
+        .await
+        .expect("rewrite request");
+    shard.db().flush().await.expect("flush");
+}
+
+#[silo::test]
+async fn floating_limit_scanner_refresh_falls_back_to_job_info_task_group() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-scanner-fallback-q";
+    settle_backlog_with_fresh_refresh(&shard, queue).await;
+    rewrite_head_waiter_task_group(&shard, "", vec![floating_limit(queue, 100)]).await;
+
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    shard.process_concurrency_grants("-", queue, 1).await;
+
+    assert_eq!(
+        count_refresh_tasks(&shard, queue).await,
+        1,
+        "an empty stored group falls back to the job's task group"
+    );
+}
+
+#[silo::test]
+async fn floating_limit_scanner_refresh_skips_unreadable_head_waiter() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-scanner-unreadable-q";
+    settle_backlog_with_fresh_refresh(&shard, queue).await;
+    let (key, _) = first_concurrency_request_kv(shard.db())
+        .await
+        .expect("one waiting request");
+    shard
+        .db()
+        .put(&key, &[0xFF, 0x00, 0x13])
+        .await
+        .expect("corrupt request");
+    shard.db().flush().await.expect("flush");
+
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    shard.process_concurrency_grants("-", queue, 1).await;
+
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+    assert!(
+        !read_floating_state(&shard, queue)
+            .await
+            .refresh_task_scheduled()
+    );
+}
+
+/// Two refresh rows for one queue, as racing writers in different
+/// milliseconds produce. Both are leased and reported; the last outcome
+/// wins and the flag ends cleared.
+#[silo::test]
+async fn floating_limit_two_refresh_rows_are_both_leased_and_reported() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let queue = "fl-two-rows-q";
+    enqueue_floating(&shard, queue, 1).await;
+    write_orphaned_refresh_state(&shard, queue, Some(now_ms())).await;
+
+    let base = now_ms();
+    for (i, task_id) in ["refresh-a", "refresh-b"].iter().enumerate() {
+        let at = base + i as i64;
+        let task = Task::RefreshFloatingLimit {
+            task_id: task_id.to_string(),
+            tenant: "-".to_string(),
+            queue_key: queue.to_string(),
+            current_max_concurrency: 1,
+            last_refreshed_at_ms: 0,
+            metadata: vec![],
+            task_group: "default".to_string(),
+        };
+        let key = silo::keys::task_key(
+            "default",
+            at,
+            0,
+            &format!("floating_refresh:{queue}"),
+            0,
+            at,
+        );
+        shard
+            .db()
+            .put(&key, &silo::codec::encode_task(&task))
+            .await
+            .expect("seed refresh row");
+    }
+    shard.db().flush().await.expect("flush");
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 2);
+
+    let mut leased: Vec<String> = Vec::new();
+    for _ in 0..100 {
+        let result = shard.dequeue("w", "default", 10).await.expect("dequeue");
+        leased.extend(result.refresh_tasks.iter().map(|t| t.task_id.clone()));
+        if leased.len() >= 2 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert_eq!(leased.len(), 2, "both refresh rows are leased");
+    for (i, task_id) in leased.iter().enumerate() {
+        shard
+            .report_refresh_success(task_id, 5 + i as u32)
+            .await
+            .expect("report success");
+    }
+
+    let state = read_floating_state(&shard, queue).await;
+    assert!(!state.refresh_task_scheduled());
+    assert_eq!(state.refresh_scheduled_at_ms(), None);
+    assert_eq!(state.current_max_concurrency(), 6, "the last outcome wins");
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+    assert_eq!(
+        count_lease_keys(shard.db()).await,
+        1,
+        "only the holder's lease remains"
+    );
+}

--- a/tests/floating_concurrency_tests.rs
+++ b/tests/floating_concurrency_tests.rs
@@ -2989,3 +2989,56 @@ async fn floating_limit_two_refresh_rows_are_both_leased_and_reported() {
     assert_eq!(state.current_max_concurrency(), 6, "the last outcome wins");
     assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
 }
+
+/// A floating limit state row that cannot be decoded must not stall the task
+/// group: the ticket still converts into a waiter, and only the optional
+/// refresh scheduling is skipped.
+#[silo::test]
+async fn floating_limit_request_ticket_converts_despite_unreadable_state_row() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-ticket-corrupt-state-q";
+
+    enqueue_floating(&shard, queue, 1).await;
+    shard
+        .enqueue(
+            "-",
+            Some("fl-ticket-corrupt-job".to_string()),
+            10u8,
+            now_ms() + 300,
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": 2})),
+            vec![floating_limit(queue, REFRESH_INTERVAL_MS)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue scheduled job");
+    shard
+        .db()
+        .put(
+            &silo::keys::floating_limit_state_key("-", queue),
+            &[0xFF, 0x00, 0x13],
+        )
+        .await
+        .expect("corrupt state row");
+    shard.db().flush().await.expect("flush");
+
+    let converted = poll_until(
+        || async {
+            let _ = shard
+                .dequeue("worker-1", "default", 10)
+                .await
+                .expect("dequeue");
+            count_concurrency_requests(shard.db()).await
+        },
+        |&n| n == 1,
+        5000,
+    )
+    .await;
+    assert_eq!(
+        converted, 1,
+        "the ticket becomes a waiter despite the unreadable state row"
+    );
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+}

--- a/tests/floating_concurrency_tests.rs
+++ b/tests/floating_concurrency_tests.rs
@@ -2237,3 +2237,413 @@ async fn fc_before_concurrency_wedges_floating_only_jobs_via_orphaned_holder() {
         completed,
     );
 }
+
+// ---------------------------------------------------------------------------
+// Aging out an outstanding refresh flag
+// ---------------------------------------------------------------------------
+
+fn floating_limit(queue: &str, refresh_interval_ms: i64) -> silo::job::Limit {
+    silo::job::Limit::FloatingConcurrency(silo::job::FloatingConcurrencyLimit {
+        key: queue.to_string(),
+        default_max_concurrency: 1,
+        refresh_interval_ms,
+        metadata: vec![],
+    })
+}
+
+async fn enqueue_floating(shard: &silo::job_store_shard::JobStoreShard, queue: &str, tag: u32) {
+    shard
+        .enqueue(
+            "-",
+            None,
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": tag})),
+            vec![floating_limit(queue, 100)],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue floating job");
+}
+
+/// Overwrite the durable floating limit state row for `queue` with the flag
+/// set and no task row or lease behind it, stamped at `scheduled_at_ms`.
+async fn write_orphaned_refresh_state(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+    scheduled_at_ms: Option<i64>,
+) {
+    let state = silo::job::FloatingLimitState {
+        current_max_concurrency: 1,
+        last_refreshed_at_ms: 0,
+        refresh_task_scheduled: true,
+        refresh_interval_ms: 100,
+        default_max_concurrency: 1,
+        retry_count: 0,
+        next_retry_at_ms: None,
+        metadata: vec![],
+        refresh_scheduled_at_ms: scheduled_at_ms,
+    };
+    shard
+        .db()
+        .put(
+            &silo::keys::floating_limit_state_key("-", queue),
+            &silo::codec::encode_floating_limit_state(&state),
+        )
+        .await
+        .expect("put state");
+    shard.db().flush().await.expect("flush state");
+}
+
+async fn count_refresh_tasks(shard: &silo::job_store_shard::JobStoreShard, queue: &str) -> usize {
+    shard
+        .peek_tasks("default", 100)
+        .await
+        .expect("peek tasks")
+        .iter()
+        .filter(|t| matches!(t, Task::RefreshFloatingLimit { queue_key, .. } if queue_key == queue))
+        .count()
+}
+
+async fn read_floating_state(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+) -> silo::codec::DecodedFloatingLimitState {
+    let raw = shard
+        .db()
+        .get(&silo::keys::floating_limit_state_key("-", queue))
+        .await
+        .expect("db get")
+        .expect("state should exist");
+    silo::codec::decode_floating_limit_state(raw).expect("decode state")
+}
+
+fn read_refresh_reset_total(metrics: &silo::metrics::Metrics) -> f64 {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|f| f.get_name() == "silo_floating_limit_refresh_reset_total")
+        .map(|f| {
+            f.get_metric()
+                .iter()
+                .filter(|m| {
+                    m.get_label()
+                        .iter()
+                        .any(|l| l.get_name() == "reason" && l.get_value() == "stale_scheduled")
+                })
+                .map(|m| m.get_counter().get_value())
+                .sum()
+        })
+        .unwrap_or(0.0)
+}
+
+/// The env-614696 shape: `refresh_task_scheduled` is set but no task row and
+/// no lease exist, so nothing will ever clear it. A waiter-producing enqueue
+/// must schedule a replacement refresh once the stamp is older than the
+/// threshold, and must not while the stamp is fresh.
+#[silo::test]
+async fn floating_limit_orphaned_refresh_flag_ages_out_after_threshold() {
+    let (_tmp, shard, _metrics) = open_temp_shard_with_floating_refresh_stale_ms(60_000).await;
+    let queue = "fl-orphaned-flag-q";
+
+    // j1 holds the single slot so every later enqueue is a waiter.
+    enqueue_floating(&shard, queue, 1).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+
+    // Fresh stamp: the outstanding refresh is trusted, no replacement.
+    write_orphaned_refresh_state(&shard, queue, Some(now_ms())).await;
+    enqueue_floating(&shard, queue, 2).await;
+    assert_eq!(
+        count_refresh_tasks(&shard, queue).await,
+        0,
+        "a refresh scheduled within the threshold must not be replaced"
+    );
+
+    // Stamp older than the threshold: the flag is aged out and replaced.
+    write_orphaned_refresh_state(&shard, queue, Some(now_ms() - 60_001)).await;
+    enqueue_floating(&shard, queue, 3).await;
+    assert_eq!(
+        count_refresh_tasks(&shard, queue).await,
+        1,
+        "a refresh scheduled longer ago than the threshold must be replaced"
+    );
+    let state = read_floating_state(&shard, queue).await;
+    assert!(state.refresh_task_scheduled());
+    let stamp = state
+        .refresh_scheduled_at_ms()
+        .expect("replacement is stamped");
+    assert!(
+        now_ms() - stamp < 60_000,
+        "replacement stamp {stamp} should be current"
+    );
+}
+
+/// Schedule a refresh for `queue` by parking a waiter behind a holder, then
+/// lease it. The returned dequeue holds the refresh task and the holder job.
+async fn schedule_and_lease_refresh(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+) -> silo::job_store_shard::DequeueResult {
+    enqueue_floating(shard, queue, 1).await;
+    enqueue_floating(shard, queue, 2).await;
+    assert_eq!(count_refresh_tasks(shard, queue).await, 1);
+    let result = shard
+        .dequeue("worker-1", "default", 10)
+        .await
+        .expect("dequeue");
+    assert_eq!(
+        result.refresh_tasks.len(),
+        1,
+        "refresh task should be leased"
+    );
+    result
+}
+
+#[silo::test]
+async fn floating_limit_just_scheduled_refresh_is_stamped_and_not_replaced() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let queue = "fl-just-scheduled-q";
+
+    enqueue_floating(&shard, queue, 1).await;
+    enqueue_floating(&shard, queue, 2).await;
+    let state = read_floating_state(&shard, queue).await;
+    assert!(state.refresh_task_scheduled());
+    let stamp = state
+        .refresh_scheduled_at_ms()
+        .expect("scheduling stamps the row");
+    assert!(
+        (now_ms() - stamp).abs() < 5_000,
+        "stamp {stamp} should be now"
+    );
+
+    // A later waiter in a different millisecond sees a trusted refresh.
+    std::thread::sleep(std::time::Duration::from_millis(3));
+    enqueue_floating(&shard, queue, 3).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
+    assert_eq!(
+        read_floating_state(&shard, queue)
+            .await
+            .refresh_scheduled_at_ms(),
+        Some(stamp),
+        "a trusted refresh keeps its original stamp"
+    );
+}
+
+#[silo::test]
+async fn floating_limit_refresh_success_clears_scheduled_stamp() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let queue = "fl-success-stamp-q";
+    let task_id = schedule_and_lease_refresh(&shard, queue)
+        .await
+        .refresh_tasks[0]
+        .task_id
+        .clone();
+
+    shard
+        .report_refresh_success(&task_id, 4)
+        .await
+        .expect("report success");
+
+    let state = read_floating_state(&shard, queue).await;
+    assert!(!state.refresh_task_scheduled());
+    assert_eq!(state.refresh_scheduled_at_ms(), None);
+    assert_eq!(state.current_max_concurrency(), 4);
+}
+
+#[silo::test]
+async fn floating_limit_refresh_failure_with_waiters_stamps_retry_start_time() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let queue = "fl-failure-waiters-stamp-q";
+    let task_id = schedule_and_lease_refresh(&shard, queue)
+        .await
+        .refresh_tasks[0]
+        .task_id
+        .clone();
+
+    shard
+        .report_refresh_failure(&task_id, "boom", "upstream down")
+        .await
+        .expect("report failure");
+
+    let state = read_floating_state(&shard, queue).await;
+    assert!(
+        state.refresh_task_scheduled(),
+        "waiters keep a retry outstanding"
+    );
+    let next_retry = state.next_retry_at_ms().expect("failure sets a retry time");
+    assert_eq!(
+        state.refresh_scheduled_at_ms(),
+        Some(next_retry),
+        "the retry is stamped with its own start time, not the failure time"
+    );
+    assert!(next_retry > now_ms() - 5_000);
+}
+
+#[silo::test]
+async fn floating_limit_refresh_failure_without_waiters_clears_scheduled_stamp() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let queue = "fl-failure-no-waiters-stamp-q";
+    let leased = schedule_and_lease_refresh(&shard, queue).await;
+    let task_id = leased.refresh_tasks[0].task_id.clone();
+
+    // Finish the holder so the waiter is granted and no request row remains
+    // when the failure is reported. The grant scanner runs asynchronously.
+    for task in &leased.tasks {
+        shard
+            .report_attempt_outcome(
+                task.attempt().task_id(),
+                AttemptOutcome::Success { result: vec![] },
+            )
+            .await
+            .expect("finish holder");
+    }
+    let cleared = poll_until(
+        || async { first_concurrency_request_kv(shard.db()).await.is_none() },
+        |&is_none| is_none,
+        5000,
+    )
+    .await;
+    assert!(cleared, "waiting requests should be cleared");
+
+    shard
+        .report_refresh_failure(&task_id, "boom", "upstream down")
+        .await
+        .expect("report failure");
+
+    let state = read_floating_state(&shard, queue).await;
+    assert!(!state.refresh_task_scheduled());
+    assert_eq!(state.refresh_scheduled_at_ms(), None);
+    assert!(
+        state.next_retry_at_ms().is_some(),
+        "backoff is still recorded"
+    );
+}
+
+#[silo::test]
+async fn floating_limit_refresh_lease_expiry_clears_scheduled_stamp() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let queue = "fl-reaper-stamp-q";
+    let task_id = schedule_and_lease_refresh(&shard, queue)
+        .await
+        .refresh_tasks[0]
+        .task_id
+        .clone();
+    assert!(
+        read_floating_state(&shard, queue)
+            .await
+            .refresh_scheduled_at_ms()
+            .is_some()
+    );
+
+    let lease_key = silo::keys::leased_task_key(&task_id);
+    let lease_raw = shard
+        .db()
+        .get(&lease_key)
+        .await
+        .expect("db get")
+        .expect("lease exists");
+    let decoded_lease = decode_lease(lease_raw).expect("decode lease");
+    let expired = LeaseRecord {
+        worker_id: decoded_lease.worker_id().to_string(),
+        task: decoded_lease.to_task().unwrap(),
+        expiry_ms: now_ms() - 1,
+        started_at_ms: decoded_lease.started_at_ms(),
+    };
+    shard
+        .db()
+        .put(&lease_key, &encode_lease(&expired))
+        .await
+        .expect("put expired lease");
+    shard.db().flush().await.expect("flush");
+
+    assert_eq!(shard.reap_expired_leases("-").await.expect("reap"), 1);
+
+    let state = read_floating_state(&shard, queue).await;
+    assert!(!state.refresh_task_scheduled());
+    assert_eq!(state.refresh_scheduled_at_ms(), None);
+}
+
+/// A refresh task leased before its flag was aged out reports back after a
+/// replacement was scheduled. The late success applies and clears the flag.
+#[silo::test]
+async fn floating_limit_late_success_on_superseded_refresh_applies_cleanly() {
+    let (_tmp, shard) = open_temp_shard().await;
+    let queue = "fl-late-success-q";
+    let stale_task_id = schedule_and_lease_refresh(&shard, queue)
+        .await
+        .refresh_tasks[0]
+        .task_id
+        .clone();
+
+    // Age the outstanding flag out and let a new waiter schedule a replacement.
+    write_orphaned_refresh_state(&shard, queue, Some(now_ms() - 120_000)).await;
+    enqueue_floating(&shard, queue, 3).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
+
+    shard
+        .report_refresh_success(&stale_task_id, 9)
+        .await
+        .expect("late success applies");
+
+    let state = read_floating_state(&shard, queue).await;
+    assert_eq!(state.current_max_concurrency(), 9);
+    assert!(!state.refresh_task_scheduled());
+    assert_eq!(state.refresh_scheduled_at_ms(), None);
+
+    // The replacement is still leasable and its outcome applies too.
+    let result = shard
+        .dequeue("worker-2", "default", 10)
+        .await
+        .expect("dequeue replacement");
+    assert_eq!(result.refresh_tasks.len(), 1);
+    shard
+        .report_refresh_success(&result.refresh_tasks[0].task_id, 11)
+        .await
+        .expect("replacement success applies");
+    let state = read_floating_state(&shard, queue).await;
+    assert_eq!(state.current_max_concurrency(), 11);
+    assert!(!state.refresh_task_scheduled());
+}
+
+#[silo::test]
+async fn floating_limit_stale_flag_reset_counts_only_when_replacement_written() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_floating_refresh_stale_ms(60_000).await;
+    let queue = "fl-reset-metric-q";
+
+    // Stale flag but the enqueue is granted and nothing waits: no reset.
+    write_orphaned_refresh_state(&shard, queue, None).await;
+    enqueue_floating(&shard, queue, 1).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+    assert_eq!(read_refresh_reset_total(&metrics), 0.0);
+
+    // Same stale flag with a waiter: the replacement is written and counted.
+    write_orphaned_refresh_state(&shard, queue, None).await;
+    enqueue_floating(&shard, queue, 2).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
+    assert_eq!(read_refresh_reset_total(&metrics), 1.0);
+
+    // A trusted refresh is not a reset.
+    enqueue_floating(&shard, queue, 3).await;
+    assert_eq!(read_refresh_reset_total(&metrics), 1.0);
+}
+
+#[silo::test]
+async fn floating_limit_stale_threshold_setting_governs_age_out() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_floating_refresh_stale_ms(300_000).await;
+    let queue = "fl-threshold-setting-q";
+    enqueue_floating(&shard, queue, 1).await;
+
+    // 61 s old is past the default threshold but inside this shard's 300 s.
+    write_orphaned_refresh_state(&shard, queue, Some(now_ms() - 61_000)).await;
+    enqueue_floating(&shard, queue, 2).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+    assert_eq!(read_refresh_reset_total(&metrics), 0.0);
+
+    write_orphaned_refresh_state(&shard, queue, Some(now_ms() - 300_001)).await;
+    enqueue_floating(&shard, queue, 3).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
+    assert_eq!(read_refresh_reset_total(&metrics), 1.0);
+}

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2662,6 +2662,7 @@ async fn grant_scanner_precheck_floating_follows_durable_state() {
             retry_count: 0,
             next_retry_at_ms: None,
             metadata: vec![],
+            refresh_scheduled_at_ms: Some(now),
         })
     };
     let state_key = silo::keys::floating_limit_state_key(tenant, queue);
@@ -6253,6 +6254,7 @@ async fn grant_scanner_next_hop_skip_floating_follows_durable_state() {
             retry_count: 0,
             next_retry_at_ms: None,
             metadata: vec![],
+            refresh_scheduled_at_ms: Some(now),
         })
     };
 

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -210,6 +210,8 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             terminal_job_expire_s: None,
             count_from_status_counters: true,
             floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
+            broker_tombstone_revive_after_generations:
+                silo::settings::DEFAULT_BROKER_TOMBSTONE_REVIVE_AFTER_GENERATIONS,
         },
         ShardRange::full(),
     )
@@ -257,6 +259,8 @@ pub async fn open_temp_shard_with_grant_scanner_config(
             terminal_job_expire_s: None,
             count_from_status_counters: true,
             floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
+            broker_tombstone_revive_after_generations:
+                silo::settings::DEFAULT_BROKER_TOMBSTONE_REVIVE_AFTER_GENERATIONS,
         },
         ShardRange::full(),
     )
@@ -717,6 +721,38 @@ pub async fn open_temp_shard_with_floating_refresh_stale_ms(
         path: tmp.path().to_string_lossy().to_string(),
         slatedb: Some(fast_flush_slatedb_settings()),
         floating_refresh_stale_ms: stale_ms,
+        ..Default::default()
+    };
+    let metrics = silo::metrics::init().expect("init metrics");
+    let shard = JobStoreShard::open(
+        &cfg,
+        rate_limiter,
+        Some(metrics.clone()),
+        ShardRange::full(),
+    )
+    .await
+    .expect("open shard");
+    (tmp, shard, metrics)
+}
+
+/// Open a temp shard with a custom `broker_tombstone_revive_after_generations`
+/// bound and a fresh Metrics registry, for tests that revive a task row the
+/// broker is still suppressing behind an ack tombstone.
+pub async fn open_temp_shard_with_tombstone_revive_after_generations(
+    revive_after: u64,
+) -> (
+    tempfile::TempDir,
+    std::sync::Arc<JobStoreShard>,
+    silo::metrics::Metrics,
+) {
+    let rate_limiter = MockGubernatorClient::new_arc();
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = DatabaseConfig {
+        name: "test".to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        broker_tombstone_revive_after_generations: revive_after,
         ..Default::default()
     };
     let metrics = silo::metrics::init().expect("init metrics");

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -703,11 +703,10 @@ pub fn metric_value_or_zero(body: &str, substrings: &[&str]) -> f64 {
         .unwrap_or(0.0)
 }
 
-/// Open a temp shard with a custom `floating_refresh_stale_ms` threshold and
-/// a fresh Metrics registry, for tests that age out an outstanding floating
-/// limit refresh flag.
-pub async fn open_temp_shard_with_floating_refresh_stale_ms(
-    stale_ms: u64,
+/// Open a temp shard wired to a fresh Metrics registry, applying `overrides`
+/// to the `DatabaseConfig` before opening.
+pub async fn open_temp_shard_with_metrics_and_config(
+    overrides: impl FnOnce(&mut DatabaseConfig),
 ) -> (
     tempfile::TempDir,
     std::sync::Arc<JobStoreShard>,
@@ -715,14 +714,14 @@ pub async fn open_temp_shard_with_floating_refresh_stale_ms(
 ) {
     let rate_limiter = MockGubernatorClient::new_arc();
     let tmp = tempfile::tempdir().unwrap();
-    let cfg = DatabaseConfig {
+    let mut cfg = DatabaseConfig {
         name: "test".to_string(),
         backend: Backend::Fs,
         path: tmp.path().to_string_lossy().to_string(),
         slatedb: Some(fast_flush_slatedb_settings()),
-        floating_refresh_stale_ms: stale_ms,
         ..Default::default()
     };
+    overrides(&mut cfg);
     let metrics = silo::metrics::init().expect("init metrics");
     let shard = JobStoreShard::open(
         &cfg,
@@ -735,9 +734,21 @@ pub async fn open_temp_shard_with_floating_refresh_stale_ms(
     (tmp, shard, metrics)
 }
 
+/// Open a temp shard with a custom `floating_refresh_stale_ms` threshold, for
+/// tests that age out an outstanding floating limit refresh flag.
+pub async fn open_temp_shard_with_floating_refresh_stale_ms(
+    stale_ms: u64,
+) -> (
+    tempfile::TempDir,
+    std::sync::Arc<JobStoreShard>,
+    silo::metrics::Metrics,
+) {
+    open_temp_shard_with_metrics_and_config(|cfg| cfg.floating_refresh_stale_ms = stale_ms).await
+}
+
 /// Open a temp shard with a custom `broker_tombstone_revive_after_generations`
-/// bound and a fresh Metrics registry, for tests that revive a task row the
-/// broker is still suppressing behind an ack tombstone.
+/// bound, for tests that revive a task row the broker is still suppressing
+/// behind an ack tombstone.
 pub async fn open_temp_shard_with_tombstone_revive_after_generations(
     revive_after: u64,
 ) -> (
@@ -745,24 +756,43 @@ pub async fn open_temp_shard_with_tombstone_revive_after_generations(
     std::sync::Arc<JobStoreShard>,
     silo::metrics::Metrics,
 ) {
-    let rate_limiter = MockGubernatorClient::new_arc();
-    let tmp = tempfile::tempdir().unwrap();
-    let cfg = DatabaseConfig {
-        name: "test".to_string(),
-        backend: Backend::Fs,
-        path: tmp.path().to_string_lossy().to_string(),
-        slatedb: Some(fast_flush_slatedb_settings()),
-        broker_tombstone_revive_after_generations: revive_after,
-        ..Default::default()
-    };
-    let metrics = silo::metrics::init().expect("init metrics");
-    let shard = JobStoreShard::open(
-        &cfg,
-        rate_limiter,
-        Some(metrics.clone()),
-        ShardRange::full(),
-    )
+    open_temp_shard_with_metrics_and_config(|cfg| {
+        cfg.broker_tombstone_revive_after_generations = revive_after
+    })
     .await
-    .expect("open shard");
-    (tmp, shard, metrics)
+}
+
+/// Dequeue from `task_group` until `n` RefreshFloatingLimit tasks have been
+/// leased, or `timeout` elapses. Each dequeue against an empty buffer wakes
+/// the broker scanner, so this also advances scan generations. Run tasks
+/// leased along the way are returned too so callers can settle them.
+pub async fn dequeue_refresh_tasks_until(
+    shard: &JobStoreShard,
+    worker: &str,
+    task_group: &str,
+    n: usize,
+    timeout: Duration,
+) -> silo::job_store_shard::DequeueResult {
+    let mut merged = silo::job_store_shard::DequeueResult {
+        tasks: Vec::new(),
+        refresh_tasks: Vec::new(),
+    };
+    let deadline = std::time::Instant::now() + timeout;
+    while merged.refresh_tasks.len() < n {
+        let batch = shard
+            .dequeue(worker, task_group, 10)
+            .await
+            .expect("dequeue");
+        merged.tasks.extend(batch.tasks);
+        merged.refresh_tasks.extend(batch.refresh_tasks);
+        if merged.refresh_tasks.len() < n {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for {n} refresh tasks in {task_group}; got {}",
+                merged.refresh_tasks.len()
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+    merged
 }

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -209,6 +209,7 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
         },
         ShardRange::full(),
     )
@@ -255,6 +256,7 @@ pub async fn open_temp_shard_with_grant_scanner_config(
             completed_job_expire_s: None,
             terminal_job_expire_s: None,
             count_from_status_counters: true,
+            floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
         },
         ShardRange::full(),
     )
@@ -695,4 +697,36 @@ pub fn metric_value_or_zero(body: &str, substrings: &[&str]) -> f64 {
         .and_then(|line| line.rsplit_once(' '))
         .and_then(|(_, v)| v.parse::<f64>().ok())
         .unwrap_or(0.0)
+}
+
+/// Open a temp shard with a custom `floating_refresh_stale_ms` threshold and
+/// a fresh Metrics registry, for tests that age out an outstanding floating
+/// limit refresh flag.
+pub async fn open_temp_shard_with_floating_refresh_stale_ms(
+    stale_ms: u64,
+) -> (
+    tempfile::TempDir,
+    std::sync::Arc<JobStoreShard>,
+    silo::metrics::Metrics,
+) {
+    let rate_limiter = MockGubernatorClient::new_arc();
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = DatabaseConfig {
+        name: "test".to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(fast_flush_slatedb_settings()),
+        floating_refresh_stale_ms: stale_ms,
+        ..Default::default()
+    };
+    let metrics = silo::metrics::init().expect("init metrics");
+    let shard = JobStoreShard::open(
+        &cfg,
+        rate_limiter,
+        Some(metrics.clone()),
+        ShardRange::full(),
+    )
+    .await
+    .expect("open shard");
+    (tmp, shard, metrics)
 }


### PR DESCRIPTION
## Why

A floating concurrency limit's cap is only updated by a `RefreshFloatingLimit` task that a worker leases and reports on. While one is outstanding, `refresh_task_scheduled` is set and silo refuses to schedule another. Two wedges in production left that flag set with no refresh ever completing, freezing tenants' caps at a stale value:

- The task broker's in-memory ack tombstone kept suppressing a refresh task row that was still durable in the DB. Re-observing the key on every scan extended the tombstone forever, so the row was hidden from workers until the pod restarted (shard `a2266063`, env 621258, stuck for eleven days).
- The flag was set with no task row and no lease behind it, so nothing could ever clear it, and a restart did not help (same shard, env 614696).

A third gap compounded both: refreshes were only triggered from the enqueue path, so a tenant with a deep backlog and no fresh enqueues never had its cap refreshed even when nothing was wedged.

## What

Three mechanisms, one per commit, plus a review-phase commit:

1. **Age out the outstanding-refresh flag.** `FloatingLimitState` gains a nullable `refresh_scheduled_at_ms`, appended as the last flatbuffer field so rows written before it decode unchanged (a checked-in byte fixture pins this). A flag older than the new `floating_refresh_stale_ms` setting (default 60 s), or a row with no stamp, is treated as no outstanding refresh. Writing a replacement over a stale flag emits a warn log and `silo_floating_limit_refresh_reset_total`. The failure path stamps the retry's own future start time so a backed-off retry does not read as stale before it is claimable. Rows with no stamp are stale immediately, which is the intended one-time recovery for already-wedged tenants on deploy; scheduling still requires waiters, so idle tenants produce nothing.
2. **Bound broker tombstone suppression.** Each tombstone records the generation it was inserted at alongside the generation it was last observed. Expiry stays keyed to last-observed. Once a key has been re-observed past the new `broker_tombstone_revive_after_generations` setting (default 64), the scanner point-reads the row outside the tombstone lock: a present row is revived, buffered, and counted under a new `revived` scan outcome; an absent row keeps being suppressed and re-arms the bound.
3. **Schedule refreshes from the dequeue and grant paths.** The grant scanner's at-capacity precheck hands a saturated floating queue to the shard through a new default-no-op method on the `LimitChainResumer` trait. The shard re-reads the state row, judges readiness with its own threshold, takes the task group from the head waiting request (falling back to the job's info row for an empty stored group, and scheduling nothing when the record is unreadable), writes the task in its own batch, and wakes that group's broker. The RequestTicket handler schedules when a scheduled-start ticket lands as a waiter, supplying the waiter signal itself since its request row is still in the uncommitted batch.

Late outcomes from a superseded refresh task go through the existing success and failure handlers unchanged; the last outcome wins and no dedupe is added.

## Reviewing

- The flatbuffer field order matters: `refresh_scheduled_at_ms` must stay after `metadata` because the table uses implicit field ids.
- Every `..to_owned()` spread on `FloatingLimitState` sets the stamp explicitly; a spread that omits it would silently carry a stale stamp forward.
- In `task_broker.rs`, no mutex guard is held across the point-read await; the guard is re-taken only to remove the entry on revival.
- The observability guide gains the reset counter, the `revived` outcome, and reworded tombstone guidance.
- The two bench helpers and the shard factory only gain the new shard open options; no benchmark logic changes. The golden-shard cache key in CI hashes `benches/bench_helpers.rs`, so the benchmark job rebuilds the golden shard once for this branch.
- Tests reproduce both wedge shapes and the no-enqueue backlog through the public shard surface. Threshold crossings come from backdated state rows or shard open options, never from advancing tokio's paused clock, since silo's clock is `SystemTime`.
