### PR TITLE
Deliver floating limit refreshes through a per-shard refresh index

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -18,7 +18,7 @@ Tenants are assigned to shards via range-based partitioning (`src/shard_range.rs
 
 ## Storage
 
-Each shard is backed by a SlateDB instance (an LSM on object storage). Keys are binary-encoded using `storekey` for lexicographic ordering (`src/keys.rs`). Key prefixes: `0x01` job info, `0x02` job status, `0x03` status/time index, `0x04` metadata index, `0x05` tasks (execution queue), `0x06` leases, `0x07` attempts, `0x08`/`0x09` concurrency requests/holders, `0x0A` cancelled, `0x0B` floating limits, `0xF0+` counters/cleanup.
+Each shard is backed by a SlateDB instance (an LSM on object storage). Keys are binary-encoded using `storekey` for lexicographic ordering (`src/keys.rs`). Key prefixes: `0x01` job info, `0x02` job status, `0x03` status/time index, `0x04` metadata index, `0x05` tasks (execution queue), `0x06` leases, `0x07` attempts, `0x08`/`0x09` concurrency requests/holders, `0x0A` cancelled, `0x0B` floating limits, `0x0C` refresh index (pending floating limit refreshes, one per queue per task group), `0xF0+` counters/cleanup.
 
 ## Shard Lifecycle
 

--- a/benches/bench_helpers.rs
+++ b/benches/bench_helpers.rs
@@ -618,6 +618,7 @@ pub async fn clone_golden_shard(
             terminal_job_expire_s: None,
             count_from_status_counters: true,
             floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
+            floating_refresh_stale_max_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MAX_MS,
             broker_tombstone_revive_after_generations:
                 silo::settings::DEFAULT_BROKER_TOMBSTONE_REVIVE_AFTER_GENERATIONS,
             grant_scanner: silo::concurrency::GrantScannerConfig::default(),

--- a/benches/grant_latency.rs
+++ b/benches/grant_latency.rs
@@ -272,6 +272,7 @@ async fn open_shard(
             terminal_job_expire_s: None,
             count_from_status_counters: true,
             floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
+            floating_refresh_stale_max_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MAX_MS,
             broker_tombstone_revive_after_generations:
                 silo::settings::DEFAULT_BROKER_TOMBSTONE_REVIVE_AFTER_GENERATIONS,
             grant_scanner: silo::concurrency::GrantScannerConfig::default(),

--- a/docs/src/content/docs/guides/internals.mdx
+++ b/docs/src/content/docs/guides/internals.mdx
@@ -45,6 +45,7 @@ Silo uses the [storekey](https://crates.io/crates/storekey) crate for binary key
 | 0x09 | Concurrency holder | Tasks holding concurrency slots: `(tenant, queue, task_id)` |
 | 0x0A | Job cancelled | Cancellation flags: `(tenant, job_id)` |
 | 0x0B | Floating limit | Dynamic concurrency limit state: `(tenant, queue_key)` |
+| 0x0C | Refresh task | Pending floating limit refreshes, one per queue per task group: `(task_group, tenant, queue_key)` |
 | 0xF0-0xFF | System | Internal counters, cleanup state, and metadata. Includes per-shard total/completed job counters (`0xF0`, `0xF1`), cleanup progress (`0xF2`-`0xF6`), per-queue concurrency requester counters (`0xF7`), and per-tenant status counters (`0xF8`) maintained via merge operator on every status transition. |
 
 ## Clustering approach

--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -107,12 +107,12 @@ Concurrency limits control how many jobs with the same concurrency key can run s
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `silo_concurrency_tickets_granted_total` | Counter | - | Total concurrency tickets granted |
-| `silo_floating_limit_refresh_reset_total` | Counter | `shard`, `reason` | Floating limit refresh tasks scheduled over an outstanding-refresh flag that silo treated as lost. `reason` is `stale_scheduled`: the flag had been set longer than `floating_refresh_stale_ms` (default 60 s), or the state row carries no scheduled-at stamp |
+| `silo_floating_limit_refresh_reset_total` | Counter | `shard`, `reason` | Floating limit refresh tasks scheduled over an outstanding-refresh flag that silo treated as lost. `reason` is `stale_scheduled`: the flag had been set longer than the queue's stale window, or the state row carries no scheduled-at stamp. The window starts at `floating_refresh_stale_ms` (default 60 s) and doubles with each consecutive reset of the same queue up to `floating_refresh_stale_max_ms` (default 1 h); any refresh outcome returns it to the base |
 
 **Key insights:**
 - Track `silo_concurrency_tickets_granted_total` rate to understand throughput through limited queues
 - Pending floating limit refreshes live in a per-shard refresh index, one row per queue per task group, and are handed to the next worker that polls the task group before any job work is claimed, so a refresh is never queued behind the group's job backlog. The `floating_refresh_tasks` SQL table lists them (see the [querying guide](/guides/querying))
-- `silo_floating_limit_refresh_reset_total` should stay near zero. A steady rate means refresh tasks are being lost between scheduling and completion (a lost index row or a lost lease); the accompanying warn log names the tenant, queue key, and flag age. A state row with no stamp counts once, when its first replacement is written
+- `silo_floating_limit_refresh_reset_total` should stay near zero. A steady rate means refreshes are being scheduled but not leased: a task group no worker polls, or a lost index row. A leased refresh whose worker never reports clears the count when its lease expires, so it does not show up here. The accompanying warn log (`floating limit refresh flag is stale; scheduling a replacement refresh`) names the tenant, queue key, and flag age, plus `stale_resets` (the queue's consecutive reset count, including this one) and `next_stale_window_ms` (how long the replacement is trusted); a climbing `stale_resets` marks a queue stuck in backoff, a value of 1 a one-shot recovery. A state row with no stamp counts once, when its first replacement is written
 
 ### gRPC Metrics
 

--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -111,7 +111,8 @@ Concurrency limits control how many jobs with the same concurrency key can run s
 
 **Key insights:**
 - Track `silo_concurrency_tickets_granted_total` rate to understand throughput through limited queues
-- `silo_floating_limit_refresh_reset_total` should stay near zero. A steady rate means refresh tasks are being lost between scheduling and completion (a lost task row, lost lease, or broker suppression); the accompanying warn log names the tenant, queue key, and flag age. A state row with no stamp counts once, when its first replacement is written
+- Pending floating limit refreshes live in a per-shard refresh index, one row per queue per task group, and are handed to the next worker that polls the task group before any job work is claimed, so a refresh is never queued behind the group's job backlog. The `floating_refresh_tasks` SQL table lists them (see the [querying guide](/guides/querying))
+- `silo_floating_limit_refresh_reset_total` should stay near zero. A steady rate means refresh tasks are being lost between scheduling and completion (a lost index row or a lost lease); the accompanying warn log names the tenant, queue key, and flag age. A state row with no stamp counts once, when its first replacement is written
 
 ### gRPC Metrics
 

--- a/docs/src/content/docs/guides/querying.mdx
+++ b/docs/src/content/docs/guides/querying.mdx
@@ -80,7 +80,7 @@ Use `siloctl cluster info` to see all shards and their owners. If you know the t
 
 ## Tables
 
-Silo exposes five tables: `jobs`, `tasks`, `queues`, `tenant_counts`, and `queue_counts`.
+Silo exposes six tables: `jobs`, `tasks`, `floating_refresh_tasks`, `queues`, `tenant_counts`, and `queue_counts`.
 
 ### `jobs` Table
 
@@ -119,6 +119,23 @@ This table scans the raw task queue storage. Performance may be poor for large d
 | `job_id` | String | The job this task belongs to |
 | `attempt` | UInt32 | Attempt number |
 | `variant_type` | String | Task type: `RunAttempt`, `RequestTicket`, `CheckRateLimit`, `RefreshFloatingLimit` |
+
+### `floating_refresh_tasks` Table
+
+Lists the pending floating limit refreshes. Each row is a refresh task waiting in a shard's refresh index for the next worker that polls its task group; the row is removed when a worker leases it. A backed-off retry carries the time before which it will not be handed out.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `shard_id` | String | UUID of the shard holding the pending refresh |
+| `task_group` | String | Task group whose workers receive the refresh |
+| `tenant` | String | Tenant identifier |
+| `queue_key` | String | The floating concurrency queue being refreshed |
+| `task_id` | String | Task ID the worker leases and reports on |
+| `not_before_ms` | Int64 (nullable) | Earliest time the refresh is handed out, set on a retry after a reported failure; null means claimable now |
+| `current_max_concurrency` | UInt32 | The queue's max concurrency when the refresh was scheduled |
+| `last_refreshed_at_ms` | Int64 | Unix timestamp in milliseconds of the queue's last successful refresh |
+
+Filtering by `task_group`, and by `tenant` together with `task_group`, narrows the scan to a key prefix.
 
 ### `queues` Table
 
@@ -422,6 +439,14 @@ WHERE task_group = 'emails'
 
 -- Slow: full scan across all task groups
 SELECT * FROM tasks
+```
+
+The `floating_refresh_tasks` table follows the same rule: filter by `task_group`, and add `tenant` to narrow the prefix further.
+
+```sql
+-- Pending refreshes one tenant's workers in a group will receive
+SELECT queue_key, task_id, not_before_ms FROM floating_refresh_tasks
+WHERE task_group = 'emails' AND tenant = 'customer-123'
 ```
 
 ### Use LIMIT

--- a/schema/internal_storage.fbs
+++ b/schema/internal_storage.fbs
@@ -129,6 +129,11 @@ table RefreshFloatingLimit {
   last_refreshed_at_ms: int64;
   metadata: [KeyValuePair];
   task_group: string;
+  // Append new fields after this one: the table uses implicit field ids, so
+  // inserting a field earlier renumbers every later slot and misreads stored
+  // rows. Set only on refresh index rows: a backed-off retry is not
+  // claimable before this time. Null means claimable now.
+  not_before_ms: int64 = null;
 }
 
 union TaskVariant {

--- a/schema/internal_storage.fbs
+++ b/schema/internal_storage.fbs
@@ -129,9 +129,9 @@ table RefreshFloatingLimit {
   last_refreshed_at_ms: int64;
   metadata: [KeyValuePair];
   task_group: string;
-  // Append new fields after this one: the table uses implicit field ids, so
-  // inserting a field earlier renumbers every later slot and misreads stored
-  // rows. Set only on refresh index rows: a backed-off retry is not
+  // Append new fields at the end of this table: it uses implicit field ids,
+  // so inserting a field earlier renumbers every later slot and misreads
+  // stored rows. Set only on refresh index rows: a backed-off retry is not
   // claimable before this time. Null means claimable now.
   not_before_ms: int64 = null;
 }
@@ -306,9 +306,9 @@ table FloatingLimitState {
   retry_count: uint32;
   next_retry_at_ms: int64 = null;
   metadata: [KeyValuePair];
-  // Append new fields after this one: the table uses implicit field ids, so
-  // inserting a field earlier renumbers every later slot and misreads stored
-  // rows.
+  // Append new fields at the end of this table: it uses implicit field ids,
+  // so inserting a field earlier renumbers every later slot and misreads
+  // stored rows.
   refresh_scheduled_at_ms: int64 = null;
   // Consecutive stale resets of the outstanding-refresh flag; rows written
   // without this field read as 0.

--- a/schema/internal_storage.fbs
+++ b/schema/internal_storage.fbs
@@ -310,4 +310,7 @@ table FloatingLimitState {
   // inserting a field earlier renumbers every later slot and misreads stored
   // rows.
   refresh_scheduled_at_ms: int64 = null;
+  // Consecutive stale resets of the outstanding-refresh flag; rows written
+  // without this field read as 0.
+  stale_reset_count: uint32;
 }

--- a/src/cluster_query.rs
+++ b/src/cluster_query.rs
@@ -39,7 +39,8 @@ use crate::job_store_shard::JobStoreShard;
 use crate::pb::QueryArrowRequest;
 use crate::pb::silo_client::SiloClient;
 use crate::query::{
-    JobsScanner, QueueCountsScanner, QueuesScanner, ScannerRef, TasksScanner, TenantCountsScanner,
+    FloatingRefreshTasksScanner, JobsScanner, QueueCountsScanner, QueuesScanner, ScannerRef,
+    TasksScanner, TenantCountsScanner, classify_floating_refresh_tasks_filters,
     classify_jobs_filters, classify_tasks_filters, explain_dataframe,
 };
 use crate::shard_range::ShardId;
@@ -135,12 +136,23 @@ impl ClusterQueryEngine {
         let tasks_schema = TasksScanner::base_schema();
         let tasks_provider = Arc::new(ClusterTableProvider::new(
             tasks_schema,
-            factory,
-            coordinator,
+            factory.clone(),
+            coordinator.clone(),
             TableKind::Tasks,
-            auth_token,
+            auth_token.clone(),
         ));
         ctx.register_table("tasks", tasks_provider)?;
+
+        // Register cluster-wide floating_refresh_tasks table over each shard's refresh index
+        let refresh_schema = FloatingRefreshTasksScanner::base_schema();
+        let refresh_provider = Arc::new(ClusterTableProvider::new(
+            refresh_schema,
+            factory,
+            coordinator,
+            TableKind::FloatingRefreshTasks,
+            auth_token,
+        ));
+        ctx.register_table("floating_refresh_tasks", refresh_provider)?;
 
         Ok(Self { ctx })
     }
@@ -227,6 +239,7 @@ enum TableKind {
     TenantCounts,
     QueueCounts,
     Tasks,
+    FloatingRefreshTasks,
 }
 
 /// A TableProvider that spans multiple shards in the cluster.
@@ -335,7 +348,10 @@ impl TableProvider for ClusterTableProvider {
         match self.table_kind {
             TableKind::Jobs => Ok(classify_jobs_filters(filters)),
             TableKind::Tasks => Ok(classify_tasks_filters(filters)),
-            _ => Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()]),
+            TableKind::FloatingRefreshTasks => Ok(classify_floating_refresh_tasks_filters(filters)),
+            TableKind::Queues | TableKind::TenantCounts | TableKind::QueueCounts => {
+                Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+            }
         }
     }
 }
@@ -495,6 +511,9 @@ impl ExecutionPlan for ClusterExecutionPlan {
                             Arc::new(QueueCountsScanner::new(Arc::clone(&shard)))
                         }
                         TableKind::Tasks => Arc::new(TasksScanner::new(Arc::clone(&shard))),
+                        TableKind::FloatingRefreshTasks => {
+                            Arc::new(FloatingRefreshTasksScanner::new(Arc::clone(&shard)))
+                        }
                     };
 
                     // Execute the scan - scanner handles projection via schema
@@ -606,6 +625,7 @@ async fn query_remote_shard_batches(
         TableKind::TenantCounts => "tenant_counts",
         TableKind::QueueCounts => "queue_counts",
         TableKind::Tasks => "tasks",
+        TableKind::FloatingRefreshTasks => "floating_refresh_tasks",
     };
 
     let sql = build_sql_query(table_name, filters, limit);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -666,6 +666,7 @@ pub fn encode_floating_limit_state(state: &FloatingLimitState) -> Vec<u8> {
             next_retry_at_ms: state.next_retry_at_ms,
             metadata: Some(metadata),
             refresh_scheduled_at_ms: state.refresh_scheduled_at_ms,
+            stale_reset_count: state.stale_reset_count,
         },
     );
     builder.finish(root, None);
@@ -1205,7 +1206,14 @@ impl DecodedFloatingLimitState {
             next_retry_at_ms: f.next_retry_at_ms(),
             metadata: self.metadata(),
             refresh_scheduled_at_ms: f.refresh_scheduled_at_ms(),
+            stale_reset_count: f.stale_reset_count(),
         }
+    }
+
+    /// Consecutive stale resets of the outstanding-refresh flag; rows
+    /// written without the field read as 0.
+    pub fn stale_reset_count(&self) -> u32 {
+        self.fb().stale_reset_count()
     }
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -336,36 +336,69 @@ fn build_task_union<'a, A: flatbuffers::Allocator + 'a>(
             );
             (fb::TaskVariant::CheckRateLimit, crl.as_union_value())
         }
-        Task::RefreshFloatingLimit {
-            task_id,
-            tenant,
-            queue_key,
-            current_max_concurrency,
-            last_refreshed_at_ms,
-            metadata,
-            task_group,
-        } => {
-            let task_id_s = builder.create_string(task_id);
-            let tenant = builder.create_string(tenant);
-            let queue_key = builder.create_string(queue_key);
-            let md = build_kv_pair_offsets(builder, metadata);
-            let metadata = builder.create_vector(&md);
-            let task_group = builder.create_string(task_group);
-            let rfl = fb::RefreshFloatingLimit::create(
-                builder,
-                &fb::RefreshFloatingLimitArgs {
-                    task_id: Some(task_id_s),
-                    tenant: Some(tenant),
-                    queue_key: Some(queue_key),
-                    current_max_concurrency: *current_max_concurrency,
-                    last_refreshed_at_ms: *last_refreshed_at_ms,
-                    metadata: Some(metadata),
-                    task_group: Some(task_group),
-                },
-            );
+        Task::RefreshFloatingLimit { .. } => {
+            let rfl = build_refresh_floating_limit(builder, task, None);
             (fb::TaskVariant::RefreshFloatingLimit, rfl.as_union_value())
         }
     }
+}
+
+/// Build the `RefreshFloatingLimit` table for `task`, which must be that
+/// variant. `not_before_ms` is set only on refresh index rows.
+fn build_refresh_floating_limit<'a, A: flatbuffers::Allocator + 'a>(
+    builder: &mut FlatBufferBuilder<'a, A>,
+    task: &Task,
+    not_before_ms: Option<i64>,
+) -> flatbuffers::WIPOffset<fb::RefreshFloatingLimit<'a>> {
+    let Task::RefreshFloatingLimit {
+        task_id,
+        tenant,
+        queue_key,
+        current_max_concurrency,
+        last_refreshed_at_ms,
+        metadata,
+        task_group,
+    } = task
+    else {
+        unreachable!("build_refresh_floating_limit takes a RefreshFloatingLimit task");
+    };
+    let task_id_s = builder.create_string(task_id);
+    let tenant = builder.create_string(tenant);
+    let queue_key = builder.create_string(queue_key);
+    let md = build_kv_pair_offsets(builder, metadata);
+    let metadata = builder.create_vector(&md);
+    let task_group = builder.create_string(task_group);
+    fb::RefreshFloatingLimit::create(
+        builder,
+        &fb::RefreshFloatingLimitArgs {
+            task_id: Some(task_id_s),
+            tenant: Some(tenant),
+            queue_key: Some(queue_key),
+            current_max_concurrency: *current_max_concurrency,
+            last_refreshed_at_ms: *last_refreshed_at_ms,
+            metadata: Some(metadata),
+            task_group: Some(task_group),
+            not_before_ms,
+        },
+    )
+}
+
+/// Encode a refresh index row: the `RefreshFloatingLimit` task plus the
+/// time before which it is not claimable (`None` for claimable now). The
+/// row decodes through `decode_task_validated` like any task value.
+#[inline]
+pub fn encode_refresh_index_row(task: &Task, not_before_ms: Option<i64>) -> Vec<u8> {
+    let mut builder = FlatBufferBuilder::with_capacity(256);
+    let rfl = build_refresh_floating_limit(&mut builder, task, not_before_ms);
+    let root = fb::Task::create(
+        &mut builder,
+        &fb::TaskArgs {
+            variant_type: fb::TaskVariant::RefreshFloatingLimit,
+            variant: Some(rfl.as_union_value()),
+        },
+    );
+    builder.finish(root, None);
+    builder.finished_data().to_vec()
 }
 
 // ---------------------------------------------------------------------------
@@ -894,6 +927,14 @@ impl DecodedTask {
 
     pub fn as_refresh_floating_limit(&self) -> Option<fb::RefreshFloatingLimit<'_>> {
         self.fb().variant_as_refresh_floating_limit()
+    }
+
+    /// For a refresh index row, the time before which the refresh is not
+    /// claimable. `None` for rows claimable now, including rows encoded
+    /// without the field.
+    pub fn not_before_ms(&self) -> Option<i64> {
+        self.as_refresh_floating_limit()
+            .and_then(|r| r.not_before_ms())
     }
 
     /// Materialize a fully-owned Task from the FlatBuffer data.

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -157,6 +157,11 @@ pub trait LimitChainResumer: Send + Sync {
     /// is a no-op for resumers with no broker access.
     fn wakeup_task_groups(&self, _groups: &[String]) {}
 
+    /// The chunk that wrote refresh index rows under `task_groups` is
+    /// durable; the shard marks those groups pending for its refresh drain.
+    /// Default is a no-op for resumers with no shard access.
+    fn refresh_index_rows_committed(&self, _task_groups: &[String]) {}
+
     /// The grant scanner found the floating queue `(tenant, queue)` at
     /// capacity with pending grant demand and skipped its request scan. The
     /// shard-side implementation verifies a waiter exists, decides whether a
@@ -3013,7 +3018,11 @@ impl ConcurrencyManager {
 
                 if chunk_grants.len() >= self.grant_scanner_commit_chunk_size {
                     let commit_batch = std::mem::replace(&mut batch, WriteBatch::new());
-                    chunk_scheduled_refreshes = ScheduledRefreshes::default();
+                    let refresh_groups: Vec<String> =
+                        std::mem::take(&mut chunk_scheduled_refreshes)
+                            .task_groups()
+                            .map(str::to_string)
+                            .collect();
                     let stale_deletes = std::mem::take(&mut chunk_stale);
                     if self
                         .commit_grant_chunk(
@@ -3033,6 +3042,9 @@ impl ConcurrencyManager {
                         record_invocation(scanned_this_invocation, total_stale_deleted);
                         return all_granted_groups;
                     }
+                    if let (Some(resumer), false) = (&chain_resumer, refresh_groups.is_empty()) {
+                        resumer.refresh_index_rows_committed(&refresh_groups);
+                    }
                     total_granted += chunk_grants.len();
                     total_stale_deleted += stale_deletes;
                     all_granted_groups.extend(chunk_grants.drain(..).map(|(_, tg)| tg));
@@ -3050,6 +3062,10 @@ impl ConcurrencyManager {
                 continue;
             }
             let commit_batch = std::mem::replace(&mut batch, WriteBatch::new());
+            let refresh_groups: Vec<String> = chunk_scheduled_refreshes
+                .task_groups()
+                .map(str::to_string)
+                .collect();
             let stale_deletes = std::mem::take(&mut chunk_stale);
             if self
                 .commit_grant_chunk(
@@ -3068,6 +3084,9 @@ impl ConcurrencyManager {
             {
                 record_invocation(scanned_this_invocation, total_stale_deleted);
                 return all_granted_groups;
+            }
+            if let (Some(resumer), false) = (&chain_resumer, refresh_groups.is_empty()) {
+                resumer.refresh_index_rows_committed(&refresh_groups);
             }
             total_granted += chunk_grants.len();
             total_stale_deleted += stale_deletes;

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -50,6 +50,7 @@ use slatedb::config::WriteOptions;
 
 use crate::instrumented_db::InstrumentedDb;
 
+use crate::job_store_shard::ScheduledRefreshes;
 use crate::job_store_shard::counters::{decode_counter, encode_counter};
 use crate::job_store_shard::helpers::{WriteBatcher, live_terminal_row_exists};
 
@@ -138,12 +139,15 @@ pub struct ResumeChainParams {
 #[async_trait::async_trait]
 pub trait LimitChainResumer: Send + Sync {
     /// Append edits to `batch` that continue the limit chain from
-    /// `params.limit_index`. Returns the `(queue, task_id)` pairs of any
-    /// additional in-memory concurrency reservations the chain made (so the
-    /// caller can roll them back if the batch write fails).
+    /// `params.limit_index`. `scheduled_refreshes` is shared by every chain
+    /// resumed into the same batch, so a downstream floating queue's refresh
+    /// is scheduled once per batch. Returns the `(queue, task_id)` pairs of
+    /// any additional in-memory concurrency reservations the chain made (so
+    /// the caller can roll them back if the batch write fails).
     async fn resume_chain(
         &self,
         batch: &mut slatedb::WriteBatch,
+        scheduled_refreshes: &mut ScheduledRefreshes,
         params: ResumeChainParams,
     ) -> Result<Vec<(String, String)>, ConcurrencyError>;
 
@@ -2412,6 +2416,7 @@ impl ConcurrencyManager {
             let needed = (count as usize - total_granted).min(self.grant_scanner_batch_size);
 
             let mut batch = WriteBatch::new();
+            let mut chunk_scheduled_refreshes = ScheduledRefreshes::default();
             let mut stale_and_corrupt_count: usize = 0;
 
             // --- Scan batch of candidates ---
@@ -2979,7 +2984,10 @@ impl ConcurrencyManager {
                     read_cache: read_cache.clone(),
                 };
 
-                match resumer.resume_chain(&mut batch, resume_params).await {
+                match resumer
+                    .resume_chain(&mut batch, &mut chunk_scheduled_refreshes, resume_params)
+                    .await
+                {
                     Ok(chain_grants) => {
                         // Each (queue, task_id) the chain reserved must roll back
                         // alongside ours if this chunk's write fails.
@@ -3005,6 +3013,7 @@ impl ConcurrencyManager {
 
                 if chunk_grants.len() >= self.grant_scanner_commit_chunk_size {
                     let commit_batch = std::mem::replace(&mut batch, WriteBatch::new());
+                    chunk_scheduled_refreshes = ScheduledRefreshes::default();
                     let stale_deletes = std::mem::take(&mut chunk_stale);
                     if self
                         .commit_grant_chunk(

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -305,6 +305,7 @@ impl ShardFactory {
                         terminal_job_expire_s: template.terminal_job_expire_s,
                         count_from_status_counters: template.count_from_status_counters,
                         floating_refresh_stale_ms: template.floating_refresh_stale_ms,
+                        floating_refresh_stale_max_ms: template.floating_refresh_stale_max_ms,
                         broker_tombstone_revive_after_generations: template
                             .broker_tombstone_revive_after_generations,
                     },
@@ -1131,6 +1132,7 @@ impl ShardFactory {
                 terminal_job_expire_s: self.template.terminal_job_expire_s,
                 count_from_status_counters: self.template.count_from_status_counters,
                 floating_refresh_stale_ms: self.template.floating_refresh_stale_ms,
+                floating_refresh_stale_max_ms: self.template.floating_refresh_stale_max_ms,
                 broker_tombstone_revive_after_generations: self
                     .template
                     .broker_tombstone_revive_after_generations,

--- a/src/job.rs
+++ b/src/job.rs
@@ -55,6 +55,11 @@ pub struct FloatingLimitState {
     /// than the shard's stale threshold, or with this field absent, is
     /// treated as no outstanding refresh so a lost task cannot pin the cap.
     pub refresh_scheduled_at_ms: Option<i64>,
+    /// Consecutive times the outstanding-refresh flag was found stale and
+    /// replaced. Each doubles the stale window from the shard's base up to
+    /// its cap; any refresh outcome (success, reported failure, lease
+    /// expiry) resets it to 0.
+    pub stale_reset_count: u32,
 }
 
 /// Rate limiting algorithm used by Gubernator

--- a/src/job_store_shard/cleanup.rs
+++ b/src/job_store_shard/cleanup.rs
@@ -12,8 +12,8 @@ use crate::keys::{
     self, end_bound, parse_attempt_key, parse_concurrency_holder_key,
     parse_concurrency_request_key, parse_concurrency_requester_counter_key,
     parse_floating_limit_key, parse_job_cancelled_key, parse_job_info_key, parse_job_status_key,
-    parse_metadata_index_key, parse_status_time_index_key, parse_tenant_status_counter_key,
-    tasks_prefix,
+    parse_metadata_index_key, parse_refresh_task_key, parse_status_time_index_key,
+    parse_tenant_status_counter_key, tasks_prefix,
 };
 use crate::shard_range::ShardRange;
 use slatedb::WriteBatch;
@@ -167,6 +167,11 @@ impl JobStoreShard {
             (
                 vec![prefix::FLOATING_LIMIT],
                 Box::new(|key, _| parse_floating_limit_key(key).map(|p| p.tenant)),
+            ),
+            // Refresh index keys (0x0C)
+            (
+                vec![prefix::REFRESH_TASK],
+                Box::new(|key, _| parse_refresh_task_key(key).map(|p| p.tenant)),
             ),
             // Concurrency requester counter keys (0xF7)
             (

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -16,7 +16,9 @@ use crate::job_store_shard::helpers::{
     DbWriteBatcher, decode_job_status_owned, live_terminal_row_exists, now_epoch_ms,
 };
 use crate::job_store_shard::holder_release_guard::PendingHolderReleaseGuard;
-use crate::job_store_shard::{DequeueResult, JobStoreShard, JobStoreShardError, LimitTaskParams};
+use crate::job_store_shard::{
+    DequeueResult, JobStoreShard, JobStoreShardError, LimitTaskParams, ScheduledRefreshes,
+};
 use crate::keys::{
     ParsedTaskKey, attempt_key, concurrency_holder_key, job_info_key, job_status_key,
     leased_task_key, parse_task_key,
@@ -61,6 +63,9 @@ struct DequeueIterationState {
     /// so a second RequestTicket / CheckRateLimit for the same attempt within
     /// one iteration is caught here.
     materialized_attempts: HashSet<(String, String, u32)>,
+    /// Floating queues whose refresh a chain continuation in this
+    /// iteration's batch already scheduled.
+    scheduled_refreshes: ScheduledRefreshes,
     processed_internal: bool,
 }
 
@@ -78,6 +83,7 @@ impl DequeueIterationState {
             converted_requests: Vec::new(),
             leased_task_ids: HashSet::new(),
             materialized_attempts: HashSet::new(),
+            scheduled_refreshes: ScheduledRefreshes::default(),
             processed_internal: false,
         }
     }
@@ -939,6 +945,7 @@ impl JobStoreShard {
                     held_queues: new_held,
                     task_group: &req_task_group,
                     skip_try_reserve: false,
+                    scheduled_refreshes: &mut state.scheduled_refreshes,
                 },
             )
             .await?;
@@ -1154,6 +1161,7 @@ impl JobStoreShard {
                             held_queues: held_queues.clone(),
                             task_group: check_task_group,
                             skip_try_reserve: false,
+                            scheduled_refreshes: &mut state.scheduled_refreshes,
                         },
                     )
                     .await?;

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -240,21 +240,28 @@ impl JobStoreShard {
     /// RunAttempt tasks for job execution and RefreshFloatingLimit tasks for workers to refresh floating limits.
     ///
     /// The `task_group` parameter specifies which task group to poll for tasks.
+    ///
+    /// Pending refreshes are drained from the group's refresh index before
+    /// any job work is claimed from the broker, so a refresh is handed over
+    /// regardless of the group's job backlog, even when `max_tasks` is zero
+    /// or the broker buffer is empty. Refresh rows still in the task line
+    /// are leased when the broker reaches them.
     pub async fn dequeue(
         &self,
         worker_id: &str,
         task_group: &str,
         max_tasks: usize,
     ) -> Result<DequeueResult, JobStoreShardError> {
+        let mut refresh_out: Vec<LeasedRefreshTask> =
+            self.drain_pending_refreshes(worker_id, task_group).await?;
         if max_tasks == 0 {
             return Ok(DequeueResult {
                 tasks: Vec::new(),
-                refresh_tasks: Vec::new(),
+                refresh_tasks: refresh_out,
             });
         }
 
         let mut out: Vec<LeasedTask> = Vec::new();
-        let mut refresh_out: Vec<LeasedRefreshTask> = Vec::new();
         // Tuple: (tenant, job_view, encoded_attempt_bytes)
         // We keep the encoded bytes to construct JobAttemptView without a DB readback.
         let mut pending_attempts: Vec<(String, JobView, Vec<u8>)> = Vec::with_capacity(max_tasks);

--- a/src/job_store_shard/dequeue.rs
+++ b/src/job_store_shard/dequeue.rs
@@ -463,6 +463,7 @@ impl JobStoreShard {
                 return Err(JobStoreShardError::from(e));
             }
             dst_events::confirm_write(write_op);
+            self.mark_refresh_pending_groups(state.scheduled_refreshes.task_groups());
 
             // DB write succeeded — grants are now backed by durable holder
             // rows, no rollback needed. Clear the guard's buffer (keeps it
@@ -875,6 +876,7 @@ impl JobStoreShard {
                 && let Err(e) = self
                     .schedule_floating_refresh_for_ticket(
                         &mut writer,
+                        &mut state.scheduled_refreshes,
                         &tenant,
                         fl,
                         now_ms,

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -739,14 +739,20 @@ impl JobStoreShard {
 
                 Limit::FloatingConcurrency(fl) => {
                     // Get/create floating limit state and maybe schedule refresh
-                    let state = self
-                        .get_or_create_floating_limit_state(writer, tenant, fl)
-                        .await?;
                     // A refresh this batch already scheduled is invisible to
-                    // the durable read above, so the row would read as stale
-                    // again from every later walk into the same batch.
-                    let refresh_ready = !scheduled_refreshes.contains(tenant, &fl.key)
-                        && self.floating_limit_refresh_ready(&state, now_ms);
+                    // durable reads: the row would read as stale again from
+                    // every later walk into the same batch, and a cold-path
+                    // create would overwrite the batch's flag on commit.
+                    let already_scheduled = scheduled_refreshes.contains(tenant, &fl.key);
+                    let state = if already_scheduled {
+                        self.floating_limit_state_or_default(writer, tenant, fl)
+                            .await?
+                    } else {
+                        self.get_or_create_floating_limit_state(writer, tenant, fl)
+                            .await?
+                    };
+                    let refresh_ready =
+                        !already_scheduled && self.floating_limit_refresh_ready(&state, now_ms);
 
                     // Try immediate grant using current max concurrency
                     let current_max = state.current_max_concurrency();

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -27,19 +27,31 @@ use crate::retry::RetryPolicy;
 use crate::task::{GubernatorRateLimitData, Task};
 
 /// Floating queues for which one write batch has already scheduled a
-/// refresh. Batch reads see the durable state row, not the batch's pending
-/// puts, so without this record every chain walked into the same batch
-/// would judge the same stale flag and write its own replacement refresh.
+/// refresh, with the task group each refresh index row was written under.
+/// Batch reads see the durable state row, not the batch's pending puts, so
+/// without this record every chain walked into the same batch would judge
+/// the same stale flag and write its own replacement refresh. Once the
+/// batch is durable, its owner marks the recorded groups pending for the
+/// refresh drain.
 #[derive(Debug, Default)]
-pub struct ScheduledRefreshes(Vec<(String, String)>);
+pub struct ScheduledRefreshes(Vec<(String, String, String)>);
 
 impl ScheduledRefreshes {
-    fn contains(&self, tenant: &str, queue_key: &str) -> bool {
-        self.0.iter().any(|(t, q)| t == tenant && q == queue_key)
+    pub(crate) fn contains(&self, tenant: &str, queue_key: &str) -> bool {
+        self.0.iter().any(|(t, q, _)| t == tenant && q == queue_key)
     }
 
-    fn record(&mut self, tenant: &str, queue_key: &str) {
-        self.0.push((tenant.to_string(), queue_key.to_string()));
+    pub(crate) fn record(&mut self, tenant: &str, queue_key: &str, task_group: &str) {
+        self.0.push((
+            tenant.to_string(),
+            queue_key.to_string(),
+            task_group.to_string(),
+        ));
+    }
+
+    /// Task groups that received an index row in this batch.
+    pub fn task_groups(&self) -> impl Iterator<Item = &str> {
+        self.0.iter().map(|(_, _, g)| g.as_str())
     }
 }
 
@@ -225,10 +237,12 @@ impl JobStoreShard {
         task_group: &str,
     ) -> Result<(), JobStoreShardError> {
         let mut batch = WriteBatch::new();
+        let mut scheduled_refreshes = ScheduledRefreshes::default();
         let background_action_metadata = metadata.clone().unwrap_or_default();
         let grants = self
             .write_enqueue_data(
                 &mut DbWriteBatcher::new(&self.db, &mut batch),
+                &mut scheduled_refreshes,
                 tenant,
                 job_id,
                 priority,
@@ -289,6 +303,7 @@ impl JobStoreShard {
             return Err(e.into());
         }
         dst_events::confirm_write(write_op);
+        self.mark_refresh_pending_groups(scheduled_refreshes.task_groups());
 
         self.finish_enqueue(job_id, task_group, start_at_ms, &grants)
             .await
@@ -350,9 +365,11 @@ impl JobStoreShard {
             return Err(JobStoreShardError::JobAlreadyExists(job_id.to_string()));
         }
 
+        let mut scheduled_refreshes = ScheduledRefreshes::default();
         let grants = self
             .write_enqueue_data(
                 &mut TxnWriter(&txn),
+                &mut scheduled_refreshes,
                 tenant,
                 job_id,
                 priority,
@@ -409,6 +426,7 @@ impl JobStoreShard {
             return Err(e.into());
         }
         dst_events::confirm_write(write_op);
+        self.mark_refresh_pending_groups(scheduled_refreshes.task_groups());
 
         self.finish_enqueue(job_id, task_group, start_at_ms, &grants)
             .await
@@ -420,6 +438,7 @@ impl JobStoreShard {
     async fn write_enqueue_data<W: WriteBatcher>(
         &self,
         writer: &mut W,
+        scheduled_refreshes: &mut ScheduledRefreshes,
         tenant: &str,
         job_id: &str,
         priority: u8,
@@ -493,7 +512,7 @@ impl JobStoreShard {
                     held_queues: Vec::new(),
                     task_group,
                     skip_try_reserve: false,
-                    scheduled_refreshes: &mut ScheduledRefreshes::default(),
+                    scheduled_refreshes,
                 },
             )
             .await
@@ -786,7 +805,7 @@ impl JobStoreShard {
                             has_waiters,
                         )?
                     {
-                        scheduled_refreshes.record(tenant, &fl.key);
+                        scheduled_refreshes.record(tenant, &fl.key, task_group);
                     }
 
                     match record_grant_outcome(

--- a/src/job_store_shard/enqueue.rs
+++ b/src/job_store_shard/enqueue.rs
@@ -26,6 +26,23 @@ use crate::keys::{
 use crate::retry::RetryPolicy;
 use crate::task::{GubernatorRateLimitData, Task};
 
+/// Floating queues for which one write batch has already scheduled a
+/// refresh. Batch reads see the durable state row, not the batch's pending
+/// puts, so without this record every chain walked into the same batch
+/// would judge the same stale flag and write its own replacement refresh.
+#[derive(Debug, Default)]
+pub struct ScheduledRefreshes(Vec<(String, String)>);
+
+impl ScheduledRefreshes {
+    fn contains(&self, tenant: &str, queue_key: &str) -> bool {
+        self.0.iter().any(|(t, q)| t == tenant && q == queue_key)
+    }
+
+    fn record(&mut self, tenant: &str, queue_key: &str) {
+        self.0.push((tenant.to_string(), queue_key.to_string()));
+    }
+}
+
 /// Parameters for creating limit-processing tasks.
 /// Bundles the many fields needed by `enqueue_limit_task_at_index` into a single struct.
 pub(crate) struct LimitTaskParams<'a> {
@@ -63,6 +80,9 @@ pub(crate) struct LimitTaskParams<'a> {
     /// This matches the Alloy model's completeFailureRetryReleaseTicket which creates a
     /// TicketRequest, not an immediate holder.
     pub skip_try_reserve: bool,
+    /// The record shared by every chain walked into the same write batch,
+    /// so a floating queue's refresh is scheduled once per batch.
+    pub scheduled_refreshes: &'a mut ScheduledRefreshes,
 }
 
 /// Result of walking a job's remaining limits.
@@ -473,6 +493,7 @@ impl JobStoreShard {
                     held_queues: Vec::new(),
                     task_group,
                     skip_try_reserve: false,
+                    scheduled_refreshes: &mut ScheduledRefreshes::default(),
                 },
             )
             .await
@@ -589,6 +610,7 @@ impl JobStoreShard {
             held_queues,
             task_group,
             skip_try_reserve,
+            scheduled_refreshes,
         } = params;
         // Walk limits in the order the client provided them — silo no longer
         // reorders. `current_index` and the `limit_index` stored in
@@ -701,7 +723,11 @@ impl JobStoreShard {
                     let state = self
                         .get_or_create_floating_limit_state(writer, tenant, fl)
                         .await?;
-                    let refresh_ready = self.floating_limit_refresh_ready(&state, now_ms);
+                    // A refresh this batch already scheduled is invisible to
+                    // the durable read above, so the row would read as stale
+                    // again from every later walk into the same batch.
+                    let refresh_ready = !scheduled_refreshes.contains(tenant, &fl.key)
+                        && self.floating_limit_refresh_ready(&state, now_ms);
 
                     // Try immediate grant using current max concurrency
                     let current_max = state.current_max_concurrency();
@@ -749,8 +775,8 @@ impl JobStoreShard {
                             .has_waiting_concurrency_requests(tenant, &fl.key)
                             .await?;
                     }
-                    if refresh_ready {
-                        self.maybe_schedule_floating_limit_refresh(
+                    if refresh_ready
+                        && self.maybe_schedule_floating_limit_refresh(
                             writer,
                             tenant,
                             &fl.key,
@@ -758,7 +784,9 @@ impl JobStoreShard {
                             now_ms,
                             task_group,
                             has_waiters,
-                        )?;
+                        )?
+                    {
+                        scheduled_refreshes.record(tenant, &fl.key);
                     }
 
                     match record_grant_outcome(

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -1,21 +1,214 @@
 //! Floating concurrency limit operations.
 
 use slatedb::WriteBatch;
+use slatedb::config::{PutOptions, Ttl, WriteOptions};
 use uuid::Uuid;
 
 use crate::codec::{
     DecodedFloatingLimitState, decode_concurrency_action, decode_floating_limit_state,
-    decode_lease, encode_floating_limit_state, encode_task,
+    decode_lease, decode_task_validated, encode_floating_limit_state, encode_lease,
+    encode_refresh_index_row,
 };
 use crate::job::{FloatingConcurrencyLimit, FloatingLimitState, JobView};
 use crate::job_store_shard::helpers::{DbWriteBatcher, WriteBatcher, now_epoch_ms};
 use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
 use crate::keys::{
     concurrency_request_prefix, end_bound, floating_limit_state_key, job_info_key, leased_task_key,
+    parse_refresh_task_key, refresh_task_group_prefix, refresh_task_key, refresh_tasks_prefix,
 };
-use crate::task::Task;
+use crate::task::{DEFAULT_LEASE_MS, LeaseRecord, LeasedRefreshTask, Task};
+
+/// Row TTL on refresh index rows. Longer than any stale window, so it only
+/// cleans up a row left under a task group no worker polls again; SlateDB
+/// applies it at flush and compaction, so it is storage cleanup, not a
+/// read-side guarantee.
+pub const REFRESH_INDEX_ROW_TTL_MS: i64 = 24 * 60 * 60 * 1000;
+
+/// Most refresh index rows one drain leases. The bound counts leased rows,
+/// not scanned rows, so backed-off retries sorting earlier in the group's
+/// range never hide a claimable row.
+pub const REFRESH_DRAIN_MAX_LEASED: usize = 16;
 
 impl JobStoreShard {
+    /// Mark `task_group` as possibly holding a refresh index row. Called
+    /// before every index put's batch commits, so a drain never skips a
+    /// group with a row in flight.
+    fn mark_refresh_pending(&self, task_group: &str) {
+        let mut groups = self
+            .refresh_pending_groups
+            .lock()
+            .expect("refresh pending groups lock");
+        *groups.entry(task_group.to_string()).or_insert(0) += 1;
+    }
+
+    /// Warm the pending-group gate from the durable refresh index at shard
+    /// open. Every group with a row is marked; a drain drops a group once it
+    /// finds the range empty.
+    pub(crate) async fn warm_refresh_pending_groups(&self) -> Result<(), JobStoreShardError> {
+        let start = refresh_tasks_prefix();
+        let end = end_bound(&start);
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options_uncached())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            if let Some(parsed) = parse_refresh_task_key(&kv.key) {
+                self.mark_refresh_pending(&parsed.task_group);
+            }
+        }
+        Ok(())
+    }
+
+    /// Test-only: write a refresh index row for `task` (a
+    /// `RefreshFloatingLimit`) directly, marking its group pending as the
+    /// scheduler would. Lets tests seed more pending refreshes than live
+    /// floating queues would produce.
+    #[doc(hidden)]
+    pub async fn put_refresh_index_row_for_test(
+        &self,
+        task: &Task,
+        not_before_ms: Option<i64>,
+    ) -> Result<(), JobStoreShardError> {
+        let Task::RefreshFloatingLimit {
+            tenant,
+            queue_key,
+            task_group,
+            ..
+        } = task
+        else {
+            return Err(JobStoreShardError::InvalidArgument(
+                "refresh index rows hold RefreshFloatingLimit tasks".to_string(),
+            ));
+        };
+        let mut batch = WriteBatch::new();
+        batch.put_with_options(
+            refresh_task_key(task_group, tenant, queue_key),
+            encode_refresh_index_row(task, not_before_ms),
+            &PutOptions {
+                ttl: Ttl::ExpireAt(now_epoch_ms() + REFRESH_INDEX_ROW_TTL_MS),
+            },
+        );
+        self.mark_refresh_pending(task_group);
+        self.db.write(batch).await?;
+        Ok(())
+    }
+
+    /// Lease every claimable refresh index row under `task_group`, up to
+    /// `REFRESH_DRAIN_MAX_LEASED`, in one durable batch. Rows for tenants
+    /// outside the shard range are deleted; rows whose `not_before_ms` is in
+    /// the future stay for a later drain. Index keys never reach the task
+    /// broker, so nothing here is acked or tombstoned.
+    pub async fn drain_pending_refreshes(
+        &self,
+        worker_id: &str,
+        task_group: &str,
+    ) -> Result<Vec<LeasedRefreshTask>, JobStoreShardError> {
+        let generation = {
+            let groups = self
+                .refresh_pending_groups
+                .lock()
+                .expect("refresh pending groups lock");
+            groups.get(task_group).copied()
+        };
+        let Some(generation) = generation else {
+            return Ok(Vec::new());
+        };
+
+        let now_ms = now_epoch_ms();
+        let expiry_ms = now_ms + DEFAULT_LEASE_MS;
+        let shard_range = self.get_range();
+        let start = refresh_task_group_prefix(task_group);
+        let end = end_bound(&start);
+        let mut iter = self
+            .db
+            .scan_with_options::<Vec<u8>, _>(start..end, &crate::scan_options())
+            .await?;
+
+        let mut batch = WriteBatch::new();
+        let mut leased = Vec::new();
+        let mut range_empty = true;
+        while let Some(kv) = iter.next().await? {
+            range_empty = false;
+            let Some(parsed) = parse_refresh_task_key(&kv.key) else {
+                continue;
+            };
+            if !shard_range.contains_tenant(&parsed.tenant) {
+                tracing::debug!(
+                    tenant = %parsed.tenant,
+                    queue_key = %parsed.queue_key,
+                    range = %shard_range,
+                    "dropping defunct refresh index row (tenant outside shard range)"
+                );
+                batch.delete(&kv.key);
+                continue;
+            }
+            let decoded = match decode_task_validated(kv.value) {
+                Ok(decoded) => decoded,
+                Err(e) => {
+                    tracing::warn!(
+                        tenant = %parsed.tenant,
+                        queue_key = %parsed.queue_key,
+                        error = %e,
+                        "refresh index row is unreadable; skipping"
+                    );
+                    continue;
+                }
+            };
+            if decoded.not_before_ms().is_some_and(|t| now_ms < t) {
+                continue;
+            }
+            if leased.len() >= REFRESH_DRAIN_MAX_LEASED {
+                break;
+            }
+            let Some(rfl) = decoded.as_refresh_floating_limit() else {
+                continue;
+            };
+            let task_id = rfl.task_id().unwrap_or_default().to_string();
+            let record = LeaseRecord {
+                worker_id: worker_id.to_string(),
+                task: decoded.to_task()?,
+                expiry_ms,
+                started_at_ms: 0,
+            };
+            batch.put(leased_task_key(&task_id), encode_lease(&record));
+            batch.delete(&kv.key);
+            leased.push(LeasedRefreshTask {
+                task_id,
+                tenant_id: parsed.tenant,
+                queue_key: parsed.queue_key,
+                current_max_concurrency: rfl.current_max_concurrency(),
+                last_refreshed_at_ms: rfl.last_refreshed_at_ms(),
+                metadata: crate::codec::fb_kv_pairs_to_owned(rfl.metadata()),
+                task_group: rfl.task_group().unwrap_or_default().to_string(),
+            });
+        }
+
+        if range_empty {
+            // A put that landed since the scan began bumped the generation
+            // and keeps the group marked.
+            let mut groups = self
+                .refresh_pending_groups
+                .lock()
+                .expect("refresh pending groups lock");
+            if groups.get(task_group) == Some(&generation) {
+                groups.remove(task_group);
+            }
+        }
+
+        if !batch.is_empty() {
+            self.db
+                .write_with_options(
+                    batch,
+                    &WriteOptions {
+                        await_durable: true,
+                        ..Default::default()
+                    },
+                )
+                .await?;
+        }
+        Ok(leased)
+    }
+
     /// True when the state's outstanding-refresh flag is set but the refresh
     /// was scheduled longer ago than the shard's stale threshold, or carries
     /// no stamp at all. Such a refresh is treated as lost: no task row,
@@ -128,10 +321,9 @@ impl JobStoreShard {
     /// Schedule a refresh for a floating queue the grant scanner found at
     /// capacity with pending grant demand. Readiness is judged here with the
     /// shard's stale threshold; the task group comes from the head waiter,
-    /// whose presence is what establishes the backlog. The task and state are
-    /// committed in their own batch and the group's broker is woken so the
-    /// task is claimable without waiting out scan backoff. Returns whether a
-    /// task was written.
+    /// whose presence is what establishes the backlog. The index row and
+    /// state are committed in their own batch; the next dequeue for the
+    /// group drains the row. Returns whether a row was written.
     pub(crate) async fn schedule_floating_refresh_from_scanner(
         &self,
         tenant: &str,
@@ -174,7 +366,6 @@ impl JobStoreShard {
             return Ok(false);
         }
         self.db.write(batch).await?;
-        self.brokers.wakeup(&task_group);
         Ok(true)
     }
 
@@ -235,7 +426,7 @@ impl JobStoreShard {
     }
 
     /// Check if a floating limit refresh is needed and schedule it if so.
-    /// Returns whether a refresh task was written.
+    /// Returns whether a refresh index row was written.
     ///
     /// Three call sites lazily trigger refreshes, each supplying its own
     /// waiter signal and task group: the enqueue path (a job that just
@@ -243,6 +434,9 @@ impl JobStoreShard {
     /// handler at dequeue (a scheduled-start ticket that just landed as a
     /// waiter), and the grant scanner's at-capacity precheck via
     /// `schedule_floating_refresh_from_scanner` (the head waiter's group).
+    ///
+    /// The row is keyed by `(task_group, tenant, queue_key)`, so writing
+    /// over a stale flag replaces any unclaimed row for the queue in place.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn maybe_schedule_floating_limit_refresh<W: WriteBatcher>(
         &self,
@@ -299,18 +493,12 @@ impl JobStoreShard {
             task_group: task_group.to_string(),
         };
 
-        // Use a synthetic task key with a special job_id format for floating refresh tasks
-        let task_value = encode_task(&refresh_task);
-        let synthetic_job_id = format!("floating_refresh:{queue_key}");
-        let task_key_bytes = crate::keys::task_key(
-            task_group,
-            now_ms,
-            0, // highest priority for refresh tasks
-            &synthetic_job_id,
-            0,      // attempt not used for refresh tasks
-            now_ms, // standalone refresh task; epoch is just the write time
-        );
-        writer.put(&task_key_bytes, &task_value)?;
+        writer.put_with_expire(
+            refresh_task_key(task_group, tenant, queue_key),
+            encode_refresh_index_row(&refresh_task, None),
+            now_ms + REFRESH_INDEX_ROW_TTL_MS,
+        )?;
+        self.mark_refresh_pending(task_group);
 
         // Update state to mark refresh as scheduled
         let new_state = FloatingLimitState {
@@ -467,9 +655,9 @@ impl JobStoreShard {
             .has_waiting_concurrency_requests(&tenant, &queue_key)
             .await?;
 
-        // The retry task's key starts at `next_retry_at`, which can sit up to
-        // the backoff cap in the future; stamping that (not now) keeps the
-        // retry from reading as stale before it is even claimable.
+        // The retry row is not claimable before `next_retry_at`, which can
+        // sit up to the backoff cap in the future; stamping that (not now)
+        // keeps the retry from reading as stale before it is even claimable.
         let new_state = FloatingLimitState {
             retry_count: new_retry_count,
             next_retry_at_ms: Some(next_retry_at),
@@ -482,10 +670,8 @@ impl JobStoreShard {
         let state_value = encode_floating_limit_state(&new_state);
         batch.put(&state_key, &state_value);
         if has_waiters {
-            // Schedule a new refresh task
-            let new_task_id = Uuid::new_v4().to_string();
             let refresh_task = Task::RefreshFloatingLimit {
-                task_id: new_task_id.clone(),
+                task_id: Uuid::new_v4().to_string(),
                 tenant: tenant.clone(),
                 queue_key: queue_key.clone(),
                 current_max_concurrency,
@@ -493,18 +679,14 @@ impl JobStoreShard {
                 metadata,
                 task_group: task_group.clone(),
             };
-
-            let task_value = encode_task(&refresh_task);
-            let synthetic_job_id = format!("floating_refresh:{}", queue_key);
-            let task_key_bytes = crate::keys::task_key(
-                &task_group,
-                next_retry_at,
-                0, // highest priority
-                &synthetic_job_id,
-                0,             // attempt not used for refresh tasks
-                next_retry_at, // standalone refresh task; epoch is just the write time
+            batch.put_with_options(
+                refresh_task_key(&task_group, &tenant, &queue_key),
+                encode_refresh_index_row(&refresh_task, Some(next_retry_at)),
+                &PutOptions {
+                    ttl: Ttl::ExpireAt(now_ms + REFRESH_INDEX_ROW_TTL_MS),
+                },
             );
-            batch.put(&task_key_bytes, &task_value);
+            self.mark_refresh_pending(&task_group);
         }
         batch.delete(&lease_key);
 

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -41,6 +41,23 @@ fn stale_window_ms(base_ms: i64, stale_reset_count: u32, max_ms: i64) -> i64 {
     widened.min(max_ms).max(base_ms)
 }
 
+/// The state a floating queue starts with: the limit's defaults, nothing
+/// refreshed, no refresh outstanding.
+fn default_floating_limit_state(fl: &FloatingConcurrencyLimit) -> FloatingLimitState {
+    FloatingLimitState {
+        current_max_concurrency: fl.default_max_concurrency,
+        last_refreshed_at_ms: 0,
+        refresh_task_scheduled: false,
+        refresh_interval_ms: fl.refresh_interval_ms,
+        default_max_concurrency: fl.default_max_concurrency,
+        retry_count: 0,
+        next_retry_at_ms: None,
+        metadata: fl.metadata.clone(),
+        refresh_scheduled_at_ms: None,
+        stale_reset_count: 0,
+    }
+}
+
 impl JobStoreShard {
     /// Mark `task_group` as possibly holding a refresh index row. Called
     /// only after the put's batch is durable: a mark made before the row is
@@ -477,24 +494,32 @@ impl JobStoreShard {
         }
 
         // Cold path: first time seeing this queue key, create and write new state
-        let state = FloatingLimitState {
-            current_max_concurrency: fl.default_max_concurrency,
-            last_refreshed_at_ms: 0,
-            refresh_task_scheduled: false,
-            refresh_interval_ms: fl.refresh_interval_ms,
-            default_max_concurrency: fl.default_max_concurrency,
-            retry_count: 0,
-            next_retry_at_ms: None,
-            metadata: fl.metadata.clone(),
-            refresh_scheduled_at_ms: None,
-            stale_reset_count: 0,
-        };
-
-        let state_bytes = encode_floating_limit_state(&state);
+        let state_bytes = encode_floating_limit_state(&default_floating_limit_state(fl));
         writer.put(&state_key, &state_bytes)?;
 
         // Decode what we just encoded so we return the same type
         Ok(decode_floating_limit_state(state_bytes)?)
+    }
+
+    /// The queue's durable state, or an unwritten default when no row exists
+    /// yet. For a queue this batch has already scheduled a refresh for: the
+    /// batch holds the queue's real row with the flag set, a durable read
+    /// cannot see that put, and a second cold-path create would overwrite
+    /// the flag when the batch commits.
+    pub(crate) async fn floating_limit_state_or_default<W: WriteBatcher>(
+        &self,
+        writer: &W,
+        tenant: &str,
+        fl: &FloatingConcurrencyLimit,
+    ) -> Result<DecodedFloatingLimitState, JobStoreShardError> {
+        let raw = match writer
+            .get(&floating_limit_state_key(tenant, &fl.key))
+            .await?
+        {
+            Some(raw) => raw,
+            None => encode_floating_limit_state(&default_floating_limit_state(fl)).into(),
+        };
+        Ok(decode_floating_limit_state(raw)?)
     }
 
     /// Check if a floating limit refresh is needed and schedule it if so.

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -29,6 +29,17 @@ pub const REFRESH_INDEX_ROW_TTL_MS: i64 = 24 * 60 * 60 * 1000;
 /// range never hide a claimable row.
 pub const REFRESH_DRAIN_MAX_LEASED: usize = 16;
 
+/// `base_ms` doubled `stale_reset_count` times, capped at `max_ms`, with
+/// the shift saturating instead of overflowing.
+fn stale_window_ms(base_ms: i64, stale_reset_count: u32, max_ms: i64) -> i64 {
+    let widened = if stale_reset_count >= i64::BITS - 1 {
+        i64::MAX
+    } else {
+        base_ms.saturating_mul(1i64 << stale_reset_count)
+    };
+    widened.min(max_ms)
+}
+
 impl JobStoreShard {
     /// Mark `task_group` as possibly holding a refresh index row. Called
     /// before every index put's batch commits, so a drain never skips a
@@ -209,15 +220,26 @@ impl JobStoreShard {
         Ok(leased)
     }
 
+    /// The stale window for a state row: the shard's base window doubled per
+    /// consecutive stale reset the row records, capped at the shard's max.
+    /// Shifts saturate, so a large count reads as the cap.
+    fn floating_limit_stale_window_ms(&self, state: &DecodedFloatingLimitState) -> i64 {
+        stale_window_ms(
+            self.floating_refresh_stale_ms,
+            state.stale_reset_count(),
+            self.floating_refresh_stale_max_ms,
+        )
+    }
+
     /// True when the state's outstanding-refresh flag is set but the refresh
-    /// was scheduled longer ago than the shard's stale threshold, or carries
-    /// no stamp at all. Such a refresh is treated as lost: no task row,
-    /// lease, or in-memory suppression may pin a tenant's cap forever.
+    /// was scheduled longer ago than the row's stale window, or carries no
+    /// stamp at all. Such a refresh is treated as lost: no index row, lease,
+    /// or in-memory suppression may pin a tenant's cap forever.
     fn floating_limit_refresh_stale(&self, state: &DecodedFloatingLimitState, now_ms: i64) -> bool {
         state.refresh_task_scheduled()
             && state
                 .refresh_scheduled_at_ms()
-                .is_none_or(|at| now_ms - at > self.floating_refresh_stale_ms)
+                .is_none_or(|at| now_ms - at > self.floating_limit_stale_window_ms(state))
     }
 
     /// True when a refresh task is scheduled and still trusted to complete.
@@ -416,6 +438,7 @@ impl JobStoreShard {
             next_retry_at_ms: None,
             metadata: fl.metadata.clone(),
             refresh_scheduled_at_ms: None,
+            stale_reset_count: 0,
         };
 
         let state_bytes = encode_floating_limit_state(&state);
@@ -467,13 +490,24 @@ impl JobStoreShard {
         }
 
         // Reaching here with the flag still set means the outstanding refresh
-        // aged out; this write replaces it.
+        // aged out; this write replaces it and widens the next stale window.
+        // A first schedule after a clean outcome keeps the count the outcome
+        // wrote, so a healthy refresh cycle never widens the window.
+        let mut stale_reset_count = state.stale_reset_count();
         if state.refresh_task_scheduled() {
             let age_ms = state.refresh_scheduled_at_ms().map(|at| now_ms - at);
+            stale_reset_count = stale_reset_count.saturating_add(1);
+            let next_stale_window_ms = stale_window_ms(
+                self.floating_refresh_stale_ms,
+                stale_reset_count,
+                self.floating_refresh_stale_max_ms,
+            );
             tracing::warn!(
                 tenant = %tenant,
                 queue_key = %queue_key,
                 age_ms = ?age_ms,
+                stale_resets = stale_reset_count,
+                next_stale_window_ms,
                 "floating limit refresh flag is stale; scheduling a replacement refresh"
             );
             if let Some(m) = &self.metrics {
@@ -504,6 +538,7 @@ impl JobStoreShard {
         let new_state = FloatingLimitState {
             refresh_task_scheduled: true,
             refresh_scheduled_at_ms: Some(now_ms),
+            stale_reset_count,
             ..state.to_owned()
         };
         let state_key = floating_limit_state_key(tenant, queue_key);
@@ -561,6 +596,7 @@ impl JobStoreShard {
             refresh_scheduled_at_ms: None,
             retry_count: 0,
             next_retry_at_ms: None,
+            stale_reset_count: 0,
             ..decoded_state.to_owned()
         };
 
@@ -663,6 +699,7 @@ impl JobStoreShard {
             next_retry_at_ms: Some(next_retry_at),
             refresh_task_scheduled: has_waiters,
             refresh_scheduled_at_ms: has_waiters.then_some(next_retry_at),
+            stale_reset_count: 0,
             ..decoded_state.to_owned()
         };
 

--- a/src/job_store_shard/floating.rs
+++ b/src/job_store_shard/floating.rs
@@ -11,7 +11,7 @@ use crate::codec::{
 };
 use crate::job::{FloatingConcurrencyLimit, FloatingLimitState, JobView};
 use crate::job_store_shard::helpers::{DbWriteBatcher, WriteBatcher, now_epoch_ms};
-use crate::job_store_shard::{JobStoreShard, JobStoreShardError};
+use crate::job_store_shard::{JobStoreShard, JobStoreShardError, ScheduledRefreshes};
 use crate::keys::{
     concurrency_request_prefix, end_bound, floating_limit_state_key, job_info_key, leased_task_key,
     parse_refresh_task_key, refresh_task_group_prefix, refresh_task_key, refresh_tasks_prefix,
@@ -30,26 +30,48 @@ pub const REFRESH_INDEX_ROW_TTL_MS: i64 = 24 * 60 * 60 * 1000;
 pub const REFRESH_DRAIN_MAX_LEASED: usize = 16;
 
 /// `base_ms` doubled `stale_reset_count` times, capped at `max_ms`, with
-/// the shift saturating instead of overflowing.
+/// the shift saturating instead of overflowing. A cap below the base is
+/// treated as the base: the cap bounds growth, it never shrinks the window.
 fn stale_window_ms(base_ms: i64, stale_reset_count: u32, max_ms: i64) -> i64 {
     let widened = if stale_reset_count >= i64::BITS - 1 {
         i64::MAX
     } else {
         base_ms.saturating_mul(1i64 << stale_reset_count)
     };
-    widened.min(max_ms)
+    widened.min(max_ms).max(base_ms)
 }
 
 impl JobStoreShard {
     /// Mark `task_group` as possibly holding a refresh index row. Called
-    /// before every index put's batch commits, so a drain never skips a
-    /// group with a row in flight.
+    /// only after the put's batch is durable: a mark made before the row is
+    /// visible could be cleared by a drain that scans the still-empty range,
+    /// leaving the committed row unmarked. A drain that runs between the
+    /// commit and the mark misses the row once; the next drain sees it.
     fn mark_refresh_pending(&self, task_group: &str) {
         let mut groups = self
             .refresh_pending_groups
             .lock()
             .expect("refresh pending groups lock");
         *groups.entry(task_group.to_string()).or_insert(0) += 1;
+    }
+
+    /// Mark every group in `task_groups` pending, after the batch that wrote
+    /// their index rows is durable.
+    pub(crate) fn mark_refresh_pending_groups<'a>(
+        &self,
+        task_groups: impl IntoIterator<Item = &'a str>,
+    ) {
+        for task_group in task_groups {
+            self.mark_refresh_pending(task_group);
+        }
+    }
+
+    /// Whether `task_group` may hold a refresh index row.
+    fn refresh_group_pending(&self, task_group: &str) -> bool {
+        self.refresh_pending_groups
+            .lock()
+            .expect("refresh pending groups lock")
+            .contains_key(task_group)
     }
 
     /// Warm the pending-group gate from the durable refresh index at shard
@@ -99,21 +121,30 @@ impl JobStoreShard {
                 ttl: Ttl::ExpireAt(now_epoch_ms() + REFRESH_INDEX_ROW_TTL_MS),
             },
         );
-        self.mark_refresh_pending(task_group);
         self.db.write(batch).await?;
+        self.mark_refresh_pending(task_group);
         Ok(())
     }
 
     /// Lease every claimable refresh index row under `task_group`, up to
     /// `REFRESH_DRAIN_MAX_LEASED`, in one durable batch. Rows for tenants
-    /// outside the shard range are deleted; rows whose `not_before_ms` is in
-    /// the future stay for a later drain. Index keys never reach the task
-    /// broker, so nothing here is acked or tombstoned.
+    /// outside the shard range and unreadable rows are deleted; rows whose
+    /// `not_before_ms` is in the future stay for a later drain. Index keys
+    /// never reach the task broker, so nothing here is acked or tombstoned.
+    /// Drains on one shard are serialized from scan to commit, so two
+    /// workers polling the same group cannot both lease one row; the
+    /// pending-group check runs first so idle groups never wait on the lock.
     pub async fn drain_pending_refreshes(
         &self,
         worker_id: &str,
         task_group: &str,
     ) -> Result<Vec<LeasedRefreshTask>, JobStoreShardError> {
+        if !self.refresh_group_pending(task_group) {
+            return Ok(Vec::new());
+        }
+        let _drain = self.refresh_drain_lock.lock().await;
+        // Re-read under the lock: the drain that just released it may have
+        // emptied the range and cleared the group.
         let generation = {
             let groups = self
                 .refresh_pending_groups
@@ -156,12 +187,16 @@ impl JobStoreShard {
             let decoded = match decode_task_validated(kv.value) {
                 Ok(decoded) => decoded,
                 Err(e) => {
+                    // The state row's stale window reschedules a readable
+                    // replacement; keeping the row would pin the group
+                    // pending until its TTL.
                     tracing::warn!(
                         tenant = %parsed.tenant,
                         queue_key = %parsed.queue_key,
                         error = %e,
-                        "refresh index row is unreadable; skipping"
+                        "refresh index row is unreadable; dropping it"
                     );
+                    batch.delete(&kv.key);
                     continue;
                 }
             };
@@ -195,8 +230,10 @@ impl JobStoreShard {
         }
 
         if range_empty {
-            // A put that landed since the scan began bumped the generation
-            // and keeps the group marked.
+            // A put committed and marked since the scan began bumped the
+            // generation and keeps the group marked. This relies on marks
+            // being made only after their row is durable (see
+            // `mark_refresh_pending`).
             let mut groups = self
                 .refresh_pending_groups
                 .lock()
@@ -388,27 +425,39 @@ impl JobStoreShard {
             return Ok(false);
         }
         self.db.write(batch).await?;
+        self.mark_refresh_pending(&task_group);
         Ok(true)
     }
 
     /// Schedule a refresh for a RequestTicket that just landed as a waiter on
     /// a floating queue. The ticket's own request row sits in the uncommitted
     /// batch, invisible to the durable waiter probe, so the ticket supplies
-    /// the waiter signal directly. Returns whether a task was written.
+    /// the waiter signal directly. `scheduled_refreshes` is the batch's
+    /// record: a queue already scheduled in this batch is skipped, and a
+    /// written row is recorded for the batch owner to mark once durable.
+    /// Returns whether a row was written.
     pub(crate) async fn schedule_floating_refresh_for_ticket<W: WriteBatcher>(
         &self,
         writer: &mut W,
+        scheduled_refreshes: &mut ScheduledRefreshes,
         tenant: &str,
         fl: &FloatingConcurrencyLimit,
         now_ms: i64,
         task_group: &str,
     ) -> Result<bool, JobStoreShardError> {
+        if scheduled_refreshes.contains(tenant, &fl.key) {
+            return Ok(false);
+        }
         let state = self
             .get_or_create_floating_limit_state(writer, tenant, fl)
             .await?;
-        self.maybe_schedule_floating_limit_refresh(
+        let written = self.maybe_schedule_floating_limit_refresh(
             writer, tenant, &fl.key, &state, now_ms, task_group, true,
-        )
+        )?;
+        if written {
+            scheduled_refreshes.record(tenant, &fl.key, task_group);
+        }
+        Ok(written)
     }
 
     /// Get or create the floating limit state for a given queue key.
@@ -532,7 +581,6 @@ impl JobStoreShard {
             encode_refresh_index_row(&refresh_task, None),
             now_ms + REFRESH_INDEX_ROW_TTL_MS,
         )?;
-        self.mark_refresh_pending(task_group);
 
         // Update state to mark refresh as scheduled
         let new_state = FloatingLimitState {
@@ -723,13 +771,13 @@ impl JobStoreShard {
                     ttl: Ttl::ExpireAt(now_ms + REFRESH_INDEX_ROW_TTL_MS),
                 },
             );
-            self.mark_refresh_pending(&task_group);
         }
         batch.delete(&lease_key);
 
         self.db.write(batch).await?;
 
         if has_waiters {
+            self.mark_refresh_pending(&task_group);
             tracing::warn!(
                 queue_key = %queue_key,
                 error_code = %error_code,
@@ -750,5 +798,43 @@ impl JobStoreShard {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stale_window_ms;
+
+    #[test]
+    fn stale_window_doubles_per_reset_up_to_the_cap() {
+        let cases = [
+            (60_000, 0, 3_600_000, 60_000),
+            (60_000, 1, 3_600_000, 120_000),
+            (60_000, 5, 3_600_000, 1_920_000),
+            (60_000, 6, 3_600_000, 3_600_000),
+            (100, 2, 300, 300),
+        ];
+        for (base, count, max, want) in cases {
+            assert_eq!(
+                stale_window_ms(base, count, max),
+                want,
+                "stale_window_ms({base}, {count}, {max})"
+            );
+        }
+    }
+
+    #[test]
+    fn stale_window_saturates_instead_of_overflowing() {
+        assert_eq!(stale_window_ms(60_000, 62, i64::MAX), i64::MAX);
+        assert_eq!(stale_window_ms(60_000, 63, i64::MAX), i64::MAX);
+        assert_eq!(stale_window_ms(1, u32::MAX, i64::MAX), i64::MAX);
+        assert_eq!(stale_window_ms(i64::MAX, 1, i64::MAX), i64::MAX);
+    }
+
+    #[test]
+    fn stale_window_never_shrinks_below_the_base() {
+        assert_eq!(stale_window_ms(60_000, 0, 1_000), 60_000);
+        assert_eq!(stale_window_ms(60_000, 3, 1_000), 60_000);
+        assert_eq!(stale_window_ms(0, 5, 3_600_000), 0);
     }
 }

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -17,7 +17,9 @@ use crate::job_store_shard::helpers::{
     TxnWriter, decode_job_status_owned, find_task_by_identity, now_epoch_ms,
     put_with_optional_expire, retry_on_txn_conflict,
 };
-use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
+use crate::job_store_shard::{
+    JobStoreShard, JobStoreShardError, LimitTaskParams, ScheduledRefreshes,
+};
 use crate::keys::{
     attempt_key, attempt_prefix, concurrency_holder_key, end_bound, idx_metadata_key,
     job_cancelled_key, job_info_key, job_status_key,
@@ -296,6 +298,7 @@ impl JobStoreShard {
                         held_queues: Vec::new(),
                         task_group: &params.task_group,
                         skip_try_reserve: false,
+                        scheduled_refreshes: &mut ScheduledRefreshes::default(),
                     },
                 )
                 .await?
@@ -748,6 +751,7 @@ impl JobStoreShard {
                         held_queues: Vec::new(),
                         task_group: &task_group,
                         skip_try_reserve: false,
+                        scheduled_refreshes: &mut ScheduledRefreshes::default(),
                     },
                 )
                 .await

--- a/src/job_store_shard/import.rs
+++ b/src/job_store_shard/import.rs
@@ -273,6 +273,7 @@ impl JobStoreShard {
         // [SILO-IMP-CONC-3] Queue at capacity -> try_reserve fails in enqueue_limit_task_at_index
         // [SILO-IMP-CONC-4] Request created (no task in DB) when concurrency queued
         let mut grants = Vec::new();
+        let mut scheduled_refreshes = ScheduledRefreshes::default();
         if !is_terminal {
             let next_attempt = num_attempts + 1;
             let task_id = Uuid::new_v4().to_string();
@@ -298,7 +299,7 @@ impl JobStoreShard {
                         held_queues: Vec::new(),
                         task_group: &params.task_group,
                         skip_try_reserve: false,
-                        scheduled_refreshes: &mut ScheduledRefreshes::default(),
+                        scheduled_refreshes: &mut scheduled_refreshes,
                     },
                 )
                 .await?
@@ -347,6 +348,7 @@ impl JobStoreShard {
         if let Some(op) = write_op {
             dst_events::confirm_write(op);
         }
+        self.mark_refresh_pending_groups(scheduled_refreshes.task_groups());
 
         // For non-terminal, finish enqueue (flush + broker wakeup)
         if !is_terminal {
@@ -723,6 +725,7 @@ impl JobStoreShard {
 
         // Create new scheduling state if non-terminal
         let mut grants = Vec::new();
+        let mut scheduled_refreshes = ScheduledRefreshes::default();
         if !is_terminal {
             let next_attempt = total_attempts + 1;
             let new_task_id = Uuid::new_v4().to_string();
@@ -751,7 +754,7 @@ impl JobStoreShard {
                         held_queues: Vec::new(),
                         task_group: &task_group,
                         skip_try_reserve: false,
-                        scheduled_refreshes: &mut ScheduledRefreshes::default(),
+                        scheduled_refreshes: &mut scheduled_refreshes,
                     },
                 )
                 .await
@@ -832,6 +835,7 @@ impl JobStoreShard {
         if let Some(op) = write_op {
             dst_events::confirm_write(op);
         }
+        self.mark_refresh_pending_groups(scheduled_refreshes.task_groups());
 
         // [SILO-REIMP-6] Remove buffered tasks for this job.
         // Must happen after commit so the scanner cannot re-buffer old tasks from DB.

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -168,6 +168,7 @@ impl JobStoreShard {
         let mut followup_next_time: Option<i64> = None;
         // Track grants from retry scheduling for rollback if DB write fails
         let mut retry_grants: Vec<(String, String)> = Vec::new();
+        let mut retry_scheduled_refreshes = ScheduledRefreshes::default();
         let mut background_action_transitions: Vec<BackgroundActionMetricTransition> = Vec::new();
         // Track the new job status for DST event emission
         let mut new_job_status_for_dst: Option<String> = None;
@@ -295,7 +296,7 @@ impl JobStoreShard {
                                     held_queues: Vec::new(),
                                     task_group,
                                     skip_try_reserve: true,
-                                    scheduled_refreshes: &mut ScheduledRefreshes::default(),
+                                    scheduled_refreshes: &mut retry_scheduled_refreshes,
                                 },
                             )
                             .await?
@@ -478,6 +479,7 @@ impl JobStoreShard {
             return Err(e.into());
         }
         dst_events::confirm_write(write_op);
+        self.mark_refresh_pending_groups(retry_scheduled_refreshes.task_groups());
 
         // Post-commit: release in-memory concurrency counts and signal grant
         // scanner. Drain the guard (leaving it armed-but-empty so its Drop is a

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -14,7 +14,9 @@ use crate::job_attempt::{AttemptOutcome, AttemptStatus, JobAttempt};
 use crate::job_store_shard::counters::BackgroundActionMetricTransition;
 use crate::job_store_shard::helpers::{DbWriteBatcher, WriteBatcher, now_epoch_ms};
 use crate::job_store_shard::holder_release_guard::PendingHolderReleaseGuard;
-use crate::job_store_shard::{JobStoreShard, JobStoreShardError, LimitTaskParams};
+use crate::job_store_shard::{
+    JobStoreShard, JobStoreShardError, LimitTaskParams, ScheduledRefreshes,
+};
 use crate::keys::{
     attempt_key, attempt_prefix, concurrency_holder_key, concurrency_holders_tenant_prefix,
     end_bound, floating_limit_state_key, idx_metadata_key, job_cancelled_key, job_info_key,
@@ -293,6 +295,7 @@ impl JobStoreShard {
                                     held_queues: Vec::new(),
                                     task_group,
                                     skip_try_reserve: true,
+                                    scheduled_refreshes: &mut ScheduledRefreshes::default(),
                                 },
                             )
                             .await?

--- a/src/job_store_shard/lease.rs
+++ b/src/job_store_shard/lease.rs
@@ -664,6 +664,7 @@ impl JobStoreShard {
         let new_state = FloatingLimitState {
             refresh_task_scheduled: false,
             refresh_scheduled_at_ms: None,
+            stale_reset_count: 0,
             ..decoded_state.to_owned()
         };
 

--- a/src/job_store_shard/limit_chain.rs
+++ b/src/job_store_shard/limit_chain.rs
@@ -123,6 +123,12 @@ impl LimitChainResumer for ShardChainResumer {
         }
     }
 
+    fn refresh_index_rows_committed(&self, task_groups: &[String]) {
+        if let Some(shard) = self.shard.upgrade() {
+            shard.mark_refresh_pending_groups(task_groups.iter().map(String::as_str));
+        }
+    }
+
     async fn maybe_schedule_floating_refresh(
         &self,
         tenant: &str,

--- a/src/job_store_shard/limit_chain.rs
+++ b/src/job_store_shard/limit_chain.rs
@@ -20,7 +20,7 @@ use crate::codec::DecodedFloatingLimitState;
 use crate::concurrency::{ConcurrencyError, LimitChainResumer, ResumeChainParams};
 use crate::job_store_shard::helpers::DbWriteBatcher;
 use crate::job_store_shard::{
-    JobStoreShard, JobStoreShardError, LimitTaskParams, LimitTaskWriteResult,
+    JobStoreShard, JobStoreShardError, LimitTaskParams, LimitTaskWriteResult, ScheduledRefreshes,
 };
 
 pub(crate) struct ShardChainResumer {
@@ -40,6 +40,7 @@ impl LimitChainResumer for ShardChainResumer {
     async fn resume_chain(
         &self,
         batch: &mut WriteBatch,
+        scheduled_refreshes: &mut ScheduledRefreshes,
         params: ResumeChainParams,
     ) -> Result<Vec<(String, String)>, ConcurrencyError> {
         let shard = self
@@ -98,6 +99,7 @@ impl LimitChainResumer for ShardChainResumer {
                     held_queues: params.held_queues.clone(),
                     task_group: &params.task_group,
                     skip_try_reserve: false,
+                    scheduled_refreshes,
                 },
             )
             .await

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -258,6 +258,9 @@ pub struct JobStoreShard {
     /// unchanged generation. `BTreeMap` keeps iteration deterministic for
     /// the simulation harness.
     pub(crate) refresh_pending_groups: std::sync::Mutex<std::collections::BTreeMap<String, u64>>,
+    /// Serializes refresh index drains from scan to commit, so concurrent
+    /// polls for one group cannot both lease the same row.
+    pub(crate) refresh_drain_lock: tokio::sync::Mutex<()>,
 }
 
 #[derive(Debug, Error)]
@@ -626,6 +629,7 @@ impl JobStoreShard {
             floating_refresh_stale_max_ms: i64::try_from(floating_refresh_stale_max_ms)
                 .unwrap_or(i64::MAX),
             refresh_pending_groups: std::sync::Mutex::new(std::collections::BTreeMap::new()),
+            refresh_drain_lock: tokio::sync::Mutex::new(()),
         });
 
         // The refresh index holds at most one row per floating queue with a

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -134,6 +134,9 @@ pub struct OpenShardOptions {
     /// before a replacement refresh may be scheduled. Populated from
     /// `DatabaseConfig::floating_refresh_stale_ms`.
     pub floating_refresh_stale_ms: u64,
+    /// Cap (ms) on the stale window widened by consecutive stale resets.
+    /// Populated from `DatabaseConfig::floating_refresh_stale_max_ms`.
+    pub floating_refresh_stale_max_ms: u64,
     /// Scan generations an ack tombstone may keep suppressing a re-observed
     /// task key before the broker point-reads the row. Populated from
     /// `DatabaseConfig::broker_tombstone_revive_after_generations`.
@@ -244,8 +247,11 @@ pub struct JobStoreShard {
     /// from per-status counters instead of a full status-index scan.
     pub(crate) count_from_status_counters: bool,
     /// Age (ms) past which a set `refresh_task_scheduled` flag is treated as
-    /// a lost refresh rather than an outstanding one.
+    /// a lost refresh rather than an outstanding one, before consecutive
+    /// stale resets widen it.
     pub(crate) floating_refresh_stale_ms: i64,
+    /// The widest the stale window grows under consecutive stale resets.
+    pub(crate) floating_refresh_stale_max_ms: i64,
     /// Task groups that may hold a refresh index row, each with a generation
     /// bumped by every index put. A drain skips groups not present here and
     /// removes a group only when its scan found the range empty at an
@@ -446,6 +452,7 @@ impl JobStoreShard {
                 terminal_job_expire_s: cfg.terminal_job_expire_s,
                 count_from_status_counters: cfg.count_from_status_counters,
                 floating_refresh_stale_ms: cfg.floating_refresh_stale_ms,
+                floating_refresh_stale_max_ms: cfg.floating_refresh_stale_max_ms,
                 broker_tombstone_revive_after_generations: cfg
                     .broker_tombstone_revive_after_generations,
             },
@@ -493,6 +500,7 @@ impl JobStoreShard {
             terminal_job_expire_s,
             count_from_status_counters,
             floating_refresh_stale_ms,
+            floating_refresh_stale_max_ms,
             broker_tombstone_revive_after_generations,
         } = options;
 
@@ -615,6 +623,8 @@ impl JobStoreShard {
             // Epoch-ms arithmetic needs an i64; a value past i64::MAX saturates
             // and means only stamp-less rows ever read as stale.
             floating_refresh_stale_ms: i64::try_from(floating_refresh_stale_ms).unwrap_or(i64::MAX),
+            floating_refresh_stale_max_ms: i64::try_from(floating_refresh_stale_max_ms)
+                .unwrap_or(i64::MAX),
             refresh_pending_groups: std::sync::Mutex::new(std::collections::BTreeMap::new()),
         });
 

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -31,6 +31,7 @@ pub use restart::JobNotRestartableError;
 
 pub use enqueue::ScheduledRefreshes;
 pub(crate) use enqueue::{LimitTaskParams, LimitTaskWriteResult};
+pub use floating::{REFRESH_DRAIN_MAX_LEASED, REFRESH_INDEX_ROW_TTL_MS};
 use helpers::DbWriteBatcher;
 use helpers::WriteBatcher;
 pub use helpers::now_epoch_ms;
@@ -245,6 +246,12 @@ pub struct JobStoreShard {
     /// Age (ms) past which a set `refresh_task_scheduled` flag is treated as
     /// a lost refresh rather than an outstanding one.
     pub(crate) floating_refresh_stale_ms: i64,
+    /// Task groups that may hold a refresh index row, each with a generation
+    /// bumped by every index put. A drain skips groups not present here and
+    /// removes a group only when its scan found the range empty at an
+    /// unchanged generation. `BTreeMap` keeps iteration deterministic for
+    /// the simulation harness.
+    pub(crate) refresh_pending_groups: std::sync::Mutex<std::collections::BTreeMap<String, u64>>,
 }
 
 #[derive(Debug, Error)]
@@ -608,7 +615,19 @@ impl JobStoreShard {
             // Epoch-ms arithmetic needs an i64; a value past i64::MAX saturates
             // and means only stamp-less rows ever read as stale.
             floating_refresh_stale_ms: i64::try_from(floating_refresh_stale_ms).unwrap_or(i64::MAX),
+            refresh_pending_groups: std::sync::Mutex::new(std::collections::BTreeMap::new()),
         });
+
+        // The refresh index holds at most one row per floating queue with a
+        // pending refresh, so warming the pending-group gate from it is one
+        // small prefix scan, and it runs on every open.
+        let warm_started = std::time::Instant::now();
+        shard.warm_refresh_pending_groups().await?;
+        tracing::debug!(
+            shard = %shard.name,
+            elapsed_ms = warm_started.elapsed().as_millis() as u64,
+            "shard open: warm refresh pending groups"
+        );
 
         // Install the chain resumer before starting the grant scanner so the
         // scanner's first wake-up has a working callback for resuming limit

--- a/src/job_store_shard/mod.rs
+++ b/src/job_store_shard/mod.rs
@@ -29,6 +29,7 @@ pub use import::JobNotReimportableError;
 pub use lease_task::JobNotLeaseableError;
 pub use restart::JobNotRestartableError;
 
+pub use enqueue::ScheduledRefreshes;
 pub(crate) use enqueue::{LimitTaskParams, LimitTaskWriteResult};
 use helpers::DbWriteBatcher;
 use helpers::WriteBatcher;

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -24,6 +24,7 @@ pub mod prefix {
     pub const CONCURRENCY_HOLDER: u8 = 0x09;
     pub const JOB_CANCELLED: u8 = 0x0A;
     pub const FLOATING_LIMIT: u8 = 0x0B;
+    pub const REFRESH_TASK: u8 = 0x0C;
     pub const COUNTER_TOTAL_JOBS: u8 = 0xF0;
     pub const COUNTER_COMPLETED_JOBS: u8 = 0xF1;
     pub const CLEANUP_PROGRESS: u8 = 0xF2;
@@ -569,6 +570,51 @@ pub fn parse_floating_limit_key(key: &[u8]) -> Option<ParsedFloatingLimitKey> {
     }
     let (tenant, queue_key): (String, String) = decode(&key[1..]).ok()?;
     Some(ParsedFloatingLimitKey { tenant, queue_key })
+}
+
+/// The refresh index row for a floating queue's pending refresh task. One
+/// row per queue per task group; a drain for `task_group` scans its prefix
+/// and hands every claimable row to the polling worker, independent of the
+/// group's job backlog in the task line.
+pub fn refresh_task_key(task_group: &str, tenant: &str, queue_key: &str) -> Vec<u8> {
+    encode_with_prefix(prefix::REFRESH_TASK, &(task_group, tenant, queue_key))
+}
+
+/// Prefix for scanning the refresh index rows of one task group.
+pub fn refresh_task_group_prefix(task_group: &str) -> Vec<u8> {
+    encode_with_prefix(prefix::REFRESH_TASK, &(task_group,))
+}
+
+/// Prefix for scanning the refresh index rows of one tenant within a task
+/// group.
+pub fn refresh_task_tenant_prefix(task_group: &str, tenant: &str) -> Vec<u8> {
+    encode_with_prefix(prefix::REFRESH_TASK, &(task_group, tenant))
+}
+
+/// Prefix for scanning every refresh index row.
+pub fn refresh_tasks_prefix() -> Vec<u8> {
+    vec![prefix::REFRESH_TASK]
+}
+
+/// Parsed refresh index key components.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedRefreshTaskKey {
+    pub task_group: String,
+    pub tenant: String,
+    pub queue_key: String,
+}
+
+/// Parse a refresh index key back to its components.
+pub fn parse_refresh_task_key(key: &[u8]) -> Option<ParsedRefreshTaskKey> {
+    if key.first() != Some(&prefix::REFRESH_TASK) {
+        return None;
+    }
+    let (task_group, tenant, queue_key): (String, String, String) = decode(&key[1..]).ok()?;
+    Some(ParsedRefreshTaskKey {
+        task_group,
+        tenant,
+        queue_key,
+    })
 }
 
 /// Key for the total jobs counter for this shard.

--- a/src/query.rs
+++ b/src/query.rs
@@ -3128,10 +3128,10 @@ pub fn classify_floating_refresh_tasks_filters(
         .iter()
         .map(|f| {
             let exact = match (&strategy, parse_eq_filter(&unqualify_expr(f))) {
-                (FloatingRefreshTasksScanStrategy::Prefix { .. }, Some((col, _)))
+                (FloatingRefreshTasksScanStrategy::Prefix { task_group, .. }, Some((col, val)))
                     if col == "task_group" =>
                 {
-                    true
+                    *task_group == val
                 }
                 (FloatingRefreshTasksScanStrategy::Prefix { tenant, .. }, Some((col, val)))
                     if col == "tenant" =>

--- a/src/query.rs
+++ b/src/query.rs
@@ -187,6 +187,14 @@ impl ShardQueryEngine {
         let tasks_provider = Arc::new(SiloTableProvider::new(tasks_schema, tasks_scanner));
         ctx.register_table("tasks", tasks_provider)?;
 
+        // Register floating_refresh_tasks table over the refresh index
+        let refresh_schema = FloatingRefreshTasksScanner::base_schema();
+        let refresh_scanner: ScannerRef = Arc::new(FloatingRefreshTasksScanner {
+            shard: Arc::clone(&shard),
+        });
+        let refresh_provider = Arc::new(SiloTableProvider::new(refresh_schema, refresh_scanner));
+        ctx.register_table("floating_refresh_tasks", refresh_provider)?;
+
         Ok(Self { ctx })
     }
 
@@ -3011,6 +3019,263 @@ impl Scan for TasksScanner {
                                 other
                             )))?
                         }
+                    };
+                    cols.push(col);
+                }
+
+                yield RecordBatch::try_new(Arc::clone(&proj), cols).map_err(exec_err)?;
+            }
+        };
+
+        Box::pin(RecordBatchStreamAdapter::new(projection, Box::pin(stream)))
+    }
+}
+
+/// Scanner for the `floating_refresh_tasks` table over the refresh index:
+/// one row per floating queue with a pending cap refresh, keyed by
+/// `(task_group, tenant, queue_key)`. `task_group` and `tenant` equality
+/// filters push down as key prefix bounds; `tenant` narrows the prefix only
+/// together with `task_group`.
+///
+/// Schema: shard_id, task_group, tenant, queue_key, task_id, not_before_ms,
+/// current_max_concurrency, last_refreshed_at_ms
+pub struct FloatingRefreshTasksScanner {
+    pub(crate) shard: Arc<JobStoreShard>,
+}
+
+impl FloatingRefreshTasksScanner {
+    pub fn new(shard: Arc<JobStoreShard>) -> Self {
+        Self { shard }
+    }
+
+    pub fn base_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("shard_id", DataType::Utf8, false),
+            Field::new("task_group", DataType::Utf8, false),
+            Field::new("tenant", DataType::Utf8, false),
+            Field::new("queue_key", DataType::Utf8, false),
+            Field::new("task_id", DataType::Utf8, false),
+            Field::new("not_before_ms", DataType::Int64, true),
+            Field::new("current_max_concurrency", DataType::UInt32, false),
+            Field::new("last_refreshed_at_ms", DataType::Int64, false),
+        ]))
+    }
+}
+
+impl std::fmt::Debug for FloatingRefreshTasksScanner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("FloatingRefreshTasksScanner")
+    }
+}
+
+/// Scan strategy for the `floating_refresh_tasks` table: the key prefix the
+/// pushed-down equality filters bound the scan to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FloatingRefreshTasksScanStrategy {
+    /// Scan one task group, optionally one tenant within it.
+    Prefix {
+        task_group: String,
+        tenant: Option<String>,
+    },
+    /// Scan the whole index.
+    FullScan,
+}
+
+impl std::fmt::Display for FloatingRefreshTasksScanStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FloatingRefreshTasksScanStrategy::Prefix { task_group, tenant } => {
+                write!(
+                    f,
+                    "Prefix(task_group={:?}, tenant={:?})",
+                    task_group, tenant
+                )
+            }
+            FloatingRefreshTasksScanStrategy::FullScan => write!(f, "FullScan"),
+        }
+    }
+}
+
+/// Parse filters into a `FloatingRefreshTasksScanStrategy`.
+pub fn parse_floating_refresh_tasks_scan_strategy(
+    filters: &[Expr],
+) -> FloatingRefreshTasksScanStrategy {
+    let mut task_group: Option<String> = None;
+    let mut tenant: Option<String> = None;
+    for f in filters {
+        if let Some((col, val)) = parse_eq_filter(f) {
+            match col.as_str() {
+                "task_group" => task_group = Some(val),
+                "tenant" => tenant = Some(val),
+                _ => {}
+            }
+        }
+    }
+    match task_group {
+        Some(task_group) => FloatingRefreshTasksScanStrategy::Prefix { task_group, tenant },
+        None => FloatingRefreshTasksScanStrategy::FullScan,
+    }
+}
+
+/// Classify `floating_refresh_tasks` filters for pushdown: the equalities
+/// the prefix scan answers are Exact, everything else is re-applied.
+pub fn classify_floating_refresh_tasks_filters(
+    filters: &[&Expr],
+) -> Vec<TableProviderFilterPushDown> {
+    let unqualified_filters: Vec<Expr> = filters.iter().map(|f| unqualify_expr(f)).collect();
+    let strategy = parse_floating_refresh_tasks_scan_strategy(&unqualified_filters);
+    filters
+        .iter()
+        .map(|f| {
+            let exact = match (&strategy, parse_eq_filter(&unqualify_expr(f))) {
+                (FloatingRefreshTasksScanStrategy::Prefix { .. }, Some((col, _)))
+                    if col == "task_group" =>
+                {
+                    true
+                }
+                (FloatingRefreshTasksScanStrategy::Prefix { tenant, .. }, Some((col, val)))
+                    if col == "tenant" =>
+                {
+                    tenant.as_deref() == Some(val.as_str())
+                }
+                _ => false,
+            };
+            if exact {
+                TableProviderFilterPushDown::Exact
+            } else {
+                TableProviderFilterPushDown::Inexact
+            }
+        })
+        .collect()
+}
+
+impl Scan for FloatingRefreshTasksScanner {
+    fn describe(&self, filters: &[Expr], limit: Option<usize>) -> String {
+        let strategy = parse_floating_refresh_tasks_scan_strategy(filters);
+        format!("floating_refresh_tasks[{}], limit={:?}", strategy, limit)
+    }
+
+    fn classify_filters(&self, filters: &[&Expr]) -> Vec<TableProviderFilterPushDown> {
+        classify_floating_refresh_tasks_filters(filters)
+    }
+
+    fn scan(
+        &self,
+        projection: SchemaRef,
+        filters: &[Expr],
+        batch_size: usize,
+        limit: Option<usize>,
+    ) -> SendableRecordBatchStream {
+        let strategy = parse_floating_refresh_tasks_scan_strategy(filters);
+        let shard = Arc::clone(&self.shard);
+        let proj = Arc::clone(&projection);
+
+        let stream = async_stream::try_stream! {
+            let start = match &strategy {
+                FloatingRefreshTasksScanStrategy::Prefix {
+                    task_group,
+                    tenant: Some(tenant),
+                } => crate::keys::refresh_task_tenant_prefix(task_group, tenant),
+                FloatingRefreshTasksScanStrategy::Prefix { task_group, tenant: None } => {
+                    crate::keys::refresh_task_group_prefix(task_group)
+                }
+                FloatingRefreshTasksScanStrategy::FullScan => crate::keys::refresh_tasks_prefix(),
+            };
+            let end = crate::keys::end_bound(&start);
+
+            let mut cursor = shard
+                .open_range_cursor(start, end, &crate::scan_options())
+                .await
+                .map_err(exec_err)?;
+            let shard_id = shard.name().to_string();
+            let mut buf: VecDeque<KeyValue> = VecDeque::new();
+            let mut exhausted = false;
+            let mut total_emitted: usize = 0;
+
+            loop {
+                if limit.is_some_and(|l| total_emitted >= l) {
+                    break;
+                }
+                let remaining = limit.map(|l| l - total_emitted).unwrap_or(batch_size);
+                let target = remaining.min(batch_size).max(1);
+
+                let mut shard_ids = Vec::with_capacity(target);
+                let mut task_groups = Vec::with_capacity(target);
+                let mut tenants = Vec::with_capacity(target);
+                let mut queue_keys = Vec::with_capacity(target);
+                let mut task_ids = Vec::with_capacity(target);
+                let mut not_befores: Vec<Option<i64>> = Vec::with_capacity(target);
+                let mut current_maxes = Vec::with_capacity(target);
+                let mut last_refreshed = Vec::with_capacity(target);
+                let mut batch_count: usize = 0;
+
+                while batch_count < target {
+                    if buf.is_empty() {
+                        if exhausted {
+                            break;
+                        }
+                        let chunk = cursor
+                            .next_kv_chunk(batch_size.max(DEFAULT_SCAN_CHUNK))
+                            .await
+                            .map_err(exec_err)?;
+                        if chunk.is_empty() {
+                            exhausted = true;
+                            break;
+                        }
+                        buf.extend(chunk);
+                    }
+                    let kv = buf.pop_front().expect("buffer non-empty");
+                    let Some(parsed) = crate::keys::parse_refresh_task_key(&kv.key) else {
+                        continue;
+                    };
+                    let decoded = match crate::codec::decode_task_validated(
+                        bytes::Bytes::copy_from_slice(&kv.value),
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => continue,
+                    };
+                    let Some(rfl) = decoded.as_refresh_floating_limit() else {
+                        continue;
+                    };
+
+                    shard_ids.push(shard_id.clone());
+                    task_groups.push(parsed.task_group);
+                    tenants.push(parsed.tenant);
+                    queue_keys.push(parsed.queue_key);
+                    task_ids.push(rfl.task_id().unwrap_or_default().to_string());
+                    not_befores.push(rfl.not_before_ms());
+                    current_maxes.push(rfl.current_max_concurrency());
+                    last_refreshed.push(rfl.last_refreshed_at_ms());
+                    batch_count += 1;
+                }
+
+                if batch_count == 0 {
+                    break;
+                }
+                total_emitted += batch_count;
+
+                if proj.fields().is_empty() {
+                    yield make_empty_projection_batch(&proj, batch_count)?;
+                    continue;
+                }
+
+                let mut cols: Vec<ArrayRef> = Vec::with_capacity(proj.fields().len());
+                for f in proj.fields() {
+                    let col: ArrayRef = match f.name().as_str() {
+                        "shard_id" => Arc::new(StringArray::from(shard_ids.clone())),
+                        "task_group" => Arc::new(StringArray::from(task_groups.clone())),
+                        "tenant" => Arc::new(StringArray::from(tenants.clone())),
+                        "queue_key" => Arc::new(StringArray::from(queue_keys.clone())),
+                        "task_id" => Arc::new(StringArray::from(task_ids.clone())),
+                        "not_before_ms" => Arc::new(Int64Array::from(not_befores.clone())),
+                        "current_max_concurrency" => {
+                            Arc::new(UInt32Array::from(current_maxes.clone()))
+                        }
+                        "last_refreshed_at_ms" => Arc::new(Int64Array::from(last_refreshed.clone())),
+                        other => Err(DataFusionError::Execution(format!(
+                            "unknown floating_refresh_tasks column: {}",
+                            other
+                        )))?,
                     };
                     cols.push(col);
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -103,6 +103,30 @@ fn proto_limit_to_job_limit(proto: Limit) -> Option<crate::job::Limit> {
     }
 }
 
+/// Convert a leased refresh task into its proto message. The default `-`
+/// tenant is reported as no tenant.
+fn refresh_task_to_proto(
+    rt: crate::task::LeasedRefreshTask,
+    shard_id: &crate::shard_range::ShardId,
+) -> RefreshFloatingLimitTask {
+    let tenant_id = if rt.tenant_id == "-" {
+        None
+    } else {
+        Some(rt.tenant_id)
+    };
+    RefreshFloatingLimitTask {
+        id: rt.task_id,
+        queue_key: rt.queue_key,
+        current_max_concurrency: rt.current_max_concurrency,
+        last_refreshed_at_ms: rt.last_refreshed_at_ms,
+        metadata: rt.metadata.into_iter().collect(),
+        lease_ms: DEFAULT_LEASE_MS,
+        shard: shard_id.to_string(),
+        task_group: rt.task_group,
+        tenant_id,
+    }
+}
+
 /// Convert a `LeasedTask` into a proto `Task` message.
 fn leased_task_to_proto(lt: &crate::task::LeasedTask, shard_id: &str) -> Task {
     let job = lt.job();
@@ -1302,10 +1326,22 @@ impl Silo for SiloService {
         let mut all_refresh_tasks = Vec::new();
         let mut remaining = max_tasks;
 
-        // Poll each shard until we have enough tasks or exhausted all shards
+        // Poll each shard until we have enough tasks or exhausted all shards.
+        // A shard skipped once the job budget is met still drains its
+        // pending refreshes for the group: a refresh is handed to the next
+        // worker asking for its group, whichever shard it waits on.
         for (shard_id, shard) in shards_to_poll {
             if remaining == 0 {
-                break;
+                let refreshes = shard
+                    .drain_pending_refreshes(&r.worker_id, &r.task_group)
+                    .await
+                    .map_err(map_err)?;
+                all_refresh_tasks.extend(
+                    refreshes
+                        .into_iter()
+                        .map(|rt| refresh_task_to_proto(rt, &shard_id)),
+                );
+                continue;
             }
 
             let poll_start = std::time::Instant::now();
@@ -1343,26 +1379,12 @@ impl Silo for SiloService {
                 all_tasks.push(leased_task_to_proto(&lt, &shard_str));
             }
 
-            for rt in result.refresh_tasks {
-                // Get tenant_id, using None if it's the default "-" tenant
-                let tenant_id = if rt.tenant_id == "-" {
-                    None
-                } else {
-                    Some(rt.tenant_id)
-                };
-
-                all_refresh_tasks.push(RefreshFloatingLimitTask {
-                    id: rt.task_id,
-                    queue_key: rt.queue_key,
-                    current_max_concurrency: rt.current_max_concurrency,
-                    last_refreshed_at_ms: rt.last_refreshed_at_ms,
-                    metadata: rt.metadata.into_iter().collect(),
-                    lease_ms: DEFAULT_LEASE_MS,
-                    shard: shard_id.to_string(),
-                    task_group: rt.task_group,
-                    tenant_id,
-                });
-            }
+            all_refresh_tasks.extend(
+                result
+                    .refresh_tasks
+                    .into_iter()
+                    .map(|rt| refresh_task_to_proto(rt, &shard_id)),
+            );
 
             // Record dequeue metrics per shard
             if let Some(ref m) = self.metrics

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -404,7 +404,8 @@ pub struct DatabaseTemplate {
     /// Cap (ms) on the stale window after consecutive stale resets of one
     /// queue's flag: the window is `floating_refresh_stale_ms` doubled per
     /// consecutive reset, up to this value. Any refresh outcome resets the
-    /// count. Defaults to 3600000.
+    /// count. A cap below the base window is treated as the base. Defaults
+    /// to 3600000.
     #[serde(default = "default_floating_refresh_stale_max_ms")]
     pub floating_refresh_stale_max_ms: u64,
     /// Scan generations an ack tombstone may keep suppressing a task key the

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -267,6 +267,17 @@ fn default_floating_refresh_stale_ms() -> u64 {
     DEFAULT_FLOATING_REFRESH_STALE_MS
 }
 
+/// Default for `floating_refresh_stale_max_ms`: the widest the stale window
+/// grows. Each consecutive stale reset of one queue's flag doubles the
+/// window from `floating_refresh_stale_ms`, so a refresh that is scheduled
+/// but never leased costs a bounded number of resets per hour instead of
+/// one per base window.
+pub const DEFAULT_FLOATING_REFRESH_STALE_MAX_MS: u64 = 3_600_000;
+
+fn default_floating_refresh_stale_max_ms() -> u64 {
+    DEFAULT_FLOATING_REFRESH_STALE_MAX_MS
+}
+
 /// Default for `broker_tombstone_revive_after_generations`: how many scan
 /// generations an ack tombstone may keep suppressing a re-observed task key
 /// before the broker point-reads the row and, if it is still durable,
@@ -390,6 +401,12 @@ pub struct DatabaseTemplate {
     /// immediately. Defaults to 60000.
     #[serde(default = "default_floating_refresh_stale_ms")]
     pub floating_refresh_stale_ms: u64,
+    /// Cap (ms) on the stale window after consecutive stale resets of one
+    /// queue's flag: the window is `floating_refresh_stale_ms` doubled per
+    /// consecutive reset, up to this value. Any refresh outcome resets the
+    /// count. Defaults to 3600000.
+    #[serde(default = "default_floating_refresh_stale_max_ms")]
+    pub floating_refresh_stale_max_ms: u64,
     /// Scan generations an ack tombstone may keep suppressing a task key the
     /// scanner keeps re-observing before the broker point-reads the row and
     /// revives it if it is still durable. Defaults to 64.
@@ -471,6 +488,7 @@ impl Default for DatabaseTemplate {
             grant_scanner_live_headroom_fraction: default_grant_scanner_live_headroom_fraction(),
             grant_scanner_commit_chunk_size: default_grant_scanner_commit_chunk_size(),
             floating_refresh_stale_ms: default_floating_refresh_stale_ms(),
+            floating_refresh_stale_max_ms: default_floating_refresh_stale_max_ms(),
             broker_tombstone_revive_after_generations:
                 default_broker_tombstone_revive_after_generations(),
             completed_job_expire_s: None,
@@ -838,6 +856,11 @@ pub struct DatabaseConfig {
     /// to 60000.
     #[serde(default = "default_floating_refresh_stale_ms")]
     pub floating_refresh_stale_ms: u64,
+    /// Cap (ms) on the stale window after consecutive stale resets. See
+    /// `DatabaseTemplate::floating_refresh_stale_max_ms` for details.
+    /// Defaults to 3600000.
+    #[serde(default = "default_floating_refresh_stale_max_ms")]
+    pub floating_refresh_stale_max_ms: u64,
     /// Scan generations an ack tombstone may suppress a re-observed task key.
     /// See `DatabaseTemplate::broker_tombstone_revive_after_generations` for
     /// details. Defaults to 64.
@@ -895,6 +918,7 @@ impl Default for DatabaseConfig {
             grant_scanner_live_headroom_fraction: default_grant_scanner_live_headroom_fraction(),
             grant_scanner_commit_chunk_size: default_grant_scanner_commit_chunk_size(),
             floating_refresh_stale_ms: default_floating_refresh_stale_ms(),
+            floating_refresh_stale_max_ms: default_floating_refresh_stale_max_ms(),
             broker_tombstone_revive_after_generations:
                 default_broker_tombstone_revive_after_generations(),
             completed_job_expire_s: None,
@@ -1099,6 +1123,7 @@ mod tests {
         )
         .expect("template without refresh settings should parse");
         assert_eq!(template.floating_refresh_stale_ms, 60_000);
+        assert_eq!(template.floating_refresh_stale_max_ms, 3_600_000);
         assert_eq!(template.broker_tombstone_revive_after_generations, 64);
 
         let config: DatabaseConfig = toml::from_str(
@@ -1110,6 +1135,7 @@ mod tests {
         )
         .expect("config without refresh settings should parse");
         assert_eq!(config.floating_refresh_stale_ms, 60_000);
+        assert_eq!(config.floating_refresh_stale_max_ms, 3_600_000);
         assert_eq!(config.broker_tombstone_revive_after_generations, 64);
     }
 }

--- a/templates/sql.html
+++ b/templates/sql.html
@@ -39,7 +39,7 @@
                 </div>
                 <div class="flex items-center justify-between">
                     <div class="text-xs text-zinc-500">
-                        Available tables: <code class="text-emerald-400">jobs</code>, <code class="text-emerald-400">queues</code>, <code class="text-emerald-400">tasks</code>, <code class="text-emerald-400">tenant_counts</code>, <code class="text-emerald-400">queue_counts</code>
+                        Available tables: <code class="text-emerald-400">jobs</code>, <code class="text-emerald-400">queues</code>, <code class="text-emerald-400">tasks</code>, <code class="text-emerald-400">floating_refresh_tasks</code>, <code class="text-emerald-400">tenant_counts</code>, <code class="text-emerald-400">queue_counts</code>
                     </div>
                     <button type="submit" 
                             class="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium transition-colors flex items-center gap-2">

--- a/tests/broker_tombstone_revive_tests.rs
+++ b/tests/broker_tombstone_revive_tests.rs
@@ -11,50 +11,12 @@ mod test_helpers;
 
 use std::time::Duration;
 
-use silo::codec::decode_task_validated;
 use silo::job_store_shard::JobStoreShard;
 use test_helpers::*;
 
-/// Scan the durable task rows and return the first RefreshFloatingLimit row.
-async fn find_refresh_task_row(shard: &JobStoreShard) -> Option<(Vec<u8>, bytes::Bytes)> {
-    let start = silo::keys::tasks_prefix();
-    let end = silo::keys::end_bound(&start);
-    let mut iter = shard
-        .db()
-        .scan::<Vec<u8>, _>(start..end)
-        .await
-        .expect("scan tasks");
-    while let Some(kv) = iter.next().await.expect("iterate tasks") {
-        let decoded = decode_task_validated(kv.value.clone()).expect("decode task");
-        if decoded.as_refresh_floating_limit().is_some() {
-            return Some((kv.key.to_vec(), kv.value));
-        }
-    }
-    None
-}
-
-async fn enqueue_floating(shard: &JobStoreShard, queue: &str, tag: u32) {
-    shard
-        .enqueue(
-            "-",
-            None,
-            10u8,
-            now_ms(),
-            None,
-            msgpack_payload(&serde_json::json!({"j": tag})),
-            vec![silo::job::Limit::FloatingConcurrency(
-                silo::job::FloatingConcurrencyLimit {
-                    key: queue.to_string(),
-                    default_max_concurrency: 1,
-                    refresh_interval_ms: 100,
-                    metadata: vec![],
-                },
-            )],
-            None,
-            "default",
-        )
-        .await
-        .expect("enqueue floating job");
+/// The first durable task row in the task line.
+async fn find_task_row(shard: &JobStoreShard) -> Option<(Vec<u8>, bytes::Bytes)> {
+    first_task_kv(shard.db()).await
 }
 
 fn read_revived_total(metrics: &silo::metrics::Metrics) -> f64 {
@@ -64,35 +26,40 @@ fn read_revived_total(metrics: &silo::metrics::Metrics) -> f64 {
     )
 }
 
-/// A refresh task row the broker acked and tombstoned is still durable under
+/// A RunAttempt row the broker acked and tombstoned is still durable under
 /// the same bytes. With a revive bound of one scan generation, driving scans
 /// through dequeue wakeups must lease it again without a process restart.
+/// The same worker leases both times: a still-live lease held by the same
+/// worker is re-delivered by overwrite, the requeue-after-ambiguous-commit
+/// recovery.
 #[silo::test]
 async fn tombstoned_task_row_still_durable_is_revived_and_leased() {
     let (_tmp, shard, metrics) = open_temp_shard_with_tombstone_revive_after_generations(1).await;
-    let queue = "tombstone-revive-q";
 
-    // A holder plus a waiter schedules a refresh task row.
-    enqueue_floating(&shard, queue, 1).await;
-    enqueue_floating(&shard, queue, 2).await;
-    let (row_key, row_value) = find_refresh_task_row(&shard)
+    shard
+        .enqueue(
+            "-",
+            Some("revive-job".to_string()),
+            10u8,
+            now_ms(),
+            None,
+            msgpack_payload(&serde_json::json!({"j": 1})),
+            vec![],
+            None,
+            "default",
+        )
         .await
-        .expect("refresh task row is durable before dequeue");
+        .expect("enqueue");
+    let (row_key, row_value) = find_task_row(&shard)
+        .await
+        .expect("task row is durable before dequeue");
 
     // Dequeue acks the row: the key is deleted and tombstoned in the broker.
-    let first =
-        dequeue_refresh_tasks_until(&shard, "worker-1", "default", 1, Duration::from_secs(30))
-            .await
-            .refresh_tasks[0]
-            .task_id
-            .clone();
-    shard
-        .report_refresh_success(&first, 1)
-        .await
-        .expect("report refresh success");
+    let first = dequeue_task_ids_until(&shard, "worker-1", "default", 1).await;
+    assert_eq!(first.len(), 1);
     assert!(
-        find_refresh_task_row(&shard).await.is_none(),
-        "dequeue deletes the refresh task row"
+        find_task_row(&shard).await.is_none(),
+        "dequeue deletes the task row"
     );
 
     // The row comes back under the exact same bytes.
@@ -103,16 +70,11 @@ async fn tombstoned_task_row_still_durable_is_revived_and_leased() {
         .expect("put row back");
     shard.db().flush().await.expect("flush");
 
-    let second =
-        dequeue_refresh_tasks_until(&shard, "worker-2", "default", 1, Duration::from_secs(30))
-            .await
-            .refresh_tasks[0]
-            .task_id
-            .clone();
+    let second = dequeue_task_ids_until(&shard, "worker-1", "default", 1).await;
     assert_eq!(second, first, "the revived row is the same task");
     assert_eq!(read_revived_total(&metrics), 1.0);
     assert!(
-        find_refresh_task_row(&shard).await.is_none(),
+        find_task_row(&shard).await.is_none(),
         "the revived row is deleted by its second dequeue"
     );
 }

--- a/tests/cluster_query_tests.rs
+++ b/tests/cluster_query_tests.rs
@@ -1942,3 +1942,68 @@ async fn cluster_query_tasks_table_group_by_across_shards() {
     assert_eq!(groups, vec!["alpha", "beta"]);
     assert_eq!(counts, vec![3, 2]);
 }
+
+/// Seed a pending refresh for `queue` under `task_group` in `shard`'s
+/// refresh index.
+async fn seed_pending_refresh(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+    task_group: &str,
+) {
+    shard
+        .put_refresh_index_row_for_test(
+            &silo::task::Task::RefreshFloatingLimit {
+                task_id: format!("{task_group}-{queue}"),
+                tenant: "-".to_string(),
+                queue_key: queue.to_string(),
+                current_max_concurrency: 1,
+                last_refreshed_at_ms: 0,
+                metadata: vec![],
+                task_group: task_group.to_string(),
+            },
+            None,
+        )
+        .await
+        .expect("seed refresh index row");
+}
+
+/// `floating_refresh_tasks` lists every shard's pending refreshes, and its
+/// `task_group` and `tenant` filters are handled by the scan without a
+/// post-filter; a `queue_key` filter is re-applied.
+#[silo::test]
+async fn cluster_query_floating_refresh_tasks_multi_shard_pushdown() {
+    let (_temps, factory, shard_map) = create_multi_shard_factory(2).await;
+    let shard0 = get_shard(&factory, &shard_map, 0);
+    let shard1 = get_shard(&factory, &shard_map, 1);
+    seed_pending_refresh(&shard0, "q-s0", "emails").await;
+    seed_pending_refresh(&shard1, "q-s1", "emails").await;
+    seed_pending_refresh(&shard1, "q-other", "other").await;
+
+    let engine = ClusterQueryEngine::new(factory.clone(), None)
+        .await
+        .expect("create engine");
+
+    let query = "SELECT shard_id, queue_key FROM floating_refresh_tasks \
+                 WHERE task_group = 'emails' AND tenant = '-' ORDER BY queue_key";
+    let batches = query_collect(&engine, query).await;
+    assert_eq!(extract_string_column(&batches, 1), vec!["q-s0", "q-s1"]);
+    let shard_ids = extract_string_column(&batches, 0);
+    assert_eq!(shard_ids[0], shard0.name());
+    assert_eq!(shard_ids[1], shard1.name());
+
+    let explain = engine.explain(query).await.expect("explain");
+    assert!(
+        !explain.contains("FilterExec"),
+        "task_group and tenant are exact prefix filters: {explain}"
+    );
+
+    let post_filtered = "SELECT queue_key FROM floating_refresh_tasks \
+                         WHERE task_group = 'emails' AND queue_key = 'q-s1'";
+    let batches = query_collect(&engine, post_filtered).await;
+    assert_eq!(extract_string_column(&batches, 0), vec!["q-s1"]);
+    let explain = engine.explain(post_filtered).await.expect("explain");
+    assert!(
+        explain.contains("FilterExec"),
+        "queue_key is re-applied as a post-filter: {explain}"
+    );
+}

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -3,7 +3,7 @@ use silo::codec::{
     decode_floating_limit_state, decode_holder_granted_at_ms, decode_job_info,
     decode_job_status_owned, decode_lease, decode_task, decode_task_validated, encode_attempt,
     encode_concurrency_action, encode_floating_limit_state, encode_holder, encode_job_cancellation,
-    encode_job_info, encode_job_status, encode_lease, encode_task,
+    encode_job_info, encode_job_status, encode_lease, encode_refresh_index_row, encode_task,
 };
 use silo::job::{FloatingLimitState, JobCancellation, JobInfo, JobStatus, JobStatusKind};
 use silo::job_attempt::{AttemptStatus, JobAttempt};
@@ -667,4 +667,65 @@ fn test_floating_limit_state_roundtrip_refresh_scheduled_at() {
     assert_eq!(decoded.next_retry_at_ms(), None);
     assert_eq!(decoded.metadata().len(), 1);
     assert_eq!(decoded.to_owned().refresh_scheduled_at_ms, Some(5500));
+}
+
+/// A `RefreshFloatingLimit` task encoded for the task line or a lease
+/// carries no `not_before_ms`, so its decoded view reads the field as null.
+#[silo::test]
+fn test_refresh_floating_limit_without_not_before_decodes_as_null() {
+    let task = Task::RefreshFloatingLimit {
+        task_id: "refresh-1".to_string(),
+        tenant: "tenant-3".to_string(),
+        queue_key: "queue-key-abc".to_string(),
+        current_max_concurrency: 50,
+        last_refreshed_at_ms: 123456,
+        metadata: vec![],
+        task_group: "workers".to_string(),
+    };
+    let decoded = decode_task_validated(encode_task(&task)).unwrap();
+    assert_eq!(decoded.not_before_ms(), None);
+    assert_eq!(
+        decoded
+            .as_refresh_floating_limit()
+            .and_then(|r| r.queue_key())
+            .unwrap_or_default(),
+        "queue-key-abc"
+    );
+}
+
+#[silo::test]
+fn test_refresh_index_row_roundtrip_carries_not_before() {
+    let task = Task::RefreshFloatingLimit {
+        task_id: "refresh-2".to_string(),
+        tenant: "tenant-3".to_string(),
+        queue_key: "queue-key-abc".to_string(),
+        current_max_concurrency: 50,
+        last_refreshed_at_ms: 123456,
+        metadata: vec![("key1".to_string(), "val1".to_string())],
+        task_group: "workers".to_string(),
+    };
+    let claimable = decode_task_validated(encode_refresh_index_row(&task, None)).unwrap();
+    assert_eq!(claimable.not_before_ms(), None);
+
+    let backed_off =
+        decode_task_validated(encode_refresh_index_row(&task, Some(1_756_400_060_000))).unwrap();
+    assert_eq!(backed_off.not_before_ms(), Some(1_756_400_060_000));
+    let owned = backed_off.to_task().unwrap();
+    match owned {
+        Task::RefreshFloatingLimit {
+            task_id,
+            queue_key,
+            current_max_concurrency,
+            metadata,
+            task_group,
+            ..
+        } => {
+            assert_eq!(task_id, "refresh-2");
+            assert_eq!(queue_key, "queue-key-abc");
+            assert_eq!(current_max_concurrency, 50);
+            assert_eq!(metadata, vec![("key1".to_string(), "val1".to_string())]);
+            assert_eq!(task_group, "workers");
+        }
+        _ => panic!("expected RefreshFloatingLimit variant"),
+    }
 }

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -347,6 +347,7 @@ fn test_floating_limit_state_roundtrip() {
         next_retry_at_ms: Some(8000),
         metadata: vec![("source".to_string(), "api".to_string())],
         refresh_scheduled_at_ms: None,
+        stale_reset_count: 0,
     };
     let encoded = encode_floating_limit_state(&state);
     let decoded = decode_floating_limit_state(encoded).unwrap();
@@ -372,6 +373,7 @@ fn test_floating_limit_state_roundtrip_none_retry() {
         next_retry_at_ms: None,
         metadata: vec![],
         refresh_scheduled_at_ms: None,
+        stale_reset_count: 0,
     };
     let encoded = encode_floating_limit_state(&state);
     let decoded = decode_floating_limit_state(encoded).unwrap();
@@ -660,6 +662,7 @@ fn test_floating_limit_state_roundtrip_refresh_scheduled_at() {
         next_retry_at_ms: None,
         metadata: vec![("source".to_string(), "api".to_string())],
         refresh_scheduled_at_ms: Some(5500),
+        stale_reset_count: 0,
     };
     let encoded = encode_floating_limit_state(&state);
     let decoded = decode_floating_limit_state(encoded).unwrap();
@@ -728,4 +731,64 @@ fn test_refresh_index_row_roundtrip_carries_not_before() {
         }
         _ => panic!("expected RefreshFloatingLimit variant"),
     }
+}
+
+/// A floating limit state row with nine vtable slots ending at
+/// `refresh_scheduled_at_ms` and no `stale_reset_count` slot. It carries the
+/// same fields as `FLOATING_LIMIT_STATE_WITHOUT_SCHEDULED_AT` plus
+/// `refresh_scheduled_at_ms: Some(1_756_400_030_000)` and one metadata pair.
+const FLOATING_LIMIT_STATE_WITHOUT_STALE_RESET_COUNT: &[u8] = &[
+    32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 22, 0, 60, 0, 8, 0, 24, 0, 7, 0, 32, 0, 12, 0, 16, 0, 40, 0, 20,
+    0, 48, 0, 22, 0, 0, 0, 0, 0, 0, 1, 19, 0, 0, 0, 5, 0, 0, 0, 3, 0, 0, 0, 40, 0, 0, 0, 0, 28,
+    153, 241, 152, 1, 0, 0, 244, 1, 0, 0, 0, 0, 0, 0, 96, 6, 154, 241, 152, 1, 0, 0, 48, 145, 153,
+    241, 152, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 12, 0, 0, 0, 8, 0, 12, 0, 4, 0, 8, 0, 8, 0, 0, 0,
+    40, 0, 0, 0, 4, 0, 0, 0, 26, 0, 0, 0, 112, 108, 97, 116, 102, 111, 114, 109, 45, 116, 101, 110,
+    97, 110, 116, 45, 101, 110, 118, 45, 54, 49, 52, 54, 57, 54, 0, 0, 3, 0, 0, 0, 101, 110, 118,
+    0,
+];
+
+#[silo::test]
+fn test_floating_limit_state_without_stale_reset_count_decodes_as_zero() {
+    let decoded =
+        decode_floating_limit_state(FLOATING_LIMIT_STATE_WITHOUT_STALE_RESET_COUNT.to_vec())
+            .unwrap();
+    assert_eq!(decoded.current_max_concurrency(), 19);
+    assert_eq!(decoded.last_refreshed_at_ms(), 1_756_400_000_000);
+    assert!(decoded.refresh_task_scheduled());
+    assert_eq!(decoded.refresh_interval_ms(), 500);
+    assert_eq!(decoded.default_max_concurrency(), 5);
+    assert_eq!(decoded.retry_count(), 3);
+    assert_eq!(decoded.next_retry_at_ms(), Some(1_756_400_060_000));
+    assert_eq!(decoded.refresh_scheduled_at_ms(), Some(1_756_400_030_000));
+    assert_eq!(
+        decoded.metadata(),
+        vec![("env".to_string(), "platform-tenant-env-614696".to_string())]
+    );
+    assert_eq!(decoded.stale_reset_count(), 0);
+    assert_eq!(decoded.to_owned().stale_reset_count, 0);
+
+    let older =
+        decode_floating_limit_state(FLOATING_LIMIT_STATE_WITHOUT_SCHEDULED_AT.to_vec()).unwrap();
+    assert_eq!(older.stale_reset_count(), 0);
+}
+
+#[silo::test]
+fn test_floating_limit_state_roundtrip_stale_reset_count() {
+    let state = FloatingLimitState {
+        current_max_concurrency: 10,
+        last_refreshed_at_ms: 5000,
+        refresh_task_scheduled: true,
+        refresh_interval_ms: 30000,
+        default_max_concurrency: 5,
+        retry_count: 0,
+        next_retry_at_ms: None,
+        metadata: vec![],
+        refresh_scheduled_at_ms: Some(5500),
+        stale_reset_count: 7,
+    };
+    let encoded = encode_floating_limit_state(&state);
+    let decoded = decode_floating_limit_state(encoded).unwrap();
+    assert_eq!(decoded.stale_reset_count(), 7);
+    assert_eq!(decoded.refresh_scheduled_at_ms(), Some(5500));
+    assert_eq!(decoded.to_owned().stale_reset_count, 7);
 }

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -792,3 +792,20 @@ fn test_floating_limit_state_roundtrip_stale_reset_count() {
     assert_eq!(decoded.refresh_scheduled_at_ms(), Some(5500));
     assert_eq!(decoded.to_owned().stale_reset_count, 7);
 }
+
+#[silo::test]
+fn test_refresh_index_row_zero_not_before_is_distinct_from_absent() {
+    let task = Task::RefreshFloatingLimit {
+        task_id: "refresh-3".to_string(),
+        tenant: "-".to_string(),
+        queue_key: "q".to_string(),
+        current_max_concurrency: 1,
+        last_refreshed_at_ms: 0,
+        metadata: vec![],
+        task_group: "workers".to_string(),
+    };
+    let zero = decode_task_validated(encode_refresh_index_row(&task, Some(0))).unwrap();
+    assert_eq!(zero.not_before_ms(), Some(0));
+    let absent = decode_task_validated(encode_refresh_index_row(&task, None)).unwrap();
+    assert_eq!(absent.not_before_ms(), None);
+}

--- a/tests/duplicate_materialization_tests.rs
+++ b/tests/duplicate_materialization_tests.rs
@@ -492,7 +492,11 @@ async fn concurrent_chain_resumes_in_two_batches_keep_single_terminal_row() {
     for offset in [0, 1] {
         let mut batch = WriteBatch::new();
         let grants = resumer
-            .resume_chain(&mut batch, resume_params(epoch_base + offset))
+            .resume_chain(
+                &mut batch,
+                &mut silo::job_store_shard::ScheduledRefreshes::default(),
+                resume_params(epoch_base + offset),
+            )
             .await
             .expect("resume chain");
         assert!(

--- a/tests/floating_concurrency_tests.rs
+++ b/tests/floating_concurrency_tests.rs
@@ -3863,3 +3863,62 @@ async fn floating_limit_scanner_chunk_of_waiters_schedules_one_replacement_refre
     );
     assert_eq!(read_refresh_reset_total(&metrics), 1.0);
 }
+
+/// Chains walked into one batch onto a floating queue with no state row yet:
+/// the second chain schedules the refresh and sets the flag, and later
+/// chains must not overwrite that flag with a fresh default row.
+#[silo::test]
+async fn floating_limit_new_queue_scheduled_in_one_batch_keeps_its_flag() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_metrics().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-batch-new-queue-q";
+    let rate_limit = silo::job::GubernatorRateLimit {
+        name: "batch-new-queue".to_string(),
+        unique_key: format!("batch-new-queue-{}", uuid::Uuid::new_v4()),
+        limit: 100,
+        duration_ms: 60_000,
+        hits: 1,
+        algorithm: silo::job::GubernatorAlgorithm::TokenBucket,
+        behavior: 0,
+        retry_policy: silo::job::RateLimitRetryPolicy::default(),
+    };
+    for tag in 0..5u32 {
+        shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({"j": tag})),
+                vec![
+                    silo::job::Limit::RateLimit(rate_limit.clone()),
+                    floating_limit(queue, REFRESH_INTERVAL_MS),
+                ],
+                None,
+                "batch",
+            )
+            .await
+            .expect("enqueue chained job");
+    }
+
+    // The first chain takes the single slot, the second becomes a waiter and
+    // schedules the refresh, the rest wait too; nothing is drained yet.
+    let result = shard
+        .dequeue("worker-1", "batch", 100)
+        .await
+        .expect("dequeue");
+    assert_eq!(result.tasks.len(), 1);
+    assert_eq!(count_concurrency_requests(shard.db()).await, 4);
+    let state = read_floating_state(&shard, queue).await;
+    assert!(
+        state.refresh_task_scheduled(),
+        "the flag set by the second chain survives the later chains' walks"
+    );
+    assert!(state.refresh_scheduled_at_ms().is_some());
+    assert_eq!(
+        count_refresh_tasks_in_group(&shard, queue, "batch").await + result.refresh_tasks.len(),
+        1
+    );
+    assert_eq!(read_refresh_reset_total(&metrics), 0.0);
+}

--- a/tests/floating_concurrency_tests.rs
+++ b/tests/floating_concurrency_tests.rs
@@ -2258,6 +2258,18 @@ async fn write_orphaned_refresh_state(
     queue: &str,
     scheduled_at_ms: Option<i64>,
 ) {
+    write_refresh_state(shard, queue, scheduled_at_ms, 0).await;
+}
+
+/// Overwrite the durable floating limit state row for `queue` with the flag
+/// set, stamped at `scheduled_at_ms`, after `stale_reset_count` consecutive
+/// stale resets.
+async fn write_refresh_state(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+    scheduled_at_ms: Option<i64>,
+    stale_reset_count: u32,
+) {
     let state = silo::job::FloatingLimitState {
         current_max_concurrency: 1,
         last_refreshed_at_ms: 0,
@@ -2268,6 +2280,7 @@ async fn write_orphaned_refresh_state(
         next_retry_at_ms: None,
         metadata: vec![],
         refresh_scheduled_at_ms: scheduled_at_ms,
+        stale_reset_count,
     };
     shard
         .db()
@@ -3554,4 +3567,185 @@ async fn floating_limit_index_rows_carry_the_row_ttl() {
         retried >= before + ttl - 5_000 && retried <= now_ms() + ttl + 5_000,
         "retry row expire_ts {retried} is not about {ttl} ms out"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Bounded stale resets
+// ---------------------------------------------------------------------------
+
+/// Consecutive stale resets double the stale window from the base: after two
+/// resets a 100 ms base window is 400 ms wide.
+#[silo::test]
+async fn floating_limit_consecutive_stale_resets_double_the_stale_window() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_floating_refresh_stale_ms(100).await;
+    shard.stop_grant_scanner();
+    let queue = "fl-reset-backoff-q";
+    // j1 holds the single slot, so every later enqueue is a waiter.
+    enqueue_floating(&shard, queue, 1).await;
+
+    // A stamp-less flag is stale on sight: the first reset.
+    write_refresh_state(&shard, queue, None, 0).await;
+    enqueue_floating(&shard, queue, 2).await;
+    assert_eq!(
+        read_floating_state(&shard, queue).await.stale_reset_count(),
+        1
+    );
+    assert_eq!(read_refresh_reset_total(&metrics), 1.0);
+
+    // One reset widens the window to 200 ms: a stamp older than that is stale.
+    write_refresh_state(&shard, queue, Some(now_ms() - 201), 1).await;
+    enqueue_floating(&shard, queue, 3).await;
+    assert_eq!(
+        read_floating_state(&shard, queue).await.stale_reset_count(),
+        2
+    );
+    assert_eq!(read_refresh_reset_total(&metrics), 2.0);
+
+    // Two resets widen it to 400 ms: a 150 ms old stamp is still trusted.
+    write_refresh_state(&shard, queue, Some(now_ms() - 150), 2).await;
+    enqueue_floating(&shard, queue, 4).await;
+    assert_eq!(
+        read_floating_state(&shard, queue).await.stale_reset_count(),
+        2
+    );
+    assert_eq!(read_refresh_reset_total(&metrics), 2.0);
+
+    // Past 400 ms the flag is stale again and the count keeps climbing.
+    write_refresh_state(&shard, queue, Some(now_ms() - 401), 2).await;
+    enqueue_floating(&shard, queue, 5).await;
+    assert_eq!(
+        read_floating_state(&shard, queue).await.stale_reset_count(),
+        3
+    );
+    assert_eq!(read_refresh_reset_total(&metrics), 3.0);
+}
+
+/// `floating_refresh_stale_max_ms` caps the widened window.
+#[silo::test]
+async fn floating_limit_stale_window_is_capped_by_the_max_setting() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_floating_refresh_stale_window(100, 300).await;
+    shard.stop_grant_scanner();
+    let queue = "fl-reset-cap-q";
+    enqueue_floating(&shard, queue, 1).await;
+
+    // Two resets would widen the window to 400 ms; the cap holds it at 300.
+    write_refresh_state(&shard, queue, Some(now_ms() - 250), 2).await;
+    enqueue_floating(&shard, queue, 2).await;
+    assert_eq!(
+        read_floating_state(&shard, queue).await.stale_reset_count(),
+        2
+    );
+    assert_eq!(read_refresh_reset_total(&metrics), 0.0);
+
+    write_refresh_state(&shard, queue, Some(now_ms() - 301), 2).await;
+    enqueue_floating(&shard, queue, 3).await;
+    assert_eq!(
+        read_floating_state(&shard, queue).await.stale_reset_count(),
+        3
+    );
+    assert_eq!(read_refresh_reset_total(&metrics), 1.0);
+}
+
+/// Age a stamp-less flag out on `queue` so a waiter writes a replacement
+/// that records one stale reset, then lease that replacement. Returns its
+/// task id.
+async fn lease_replacement_after_one_stale_reset(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+) -> String {
+    enqueue_floating(shard, queue, 1).await;
+    write_refresh_state(shard, queue, None, 0).await;
+    enqueue_floating(shard, queue, 2).await;
+    assert_eq!(
+        read_floating_state(shard, queue).await.stale_reset_count(),
+        1
+    );
+    dequeue_refresh_tasks_until(shard, "worker-1", "default", 1, DEQUEUE_TIMEOUT)
+        .await
+        .refresh_tasks[0]
+        .task_id
+        .clone()
+}
+
+/// A reported success clears the stale reset count, and the first schedule
+/// after that clean outcome leaves it at zero.
+#[silo::test]
+async fn floating_limit_refresh_success_clears_the_stale_reset_count() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-reset-clear-success-q";
+    let task_id = lease_replacement_after_one_stale_reset(&shard, queue).await;
+
+    shard
+        .report_refresh_success(&task_id, 1)
+        .await
+        .expect("report success");
+    assert_eq!(
+        read_floating_state(&shard, queue).await.stale_reset_count(),
+        0
+    );
+
+    // The interval elapses and a new waiter schedules the next refresh: a
+    // first schedule after a clean outcome does not widen the window.
+    backdate_last_refreshed(&shard, queue).await;
+    enqueue_floating(&shard, queue, 3).await;
+    let state = read_floating_state(&shard, queue).await;
+    assert!(state.refresh_task_scheduled());
+    assert_eq!(state.stale_reset_count(), 0);
+}
+
+/// A reported failure clears the stale reset count.
+#[silo::test]
+async fn floating_limit_refresh_failure_clears_the_stale_reset_count() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-reset-clear-failure-q";
+    let task_id = lease_replacement_after_one_stale_reset(&shard, queue).await;
+
+    shard
+        .report_refresh_failure(&task_id, "boom", "upstream down")
+        .await
+        .expect("report failure");
+    let state = read_floating_state(&shard, queue).await;
+    assert_eq!(state.stale_reset_count(), 0);
+    assert_eq!(
+        state.retry_count(),
+        1,
+        "the failure backoff is still recorded"
+    );
+}
+
+/// A refresh lease expiring clears the stale reset count.
+#[silo::test]
+async fn floating_limit_refresh_lease_expiry_clears_the_stale_reset_count() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-reset-clear-expiry-q";
+    let task_id = lease_replacement_after_one_stale_reset(&shard, queue).await;
+
+    let lease_key = silo::keys::leased_task_key(&task_id);
+    let lease_raw = shard
+        .db()
+        .get(&lease_key)
+        .await
+        .expect("db get")
+        .expect("lease exists");
+    let decoded_lease = decode_lease(lease_raw).expect("decode lease");
+    let expired = LeaseRecord {
+        worker_id: decoded_lease.worker_id().to_string(),
+        task: decoded_lease.to_task().unwrap(),
+        expiry_ms: now_ms() - 1,
+        started_at_ms: decoded_lease.started_at_ms(),
+    };
+    shard
+        .db()
+        .put(&lease_key, &encode_lease(&expired))
+        .await
+        .expect("put expired lease");
+    shard.db().flush().await.expect("flush");
+
+    assert_eq!(shard.reap_expired_leases("-").await.expect("reap"), 1);
+    let state = read_floating_state(&shard, queue).await;
+    assert!(!state.refresh_task_scheduled());
+    assert_eq!(state.stale_reset_count(), 0);
 }

--- a/tests/floating_concurrency_tests.rs
+++ b/tests/floating_concurrency_tests.rs
@@ -2330,8 +2330,8 @@ async fn count_refresh_tasks_in_group(
     count
 }
 
-/// Count the `RefreshFloatingLimit` rows for `queue` sitting in the task
-/// line under `task_group`, the shape earlier builds wrote.
+/// Count the `RefreshFloatingLimit` rows for `queue` in the task line under
+/// `task_group`.
 async fn count_task_line_refresh_tasks(
     shard: &silo::job_store_shard::JobStoreShard,
     queue: &str,
@@ -3324,6 +3324,9 @@ async fn floating_limit_backed_off_retry_is_not_delivered_before_its_retry_time(
         "the retry is still pending"
     );
 
+    // The gate compares against the system clock, so the first-failure
+    // backoff (`INITIAL_BACKOFF_MS` in the failure path, one second) has to
+    // elapse for real.
     let wait = (next_retry - now_ms()).max(0) as u64 + 50;
     tokio::time::sleep(std::time::Duration::from_millis(wait)).await;
     let due = dequeue_refresh_tasks_until(&shard, "worker-1", "default", 1, DEQUEUE_TIMEOUT).await;
@@ -3426,10 +3429,10 @@ async fn floating_limit_claimable_row_behind_backed_off_rows_is_delivered() {
     assert_eq!(result.refresh_tasks[0].queue_key, "z-claimable-q");
 }
 
-/// A `RefreshFloatingLimit` row an earlier build wrote into the task line is
-/// still leased when the broker reaches it.
+/// A `RefreshFloatingLimit` row in the task line is leased when the broker
+/// reaches it.
 #[silo::test]
-async fn floating_limit_task_line_refresh_row_is_still_leased() {
+async fn floating_limit_task_line_refresh_row_is_leased_by_the_broker() {
     let (_tmp, shard) = open_temp_shard().await;
     shard.stop_grant_scanner();
     let queue = "fl-task-line-q";
@@ -3574,10 +3577,12 @@ async fn floating_limit_index_rows_carry_the_row_ttl() {
 // ---------------------------------------------------------------------------
 
 /// Consecutive stale resets double the stale window from the base: after two
-/// resets a 100 ms base window is 400 ms wide.
+/// resets a 10 s base window is 40 s wide. Windows are sized in seconds so
+/// the wall-clock between writing a backdated row and reading it cannot
+/// cross a threshold.
 #[silo::test]
 async fn floating_limit_consecutive_stale_resets_double_the_stale_window() {
-    let (_tmp, shard, metrics) = open_temp_shard_with_floating_refresh_stale_ms(100).await;
+    let (_tmp, shard, metrics) = open_temp_shard_with_floating_refresh_stale_ms(10_000).await;
     shard.stop_grant_scanner();
     let queue = "fl-reset-backoff-q";
     // j1 holds the single slot, so every later enqueue is a waiter.
@@ -3592,8 +3597,8 @@ async fn floating_limit_consecutive_stale_resets_double_the_stale_window() {
     );
     assert_eq!(read_refresh_reset_total(&metrics), 1.0);
 
-    // One reset widens the window to 200 ms: a stamp older than that is stale.
-    write_refresh_state(&shard, queue, Some(now_ms() - 201), 1).await;
+    // One reset widens the window to 20 s: a stamp older than that is stale.
+    write_refresh_state(&shard, queue, Some(now_ms() - 20_001), 1).await;
     enqueue_floating(&shard, queue, 3).await;
     assert_eq!(
         read_floating_state(&shard, queue).await.stale_reset_count(),
@@ -3601,8 +3606,8 @@ async fn floating_limit_consecutive_stale_resets_double_the_stale_window() {
     );
     assert_eq!(read_refresh_reset_total(&metrics), 2.0);
 
-    // Two resets widen it to 400 ms: a 150 ms old stamp is still trusted.
-    write_refresh_state(&shard, queue, Some(now_ms() - 150), 2).await;
+    // Two resets widen it to 40 s: a 15 s old stamp is still trusted.
+    write_refresh_state(&shard, queue, Some(now_ms() - 15_000), 2).await;
     enqueue_floating(&shard, queue, 4).await;
     assert_eq!(
         read_floating_state(&shard, queue).await.stale_reset_count(),
@@ -3610,8 +3615,8 @@ async fn floating_limit_consecutive_stale_resets_double_the_stale_window() {
     );
     assert_eq!(read_refresh_reset_total(&metrics), 2.0);
 
-    // Past 400 ms the flag is stale again and the count keeps climbing.
-    write_refresh_state(&shard, queue, Some(now_ms() - 401), 2).await;
+    // Past 40 s the flag is stale again and the count keeps climbing.
+    write_refresh_state(&shard, queue, Some(now_ms() - 40_001), 2).await;
     enqueue_floating(&shard, queue, 5).await;
     assert_eq!(
         read_floating_state(&shard, queue).await.stale_reset_count(),
@@ -3623,13 +3628,14 @@ async fn floating_limit_consecutive_stale_resets_double_the_stale_window() {
 /// `floating_refresh_stale_max_ms` caps the widened window.
 #[silo::test]
 async fn floating_limit_stale_window_is_capped_by_the_max_setting() {
-    let (_tmp, shard, metrics) = open_temp_shard_with_floating_refresh_stale_window(100, 300).await;
+    let (_tmp, shard, metrics) =
+        open_temp_shard_with_floating_refresh_stale_window(10_000, 30_000).await;
     shard.stop_grant_scanner();
     let queue = "fl-reset-cap-q";
     enqueue_floating(&shard, queue, 1).await;
 
-    // Two resets would widen the window to 400 ms; the cap holds it at 300.
-    write_refresh_state(&shard, queue, Some(now_ms() - 250), 2).await;
+    // Two resets would widen the window to 40 s; the cap holds it at 30 s.
+    write_refresh_state(&shard, queue, Some(now_ms() - 25_000), 2).await;
     enqueue_floating(&shard, queue, 2).await;
     assert_eq!(
         read_floating_state(&shard, queue).await.stale_reset_count(),
@@ -3637,7 +3643,7 @@ async fn floating_limit_stale_window_is_capped_by_the_max_setting() {
     );
     assert_eq!(read_refresh_reset_total(&metrics), 0.0);
 
-    write_refresh_state(&shard, queue, Some(now_ms() - 301), 2).await;
+    write_refresh_state(&shard, queue, Some(now_ms() - 30_001), 2).await;
     enqueue_floating(&shard, queue, 3).await;
     assert_eq!(
         read_floating_state(&shard, queue).await.stale_reset_count(),
@@ -3748,4 +3754,112 @@ async fn floating_limit_refresh_lease_expiry_clears_the_stale_reset_count() {
     let state = read_floating_state(&shard, queue).await;
     assert!(!state.refresh_task_scheduled());
     assert_eq!(state.stale_reset_count(), 0);
+}
+
+/// Two workers polling one group at the same time lease a pending refresh
+/// once: drains on a shard are serialized from scan to commit.
+#[silo::test]
+async fn floating_limit_concurrent_drains_lease_a_refresh_once() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-concurrent-drain-q";
+    enqueue_floating(&shard, queue, 1).await;
+    enqueue_floating(&shard, queue, 2).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
+
+    let (a, b) = tokio::join!(
+        shard.dequeue("worker-a", "default", 10),
+        shard.dequeue("worker-b", "default", 10)
+    );
+    let (a, b) = (a.expect("dequeue a"), b.expect("dequeue b"));
+    assert_eq!(
+        a.refresh_tasks.len() + b.refresh_tasks.len(),
+        1,
+        "one pending refresh is leased by exactly one of the two polls"
+    );
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+    assert_eq!(
+        count_lease_keys(shard.db()).await,
+        2,
+        "the holder's attempt and the refresh are the only leases"
+    );
+}
+
+/// Chains the grant scanner resumes in one commit chunk share the batch's
+/// refresh record: twelve waiters on a fixed queue whose chains continue
+/// into a floating queue at capacity with a stale flag schedule one
+/// replacement refresh and count one reset.
+#[silo::test]
+async fn floating_limit_scanner_chunk_of_waiters_schedules_one_replacement_refresh() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_floating_refresh_stale_ms(60_000).await;
+    shard.stop_grant_scanner();
+    let queue = "fl-chunk-dedupe-q";
+    let gate = "fl-chunk-gate-q";
+    let waiters = 12usize;
+    let fixed = || {
+        silo::job::Limit::Concurrency(silo::job::ConcurrencyLimit {
+            key: gate.to_string(),
+            max_concurrency: waiters as u32,
+        })
+    };
+
+    // The floating queue's single slot is held from another task group.
+    enqueue_floating_in_group(&shard, queue, 1, "other").await;
+    // Blockers fill the fixed queue so every chained job parks on it.
+    for i in 0..waiters {
+        shard
+            .enqueue(
+                "-",
+                Some(format!("blocker-{i}")),
+                10u8,
+                now_ms(),
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({"blocker": i})),
+                vec![fixed()],
+                None,
+                "chunk",
+            )
+            .await
+            .expect("enqueue blocker");
+    }
+    for i in 0..waiters {
+        shard
+            .enqueue(
+                "-",
+                Some(format!("chained-{i}")),
+                10u8,
+                now_ms(),
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({"chained": i})),
+                vec![fixed(), floating_limit(queue, REFRESH_INTERVAL_MS)],
+                None,
+                "chunk",
+            )
+            .await
+            .expect("enqueue chained job");
+    }
+    write_refresh_state(&shard, queue, None, 0).await;
+    assert_eq!(read_refresh_reset_total(&metrics), 0.0);
+
+    // Finish the blockers so the fixed queue frees all of its slots at once.
+    let leased = dequeue_task_ids_until(&shard, "worker-1", "chunk", waiters).await;
+    assert_eq!(leased.len(), waiters);
+    for task_id in &leased {
+        shard
+            .report_attempt_outcome(task_id, AttemptOutcome::Success { result: vec![] })
+            .await
+            .expect("finish blocker");
+    }
+
+    // One synchronous grant pass resumes every chained job into one chunk.
+    shard
+        .process_concurrency_grants("-", gate, waiters as u32)
+        .await;
+
+    assert_eq!(count_concurrency_requests(shard.db()).await, waiters);
+    assert_eq!(
+        count_refresh_tasks_in_group(&shard, queue, "chunk").await,
+        1
+    );
+    assert_eq!(read_refresh_reset_total(&metrics), 1.0);
 }

--- a/tests/floating_concurrency_tests.rs
+++ b/tests/floating_concurrency_tests.rs
@@ -512,15 +512,11 @@ async fn floating_concurrency_limit_schedules_refresh_when_stale() {
         .await
         .expect("enqueue j2");
 
-    // Check that a refresh task was scheduled
-    let tasks = shard.peek_tasks("default", 50).await.expect("peek tasks");
-    let has_refresh_task = tasks.iter().any(|t| {
-        matches!(
-            t,
-            Task::RefreshFloatingLimit { queue_key, .. } if queue_key == &queue
-        )
-    });
-    assert!(has_refresh_task, "refresh task should be scheduled");
+    assert_eq!(
+        count_refresh_tasks(&shard, &queue).await,
+        1,
+        "refresh task should be scheduled"
+    );
 }
 
 #[silo::test]
@@ -587,15 +583,9 @@ async fn floating_concurrency_limit_schedules_refresh_when_stale_with_waiters_ab
         "expected a waiting request after exceeding max"
     );
 
-    let tasks = shard.peek_tasks("default", 50).await.expect("peek tasks");
-    let has_refresh_task = tasks.iter().any(|t| {
-        matches!(
-            t,
-            Task::RefreshFloatingLimit { queue_key, .. } if queue_key == &queue
-        )
-    });
-    assert!(
-        has_refresh_task,
+    assert_eq!(
+        count_refresh_tasks(&shard, &queue).await,
+        1,
         "refresh task should be scheduled when waiters exist"
     );
 }
@@ -1132,10 +1122,11 @@ async fn floating_limit_refresh_failure_triggers_backoff() {
     // A new refresh task should be scheduled
     assert!(decoded.refresh_task_scheduled());
 
-    // Verify a task key exists with the floating_refresh prefix in the DB
-    // (checking peek_tasks would require advancing time past backoff)
-    let has_retry_task = first_task_kv(shard.db()).await.is_some();
-    assert!(has_retry_task, "retry task should exist in db");
+    // The retry sits in the refresh index, not claimable before its retry time.
+    let retry = read_refresh_index_row(&shard, &queue, "default")
+        .await
+        .expect("retry row exists in the refresh index");
+    assert_eq!(retry.not_before_ms(), Some(next_retry_at));
 }
 
 #[silo::test]
@@ -1304,20 +1295,9 @@ async fn floating_limit_concurrent_enqueues_no_duplicate_refresh() {
             .expect("enqueue");
     }
 
-    // Count refresh tasks
-    let tasks = shard.peek_tasks("default", 100).await.expect("peek tasks");
-    let refresh_count = tasks
-        .iter()
-        .filter(|t| {
-            matches!(
-                t,
-                Task::RefreshFloatingLimit { queue_key, .. } if queue_key == &queue
-            )
-        })
-        .count();
-
     assert_eq!(
-        refresh_count, 1,
+        count_refresh_tasks(&shard, &queue).await,
+        1,
         "should have exactly one refresh task, not duplicates"
     );
 }
@@ -1863,19 +1843,9 @@ async fn floating_limit_refresh_task_lease_expiry_allows_rescheduling() {
         .await
         .expect("enqueue j3");
 
-    // Check that a new refresh task was scheduled
-    let tasks = shard.peek_tasks("default", 50).await.expect("peek tasks");
-    let refresh_count = tasks
-        .iter()
-        .filter(|t| {
-            matches!(
-                t,
-                Task::RefreshFloatingLimit { queue_key, .. } if queue_key == &queue
-            )
-        })
-        .count();
     assert_eq!(
-        refresh_count, 1,
+        count_refresh_tasks(&shard, &queue).await,
+        1,
         "new refresh task should be scheduled after lease expiry cleanup"
     );
 }
@@ -2310,7 +2280,46 @@ async fn write_orphaned_refresh_state(
     shard.db().flush().await.expect("flush state");
 }
 
+/// The refresh index row for `queue` under `task_group`, if one is pending.
+async fn read_refresh_index_row(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+    task_group: &str,
+) -> Option<silo::codec::DecodedTask> {
+    shard
+        .db()
+        .get(&silo::keys::refresh_task_key(task_group, "-", queue))
+        .await
+        .expect("get refresh index row")
+        .map(|raw| silo::codec::decode_task_validated(raw).expect("decode refresh index row"))
+}
+
+/// Count the refresh index rows for `queue` under `task_group`. Every
+/// pending refresh is visible here, including a backed-off retry.
 async fn count_refresh_tasks_in_group(
+    shard: &silo::job_store_shard::JobStoreShard,
+    queue: &str,
+    task_group: &str,
+) -> usize {
+    let start = silo::keys::refresh_task_group_prefix(task_group);
+    let end = silo::keys::end_bound(&start);
+    let mut iter = shard
+        .db()
+        .scan::<Vec<u8>, _>(start..end)
+        .await
+        .expect("scan refresh index");
+    let mut count = 0;
+    while let Some(kv) = iter.next().await.expect("iterate refresh index") {
+        if silo::keys::parse_refresh_task_key(&kv.key).is_some_and(|p| p.queue_key == queue) {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Count the `RefreshFloatingLimit` rows for `queue` sitting in the task
+/// line under `task_group`, the shape earlier builds wrote.
+async fn count_task_line_refresh_tasks(
     shard: &silo::job_store_shard::JobStoreShard,
     queue: &str,
     task_group: &str,
@@ -2438,8 +2447,8 @@ async fn floating_limit_just_scheduled_refresh_is_stamped_and_not_replaced() {
     );
 
     // A later waiter in a different millisecond sees a trusted refresh and
-    // writes no second row. Refresh task keys are millisecond-keyed, so a
-    // wrongly written second row would be distinct and observable.
+    // writes nothing. A wrongly written replacement would land on the same
+    // index key, so the unchanged stamp is what shows no write happened.
     std::thread::sleep(std::time::Duration::from_millis(2));
     enqueue_floating(&shard, queue, 3).await;
     assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
@@ -2500,6 +2509,14 @@ async fn floating_limit_refresh_failure_with_waiters_stamps_retry_start_time() {
         "the retry is stamped with its own start time, not the failure time"
     );
     assert!(next_retry > now_ms() - 5_000);
+    let retry = read_refresh_index_row(&shard, queue, "default")
+        .await
+        .expect("the retry is pending in the refresh index");
+    assert_eq!(
+        retry.not_before_ms(),
+        Some(next_retry),
+        "the retry row is not claimable before its retry time"
+    );
 }
 
 #[silo::test]
@@ -3023,26 +3040,38 @@ async fn floating_limit_scanner_refresh_skips_unreadable_head_waiter() {
     );
 }
 
-/// Two refresh rows for one queue, as racing writers in different
-/// milliseconds produce: the first waiter schedules one, and a second waiter
-/// schedules another after the flag is aged out while the first row is still
-/// durable. Both are leased and reported; the last outcome wins and the flag
-/// ends cleared.
+/// Two refresh outcomes for one queue: the first refresh is leased, then its
+/// flag is aged out while the lease is still held and a new waiter schedules
+/// a replacement. Both are reported; the last outcome wins and the flag ends
+/// cleared.
 #[silo::test]
-async fn floating_limit_two_refresh_rows_are_both_leased_and_reported() {
+async fn floating_limit_leased_refresh_and_its_replacement_are_both_reported() {
     let (_tmp, shard) = open_temp_shard().await;
     shard.stop_grant_scanner();
-    let queue = "fl-two-rows-q";
+    let queue = "fl-two-outcomes-q";
     enqueue_floating(&shard, queue, 1).await;
     enqueue_floating(&shard, queue, 2).await;
     assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
-    write_orphaned_refresh_state(&shard, queue, Some(now_ms() - 120_000)).await;
-    std::thread::sleep(std::time::Duration::from_millis(2));
-    enqueue_floating(&shard, queue, 3).await;
-    assert_eq!(count_refresh_tasks(&shard, queue).await, 2);
 
-    let leased = dequeue_refresh_tasks_until(&shard, "w", "default", 2, DEQUEUE_TIMEOUT).await;
-    for (i, task) in leased.refresh_tasks.iter().enumerate() {
+    let first = dequeue_refresh_tasks_until(&shard, "w", "default", 1, DEQUEUE_TIMEOUT).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+    assert_eq!(
+        count_lease_keys(shard.db()).await,
+        2,
+        "the holder and the refresh are leased"
+    );
+
+    write_orphaned_refresh_state(&shard, queue, Some(now_ms() - 120_000)).await;
+    enqueue_floating(&shard, queue, 3).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
+    let second = dequeue_refresh_tasks_until(&shard, "w", "default", 1, DEQUEUE_TIMEOUT).await;
+
+    for (i, task) in first
+        .refresh_tasks
+        .iter()
+        .chain(second.refresh_tasks.iter())
+        .enumerate()
+    {
         shard
             .report_refresh_success(&task.task_id, 5 + i as u32)
             .await
@@ -3107,4 +3136,422 @@ async fn floating_limit_request_ticket_converts_despite_unreadable_state_row() {
         "the ticket becomes a waiter despite the unreadable state row"
     );
     assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Refresh delivery through the refresh index
+// ---------------------------------------------------------------------------
+
+/// Enqueue `n` plain due jobs under `task_group`.
+async fn enqueue_backlog(shard: &silo::job_store_shard::JobStoreShard, task_group: &str, n: usize) {
+    for i in 0..n {
+        shard
+            .enqueue(
+                "-",
+                Some(format!("{task_group}-backlog-{i}")),
+                10u8,
+                now_ms(),
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({"backlog": i})),
+                vec![],
+                None,
+                task_group,
+            )
+            .await
+            .expect("enqueue backlog job");
+    }
+}
+
+/// Fifty due jobs sit ahead of the refresh in the head waiter's task group.
+/// A dequeue of ten still hands the pending refresh to the worker: refresh
+/// delivery does not depend on how deep the group's job backlog is.
+#[silo::test]
+async fn floating_limit_refresh_is_delivered_ahead_of_a_deep_backlog() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-front-of-line-q";
+
+    enqueue_backlog(&shard, "default", 50).await;
+    // j1 holds the single slot; j2 lands as a waiter and schedules the refresh.
+    enqueue_floating(&shard, queue, 1).await;
+    enqueue_floating(&shard, queue, 2).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
+
+    let result = shard
+        .dequeue("worker-1", "default", 10)
+        .await
+        .expect("dequeue");
+    assert_eq!(
+        result.refresh_tasks.len(),
+        1,
+        "the pending refresh is handed over ahead of the backlog"
+    );
+    assert_eq!(result.refresh_tasks[0].queue_key, queue);
+    assert_eq!(result.tasks.len(), 10, "the job budget is still filled");
+}
+
+/// A `RefreshFloatingLimit` task for `queue` under `task_group`, the value
+/// a refresh index row holds.
+fn refresh_task(tenant: &str, queue: &str, task_group: &str) -> Task {
+    Task::RefreshFloatingLimit {
+        task_id: uuid::Uuid::new_v4().to_string(),
+        tenant: tenant.to_string(),
+        queue_key: queue.to_string(),
+        current_max_concurrency: 1,
+        last_refreshed_at_ms: 0,
+        metadata: vec![],
+        task_group: task_group.to_string(),
+    }
+}
+
+/// Count every refresh index row under `task_group`, whatever its queue.
+async fn count_refresh_index_rows(
+    shard: &silo::job_store_shard::JobStoreShard,
+    task_group: &str,
+) -> usize {
+    count_with_binary_prefix(
+        shard.db(),
+        &silo::keys::refresh_task_group_prefix(task_group),
+    )
+    .await
+}
+
+/// A task group with nothing in its broker buffer still hands over the
+/// pending refresh: the drain runs before, and independently of, the claim
+/// loop.
+#[silo::test]
+async fn floating_limit_refresh_is_delivered_from_an_idle_task_group() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-idle-group-q";
+
+    // The holder runs under `default`; the waiter's group `idle` has no task
+    // rows at all, only the refresh its enqueue scheduled.
+    enqueue_floating(&shard, queue, 1).await;
+    enqueue_floating_in_group(&shard, queue, 2, "idle").await;
+    assert_eq!(count_refresh_tasks_in_group(&shard, queue, "idle").await, 1);
+    assert!(shard.peek_tasks("idle", 10).await.expect("peek").is_empty());
+
+    let result = shard
+        .dequeue("worker-1", "idle", 10)
+        .await
+        .expect("dequeue");
+    assert!(result.tasks.is_empty());
+    assert_eq!(result.refresh_tasks.len(), 1);
+    assert_eq!(result.refresh_tasks[0].queue_key, queue);
+    assert_eq!(count_refresh_tasks_in_group(&shard, queue, "idle").await, 0);
+}
+
+/// Scheduling over a stale flag replaces the queue's unclaimed row in place:
+/// the index holds one row for the queue and the reset counter moves by one.
+#[silo::test]
+async fn floating_limit_stale_replacement_rewrites_the_index_row_in_place() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_floating_refresh_stale_ms(60_000).await;
+    shard.stop_grant_scanner();
+    let queue = "fl-in-place-q";
+
+    enqueue_floating(&shard, queue, 1).await;
+    enqueue_floating(&shard, queue, 2).await;
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
+    let first_task_id = read_refresh_index_row(&shard, queue, "default")
+        .await
+        .and_then(|row| {
+            row.as_refresh_floating_limit()
+                .map(|r| r.task_id().unwrap_or_default().to_string())
+        })
+        .expect("the first refresh is pending");
+
+    write_orphaned_refresh_state(&shard, queue, Some(now_ms() - 120_000)).await;
+    enqueue_floating(&shard, queue, 3).await;
+
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
+    assert_eq!(read_refresh_reset_total(&metrics), 1.0);
+    let replacement = read_refresh_index_row(&shard, queue, "default")
+        .await
+        .and_then(|row| {
+            row.as_refresh_floating_limit()
+                .map(|r| r.task_id().unwrap_or_default().to_string())
+        })
+        .expect("the replacement is pending");
+    assert_ne!(replacement, first_task_id, "the replacement is a new task");
+}
+
+/// A backed-off retry stays in the index unclaimable until its retry time.
+#[silo::test]
+async fn floating_limit_backed_off_retry_is_not_delivered_before_its_retry_time() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-retry-gate-q";
+    let task_id = schedule_and_lease_refresh(&shard, queue)
+        .await
+        .refresh_tasks[0]
+        .task_id
+        .clone();
+    shard
+        .report_refresh_failure(&task_id, "boom", "upstream down")
+        .await
+        .expect("report failure");
+    let next_retry = read_floating_state(&shard, queue)
+        .await
+        .next_retry_at_ms()
+        .expect("failure sets a retry time");
+    assert!(now_ms() < next_retry, "the retry is in the future");
+
+    let early = shard
+        .dequeue("worker-1", "default", 10)
+        .await
+        .expect("dequeue before retry time");
+    assert!(
+        early.refresh_tasks.is_empty(),
+        "the retry is not claimable before its retry time"
+    );
+    assert_eq!(
+        count_refresh_tasks(&shard, queue).await,
+        1,
+        "the retry is still pending"
+    );
+
+    let wait = (next_retry - now_ms()).max(0) as u64 + 50;
+    tokio::time::sleep(std::time::Duration::from_millis(wait)).await;
+    let due = dequeue_refresh_tasks_until(&shard, "worker-1", "default", 1, DEQUEUE_TIMEOUT).await;
+    assert_eq!(due.refresh_tasks[0].queue_key, queue);
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+}
+
+/// An index row for a tenant outside the shard range is dropped by the
+/// drain, not leased.
+#[silo::test]
+async fn floating_limit_defunct_index_row_is_dropped_on_dequeue() {
+    // `aaa` hashes outside the left half of the keyspace.
+    let left_half = silo::shard_range::ShardRange::new("", "8000000000000000");
+    assert!(!left_half.contains_tenant("aaa"));
+    let (_tmp, shard) = open_temp_shard_with_range(left_half).await;
+    shard.stop_grant_scanner();
+
+    shard
+        .put_refresh_index_row_for_test(&refresh_task("aaa", "fl-defunct-q", "default"), None)
+        .await
+        .expect("seed defunct row");
+    assert_eq!(count_refresh_index_rows(&shard, "default").await, 1);
+
+    let result = shard
+        .dequeue("worker-1", "default", 10)
+        .await
+        .expect("dequeue");
+    assert!(
+        result.refresh_tasks.is_empty(),
+        "a defunct row is never leased"
+    );
+    assert_eq!(count_refresh_index_rows(&shard, "default").await, 0);
+    assert_eq!(count_lease_keys(shard.db()).await, 0);
+}
+
+/// A group with more pending refreshes than one drain leases hands over at
+/// most the drain bound per dequeue and the rest on the next.
+#[silo::test]
+async fn floating_limit_drain_leases_at_most_the_bound_per_dequeue() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let bound = silo::job_store_shard::REFRESH_DRAIN_MAX_LEASED;
+    let pending = bound + 4;
+    for i in 0..pending {
+        shard
+            .put_refresh_index_row_for_test(
+                &refresh_task("-", &format!("fl-fan-q-{i:02}"), "fan"),
+                None,
+            )
+            .await
+            .expect("seed row");
+    }
+
+    let first = shard
+        .dequeue("worker-1", "fan", 100)
+        .await
+        .expect("dequeue 1");
+    assert_eq!(first.refresh_tasks.len(), bound);
+    let second = shard
+        .dequeue("worker-1", "fan", 100)
+        .await
+        .expect("dequeue 2");
+    assert_eq!(second.refresh_tasks.len(), pending - bound);
+    assert_eq!(count_refresh_index_rows(&shard, "fan").await, 0);
+    let third = shard
+        .dequeue("worker-1", "fan", 100)
+        .await
+        .expect("dequeue 3");
+    assert!(third.refresh_tasks.is_empty());
+}
+
+/// The drain bound counts leased rows, not scanned rows: a claimable row
+/// sorting after more than a bound's worth of backed-off rows is still
+/// returned on the first dequeue.
+#[silo::test]
+async fn floating_limit_claimable_row_behind_backed_off_rows_is_delivered() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let far_future = now_ms() + 3_600_000;
+    for i in 0..silo::job_store_shard::REFRESH_DRAIN_MAX_LEASED + 4 {
+        shard
+            .put_refresh_index_row_for_test(
+                &refresh_task("-", &format!("fl-backed-off-q-{i:02}"), "fan"),
+                Some(far_future),
+            )
+            .await
+            .expect("seed backed-off row");
+    }
+    // `z` sorts after every `fl-backed-off-*` key.
+    shard
+        .put_refresh_index_row_for_test(&refresh_task("-", "z-claimable-q", "fan"), None)
+        .await
+        .expect("seed claimable row");
+
+    let result = shard
+        .dequeue("worker-1", "fan", 100)
+        .await
+        .expect("dequeue");
+    assert_eq!(result.refresh_tasks.len(), 1);
+    assert_eq!(result.refresh_tasks[0].queue_key, "z-claimable-q");
+}
+
+/// A `RefreshFloatingLimit` row an earlier build wrote into the task line is
+/// still leased when the broker reaches it.
+#[silo::test]
+async fn floating_limit_task_line_refresh_row_is_still_leased() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-task-line-q";
+    let now = now_ms();
+    let task = refresh_task("-", queue, "default");
+    shard
+        .db()
+        .put(
+            &silo::keys::task_key(
+                "default",
+                now,
+                0,
+                &format!("floating_refresh:{queue}"),
+                0,
+                now,
+            ),
+            &silo::codec::encode_task(&task),
+        )
+        .await
+        .expect("write task-line refresh row");
+    shard.db().flush().await.expect("flush");
+    assert_eq!(
+        count_task_line_refresh_tasks(&shard, queue, "default").await,
+        1
+    );
+    assert_eq!(count_refresh_tasks(&shard, queue).await, 0);
+
+    let leased =
+        dequeue_refresh_tasks_until(&shard, "worker-1", "default", 1, DEQUEUE_TIMEOUT).await;
+    assert_eq!(leased.refresh_tasks[0].queue_key, queue);
+    assert_eq!(
+        count_task_line_refresh_tasks(&shard, queue, "default").await,
+        0
+    );
+    assert_eq!(count_lease_keys(shard.db()).await, 1);
+}
+
+/// A shard reopened with stock settings warms its pending-group gate from
+/// the durable index, so a refresh left pending is drained on the first
+/// dequeue after the reopen.
+#[silo::test]
+async fn floating_limit_pending_refresh_survives_a_shard_reopen() {
+    use silo::settings::{Backend, DatabaseConfig};
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = DatabaseConfig {
+        name: "test".to_string(),
+        backend: Backend::Fs,
+        path: tmp.path().to_string_lossy().to_string(),
+        slatedb: Some(test_helpers::fast_flush_slatedb_settings()),
+        ..Default::default()
+    };
+    let queue = "fl-reopen-q";
+    {
+        let shard = silo::job_store_shard::JobStoreShard::open(
+            &cfg,
+            silo::gubernator::MockGubernatorClient::new_arc(),
+            None,
+            silo::shard_range::ShardRange::full(),
+        )
+        .await
+        .expect("open shard");
+        shard.stop_grant_scanner();
+        enqueue_floating(&shard, queue, 1).await;
+        enqueue_floating(&shard, queue, 2).await;
+        assert_eq!(count_refresh_tasks(&shard, queue).await, 1);
+        shard.close().await.expect("close shard");
+    }
+    let shard = silo::job_store_shard::JobStoreShard::open(
+        &cfg,
+        silo::gubernator::MockGubernatorClient::new_arc(),
+        None,
+        silo::shard_range::ShardRange::full(),
+    )
+    .await
+    .expect("reopen shard");
+    shard.stop_grant_scanner();
+
+    let result = shard
+        .dequeue("worker-1", "default", 0)
+        .await
+        .expect("dequeue");
+    assert_eq!(
+        result.refresh_tasks.len(),
+        1,
+        "the pending refresh is drained after the reopen"
+    );
+    assert_eq!(result.refresh_tasks[0].queue_key, queue);
+}
+
+/// Index rows written by the scheduler and by the failure path carry the
+/// index row TTL.
+#[silo::test]
+async fn floating_limit_index_rows_carry_the_row_ttl() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    let queue = "fl-row-ttl-q";
+    let ttl = silo::job_store_shard::REFRESH_INDEX_ROW_TTL_MS;
+    let key = silo::keys::refresh_task_key("default", "-", queue);
+
+    let before = now_ms();
+    enqueue_floating(&shard, queue, 1).await;
+    enqueue_floating(&shard, queue, 2).await;
+    let scheduled = shard
+        .db()
+        .get_key_value(&key)
+        .await
+        .expect("get_key_value")
+        .expect("scheduled row present")
+        .expire_ts
+        .expect("scheduled row carries expire_ts");
+    assert!(
+        scheduled >= before + ttl - 5_000 && scheduled <= now_ms() + ttl + 5_000,
+        "scheduled row expire_ts {scheduled} is not about {ttl} ms out"
+    );
+
+    let task_id = dequeue_refresh_tasks_until(&shard, "worker-1", "default", 1, DEQUEUE_TIMEOUT)
+        .await
+        .refresh_tasks[0]
+        .task_id
+        .clone();
+    let before = now_ms();
+    shard
+        .report_refresh_failure(&task_id, "boom", "upstream down")
+        .await
+        .expect("report failure");
+    let retried = shard
+        .db()
+        .get_key_value(&key)
+        .await
+        .expect("get_key_value")
+        .expect("retry row present")
+        .expire_ts
+        .expect("retry row carries expire_ts");
+    assert!(
+        retried >= before + ttl - 5_000 && retried <= now_ms() + ttl + 5_000,
+        "retry row expire_ts {retried} is not about {ttl} ms out"
+    );
 }

--- a/tests/floating_concurrency_tests.rs
+++ b/tests/floating_concurrency_tests.rs
@@ -2665,6 +2665,72 @@ async fn floating_limit_stale_threshold_setting_governs_age_out() {
     assert_eq!(read_refresh_reset_total(&metrics), 1.0);
 }
 
+/// Twenty jobs whose chains continue from a rate limit into a floating queue
+/// at capacity are walked into one dequeue batch. The batch's reads see the
+/// durable state row, so every walk finds the same stale flag; the batch
+/// must still write one replacement refresh and count one reset.
+#[silo::test]
+async fn floating_limit_one_batch_of_waiters_schedules_one_replacement_refresh() {
+    let (_tmp, shard, metrics) = open_temp_shard_with_floating_refresh_stale_ms(60_000).await;
+    shard.stop_grant_scanner();
+    let queue = "fl-batch-dedupe-q";
+
+    // j1 holds the single slot, so every later job lands as a waiter.
+    enqueue_floating(&shard, queue, 1).await;
+    // A flag with no stamp behind it is stale on sight.
+    write_orphaned_refresh_state(&shard, queue, None).await;
+    assert_eq!(read_refresh_reset_total(&metrics), 0.0);
+
+    // Each chain parks on a rate limit first, so the floating queue is only
+    // reached by the dequeue that passes the rate limit, which walks all
+    // twenty chains into a single batch under the `batch` group.
+    let rate_limit = silo::job::GubernatorRateLimit {
+        name: "batch-dedupe".to_string(),
+        unique_key: format!("batch-dedupe-{}", uuid::Uuid::new_v4()),
+        limit: 100,
+        duration_ms: 60_000,
+        hits: 1,
+        algorithm: silo::job::GubernatorAlgorithm::TokenBucket,
+        behavior: 0,
+        retry_policy: silo::job::RateLimitRetryPolicy::default(),
+    };
+    for tag in 0..20u32 {
+        shard
+            .enqueue(
+                "-",
+                None,
+                10u8,
+                now_ms(),
+                None,
+                test_helpers::msgpack_payload(&serde_json::json!({"j": tag})),
+                vec![
+                    silo::job::Limit::RateLimit(rate_limit.clone()),
+                    floating_limit(queue, REFRESH_INTERVAL_MS),
+                ],
+                None,
+                "batch",
+            )
+            .await
+            .expect("enqueue chained job");
+    }
+
+    let result = shard
+        .dequeue("worker-1", "batch", 100)
+        .await
+        .expect("dequeue");
+    assert!(
+        result.tasks.is_empty(),
+        "every chained job waits on the floating queue"
+    );
+    assert_eq!(count_concurrency_requests(shard.db()).await, 20);
+    assert_eq!(
+        count_refresh_tasks_in_group(&shard, queue, "batch").await + result.refresh_tasks.len(),
+        1,
+        "one batch schedules one replacement refresh"
+    );
+    assert_eq!(read_refresh_reset_total(&metrics), 1.0);
+}
+
 // ---------------------------------------------------------------------------
 // Scheduling refreshes from the grant-scanner and RequestTicket paths
 // ---------------------------------------------------------------------------

--- a/tests/grpc_lease_tasks_refresh_tests.rs
+++ b/tests/grpc_lease_tasks_refresh_tests.rs
@@ -1,0 +1,107 @@
+mod grpc_integration_helpers;
+mod test_helpers;
+
+use std::sync::Arc;
+
+use grpc_integration_helpers::{setup_multi_shard_server, shutdown_server};
+use silo::job_store_shard::JobStoreShard;
+use silo::pb::silo_client::SiloClient;
+use silo::pb::*;
+use silo::settings::AppConfig;
+
+/// A tenant whose hash lands in `shard`'s range, taken from a small pool.
+fn tenant_on(shard: &JobStoreShard) -> &'static str {
+    ["aaa", "bbb", "lll", "mmm", "nnn", "yyy"]
+        .into_iter()
+        .find(|t| shard.get_range().contains_tenant(t))
+        .expect("one of the pool tenants hashes into the shard")
+}
+
+async fn enqueue_floating(shard: &JobStoreShard, tenant: &str, queue: &str, tag: u32) {
+    shard
+        .enqueue(
+            tenant,
+            Some(format!("{queue}-job-{tag}")),
+            10u8,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": tag})),
+            vec![silo::job::Limit::FloatingConcurrency(
+                silo::job::FloatingConcurrencyLimit {
+                    key: queue.to_string(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 100,
+                    metadata: vec![],
+                },
+            )],
+            None,
+            "default",
+        )
+        .await
+        .expect("enqueue floating job");
+}
+
+/// A lease request whose job budget is met by one shard still returns a
+/// pending refresh from another local shard for the same task group.
+#[silo::test(flavor = "multi_thread")]
+async fn lease_tasks_drains_refreshes_from_shards_it_did_not_dequeue() -> anyhow::Result<()> {
+    let (shutdown_tx, server, addr, factory, _tmp) =
+        setup_multi_shard_server(2, AppConfig::load(None).unwrap()).await?;
+    let shards: Vec<Arc<JobStoreShard>> = factory.instances().values().cloned().collect();
+    assert_eq!(shards.len(), 2);
+    let (job_shard, refresh_shard) = (&shards[0], &shards[1]);
+    for shard in &shards {
+        shard.stop_grant_scanner();
+    }
+
+    // One plain due job on the first shard fills a budget of one.
+    job_shard
+        .enqueue(
+            tenant_on(job_shard),
+            Some("budget-job".to_string()),
+            10u8,
+            test_helpers::now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({})),
+            vec![],
+            None,
+            "default",
+        )
+        .await?;
+
+    // On the second shard the holder is leased first, so its only pending
+    // work under `default` is the refresh the waiter's enqueue scheduled.
+    let tenant = tenant_on(refresh_shard);
+    let queue = "fl-fan-out-q";
+    enqueue_floating(refresh_shard, tenant, queue, 1).await;
+    let holder = refresh_shard.dequeue("setup", "default", 10).await?;
+    assert_eq!(holder.tasks.len(), 1);
+    assert!(holder.refresh_tasks.is_empty());
+    enqueue_floating(refresh_shard, tenant, queue, 2).await;
+
+    let endpoint = format!("http://{}", addr);
+    let channel = tonic::transport::Endpoint::new(endpoint)?.connect().await?;
+    let mut client = SiloClient::new(channel);
+    let resp = client
+        .lease_tasks(LeaseTasksRequest {
+            shard: None,
+            worker_id: "w1".to_string(),
+            max_tasks: 1,
+            task_group: "default".to_string(),
+        })
+        .await?
+        .into_inner();
+
+    assert_eq!(resp.tasks.len(), 1, "the job budget is filled");
+    assert_eq!(resp.tasks[0].shard, job_shard.name());
+    assert_eq!(
+        resp.refresh_tasks.len(),
+        1,
+        "the other shard's pending refresh rides along"
+    );
+    assert_eq!(resp.refresh_tasks[0].queue_key, queue);
+    assert_eq!(resp.refresh_tasks[0].shard, refresh_shard.name());
+
+    shutdown_server(shutdown_tx, server).await?;
+    Ok(())
+}

--- a/tests/job_store_shard_concurrency_tests.rs
+++ b/tests/job_store_shard_concurrency_tests.rs
@@ -2663,6 +2663,7 @@ async fn grant_scanner_precheck_floating_follows_durable_state() {
             next_retry_at_ms: None,
             metadata: vec![],
             refresh_scheduled_at_ms: Some(now),
+            stale_reset_count: 0,
         })
     };
     let state_key = silo::keys::floating_limit_state_key(tenant, queue);
@@ -6255,6 +6256,7 @@ async fn grant_scanner_next_hop_skip_floating_follows_durable_state() {
             next_retry_at_ms: None,
             metadata: vec![],
             refresh_scheduled_at_ms: Some(now),
+            stale_reset_count: 0,
         })
     };
 

--- a/tests/keys_tests.rs
+++ b/tests/keys_tests.rs
@@ -476,3 +476,27 @@ fn test_refresh_task_key_roundtrip_and_prefixes() {
     assert!(!key.starts_with(&refresh_task_group_prefix("email")));
     assert!(parse_refresh_task_key(&floating_limit_state_key("tenant-a", "queue/one")).is_none());
 }
+
+#[test]
+fn test_refresh_task_key_edge_strings_and_foreign_input() {
+    use silo::keys::{parse_refresh_task_key, refresh_task_group_prefix, refresh_task_key};
+    for (group, tenant, queue) in [("", "", ""), ("g\0x", "t\0", "q"), ("g", "-", "a/b:c")] {
+        let key = refresh_task_key(group, tenant, queue);
+        let parsed = parse_refresh_task_key(&key).expect("roundtrip");
+        assert_eq!(
+            (
+                parsed.task_group.as_str(),
+                parsed.tenant.as_str(),
+                parsed.queue_key.as_str()
+            ),
+            (group, tenant, queue)
+        );
+        assert!(key.starts_with(&refresh_task_group_prefix(group)));
+    }
+    // An embedded NUL is escaped, so a group is never a prefix of a longer group.
+    assert!(!refresh_task_key("g\0x", "t", "q").starts_with(&refresh_task_group_prefix("g")));
+    assert!(!refresh_task_key("gx", "t", "q").starts_with(&refresh_task_group_prefix("g")));
+    assert!(parse_refresh_task_key(&[]).is_none());
+    assert!(parse_refresh_task_key(&job_info_key("t", "j")).is_none());
+    assert!(parse_refresh_task_key(&task_key("g", 1, 0, "j", 1, 1)).is_none());
+}

--- a/tests/keys_tests.rs
+++ b/tests/keys_tests.rs
@@ -457,3 +457,22 @@ fn test_task_key_lookup_prefix_matches_any_epoch() {
     let other = task_key("group1", 1000, 10, "job124", 1, 0);
     assert!(!other.starts_with(&prefix));
 }
+
+#[test]
+fn test_refresh_task_key_roundtrip_and_prefixes() {
+    use silo::keys::{
+        parse_refresh_task_key, refresh_task_group_prefix, refresh_task_key,
+        refresh_task_tenant_prefix, refresh_tasks_prefix,
+    };
+    let key = refresh_task_key("emails", "tenant-a", "queue/one");
+    let parsed = parse_refresh_task_key(&key).expect("parse refresh task key");
+    assert_eq!(parsed.task_group, "emails");
+    assert_eq!(parsed.tenant, "tenant-a");
+    assert_eq!(parsed.queue_key, "queue/one");
+
+    assert!(key.starts_with(&refresh_tasks_prefix()));
+    assert!(key.starts_with(&refresh_task_group_prefix("emails")));
+    assert!(key.starts_with(&refresh_task_tenant_prefix("emails", "tenant-a")));
+    assert!(!key.starts_with(&refresh_task_group_prefix("email")));
+    assert!(parse_refresh_task_key(&floating_limit_state_key("tenant-a", "queue/one")).is_none());
+}

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -5747,6 +5747,87 @@ async fn seed_pending_refresh(
         .expect("seed refresh index row");
 }
 
+/// Enqueue a job on floating `queue` under `task_group`; the second job on a
+/// queue lands as a waiter and schedules the queue's refresh.
+async fn enqueue_floating_in_group(shard: &JobStoreShard, queue: &str, tag: u32, task_group: &str) {
+    shard
+        .enqueue(
+            "-",
+            Some(format!("{queue}-job-{tag}")),
+            10u8,
+            now_ms(),
+            None,
+            test_helpers::msgpack_payload(&serde_json::json!({"j": tag})),
+            vec![silo::job::Limit::FloatingConcurrency(
+                silo::job::FloatingConcurrencyLimit {
+                    key: queue.to_string(),
+                    default_max_concurrency: 1,
+                    refresh_interval_ms: 100,
+                    metadata: vec![],
+                },
+            )],
+            None,
+            task_group,
+        )
+        .await
+        .expect("enqueue floating job");
+}
+
+/// Rows scheduled by the enqueue path and by the failure path are listed
+/// alongside seeded rows, with the retry's `not_before_ms` carried through.
+#[silo::test]
+async fn floating_refresh_tasks_table_lists_scheduled_and_retried_refreshes() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    enqueue_floating_in_group(&shard, "q-live", 1, "emails").await;
+    enqueue_floating_in_group(&shard, "q-live", 2, "emails").await;
+    enqueue_floating_in_group(&shard, "q-retry", 1, "emails").await;
+    enqueue_floating_in_group(&shard, "q-retry", 2, "emails").await;
+    let leased = shard
+        .dequeue("worker-1", "emails", 0)
+        .await
+        .expect("drain refreshes");
+    let retry_task = leased
+        .refresh_tasks
+        .iter()
+        .find(|rt| rt.queue_key == "q-retry")
+        .expect("q-retry refresh leased");
+    shard
+        .report_refresh_failure(&retry_task.task_id, "boom", "upstream down")
+        .await
+        .expect("report failure");
+    let next_retry = {
+        let raw = shard
+            .db()
+            .get(&silo::keys::floating_limit_state_key("-", "q-retry"))
+            .await
+            .expect("get state")
+            .expect("state exists");
+        silo::codec::decode_floating_limit_state(raw)
+            .expect("decode state")
+            .next_retry_at_ms()
+            .expect("failure sets a retry time")
+    };
+    // The leased q-live refresh is gone from the index; a new waiter after
+    // the flag ages out would reschedule it, but here only the retry remains.
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql("SELECT queue_key, not_before_ms FROM floating_refresh_tasks WHERE task_group = 'emails' ORDER BY queue_key")
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    assert_eq!(extract_string_column(&batches, 0), vec!["q-retry"]);
+    let not_before = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("not_before_ms column");
+    assert_eq!(not_before.value(0), next_retry);
+}
+
 #[silo::test]
 async fn floating_refresh_tasks_table_lists_pending_refreshes() {
     let (_tmp, shard) = open_temp_shard().await;
@@ -5816,6 +5897,8 @@ async fn floating_refresh_tasks_table_pushes_task_group_and_tenant_down() {
     seed_pending_refresh(&shard, "-", "q-a", "emails", None).await;
     seed_pending_refresh(&shard, "t2", "q-b", "emails", None).await;
     seed_pending_refresh(&shard, "-", "q-c", "other", None).await;
+    // A group whose name extends the queried one sits outside its prefix.
+    seed_pending_refresh(&shard, "-", "q-e", "emails-2", None).await;
 
     let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
     let query = "SELECT queue_key FROM floating_refresh_tasks WHERE task_group = 'emails' AND tenant = '-' ORDER BY queue_key";
@@ -5842,6 +5925,22 @@ async fn floating_refresh_tasks_table_pushes_task_group_and_tenant_down() {
     assert!(
         !explain.contains("FilterExec"),
         "prefix filters are exact and need no post-filter: {explain}"
+    );
+
+    let limited =
+        "SELECT queue_key FROM floating_refresh_tasks WHERE task_group = 'emails' LIMIT 1";
+    let batches = sql
+        .sql(limited)
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    assert_eq!(extract_string_column(&batches, 0).len(), 1);
+    let explain = sql.explain(limited).await.expect("explain");
+    assert!(
+        explain.contains("limit=Some(1)"),
+        "the limit is pushed into the scan: {explain}"
     );
 
     // A tenant filter alone cannot bound the prefix and is re-applied.

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -5719,3 +5719,144 @@ fn extract_queue_counts_partial(
     }
     results
 }
+
+// ===== floating_refresh_tasks table tests =====
+
+/// Seed a pending refresh for `queue` under `task_group` in the refresh index.
+async fn seed_pending_refresh(
+    shard: &JobStoreShard,
+    tenant: &str,
+    queue: &str,
+    task_group: &str,
+    not_before_ms: Option<i64>,
+) {
+    shard
+        .put_refresh_index_row_for_test(
+            &silo::task::Task::RefreshFloatingLimit {
+                task_id: format!("{task_group}-{tenant}-{queue}"),
+                tenant: tenant.to_string(),
+                queue_key: queue.to_string(),
+                current_max_concurrency: 7,
+                last_refreshed_at_ms: 4_000,
+                metadata: vec![],
+                task_group: task_group.to_string(),
+            },
+            not_before_ms,
+        )
+        .await
+        .expect("seed refresh index row");
+}
+
+#[silo::test]
+async fn floating_refresh_tasks_table_lists_pending_refreshes() {
+    let (_tmp, shard) = open_temp_shard().await;
+    seed_pending_refresh(&shard, "-", "q-a", "emails", None).await;
+    seed_pending_refresh(&shard, "-", "q-b", "emails", Some(1_234)).await;
+    seed_pending_refresh(&shard, "t2", "q-c", "emails", None).await;
+    seed_pending_refresh(&shard, "-", "q-d", "other", None).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let batches = sql
+        .sql(
+            "SELECT task_group, tenant, queue_key, task_id, not_before_ms, current_max_concurrency, last_refreshed_at_ms \
+             FROM floating_refresh_tasks ORDER BY task_group, tenant, queue_key",
+        )
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+
+    assert_eq!(
+        extract_string_column(&batches, 0),
+        vec!["emails", "emails", "emails", "other"]
+    );
+    assert_eq!(
+        extract_string_column(&batches, 1),
+        vec!["-", "-", "t2", "-"]
+    );
+    assert_eq!(
+        extract_string_column(&batches, 2),
+        vec!["q-a", "q-b", "q-c", "q-d"]
+    );
+    assert_eq!(extract_string_column(&batches, 3)[1], "emails---q-b");
+    let not_before = batches[0]
+        .column(4)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("not_before_ms column");
+    assert!(
+        not_before.is_null(0),
+        "a claimable row has no not_before_ms"
+    );
+    assert_eq!(not_before.value(1), 1_234);
+    let current_max = batches[0]
+        .column(5)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .expect("current_max_concurrency column");
+    assert_eq!(current_max.value(0), 7);
+    let last_refreshed = batches[0]
+        .column(6)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("last_refreshed_at_ms column");
+    assert_eq!(last_refreshed.value(0), 4_000);
+}
+
+/// `task_group` and `tenant` equality filters bound the scan to a key
+/// prefix and are handled exactly: the plan carries them into the scan and
+/// adds no post-filter.
+#[silo::test]
+async fn floating_refresh_tasks_table_pushes_task_group_and_tenant_down() {
+    use silo::query::{
+        FloatingRefreshTasksScanStrategy, parse_floating_refresh_tasks_scan_strategy,
+    };
+    let (_tmp, shard) = open_temp_shard().await;
+    seed_pending_refresh(&shard, "-", "q-a", "emails", None).await;
+    seed_pending_refresh(&shard, "t2", "q-b", "emails", None).await;
+    seed_pending_refresh(&shard, "-", "q-c", "other", None).await;
+
+    let sql = ShardQueryEngine::new(Arc::clone(&shard), "jobs").expect("new ShardQueryEngine");
+    let query = "SELECT queue_key FROM floating_refresh_tasks WHERE task_group = 'emails' AND tenant = '-' ORDER BY queue_key";
+    let batches = sql
+        .sql(query)
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    assert_eq!(extract_string_column(&batches, 0), vec!["q-a"]);
+
+    let plan = sql.get_physical_plan(query).await.expect("plan");
+    let exprs =
+        ShardQueryEngine::extract_pushed_filter_exprs(&plan).expect("should have filter exprs");
+    assert_eq!(
+        parse_floating_refresh_tasks_scan_strategy(&exprs),
+        FloatingRefreshTasksScanStrategy::Prefix {
+            task_group: "emails".to_string(),
+            tenant: Some("-".to_string()),
+        }
+    );
+    let explain = sql.explain(query).await.expect("explain");
+    assert!(
+        !explain.contains("FilterExec"),
+        "prefix filters are exact and need no post-filter: {explain}"
+    );
+
+    // A tenant filter alone cannot bound the prefix and is re-applied.
+    let tenant_only = "SELECT queue_key FROM floating_refresh_tasks WHERE tenant = 't2'";
+    let batches = sql
+        .sql(tenant_only)
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect");
+    assert_eq!(extract_string_column(&batches, 0), vec!["q-b"]);
+    let explain = sql.explain(tenant_only).await.expect("explain");
+    assert!(
+        explain.contains("FilterExec"),
+        "a tenant filter without task_group is a post-filter: {explain}"
+    );
+}

--- a/tests/shard_cleanup_tests.rs
+++ b/tests/shard_cleanup_tests.rs
@@ -909,3 +909,75 @@ async fn raw_cleanup_status_reader_distinguishes_absent_from_present() {
         "raw reader returns the present status"
     );
 }
+
+/// The sweep removes refresh index rows for tenants outside the child's
+/// range alongside the other key families.
+#[silo::test]
+async fn cleanup_removes_refresh_index_rows_outside_range() {
+    let (_tmp, shard) = open_temp_shard().await;
+    shard.stop_grant_scanner();
+    // IN range: bbb; OUT range: aaa.
+    for tenant in ["aaa", "bbb"] {
+        shard
+            .put_refresh_index_row_for_test(
+                &silo::task::Task::RefreshFloatingLimit {
+                    task_id: format!("{tenant}-refresh"),
+                    tenant: tenant.to_string(),
+                    queue_key: "floating-q".to_string(),
+                    current_max_concurrency: 1,
+                    last_refreshed_at_ms: 0,
+                    metadata: vec![],
+                    task_group: "default".to_string(),
+                },
+                None,
+            )
+            .await
+            .expect("seed refresh index row");
+    }
+    shard.db().flush().await.unwrap();
+    let prefix = silo::keys::refresh_tasks_prefix();
+    assert_eq!(
+        test_helpers::count_with_binary_prefix(shard.db(), &prefix).await,
+        2
+    );
+
+    let left_range = ShardRange::new("", RANGE_BOUNDARY);
+    let result = shard
+        .after_split_cleanup_defunct_data(&left_range, 10)
+        .await
+        .expect("cleanup should succeed");
+    assert!(result.complete);
+    shard.db().flush().await.unwrap();
+
+    assert_eq!(
+        test_helpers::count_with_binary_prefix(shard.db(), &prefix).await,
+        1,
+        "only the in-range tenant's refresh row remains"
+    );
+    assert!(
+        shard
+            .db()
+            .get(&silo::keys::refresh_task_key(
+                "default",
+                "bbb",
+                "floating-q"
+            ))
+            .await
+            .unwrap()
+            .is_some(),
+        "bbb's refresh row remains (hash in range)"
+    );
+    assert!(
+        shard
+            .db()
+            .get(&silo::keys::refresh_task_key(
+                "default",
+                "aaa",
+                "floating-q"
+            ))
+            .await
+            .unwrap()
+            .is_none(),
+        "aaa's refresh row is deleted (hash out of range)"
+    );
+}

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -210,6 +210,7 @@ pub async fn open_temp_shard_with_reconcile_interval_ms(
             terminal_job_expire_s: None,
             count_from_status_counters: true,
             floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
+            floating_refresh_stale_max_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MAX_MS,
             broker_tombstone_revive_after_generations:
                 silo::settings::DEFAULT_BROKER_TOMBSTONE_REVIVE_AFTER_GENERATIONS,
         },
@@ -259,6 +260,7 @@ pub async fn open_temp_shard_with_grant_scanner_config(
             terminal_job_expire_s: None,
             count_from_status_counters: true,
             floating_refresh_stale_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MS,
+            floating_refresh_stale_max_ms: silo::settings::DEFAULT_FLOATING_REFRESH_STALE_MAX_MS,
             broker_tombstone_revive_after_generations:
                 silo::settings::DEFAULT_BROKER_TOMBSTONE_REVIVE_AFTER_GENERATIONS,
         },
@@ -744,6 +746,23 @@ pub async fn open_temp_shard_with_floating_refresh_stale_ms(
     silo::metrics::Metrics,
 ) {
     open_temp_shard_with_metrics_and_config(|cfg| cfg.floating_refresh_stale_ms = stale_ms).await
+}
+
+/// Open a temp shard with a custom base stale window and cap, for tests
+/// that back consecutive stale resets off.
+pub async fn open_temp_shard_with_floating_refresh_stale_window(
+    stale_ms: u64,
+    stale_max_ms: u64,
+) -> (
+    tempfile::TempDir,
+    std::sync::Arc<JobStoreShard>,
+    silo::metrics::Metrics,
+) {
+    open_temp_shard_with_metrics_and_config(|cfg| {
+        cfg.floating_refresh_stale_ms = stale_ms;
+        cfg.floating_refresh_stale_max_ms = stale_max_ms;
+    })
+    .await
 }
 
 /// Open a temp shard with a custom `broker_tombstone_revive_after_generations`


### PR DESCRIPTION
## Why

A floating limit's refresh task was written into the task line at the current time, so it sorted behind every due job already waiting in its task group. On a saturated floating queue that backlog is exactly the work waiting on the cap, so the request to raise the cap never reached a worker, and a replacement written over the aged-out flag joined the same line, so the age-out re-fired every stale window instead of recovering anything. Two smaller problems compounded it: every chain walked into one write batch judged the same stale flag from the durable state row and wrote its own replacement, and a stale reset had no backoff, so a refresh that was scheduled but never leased cost a warn, a counter increment, and a row every window.

## What

- **Refresh index.** Pending refreshes live under a new key prefix (`0x0C`), one row per queue per task group, so scheduling over a stale flag replaces the unclaimed row in place. A dequeue drains the group's index in its own durable batch before claiming any job work from the broker, and `LeaseTasks` drains the local shards it did not dequeue from, so a refresh reaches the next worker asking for its group regardless of backlog depth. The drain leases at most 16 rows per call, skips retries whose `not_before_ms` is in the future, drops rows for tenants outside the shard range, and after-split cleanup sweeps the new key family. Rows carry a 24 hour row TTL, and an in-memory pending-group gate warmed at shard open lets idle groups skip the scan. Refresh rows still in the task line are leased when the broker reaches them.
- **One refresh per batch.** Chains walked into one write batch (a dequeue iteration, a grant scanner commit chunk, an enqueue) share a `ScheduledRefreshes` record, so a batch schedules at most one refresh per queue and marks the index groups pending only once its write is durable. Drains on a shard are serialized so two workers polling one group cannot both lease the same row.
- **Bounded stale resets.** The state row records consecutive stale resets; the stale window is `floating_refresh_stale_ms` doubled per reset, capped by the new `floating_refresh_stale_max_ms` setting (default 3600000, carried on every setting, template, and shard open path the base window is). Success, reported failure, and refresh lease expiry reset the count, and the reset warn carries `stale_resets` and `next_stale_window_ms`.
- **Query surface and docs.** A `floating_refresh_tasks` table lists pending refreshes in both the per-shard and cluster query engines, with `task_group` and `tenant` pushed down as key prefix bounds. The querying and observability guides, the internals prefix table, the web UI SQL console's table list, and the agent notes describe the index, the table, the setting, and the warn fields.

## Compatibility

Both flatbuffer fields are appended (`not_before_ms` on `RefreshFloatingLimit`, `stale_reset_count` on `FloatingLimitState`), so rows written without them decode as null and zero. The worker protocol is unchanged: refresh tasks still arrive in the lease response's `refresh_tasks` field. No migration is needed.

## Reviewing

Start with `src/job_store_shard/floating.rs` (scheduling, the drain, the pending-group gate, the stale window), then `src/job_store_shard/enqueue.rs` and the resumer hook in `src/concurrency.rs` for the per-batch record, then `src/query.rs` for the table. The regression tests in `tests/floating_concurrency_tests.rs` are named after the shapes that failed on staging: a refresh behind fifty due jobs, twenty waiters in one batch, and consecutive stale resets.